### PR TITLE
fix(detail): surface rewatch resume state for played items

### DIFF
--- a/androidApp/src/androidMain/kotlin/com/continuum/app/android/ui/screens/detail/DetailSharedComponents.kt
+++ b/androidApp/src/androidMain/kotlin/com/continuum/app/android/ui/screens/detail/DetailSharedComponents.kt
@@ -757,17 +757,14 @@ fun computePlayLabel(
     if (detail.type == "series" && nextEpisodeLabel != null) {
         return "Play $nextEpisodeLabel"
     }
-    if (detail.type == "episode") {
-        val s = detail.seasonNumber
-        val e = detail.episodeNumber
-        if (s != null && e != null) {
-            return if (s == 0) "Play E$e" else "Play S$s·E$e"
-        }
-    }
     // Watched items store position 0 server-side, so any nonzero position is
-    // a live resume point — including a rewatch of a played item.
+    // a live resume point — including a rewatch of a played item. Checked
+    // before the episode label so an in-progress episode reads "Resume" (the
+    // player resumes either way), and bounded below the duration so stale
+    // pre-migration data (position pinned to the duration) still reads "Play".
     val pos = detail.userData?.positionSeconds
-    if (pos != null && pos > 30) {
+    val dur = detail.userData?.durationSeconds
+    if (pos != null && pos > 30 && (dur == null || dur <= 0 || pos < dur - 5)) {
         val totalSec = pos.toInt()
         val h = totalSec / 3600
         val m = (totalSec % 3600) / 60
@@ -776,6 +773,13 @@ fun computePlayLabel(
             "Resume %d:%02d:%02d".format(h, m, s)
         } else {
             "Resume %d:%02d".format(m, s)
+        }
+    }
+    if (detail.type == "episode") {
+        val s = detail.seasonNumber
+        val e = detail.episodeNumber
+        if (s != null && e != null) {
+            return if (s == 0) "Play E$e" else "Play S$s·E$e"
         }
     }
     return "Play"

--- a/androidApp/src/androidMain/kotlin/com/continuum/app/android/ui/screens/detail/DetailSharedComponents.kt
+++ b/androidApp/src/androidMain/kotlin/com/continuum/app/android/ui/screens/detail/DetailSharedComponents.kt
@@ -764,9 +764,10 @@ fun computePlayLabel(
             return if (s == 0) "Play E$e" else "Play S$s·E$e"
         }
     }
+    // Watched items store position 0 server-side, so any nonzero position is
+    // a live resume point — including a rewatch of a played item.
     val pos = detail.userData?.positionSeconds
-    val played = detail.userData?.played == true
-    if (pos != null && pos > 30 && !played) {
+    if (pos != null && pos > 30) {
         val totalSec = pos.toInt()
         val h = totalSec / 3600
         val m = (totalSec % 3600) / 60

--- a/androidApp/src/androidMain/kotlin/com/continuum/app/android/ui/screens/detail/EpisodeList.kt
+++ b/androidApp/src/androidMain/kotlin/com/continuum/app/android/ui/screens/detail/EpisodeList.kt
@@ -73,7 +73,9 @@ private fun EpisodeRow(
     val isPlayed = userData?.played == true
     val pos = userData?.positionSeconds
     val dur = userData?.durationSeconds
-    val progress = if (pos != null && dur != null && dur > 0 && !isPlayed) {
+    // Watched episodes store position 0 server-side, so a nonzero position is
+    // a live resume point and shows its bar even on a played episode (rewatch).
+    val progress = if (pos != null && dur != null && dur > 0 && pos > 0) {
         (pos / dur).toFloat().coerceIn(0f, 1f)
     } else {
         null

--- a/androidApp/src/androidMain/kotlin/com/continuum/app/android/ui/screens/detail/EpisodeList.kt
+++ b/androidApp/src/androidMain/kotlin/com/continuum/app/android/ui/screens/detail/EpisodeList.kt
@@ -75,7 +75,9 @@ private fun EpisodeRow(
     val dur = userData?.durationSeconds
     // Watched episodes store position 0 server-side, so a nonzero position is
     // a live resume point and shows its bar even on a played episode (rewatch).
-    val progress = if (pos != null && dur != null && dur > 0 && pos > 0) {
+    // The pos < dur bound keeps stale pre-migration data (position pinned to
+    // the duration) from drawing full bars on watched rows.
+    val progress = if (pos != null && dur != null && dur > 0 && pos > 0 && pos < dur) {
         (pos / dur).toFloat().coerceIn(0f, 1f)
     } else {
         null


### PR DESCRIPTION
## Context

Server PR [silo-server#117](https://github.com/Silo-Server/silo-server/pull/117) changes the watch-progress model: `completed`/`played` becomes a one-way watched latch and **watched items now report `position_seconds: 0`** instead of position pinned to the duration. A rewatch of a watched item reports `played: true` **with** a live nonzero position, and such items now appear in the Continue Watching source (`GET /progress`, home sections), which keys on `position > 0`.

A full audit of this repo found the client almost entirely position-driven already — resume seek targets read `positionSeconds` directly, watched badges key on `played`, progress fractions guard on `0 < position < duration`, and next-unwatched selection filters on `played != true`. Two detail-screen spots still assumed the old `played ⇒ position == duration` coupling:

## Changes

- **`computePlayLabel` (DetailSharedComponents.kt):** the "Resume H:MM" label was gated on `!played`, so during a rewatch the button said "Play" while tapping it actually resumed mid-stream (the player seeks to `userData.positionSeconds` unconditionally). Any nonzero position is now a live resume point, so the gate is removed.
- **`EpisodeRow` (EpisodeList.kt):** the episode progress bar was suppressed for played episodes — necessary under the old model where played rows carried a stale 100% position, but it hid the bar for a rewatch in flight. The condition is now `position > 0`: rewatched episodes show their bar (alongside the watched checkmark, matching the web app and Jellyfin/Plex), and watched episodes (position 0) stay clean.

Audited and unchanged because already compatible: phone/TV player resume seek, `TvItemDetailScreen.resumePositionSeconds()` (position-gated), `TvMediaCard`/`MediaRow`/`FeaturedCarousel`/`TvDetailEpisodeRail` progress fractions, next-unwatched episode selection, watched badge rendering, and `PlaybackSessionLifecycle` (reports position only, never derives played locally).

## Behavior notes

- Old servers: behavior is unchanged in practice — under the old model a watched item's position equals its duration only until the server migration runs; this PR is intended to ship alongside/after silo-server#117.
- Known cross-platform difference left as-is: on the season screen, iOS prefers an in-progress episode as "next up" while Android picks the first unwatched episode regardless of an active rewatch. Pre-existing, not a regression; can be aligned in a follow-up if desired.

## Testing

`./gradlew :androidApp:compileDebugKotlin` clean. UI-level change only; no unit tests cover these composables today.

---
AI-use disclosure: implemented with Claude (Claude Code), reviewed by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resume labels now appear whenever a saved position >30s is present and passes a duration sanity check, so “Resume …” shows reliably.
  * Progress bars now display for episodes with valid position/duration even if marked as watched.
  * Resume labeling takes precedence over episode-specific “Play …” formatting so in-progress items show “Resume” first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->