### PR TITLE
feat(ci): Add CI builds

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,94 @@
+name: Android Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode keystore
+        if: env.KEYSTORE_BASE64 != ''
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: echo "$KEYSTORE_BASE64" | base64 -d > ${{ github.workspace }}/release.keystore
+
+      - name: Build mobile APKs
+        env:
+          SIGNING_STORE_FILE: ${{ github.workspace }}/release.keystore
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: ./gradlew :androidApp:assembleDebug :androidApp:assembleRelease
+
+      - name: Build TV APKs
+        env:
+          SIGNING_STORE_FILE: ${{ github.workspace }}/release.keystore
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: ./gradlew :androidTvApp:assembleDebug :androidTvApp:assembleRelease
+
+      - name: Build App Bundles
+        env:
+          SIGNING_STORE_FILE: ${{ github.workspace }}/release.keystore
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: ./gradlew :androidApp:bundleRelease :androidTvApp:bundleRelease
+
+      - name: Upload mobile debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-debug-apk
+          path: androidApp/build/outputs/apk/debug/*.apk
+
+      - name: Upload mobile release APKs
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-release-apks
+          path: androidApp/build/outputs/apk/release/*.apk
+
+      - name: Upload TV debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: tv-debug-apk
+          path: androidTvApp/build/outputs/apk/debug/*.apk
+
+      - name: Upload TV release APKs
+        uses: actions/upload-artifact@v4
+        with:
+          name: tv-release-apks
+          path: androidTvApp/build/outputs/apk/release/*.apk
+
+      - name: Upload mobile AAB
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-release-aab
+          path: androidApp/build/outputs/bundle/release/*.aab
+
+      - name: Upload TV AAB
+        uses: actions/upload-artifact@v4
+        with:
+          name: tv-release-aab
+          path: androidTvApp/build/outputs/bundle/release/*.aab
+
+      - name: Clean up keystore
+        if: always()
+        run: rm -f ${{ github.workspace }}/release.keystore

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
 
     steps:
       - uses: actions/checkout@v6
@@ -32,9 +34,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Decode keystore
-        if: ${{ secrets.KEYSTORE_BASE64 != '' }}
-        env:
-          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        if: env.KEYSTORE_BASE64 != ''
         run: echo "$KEYSTORE_BASE64" | base64 -d > ${{ github.workspace }}/release.keystore
 
       - name: Build mobile APKs

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -3,28 +3,36 @@ name: Android Build
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Decode keystore
-        if: env.KEYSTORE_BASE64 != ''
+        if: ${{ secrets.KEYSTORE_BASE64 != '' }}
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: echo "$KEYSTORE_BASE64" | base64 -d > ${{ github.workspace }}/release.keystore
@@ -53,41 +61,63 @@ jobs:
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
         run: ./gradlew :androidApp:bundleRelease :androidTvApp:bundleRelease
 
-      - name: Upload mobile debug APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: mobile-debug-apk
-          path: androidApp/build/outputs/apk/debug/*.apk
+      - name: Collect build artifacts
+        if: github.event_name == 'push'
+        run: |
+          mkdir -p release-artifacts
+          for f in androidApp/build/outputs/apk/debug/*.apk; do
+            cp "$f" "release-artifacts/mobile-$(basename "$f")"
+          done
+          for f in androidApp/build/outputs/apk/release/*.apk; do
+            cp "$f" "release-artifacts/mobile-$(basename "$f")"
+          done
+          for f in androidTvApp/build/outputs/apk/debug/*.apk; do
+            cp "$f" "release-artifacts/tv-$(basename "$f")"
+          done
+          for f in androidTvApp/build/outputs/apk/release/*.apk; do
+            cp "$f" "release-artifacts/tv-$(basename "$f")"
+          done
+          for f in androidApp/build/outputs/bundle/release/*.aab; do
+            cp "$f" "release-artifacts/mobile-$(basename "$f")"
+          done
+          for f in androidTvApp/build/outputs/bundle/release/*.aab; do
+            cp "$f" "release-artifacts/tv-$(basename "$f")"
+          done
 
-      - name: Upload mobile release APKs
-        uses: actions/upload-artifact@v4
-        with:
-          name: mobile-release-apks
-          path: androidApp/build/outputs/apk/release/*.apk
+      - name: Determine release tag
+        if: github.event_name == 'push'
+        id: release-tag
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG="${{ github.ref_name }}"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "title=$TAG" >> "$GITHUB_OUTPUT"
+          else
+            VERSION=$(grep 'versionName' androidApp/build.gradle.kts | head -1 | sed 's/.*"\(.*\)".*/\1/')
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+            TAG="v${VERSION}-${SHORT_SHA}"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "title=$TAG (prerelease)" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Upload TV debug APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: tv-debug-apk
-          path: androidTvApp/build/outputs/apk/debug/*.apk
-
-      - name: Upload TV release APKs
-        uses: actions/upload-artifact@v4
-        with:
-          name: tv-release-apks
-          path: androidTvApp/build/outputs/apk/release/*.apk
-
-      - name: Upload mobile AAB
-        uses: actions/upload-artifact@v4
-        with:
-          name: mobile-release-aab
-          path: androidApp/build/outputs/bundle/release/*.aab
-
-      - name: Upload TV AAB
-        uses: actions/upload-artifact@v4
-        with:
-          name: tv-release-aab
-          path: androidTvApp/build/outputs/bundle/release/*.aab
+      - name: Create release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "${{ steps.release-tag.outputs.prerelease }}" == "true" ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          else
+            PRERELEASE_FLAG="--latest"
+          fi
+          gh release create "${{ steps.release-tag.outputs.tag }}" \
+            --title "${{ steps.release-tag.outputs.title }}" \
+            --generate-notes \
+            $PRERELEASE_FLAG \
+            release-artifacts/*
 
       - name: Clean up keystore
         if: always()


### PR DESCRIPTION
  Add CI/CD pipeline for automated Android builds and releases

  Summary
  - Add a GitHub Actions workflow (android-build.yml) that builds mobile and Android TV APKs and AABs on every push to main, on tags, and on pull requests
  - Signed release builds use a base64-encoded keystore from repository secrets, with automatic cleanup
  - Pushes to main create prerelease GitHub Releases (tagged v{version}-{sha}); pushing a v* tag creates a full release with auto-generated notes
  - Uses concurrency groups to cancel in-progress builds when new commits land
  - Pins to modern action versions: checkout@v6, setup-java@v5, gradle/actions/setup-gradle@v6

  Build matrix

  │    Target    │    Variants    │       Output        │
  │ androidApp   │ debug, release │ APK + AAB (release) │                                                                                                                                          
  │ androidTvApp │ debug, release │ APK + AAB (release) │

  Secrets required                                                                                                                                                                                 

  │         Secret         │                                 Purpose                                 │
  │ KEYSTORE_BASE64        │ Base64-encoded release keystore (optional — unsigned builds still work) │
  │ SIGNING_STORE_PASSWORD │ Keystore password                                                       │
  │ SIGNING_KEY_ALIAS      │ Key alias                                                               │
  │ SIGNING_KEY_PASSWORD   │ Key password                                                            │                                                                                             

  Test plan

  - Push to main and verify the workflow runs successfully
  - Confirm prerelease GitHub Release is created with all 6 artifacts (2 debug APKs, 2 release APKs, 2 AABs)
  - Open a PR against main and verify the build runs without creating a release
  - Tag a commit with v* and verify a non-prerelease GitHub Release is created
  - Verify builds succeed without KEYSTORE_BASE64 set (unsigned/debug-only path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build and release workflow for Android applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->