### PR TITLE
Player: DV Profile 7 direct play, mpv Atmos passthrough fix, mobile error recovery

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt
@@ -39,15 +39,19 @@ object DisplayHdrProbe {
         val hlg = Display.HdrCapabilities.HDR_TYPE_HLG in types
         val dv = Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION in types
 
-        // The panel-side probe doesn't differentiate DV profiles. The codec
+        // The panel-side probe doesn't differentiate DV profiles — Android
+        // only reports whether the link/panel carries DV at all. The codec
         // probe (MediaCodecCapabilitiesProbe) enumerates actual profile
-        // support; this layer just tells us whether the HDMI link / panel can
-        // carry DV at all. Consumers intersect the two.
+        // support (and already strips P7 without multi-instance HEVC), so
+        // this layer must list every profile we model or the intersection
+        // silently drops legitimate decoder claims — listing only [5, 8]
+        // here is what previously made native P7 support undetectable even
+        // on dual-layer-capable hardware.
         return HdrCapabilities(
             hdr10 = hdr10,
             hdr10Plus = hdr10p,
             hlg = hlg,
-            dolbyVisionProfiles = if (dv) listOf(5, 8) else emptyList(),
+            dolbyVisionProfiles = if (dv) listOf(5, 7, 8) else emptyList(),
         )
     }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -329,14 +329,19 @@ internal fun isDirectPlayableDolbyVisionProfile(
     profile: Int,
     supportedHdr: org.siloserver.silo.model.playback.HdrCapabilities,
 ): Boolean = when (profile) {
-    // Launch policy: do not claim Profile 7 direct playback until that route is
-    // validated separately. It commonly needs dual-layer handling that the
-    // current Media3 path has not proven.
-    7 -> false
     // Profile 8 carries a renderable base layer. Do not force a server fallback
     // merely because the display probe lacks native Dolby Vision/HDR; let the
     // player-error path recover if the actual decoder route fails.
     8 -> true
+    // Profile 7 (dual-layer BL+EL) and Profile 5 (no compatible base layer)
+    // need a native Dolby Vision decoder on the Media3 route.
+    // MediaCodecCapabilitiesProbe already gates the P7 claim on multi-instance
+    // HEVC (the enhancement layer needs a second concurrent decode), so
+    // membership in the intersected profile list is the whole test — the same
+    // model jellyfin-androidtv ships (DvheDtb + maxSupportedInstances >= 2).
+    // When this returns false, PlaybackRecoveryPlanner now prefers an
+    // alternate direct engine (mpv decodes the P7/P8 HDR10 base layer and
+    // tone-maps P5) before conceding a server transcode.
     else -> supportedHdr.dolbyVisionProfiles.contains(profile)
 }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackRecoveryPlanner.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackRecoveryPlanner.kt
@@ -12,8 +12,18 @@ class PlaybackRecoveryPlanner {
         attemptedEngines: Set<PlaybackEngineKind> = emptySet(),
     ): PlaybackRecoveryAction =
         when (reason) {
-            is Playability.UnsupportedDvProfile -> PlaybackRecoveryAction.ServerTranscode(
+            // An unsupported DV profile on the current (Media3) engine is not
+            // the end of direct play: mpv decodes the HDR10 base layer of
+            // P7/P8 and tone-maps P5 via gpu-next, so prefer an alternate
+            // direct engine from the plan before conceding a transcode. A
+            // remux is excluded for the same reason as unsupported audio —
+            // it copies the DV video stream verbatim, re-sending exactly what
+            // the decoder just rejected.
+            is Playability.UnsupportedDvProfile -> serverFallbackFromPlan(
+                currentPlan,
                 errorClass = "unsupported_dolby_vision_profile",
+                attemptedEngines = attemptedEngines,
+                allowRemux = false,
             )
             // An unsupported audio codec / channel layout cannot be fixed by a
             // REMUX — REMUX copies the audio stream verbatim, re-sending the exact

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
@@ -17,6 +17,8 @@ import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory
+import androidx.media3.extractor.ts.TsExtractor
 import org.siloserver.silo.common.BuildConfig
 import org.siloserver.silo.common.player.audio.DelayAudioProcessor
 import org.siloserver.silo.common.player.mpv.MpvPlayer
@@ -71,6 +73,15 @@ class SiloPlayerFactory(
         // delegates to DefaultSubtitleParserFactory and shifts cue start times
         // by the per-profile subtitle-sync value (A.3f).
         .setSubtitleParserFactory(subtitleParserFactory)
+        // HDMV DTS streams (Blu-ray-sourced M2TS) use a stream type the TS
+        // payload reader skips by default, so DTS tracks vanish from
+        // Blu-ray-remux transport streams without this flag.
+        .setTsExtractorFlags(DefaultTsPayloadReaderFactory.FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS)
+        // The default PCR search window is too small for high-bitrate 4K
+        // remux/transcode TS segments with sparse PTS — startup then fails
+        // with "timestamp not found" (androidx/media #8571-class failures).
+        // 1500 packets matches what battle-tested players ship.
+        .setTsExtractorTimestampSearchBytes(1500 * TsExtractor.TS_PACKET_SIZE)
 
     fun createPlayer(
         preferFfmpegAudio: Boolean = BuildConfig.FFMPEG_AUDIO_ENABLED,

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/mpv/MpvPlayer.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/mpv/MpvPlayer.kt
@@ -63,8 +63,18 @@ class MpvPlayer(
     private val seekForwardIncrement: Long = C.DEFAULT_SEEK_FORWARD_INCREMENT_MS,
     private val pauseAtEndOfMediaItems: Boolean = false,
     private val videoOutput: String = "gpu-next",
-    private val audioOutput: String = "aaudio",
-    private val hwDec: String = "mediacodec-copy",
+    // audiotrack first: mpv's AAudio AO cannot open IEC61937 (compressed)
+    // streams, so any `audio-spdif` passthrough request silently degrades to
+    // PCM decode under aaudio — losing Atmos/TrueHD bitstreaming. The
+    // audiotrack AO supports both PCM and passthrough; aaudio remains the
+    // fallback if audiotrack fails to initialize.
+    private val audioOutput: String = "audiotrack,aaudio",
+    // Direct rendering first (zero-copy AImageReader path on the GL renderer,
+    // available on our API-26 device floor), with copy-back as the per-codec
+    // fallback — mpv walks the list per codec at decoder init. Forcing
+    // copy-back everywhere doubles memory bandwidth on 4K streams, which is
+    // what stutters weaker TV SoCs.
+    private val hwDec: String = "mediacodec,mediacodec-copy",
     private val bufferSizeMb: Int = 64,
     private val httpHeaderFieldsProvider: () -> List<Pair<String, String>> = { emptyList() },
 ) : BasePlayer(), MPVLib.EventObserver, AudioManager.OnAudioFocusChangeListener, MpvVideoScaleController {
@@ -122,10 +132,10 @@ class MpvPlayer(
         var videoOutput: String = "gpu-next"
             private set
 
-        var audioOutput: String = "aaudio"
+        var audioOutput: String = "audiotrack,aaudio"
             private set
 
-        var hwDec: String = "mediacodec-copy"
+        var hwDec: String = "mediacodec,mediacodec-copy"
             private set
 
         var bufferSizeMb: Int = 64

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -19,13 +19,35 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
     }
 
     @Test
-    fun profile7DirectPlayStaysBlockedByLaunchPolicy() {
+    fun profile7DirectPlayRequiresNativeDualLayerSupport() {
         assertFalse(
             isDirectPlayableDolbyVisionProfile(
                 profile = 7,
-                supportedHdr = HdrCapabilities(dolbyVisionProfiles = listOf(7)),
+                supportedHdr = HdrCapabilities(dolbyVisionProfiles = listOf(5, 8)),
             ),
-            "Profile 7 remains blocked until we validate that direct route separately.",
+            "Without a native dual-layer DV decoder, Media3 cannot direct-play P7 — recovery must route to mpv or transcode instead.",
+        )
+    }
+
+    @Test
+    fun profile7DirectPlayIsAllowedWithNativeDualLayerSupport() {
+        assertTrue(
+            isDirectPlayableDolbyVisionProfile(
+                profile = 7,
+                supportedHdr = HdrCapabilities(dolbyVisionProfiles = listOf(5, 7, 8)),
+            ),
+            "Devices whose DV decoder claims dual-layer profiles with multi-instance HEVC (Shield-class) can direct-play P7.",
+        )
+    }
+
+    @Test
+    fun profile5DirectPlayRequiresNativeDolbyVisionDecoder() {
+        assertFalse(
+            isDirectPlayableDolbyVisionProfile(
+                profile = 5,
+                supportedHdr = HdrCapabilities(),
+            ),
+            "P5 has no backward-compatible base layer; without a DV decoder the Media3 route cannot render it.",
         )
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackRecoveryPlannerTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackRecoveryPlannerTest.kt
@@ -44,6 +44,64 @@ class PlaybackRecoveryPlannerTest {
     }
 
     @Test
+    fun unsupportedDvProfilePrefersAlternateDirectEngineAndNeverRemuxes() {
+        // mpv decodes the HDR10 base layer of P7, so an alternate direct
+        // engine beats a server fallback; a remux would re-send the exact DV
+        // stream the Media3 decoder just refused, so it must be skipped even
+        // when the plan offers one.
+        val plan = PlaybackExecutionPlan(
+            planId = "s1",
+            delivery = PlaybackDelivery.ORIGINAL_HTTP,
+            engine = PlaybackEngineKind.MEDIA3_DIRECT,
+            routeFamily = PlaybackRouteFamily.PLATFORM_NATIVE,
+            fallbacks = listOf(
+                PlaybackFallbackCandidate(
+                    delivery = PlaybackDelivery.ORIGINAL_HTTP,
+                    engine = PlaybackEngineKind.MPV_DIRECT,
+                    reason = "alternate_direct_engine",
+                ),
+                PlaybackFallbackCandidate(
+                    delivery = PlaybackDelivery.SERVER_REMUX_HLS,
+                    engine = PlaybackEngineKind.MEDIA3_HLS,
+                    reason = "container_adaptation",
+                ),
+            ),
+        )
+
+        val action = PlaybackRecoveryPlanner().planForPlayability(
+            currentPlan = plan,
+            reason = Playability.UnsupportedDvProfile(7),
+        )
+
+        val alternate = assertIs<PlaybackRecoveryAction.AlternateDirectEngine>(action)
+        assertEquals(PlaybackEngineKind.MPV_DIRECT, alternate.engine)
+    }
+
+    @Test
+    fun unsupportedDvProfileWithoutAlternateEngineTranscodesInsteadOfRemuxing() {
+        val plan = PlaybackExecutionPlan(
+            planId = "s1",
+            delivery = PlaybackDelivery.ORIGINAL_HTTP,
+            engine = PlaybackEngineKind.MEDIA3_DIRECT,
+            routeFamily = PlaybackRouteFamily.PLATFORM_NATIVE,
+            fallbacks = listOf(
+                PlaybackFallbackCandidate(
+                    delivery = PlaybackDelivery.SERVER_REMUX_HLS,
+                    engine = PlaybackEngineKind.MEDIA3_HLS,
+                    reason = "container_adaptation",
+                ),
+            ),
+        )
+
+        val action = PlaybackRecoveryPlanner().planForPlayability(
+            currentPlan = plan,
+            reason = Playability.UnsupportedDvProfile(7),
+        )
+
+        assertIs<PlaybackRecoveryAction.ServerTranscode>(action)
+    }
+
+    @Test
     fun playerErrorPrefersServerRemuxCandidateBeforeFullTranscode() {
         val plan = PlaybackExecutionPlan(
             planId = "s1",

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -560,6 +560,11 @@ fun PlayerScreen(
             val preflight = PlaybackPreflightListener(
                 detector = capabilityDetector,
                 onUnsupported = { verdict -> viewModel.onUnsupportedPlayback(verdict) },
+                // Runtime errors (decoder init, source, mid-stream IO) walk the
+                // same recovery ladder as preflight failures — previously the
+                // mobile player dropped these on the floor and the screen sat
+                // on a stale frame.
+                onError = { error -> viewModel.onPlayerError(error) },
             )
             controller.addListener(preflight)
             onDispose { controller.removeListener(preflight) }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -8,6 +8,8 @@ import org.siloserver.silo.common.downloads.DownloadEnqueuer
 import org.siloserver.silo.common.downloads.OfflineMediaResolver
 import org.siloserver.silo.common.player.PlaybackCapabilityDetector
 import org.siloserver.silo.common.player.Playability
+import org.siloserver.silo.common.player.PlaybackRecoveryAction
+import org.siloserver.silo.common.player.PlaybackRecoveryPlanner
 import org.siloserver.silo.common.player.PlaybackSessionLifecycle
 import org.siloserver.silo.common.player.PlaybackSessionManager
 import org.siloserver.silo.common.player.PlayerNotice
@@ -32,7 +34,10 @@ import org.siloserver.silo.model.catalog.TimeRange
 import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.model.playback.PlayMethod
 import org.siloserver.silo.model.playback.PlaybackDelivery
+import org.siloserver.silo.model.playback.PlaybackEngineKind
 import org.siloserver.silo.model.playback.PlaybackExecutionPlan
+import org.siloserver.silo.model.playback.PlaybackRouteEventRequest
+import org.siloserver.silo.model.playback.PlaybackRouteFamily
 import org.siloserver.silo.model.playback.PlaybackSessionResponse
 import org.siloserver.silo.model.playback.PlayerSubtitleInfo
 import org.siloserver.silo.model.playback.mergeDownloadedSubtitles
@@ -117,6 +122,7 @@ class PlayerViewModel(
         // Record a durable position roughly every 10s of content time (matches the
         // server reporter cadence) to bound DB/outbox churn.
         private const val POSITION_RECORD_INTERVAL_SEC = 10.0
+        private const val MAX_TRANSIENT_NETWORK_RETRIES = 1
     }
 
     data class PlayerUiState(
@@ -275,6 +281,16 @@ class PlayerViewModel(
     // Once-per-episode guard for the credits/ended trigger; reset on each load.
     private var autoAdvanceHandled = false
     private var engineSwitchFallbackAttempted = false
+
+    // Recovery ladder state — mirrors TvPlayerViewModel. The planner picks the
+    // cheapest viable fallback (alternate direct engine → server remux →
+    // transcode); attemptedEngines prevents Media3↔mpv ping-pong; the
+    // transient-network budget lets a single blip retry the SAME route instead
+    // of demoting a healthy direct stream for the rest of playback.
+    private val recoveryPlanner = PlaybackRecoveryPlanner()
+    private val attemptedEngines = mutableSetOf<PlaybackEngineKind>()
+    private var transientNetworkRetries = 0
+    private var recoveryJob: Job? = null
     val hdrEnabled: StateFlow<Boolean> = playerSettingsStore.hdrEnabledFlow
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
     val subtitleAppearance: StateFlow<SubtitleAppearance> = playerSettingsStore.subtitleAppearanceFlow
@@ -379,6 +395,8 @@ class PlayerViewModel(
         // AutoPlayGuard streak intentionally PERSISTS across episodes.)
         autoAdvanceHandled = false
         engineSwitchFallbackAttempted = false
+        attemptedEngines.clear()
+        transientNetworkRetries = 0
         // Cancel any in-flight resolve from the previous episode so its result
         // can't land on this one and overwrite the fresh next-episode pointer.
         resolveNextEpisodeJob?.cancel()
@@ -562,12 +580,7 @@ class PlayerViewModel(
      */
     fun onUnsupportedPlayback(reason: Playability) {
         val state = _uiState.value
-        val sessionId = state.sessionId ?: return
-        val versions = state.versions
-        val versionIndex = state.selectedVersionIndex
-        val selectedAudioIndex = state.selectedAudioIndex
-        val selectedSubtitleIndex = state.selectedSubtitleIndex
-        val version = versions.getOrNull(versionIndex) ?: return
+        state.sessionId ?: return
 
         val notice = when (reason) {
             is Playability.UnsupportedDvProfile ->
@@ -582,7 +595,149 @@ class PlayerViewModel(
         }
         Log.i(TAG, "Preflight fallback: $notice")
 
+        val recoveryAction = recoveryPlanner.planForPlayability(state.playbackPlan, reason, attemptedEngines)
+        if (applyAlternateDirectFallback(state, recoveryAction)) return
+        startServerRecoveryFallback(notice, recoveryAction, state)
+    }
+
+    /**
+     * Player runtime error (decoder init, source, network after prepare).
+     * Mirrors TvPlayerViewModel.onPlayerError: a transient network blip retries
+     * the SAME route a bounded number of times (budget restored once playback
+     * progresses), everything else walks the recovery ladder — alternate
+     * direct engine first, then the plan's server remux/transcode candidates.
+     * Previously the mobile player had no error handling at all: a decoder or
+     * IO failure left the screen on a stale frame/spinner forever.
+     */
+    fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+        val state = _uiState.value
+        val message = error.localizedMessage?.takeIf { msg -> msg.isNotBlank() }
+            ?: "Playback failed. Please try again."
+        val isTransientNetwork =
+            error.errorCode == androidx.media3.common.PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED ||
+                error.errorCode == androidx.media3.common.PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT
+        val plan = state.playbackPlan
+        if (isTransientNetwork &&
+            state.sessionId != null &&
+            plan != null &&
+            transientNetworkRetries < MAX_TRANSIENT_NETWORK_RETRIES
+        ) {
+            transientNetworkRetries++
+            Log.i(TAG, "Transient network error; retrying same route ($transientNetworkRetries/$MAX_TRANSIENT_NETWORK_RETRIES)")
+            // Appending to the decision trace produces a new plan object, which
+            // re-runs the screen's mount effect — a same-route remount at the
+            // current position, without a server round-trip.
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    error = null,
+                    playbackPlan = plan.copy(
+                        timeline = plan.timeline.copy(playerStartSeconds = state.position),
+                        decisionTrace = plan.decisionTrace +
+                            "client_retry=transient_network:$transientNetworkRetries",
+                    ),
+                    startPosition = state.position,
+                )
+            }
+            return
+        }
+        val recoveryAction = recoveryPlanner.planForPlayerError(state.playbackPlan, error, attemptedEngines)
+        if (applyAlternateDirectFallback(state, recoveryAction)) return
+        if (state.sessionId != null && recoveryAction != PlaybackRecoveryAction.None) {
+            startServerRecoveryFallback(message, recoveryAction, state)
+            return
+        }
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                error = message,
+                isPlaying = false,
+                isBuffering = false,
+            )
+        }
+    }
+
+    /**
+     * Client-side engine switch (Media3 ↔ mpv) without a server fallback.
+     * Updating the plan's engine + startPosition re-runs the screen's mount
+     * effect, which sends SET_ENGINE to the playback service and remounts.
+     * Returns false when the action isn't an engine switch so the caller
+     * proceeds to the server ladder.
+     */
+    private fun applyAlternateDirectFallback(
+        state: PlayerUiState,
+        recoveryAction: PlaybackRecoveryAction,
+    ): Boolean {
+        val action = recoveryAction as? PlaybackRecoveryAction.AlternateDirectEngine ?: return false
+        val plan = state.playbackPlan ?: return false
+        val sessionId = state.sessionId ?: return false
+        // Record the engine we're leaving (and the one we're moving to) so a later
+        // failure can't bounce back to an engine that already failed.
+        attemptedEngines.add(plan.engine)
+        attemptedEngines.add(action.engine)
+        val nextRouteFamily = when (action.engine) {
+            PlaybackEngineKind.MPV_DIRECT -> PlaybackRouteFamily.COMPATIBILITY_DIRECT
+            PlaybackEngineKind.MEDIA3_DIRECT -> PlaybackRouteFamily.PLATFORM_NATIVE
+            else -> plan.routeFamily
+        }
         viewModelScope.launch {
+            playbackSessionManager.reportRouteEvent(
+                sessionId = sessionId,
+                request = PlaybackRouteEventRequest(
+                    planId = plan.planId,
+                    fromEngine = plan.engine,
+                    toEngine = action.engine,
+                    delivery = plan.delivery,
+                    routeFamily = nextRouteFamily,
+                    fallbackReason = "alternate_direct_engine",
+                    errorClass = action.errorClass,
+                    claims = plan.claims,
+                    blockers = plan.capabilities.blockers,
+                ),
+            )
+        }
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                error = null,
+                playbackPlan = plan.copy(
+                    engine = action.engine,
+                    routeFamily = nextRouteFamily,
+                    timeline = plan.timeline.copy(playerStartSeconds = state.position),
+                    decisionTrace = plan.decisionTrace +
+                        "client_fallback=alternate_direct_engine:${plan.engine}->${action.engine}",
+                ),
+                startPosition = state.position,
+            )
+        }
+        return true
+    }
+
+    private fun startServerRecoveryFallback(
+        notice: String,
+        recoveryAction: PlaybackRecoveryAction,
+        state: PlayerUiState,
+    ) {
+        val sessionId = state.sessionId ?: return
+        val selectedAudioIndex = state.selectedAudioIndex
+        val selectedSubtitleIndex = state.selectedSubtitleIndex
+        val version = state.versions.getOrNull(state.selectedVersionIndex) ?: return
+        val fallbackMode = when (recoveryAction) {
+            is PlaybackRecoveryAction.ServerRemux -> PlaybackSessionManager.TranscodeMode.REMUX
+            is PlaybackRecoveryAction.AlternateDirectEngine -> PlaybackSessionManager.TranscodeMode.REMUX
+            is PlaybackRecoveryAction.ServerTranscode,
+            PlaybackRecoveryAction.None,
+            -> PlaybackSessionManager.TranscodeMode.FULL
+        }
+
+        // Single-flight: a second player/preflight error arriving before the
+        // first fallback finishes must not launch a competing transcode session
+        // (which would orphan one server session and race _uiState).
+        if (recoveryJob?.isActive == true) {
+            Log.i(TAG, "Server recovery already in flight; ignoring duplicate fallback request")
+            return
+        }
+        recoveryJob = viewModelScope.launch {
             val capabilities = capabilityDetector.detect()
             val sessionResponse = PlaybackSessionResponse(
                 sessionId = sessionId,
@@ -613,7 +768,7 @@ class PlayerViewModel(
                 session = sessionResponse,
                 seekSeconds = state.position,
                 resolution = version.resolution.orEmpty(),
-                mode = org.siloserver.silo.common.player.PlaybackSessionManager.TranscodeMode.FULL,
+                mode = fallbackMode,
                 audioTrackIndex = selectedAudioIndex,
                 subtitleTrackIndex = selectedSubtitleIndex,
                 renewSession = {
@@ -675,7 +830,15 @@ class PlayerViewModel(
             state.versions.getOrNull(state.selectedVersionIndex) != null
         ) {
             engineSwitchFallbackAttempted = true
-            onUnsupportedPlayback(Playability.StartupStalled(bufferedAheadMs = 0L, stalledForMs = 0L))
+            // Don't blindly transcode: prefer another direct engine, then fall
+            // through the plan's remux/transcode ladder. A transcode-only source
+            // can't be rescued by a remux that copies the same streams.
+            val recoveryAction = recoveryPlanner.planForEngineSwitchFailure(
+                state.playbackPlan,
+                attemptedEngines,
+            )
+            if (applyAlternateDirectFallback(state, recoveryAction)) return
+            startServerRecoveryFallback(message, recoveryAction, state)
             return
         }
         _uiState.update {
@@ -696,6 +859,12 @@ class PlayerViewModel(
         val durationSec = durationMs / 1000.0
         val bufferedSec = bufferedPositionMs / 1000.0
         val previousPosition = _uiState.value.position
+
+        // Playback is progressing — restore the transient-network retry budget so
+        // a later, unrelated blip gets a fresh retry instead of demoting at once.
+        if (positionSec > 0 && transientNetworkRetries > 0) {
+            transientNetworkRetries = 0
+        }
 
         _uiState.update { state ->
             state.copy(

--- a/docs/media3/10-reference-player-comparison.md
+++ b/docs/media3/10-reference-player-comparison.md
@@ -1,0 +1,188 @@
+Document version: July 2026 survey. Reference checkouts live at `/Volumes/NVMe/dev/github/reference-players/` (shallow clones; not part of this repo).
+
+# Reference Player Comparison — Silo Android vs. Open-Source Video Players
+
+This document records a code-level survey of seven open-source Android video
+players, focused on the axes that matter for Silo's direct-play goals: full
+codec coverage, 4K Dolby Vision profiles 5/7/8, Atmos/TrueHD/DTS audio
+passthrough, and playback robustness (error recovery, fallback ladders,
+display-mode switching). It closes with the verdict on our own player and the
+changes made as a result.
+
+Surveyed (all analyzed at their July 2026 default branches):
+
+| App | Engine(s) | Why it was surveyed |
+|---|---|---|
+| jellyfin-androidtv | Media3 (legacy `VideoManager` path + flagged rewrite) | The most mature OSS Android TV client for 4K DV + Atmos direct play |
+| Findroid | Media3 + libmpv (`dev.jdtech.mpv`) | Dual-backend Jellyfin client, closest architecture to ours |
+| jellyfin-android | Media3 | Official phone client; runtime `MediaCodecList` device profile |
+| Streamyfin | libmpv via custom Expo module | mpv-first design, tiered hwdec, careful native lifecycle |
+| NextPlayer | Media3 + NextLib (FFmpeg audio+video decoders) | Local player known for broad codec support |
+| Just Player (moneytoo/Player) | Patched Media3 fork + FFmpeg/AV1/IAMF/MPEG-H AARs | The only app with a real DV Profile 7 fallback |
+| mpv-android (is.xyz) | libmpv | Canonical libmpv frontend; surface-lifecycle reference |
+
+## 1. Comparison matrix
+
+"Silo" refers to this repo's player stack (`android-shared/.../common/player/`).
+
+| Capability | Silo | jellyfin-androidtv | Findroid | jellyfin-android | Streamyfin | NextPlayer | Just Player |
+|---|---|---|---|---|---|---|---|
+| Engine strategy | Media3 + mpv, **auto-selected per route** with server plan | Media3 only | Media3 or mpv, global user pref | Media3 only | mpv only | Media3 only | Media3 (patched fork) |
+| Capability report to server | Decoder+panel+audio-sink probes → `ClientCodecCapabilities` + per-engine envelopes | Decoder-derived `DeviceProfile` with `VideoRangeType` exclusions | **"Direct play all"** (empty profiles) | Runtime `MediaCodecList` intersection | Static "play everything" profile, DV force-excluded | n/a (local files) | n/a (local files) |
+| DV P5 | Direct when decoder+panel claim it | Direct when decoder claims it | Undeclared (decoder's problem) | Transcoded (never advertised) | Transcoded (`VideoRangeType != DOVI`) | None | Native decoder only |
+| DV P7 | **Now:** native (multi-instance gate) or mpv base-layer; was: always transcode | Direct only with `DvheDtb` + multi-instance HEVC | Undeclared | Transcoded | Transcoded | None | `mapDV7ToHevc` renderer patch (BL as HDR10) |
+| DV P8 | Direct (base layer renders as HDR10) | Direct when DV **or** HDR10 decoder present | Undeclared | Transcoded | Transcoded | None | Media3 built-in BL fallback |
+| Atmos (E-AC-3 JOC) / TrueHD passthrough | Capability-probed (`AudioCapabilitiesReceiver` + `isDirectPlaybackSupported`), MIME-preference presets, mpv `audio-spdif` | Advertised broadly; stock `DefaultAudioSink` negotiates | None (PCM decode) | None | None ("passthrough" = channel cap) | None | None |
+| FFmpeg audio fallback | Bundled `media3-decoder-ffmpeg` AAR, `MODE_PREFER` | Compiled in, `MODE_ON`/`MODE_PREFER` pref | Jellyfin fork AAR, `MODE_ON` | Extension, `MODE_ON`→`PREFER` after failure | mpv/FFmpeg native | NextLib (audio+video) | FFmpeg AAR (audio+experimental video) |
+| Error recovery | Plan-driven ladder: alternate direct engine → remux → transcode (TV; **now also mobile**) | 3-strike direct→direct-stream→transcode, 30s stabilization reset | **None** | Decoder swap, then 3-step server degrade | None native | None | Release on SOURCE error only |
+| Decoder fallback | `setEnableDecoderFallback(true)` | Same | Not set | Same + custom `MediaCodecSelector` | n/a | Same | Selector re-invalidation only |
+| Tunneling | Off (deliberate; Google TV stalls) | Off (deliberate) | **On** always | Off | n/a | Off | User toggle |
+| Refresh-rate matching | TV (`HdrDisplayController`) + phone (`RefreshRateMatcher`), integer-multiple scoring | Mode scoring incl. 2×/2.5×, scale-on-TV/device pref | None | None | None | None | Integer-multiple match, defers playback until switch completes |
+| Buffering | Device-profile-aware staged `LoadControl` | User pref (default/50s/80s) | Default | User pref | mpv 64MiB demuxer cache | Default | Default |
+
+## 2. What each app taught us
+
+### jellyfin-androidtv (the load-bearing reference)
+- **Capability detection is decoder-first, not panel-first.** The device
+  profile is built from `MediaCodecList` profile/level enumeration; panel
+  `Display.HdrCapabilities` appears only in a diagnostic report. Our
+  `MediaCodecCapabilitiesProbe` already follows this model (it was in fact
+  modeled on theirs).
+- **DV P7 requires `DolbyVisionProfileDvheDtb` plus multi-instance HEVC**
+  (`maxSupportedInstances >= 2`) — the enhancement layer needs a second
+  concurrent decode. Our probe already had this exact gate; our *policy* was
+  ignoring the result (fixed, see §4).
+- **P8's base layer is HDR10**: they allow P8 direct play whenever the device
+  has DV *or plain HDR10* decode. Our policy (`P8 → always direct, recover on
+  failure`) is a more aggressive version of the same idea.
+- **Audio: advertise broadly, let the stock `DefaultAudioSink` negotiate
+  passthrough at runtime.** No AVR-model detection. Their only knobs are
+  direct-vs-downmix and an AC3 toggle. Our approach (probing
+  `AudioCapabilitiesReceiver` and biasing track selection by reachable MIMEs)
+  is strictly more precise; theirs is simpler and relies on the recovery
+  ladder when the sink refuses.
+- **Tunneling off everywhere** — matches our choice; reported, never requested.
+- The 3-strike error ladder with a 30-second "playback stabilized" retry-reset
+  is the pattern our TV player already implements (bounded transient retries
+  reset by `onPositionChanged`); mobile now has it too.
+- A `KnownDefects` hardcoded model blocklist (Fire TV DV+HDR10+ quirks) is a
+  concept worth adopting if/when device-specific DV reports come in.
+
+### Just Player (the DV P7 trick)
+- Ships a **patched Media3 fork** whose `MediaCodecVideoRenderer` gains
+  `setMapDV7ToHevc`: when the display/decoder can't do native DV, a
+  `video/dolby-vision` P7 format is fed to the plain **HEVC HDR10 decoder**
+  (the P7 base layer is HDR10-compatible; the EL rides in unspec-62 NALs the
+  decoder ignores). Stock Media3 1.10 maps only P8→HEVC / P9→AVC — P7 is not
+  mapped, which is exactly why they patched it.
+- We chose **not** to fork Media3 for this. Our architecture already has a
+  second engine whose decoder stack (FFmpeg) handles P7 base layers natively:
+  mpv. Routing non-native P7 to mpv gets the same user outcome (HDR10
+  playback of the base layer instead of a 4K transcode) with zero fork
+  maintenance.
+- Their TS extractor hardening (`FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS`, widened
+  timestamp search — ExoPlayer issue #8571) was directly adopted (§4).
+- Their frame-rate matcher **defers playback until the display-mode switch
+  completes** — a polish item ours doesn't do yet.
+
+### Findroid / Streamyfin / jellyfin-android / NextPlayer / mpv-android
+- None of these attempt DV handling or real audio passthrough; Findroid and
+  Streamyfin delegate everything to the decoder ("direct play all" profiles),
+  jellyfin-android and Streamyfin explicitly exclude DV (transcode), and all
+  mpv users run PCM-only audio (`ao=aaudio`/`audiotrack` with no
+  `audio-spdif`).
+- Findroid's `MPVPlayer` is the ancestor of our `MpvPlayer` wrapper (same
+  `BasePlayer` bridge, same option skeleton). Notable deltas: Findroid
+  defaults `hwdec=mediacodec` (direct); we shipped `mediacodec-copy` (fixed,
+  §4). Findroid exposes raw `mpv.conf` editing as a power-user escape hatch.
+- Streamyfin's tiered hwdec (emulator→`no`, TV→`mediacodec`,
+  phone→`mediacodec-copy`) exists because direct hwdec can wedge the emulator;
+  worth remembering if emulator reports come in after the hwdec change.
+- Streamyfin and Findroid both **never call `MPVLib.destroy()`** (libmpv 1.0
+  JNI use-after-free); our wrapper manages its own lifecycle — keep an eye on
+  teardown crash telemetry.
+- mpv-android's value is its init ordering (`force-window=no` → init →
+  surface callbacks last) and surface teardown sequence (`vo=null` →
+  `force-window=no` → detach), including a self-documented race: `vo=null`
+  does not synchronously wait for VO deinit. Our `MpvPlayer` follows the same
+  shape and inherits the same theoretical race.
+- jellyfin-android's two-tier recovery (local decoder swap via
+  `EXTENSION_RENDERER_MODE_PREFER` rebuild, then progressive server
+  degradation) validates our alternate-engine-then-server ladder.
+
+## 3. Verdict on the Silo player
+
+**No rewrite.** After reading all seven codebases, ours is the most capable
+stack of the group on the axes that matter here:
+
+- We are the only client with **route-aware dual engines** (Media3 for
+  HLS/DRM/cast, mpv for hard containers/ASS/compatibility) selected per
+  playback plan with state-transfer on switch.
+- Our audio-capability probing (per-encoding `AudioTrack.isDirectPlaybackSupported`,
+  HDMI hot-plug re-detection, spatializer awareness, passthrough-biased track
+  selection) is more precise than anything surveyed — jellyfin-androidtv gets
+  by with less; everyone else has nothing.
+- Our server-negotiated execution plan with fallback candidates is a superset
+  of jellyfin's device-profile negotiation.
+- The probes (decoder DV profile/level enumeration with the multi-instance P7
+  gate) already matched the best-in-class implementation.
+
+The roughness was concentrated in five specific gaps, all fixed in this pass
+(§4). The structural criticisms that remain (a 1,700-line hand-written
+`MpvPlayer`, duplicated phone/TV ViewModel logic) are real but are refactors,
+not correctness issues, and none of the surveyed apps do better (Findroid's
+wrapper is the same shape; jellyfin-androidtv maintains two full player
+stacks).
+
+## 4. Changes made from this survey
+
+1. **Mobile player-error recovery (parity with TV)** — the phone player had
+   no `onPlayerError` wiring at all and forced a FULL transcode on any
+   preflight failure. It now runs the same ladder as TV: bounded
+   transient-network same-route retry → `PlaybackRecoveryPlanner` → alternate
+   direct engine (with `attemptedEngines` ping-pong guard and route-event
+   telemetry) → server remux → transcode, single-flighted.
+   (`PlayerViewModel.kt`, `PlayerScreen.kt`)
+2. **DV Profile 7 direct play** — policy no longer hard-refuses P7:
+   - Native path: allowed when the decoder claims a dual-layer profile *and*
+     multi-instance HEVC (the probe's existing gate; jellyfin-androidtv's
+     model). `DisplayHdrProbe` no longer strips P7 from the intersection —
+     Android panels can't report per-profile DV support, so fabricating
+     `[5, 8]` there silently vetoed legitimate decoder claims.
+   - Fallback path: `PlaybackRecoveryPlanner` now prefers an **alternate
+     direct engine** for `UnsupportedDvProfile` (mpv renders the P7/P8 HDR10
+     base layer and tone-maps P5) and excludes remux (it would re-send the
+     same rejected stream), before conceding a transcode — Just Player's
+     `mapDV7ToHevc` outcome without a Media3 fork.
+   (`PlaybackCapabilityDetector.kt`, `DisplayHdrProbe.kt`,
+   `PlaybackRecoveryPlanner.kt`, tests updated)
+3. **mpv audio passthrough actually bitstreams now** — `ao` was `aaudio`,
+   whose mpv AO cannot open compressed (IEC61937) streams, so our
+   `audio-spdif` configuration silently decoded Atmos/TrueHD to PCM. Default
+   is now `audiotrack,aaudio`. (`MpvPlayer.kt`)
+4. **mpv hwdec is direct-first** — `mediacodec,mediacodec-copy` instead of
+   forced copy-back (which doubles memory bandwidth on 4K); mpv falls back
+   per-codec automatically. Matches mpv-android/Findroid/Streamyfin-TV.
+   (`MpvPlayer.kt`)
+5. **TS extractor hardening** — `FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS` (DTS in
+   Blu-ray-sourced M2TS) and a 1500-packet timestamp search window for
+   high-bitrate/sparse-PTS transport streams. (`SiloPlayerFactory.kt`)
+
+## 5. Ideas noted but deliberately not adopted (yet)
+
+- **Media3 fork with `mapDV7ToHevc`** — mpv routing covers the same content;
+  a fork is a standing maintenance tax.
+- **Tunneling toggle** (Just Player) — we ship tunneling-off for cause
+  (Google TV Streamer stalls); revisit only with a per-device allowlist.
+- **`KnownDefects` device blocklist** (jellyfin-androidtv) — no confirmed
+  device-specific DV defects in our telemetry yet; adopt the pattern when the
+  first one lands.
+- **Defer playback until display-mode switch completes** (Just Player) —
+  polish; our seamless-only `VIDEO_CHANGE_FRAME_RATE_STRATEGY` avoids the
+  worst of the mode-switch black-frame problem already.
+- **Audio night mode / loudness normalization** (jellyfin-androidtv
+  `DynamicsProcessing` limiter; NextPlayer `LoudnessEnhancer`) — feature work,
+  not a fix; note that applying an audio effect to the session **forces PCM**
+  and is therefore mutually exclusive with passthrough.
+- **User-editable `mpv.conf`** (Findroid) — power-user escape hatch worth
+  considering once the mpv route stabilizes.

--- a/docs/media3/README.md
+++ b/docs/media3/README.md
@@ -51,6 +51,12 @@ cases; this document suite remains the Media3 reference.
   Playback Core v2 spec for Android TV: Media3/MPV first-class route planning,
   direct-play-first fallbacks, server/client contract changes, and validation
   gates for 4K, HDR, Dolby Vision, Atmos, passthrough, and subtitles.
+- **[10 - Reference player comparison](10-reference-player-comparison.md)** -
+  July 2026 code survey of jellyfin-androidtv, Findroid, jellyfin-android,
+  Streamyfin, NextPlayer, Just Player, and mpv-android against the Silo stack:
+  DV P5/7/8 strategies, passthrough handling, error-recovery ladders, and the
+  changes adopted from the survey (mobile recovery parity, DV P7 direct play,
+  mpv passthrough AO fix, direct-first hwdec, TS extractor hardening).
 
 ## Quick answers
 
@@ -73,10 +79,12 @@ cases; this document suite remains the Media3 reference.
   3:2 pulldown judder. Turn on refresh-rate matching — **06 §1.3** — and enable
   tunneling — **05 §2**. If the AVR adds fixed latency, tunneling is also what gives
   you frame-accurate sync without estimating the latency in app code.
-- **"How do I handle DV Profile 7 sources?"** Do not advertise P7 as Android TV
-  Dolby Vision direct play for launch. Use HDR10 base-layer playback, Profile 8.1
-  normalization/remux, or transcode with metadata-loss warnings. **09** is the
-  current route-planning source of truth.
+- **"How do I handle DV Profile 7 sources?"** P7 direct-plays on the Media3
+  route only when the decoder claims a dual-layer DV profile with
+  multi-instance HEVC (`MediaCodecCapabilitiesProbe.supportsDvProfile7`);
+  otherwise `PlaybackRecoveryPlanner` prefers the mpv engine (HDR10 base-layer
+  playback) before conceding a transcode. See **10 §4** for the policy change
+  and **09** for the route-planning contract.
 - **"Where does the `AnalyticsListener` go?"** **08 §8**. Minimum set: decoder init
   name, dropped-frames count, audio underruns. Pair with Media3's built-in
   `EventLogger` under `BuildConfig.DEBUG` for bring-up.


### PR DESCRIPTION
## Summary

Follow-up to a code-level survey of seven open-source Android video players (jellyfin-androidtv, Findroid, jellyfin-android, Streamyfin, NextPlayer, Just Player, mpv-android — shallow-cloned and read end-to-end). The survey's conclusion: our player architecture already exceeds every surveyed app on engine routing, capability probing, and fallback planning — so **no rewrite**, but five concrete gaps were found and are fixed here. The full comparison lives in `docs/media3/10-reference-player-comparison.md`.

### Fixes

1. **Mobile player-error recovery (parity with TV)** — the phone player had no `onPlayerError` wiring and forced a FULL transcode on any preflight failure. It now runs the TV ladder: bounded transient-network same-route retry → `PlaybackRecoveryPlanner` → alternate direct engine (`attemptedEngines` ping-pong guard, route-event telemetry) → server remux → transcode, single-flighted. (`PlayerViewModel.kt`, `PlayerScreen.kt`)
2. **Dolby Vision Profile 7 direct play** — policy no longer hard-refuses P7:
   - Native: allowed when the decoder claims dual-layer DV **and** multi-instance HEVC (`MediaCodecCapabilitiesProbe`'s existing gate — the same model jellyfin-androidtv ships). `DisplayHdrProbe` no longer fabricates a `[5, 8]` panel profile list that silently vetoed legitimate P7 decoder claims.
   - Fallback: `UnsupportedDvProfile` now prefers an alternate direct engine (mpv renders the P7/P8 HDR10 base layer, tone-maps P5) and excludes remux (it re-sends the exact stream the decoder rejected) before conceding a transcode — Just Player's `mapDV7ToHevc` outcome without maintaining a Media3 fork.
3. **mpv Atmos/TrueHD passthrough actually bitstreams** — default `ao` was `aaudio`, whose mpv AO cannot open IEC61937 (compressed) streams, so the existing `audio-spdif` config silently decoded to PCM. Now `audiotrack,aaudio`.
4. **mpv hwdec direct-first** — `mediacodec,mediacodec-copy` instead of forced copy-back (double memory bandwidth on 4K); mpv falls back per-codec automatically.
5. **TS extractor hardening** — `FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS` (DTS in Blu-ray-sourced M2TS) + 1500-packet timestamp search window. (`SiloPlayerFactory.kt`)

### Server follow-up (separate repo)

The resolver still emits the `dolby_vision_profile_7_not_launch_claimed` blocker, which preempts the new client ladder with an immediate FULL transcode. To realize the P7 benefit it should stop blocking P7 (or list `MPV_DIRECT` as a fallback) now that clients claim and handle it honestly.

## Test plan

- [x] `:android-shared:testDebugUnitTest` — passes, including new tests: P7 policy (native-gated, P5 unchanged, P8 unchanged) and planner behavior (`UnsupportedDvProfile` → alternate engine, never remux)
- [x] `:androidApp:testDebugUnitTest`, `:shared:testDebugUnitTest` — pass
- [x] `:androidApp:assembleDebug`, `:androidTvApp:assembleDebug` — build
- [x] `:androidTvApp:testDebugUnitTest` — passes; note `TvAuthSingleFlightTest` is load-flaky on main too (Ktor `MockEngine` real-dispatcher work racing a virtual-time `withTimeout`) — unrelated to this diff, worth a separate fix
- [ ] On-device: DV P7 MKV on a non-DV HDR10 device (expect mpv base-layer HDR10 playback, not transcode) — blocked on the server-side blocker change
- [ ] On-device: TrueHD/Atmos MKV over HDMI on the mpv route (expect bitstream passthrough on the AVR display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaKRXz1mtnsDm6pn1LDkmz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Dolby Vision playback handling, including broader support for Profile 7 and smarter fallback to alternate playback paths.
  * Updated playback defaults to better prioritize audio output and hardware decoding options.

* **Bug Fixes**
  * Improved recovery from playback errors and transient network issues to reduce failed or interrupted playback.
  * Enhanced support for certain transport stream files and audio tracks.

* **Documentation**
  * Added updated player-comparison guidance and revised Dolby Vision Profile 7 playback recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->