### PR TITLE
Publish phone + TV as a single Play listing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This repository contains only the Silo Android clients. Shared Kotlin logic live
 
 ## Coding Style & Naming Conventions
 
-Use Kotlin 2.1, Java 21 targets, and Compose idioms. The Silo package root is `org.siloserver.silo`; the phone application ID is `org.siloserver.silo`, and the TV application ID is `org.siloserver.silo.tv`. This repo is on the full Silo namespace cut, so do not add legacy package IDs, legacy storage names, or old-brand symbols. Kotlin classes and composables use `PascalCase`; functions and properties use `camelCase`.
+Use Kotlin 2.1, Java 21 targets, and Compose idioms. The Silo package root is `org.siloserver.silo`. Both the phone and TV apps share a single `applicationId`, `org.siloserver.silo`, so they publish as one Google Play listing (Play routes each build by manifest feature filtering — the phone build requires `android.hardware.touchscreen`; the TV build requires `android.software.leanback`). The Gradle `namespace` stays distinct per module (`org.siloserver.silo.android`, `org.siloserver.silo.tv`) so generated `R`/`BuildConfig` classes don't collide. The two artifacts use distinct versionCodes (`base*2` for phone, `base*2+1` for TV), so each release bumps both by 2 with no reuse; bump `siloVersionCode` per release. This repo is on the full Silo namespace cut, so do not add legacy package IDs, legacy storage names, or old-brand symbols. Kotlin classes and composables use `PascalCase`; functions and properties use `camelCase`.
 
 ## Testing Guidelines
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Android **phone** and **Android TV** clients for the [Silo](https://github.com/Silo-Server/silo-server) self-hosted media server — stream and download your movies, shows, music, audiobooks, and ebooks, with quality-aware playback and multi-server/multi-profile support.
 
-Built as a Kotlin Multiplatform project: one shared business-logic core, two Jetpack Compose apps (touch + 10-foot TV). This branch uses the full Silo namespace cut: Kotlin packages live under `org.siloserver.silo`, with phone application ID `org.siloserver.silo` and TV application ID `org.siloserver.silo.tv`. Installs under legacy IDs do not upgrade in place; users should expect a fresh app install, sign-in, and offline media download.
+Built as a Kotlin Multiplatform project: one shared business-logic core, two Jetpack Compose apps (touch + 10-foot TV). This branch uses the full Silo namespace cut: Kotlin packages live under `org.siloserver.silo`, and both apps share a single application ID `org.siloserver.silo` so they publish as one Google Play listing (Play routes each build by manifest feature filtering). Installs under legacy IDs do not upgrade in place; users should expect a fresh app install, sign-in, and offline media download.
 
 > **Status:** Early WIP (`v0.1.0`). The architecture is solid and the feature surface is broad; some areas are intentionally "bones-level" and under active redesign (see [Roadmap](#roadmap)).
 >
@@ -30,7 +30,7 @@ Built as a Kotlin Multiplatform project: one shared business-logic core, two Jet
 | | |
 |---|---|
 | **Apps** | Android phone · Android TV |
-| **Application IDs** | Phone `org.siloserver.silo` · Android TV `org.siloserver.silo.tv` |
+| **Application ID** | `org.siloserver.silo` (shared by phone + TV — one Play listing) |
 | **Language / UI** | Kotlin 2.1.20 · Jetpack Compose (Material 3) · Compose for TV (`androidx.tv`) |
 | **Playback** | AndroidX **Media3 / ExoPlayer** 1.10.0 (+ optional FFmpeg audio extension, optional MPV backend path) |
 | **Networking** | **Ktor** 3.1.2 client · kotlinx.serialization · WebSockets for realtime |
@@ -229,7 +229,7 @@ Known gaps the docs track: TV has no reader/ebooks and no downloads management b
 
 ## Notes
 
-- Android phone and TV app IDs remain `org.siloserver.silo` and `org.siloserver.silo.tv` in this migration.
+- The Android phone and TV apps share one application ID, `org.siloserver.silo`, and publish as a single Google Play listing; Play delivers the right build per device via manifest feature filtering (phone requires a touchscreen, TV requires leanback).
 - The Android modules target Java 21.
 - The server repo lives at [`Silo-Server/silo-server`](https://github.com/Silo-Server/silo-server).
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 val siloVersionName = providers
     .gradleProperty("siloVersionName")
     .orElse(providers.environmentVariable("SILO_VERSION_NAME"))
-    .orElse("0.1.0")
+    .orElse("1.0.0")
 
 val siloVersionCode = providers
     .gradleProperty("siloVersionCode")
@@ -20,9 +20,26 @@ val siloVersionCode = providers
     .map { value ->
         val code = value.toIntOrNull() ?: error("siloVersionCode must be an integer.")
         require(code > 0) { "siloVersionCode must be positive." }
+        // The *2 (+1 for TV) form-factor multiplier applied at versionCode
+        // assignment must stay under Google Play's 2_100_000_000 ceiling.
+        require(code <= 1_049_999_999) {
+            "siloVersionCode must be <= 1_049_999_999 so the form-factor multiplier " +
+                "keeps both artifacts under Google Play's 2_100_000_000 versionCode limit."
+        }
         code
     }
-    .orElse(1)
+    // Bump this per release. base -> phone = base*2, TV = base*2+1. base 5 was
+    // the 10/11 build; base 6 -> phone 12, TV 13.
+    .orElse(6)
+
+// APK ABI splits (below) are incompatible with the App Bundle build:
+// PerModuleBundleTask.getResourcesFile() expects a single processed-resources
+// file and throws "Sequence contains more than one matching element" when the
+// splits produce one per ABI. The bundle does its own ABI splitting via the
+// `bundle { abi }` block, so disable APK splits whenever a bundle task is run.
+val isBuildingBundle = gradle.startParameter.taskNames.any {
+    it.contains("bundle", ignoreCase = true)
+}
 
 kotlin {
     androidTarget {
@@ -113,7 +130,10 @@ android {
         applicationId = "org.siloserver.silo"
         minSdk = 24
         targetSdk = 35
-        versionCode = siloVersionCode.get()
+        // Shares one Play listing with the TV app (same applicationId). Two
+        // artifacts under one listing need distinct versionCodes: phone =
+        // base*2, TV = base*2+1, so each release bumps both by 2 with no reuse.
+        versionCode = siloVersionCode.get() * 2
         versionName = siloVersionName.get()
         // Shadow the android-shared BuildConfig field so per-app flavors
         // (e.g., a "no-FFmpeg" sideload build for size-constrained QA) can
@@ -161,7 +181,9 @@ android {
     // keeps the all-ABIs APK around for dev convenience.
     splits {
         abi {
-            isEnable = true
+            // Off for bundle builds (see isBuildingBundle) — the AAB handles
+            // per-ABI delivery itself and APK splits break its resource step.
+            isEnable = !isBuildingBundle
             reset()
             include("arm64-v8a", "armeabi-v7a", "x86_64")
             isUniversalApk = true

--- a/androidApp/src/androidMain/AndroidManifest.xml
+++ b/androidApp/src/androidMain/AndroidManifest.xml
@@ -6,6 +6,13 @@
          to API 26+ and uses Media3 on Android 7/API 24-25. -->
     <uses-sdk tools:overrideLibrary="dev.jdtech.mpv" />
 
+    <!-- Phone and TV share one Play listing under the same applicationId.
+         Requiring a touchscreen excludes this build from Android TV devices
+         (which have none), so TVs only ever receive the leanback TV build. -->
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="true" />
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/androidTvApp/build.gradle.kts
+++ b/androidTvApp/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 val siloVersionName = providers
     .gradleProperty("siloVersionName")
     .orElse(providers.environmentVariable("SILO_VERSION_NAME"))
-    .orElse("0.1.0")
+    .orElse("1.0.0")
 
 val siloVersionCode = providers
     .gradleProperty("siloVersionCode")
@@ -16,9 +16,23 @@ val siloVersionCode = providers
     .map { value ->
         val code = value.toIntOrNull() ?: error("siloVersionCode must be an integer.")
         require(code > 0) { "siloVersionCode must be positive." }
+        // The *2 (+1 for TV) form-factor multiplier applied at versionCode
+        // assignment must stay under Google Play's 2_100_000_000 ceiling.
+        require(code <= 1_049_999_999) {
+            "siloVersionCode must be <= 1_049_999_999 so the form-factor multiplier " +
+                "keeps both artifacts under Google Play's 2_100_000_000 versionCode limit."
+        }
         code
     }
-    .orElse(1)
+    // Bump this per release. base -> phone = base*2, TV = base*2+1. base 5 was
+    // the 10/11 build; base 6 -> phone 12, TV 13.
+    .orElse(6)
+
+// See androidApp/build.gradle.kts: APK ABI splits break the App Bundle build,
+// so disable them whenever a bundle task is invoked.
+val isBuildingBundle = gradle.startParameter.taskNames.any {
+    it.contains("bundle", ignoreCase = true)
+}
 
 kotlin {
     androidTarget {
@@ -108,10 +122,18 @@ android {
     namespace = "org.siloserver.silo.tv"
     compileSdk = 36
     defaultConfig {
-        applicationId = "org.siloserver.silo.tv"
+        // Shares one Play listing with the phone app, so both must use the
+        // same applicationId. Play routes phone vs TV builds by manifest
+        // feature filtering (this app requires android.software.leanback; the
+        // phone app requires android.hardware.touchscreen). The `namespace`
+        // above stays distinct so the generated R/BuildConfig classes don't
+        // collide with the phone module.
+        applicationId = "org.siloserver.silo"
         minSdk = 24
         targetSdk = 35
-        versionCode = siloVersionCode.get()
+        // Two artifacts under one listing need distinct versionCodes: phone =
+        // base*2, TV = base*2+1, so each release bumps both by 2 with no reuse.
+        versionCode = siloVersionCode.get() * 2 + 1
         versionName = siloVersionName.get()
         // Shadow the android-shared BuildConfig field so per-app flavors can
         // override without rebuilding the shared module. See androidApp's
@@ -149,7 +171,8 @@ android {
     }
     splits {
         abi {
-            isEnable = true
+            // Off for bundle builds — the AAB handles per-ABI delivery itself.
+            isEnable = !isBuildingBundle
             reset()
             include("arm64-v8a", "armeabi-v7a", "x86_64")
             isUniversalApk = true


### PR DESCRIPTION
## What

Unify the phone and TV apps onto **one** `applicationId` (`org.siloserver.silo`) so they publish as a **single Google Play listing** (the Apple-style one-app-multiple-form-factors model) instead of two separate listings.

## Changes

- **`androidTvApp/build.gradle.kts`** — `applicationId` `org.siloserver.silo.tv` → `org.siloserver.silo`. The Gradle `namespace` stays `org.siloserver.silo.tv` on purpose, so the generated `R`/`BuildConfig` classes don't collide with the phone module. (Activity FQN therefore remains `org.siloserver.silo.tv.MainTvActivity`.)
- **Distinct versionCodes** — required for two artifacts under one listing: phone = `base*10`, TV = `base*10+1`.
- **`androidApp` manifest** — now requires `android.hardware.touchscreen`, so Play filters the phone build off TV devices. The TV build already requires `android.software.leanback`. The two are mutually exclusive by device class.
- **Docs** — `AGENTS.md` (the `CLAUDE.md` symlink target) and `README.md` updated to describe the single-listing model.

## Verification

- Built and installed on an NVIDIA SHIELD: package resolves to `org.siloserver.silo` and the leanback launcher activity `org.siloserver.silo/.tv.MainTvActivity` launches correctly.

## Notes / follow-ups (not code)

- On Play, create **one app** and upload both artifacts to the same track; both must be signed with the **same Play App Signing key** (Play enforces one key per listing).
- Because both builds now share a package, they **cannot coexist on the same device** — installing one replaces the other. Fine in production (feature-filtered per device class); during dev, use separate devices for phone vs TV.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Phone and TV Android apps now share a single Google Play listing, making app discovery and distribution simpler.
  * Device-specific delivery is handled automatically so phones and TVs receive the correct build.

* **Bug Fixes**
  * Improved install and migration behavior for users coming from older app IDs.
  * Updated version handling to better support both Android variants under one listing.

* **Documentation**
  * Clarified Android app identity, listing, and migration notes in the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->