### PR TITLE
Fix v0.2.5 Android TV playback feedback

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
@@ -381,6 +381,30 @@ internal fun displayedSubtitleVideoRect(
     )
 }
 
+internal fun displayedSubtitleContentFrameRect(
+    viewWidth: Int,
+    viewHeight: Int,
+    frameLeft: Int,
+    frameTop: Int,
+    frameWidth: Int,
+    frameHeight: Int,
+): SubtitleVideoRect? {
+    if (viewWidth <= 0 || viewHeight <= 0 || frameWidth <= 0 || frameHeight <= 0) {
+        return null
+    }
+    val visibleLeft = frameLeft.coerceAtLeast(0)
+    val visibleTop = frameTop.coerceAtLeast(0)
+    val visibleRight = (frameLeft + frameWidth).coerceAtMost(viewWidth)
+    val visibleBottom = (frameTop + frameHeight).coerceAtMost(viewHeight)
+    if (visibleRight <= visibleLeft || visibleBottom <= visibleTop) return null
+    return SubtitleVideoRect(
+        left = visibleLeft - frameLeft,
+        top = visibleTop - frameTop,
+        width = visibleRight - visibleLeft,
+        height = visibleBottom - visibleTop,
+    )
+}
+
 @UnstableApi
 private class SubtitleVideoRectSync(playerView: PlayerView) :
     View.OnLayoutChangeListener,
@@ -439,14 +463,15 @@ private class SubtitleVideoRectSync(playerView: PlayerView) :
     private fun applyRect(playerView: PlayerView) {
         val subtitleView = playerView.subtitleView ?: return
         val videoSize = playerView.player?.videoSize ?: VideoSize.UNKNOWN
-        val rect = displayedSubtitleVideoRect(
-            viewWidth = playerView.width,
-            viewHeight = playerView.height,
-            videoWidth = videoSize.width,
-            videoHeight = videoSize.height,
-            videoPixelWidthHeightRatio = videoSize.pixelWidthHeightRatio,
-            resizeMode = playerView.resizeMode,
-        )
+        val rect = playerView.contentFrameSubtitleRect()
+            ?: displayedSubtitleVideoRect(
+                viewWidth = playerView.width,
+                viewHeight = playerView.height,
+                videoWidth = videoSize.width,
+                videoHeight = videoSize.height,
+                videoPixelWidthHeightRatio = videoSize.pixelWidthHeightRatio,
+                resizeMode = playerView.resizeMode,
+            )
         val current = subtitleView.layoutParams as? FrameLayout.LayoutParams
         val params = current ?: FrameLayout.LayoutParams(rect.width, rect.height)
         val gravity = Gravity.TOP or Gravity.START
@@ -477,6 +502,20 @@ private class SubtitleVideoRectSync(playerView: PlayerView) :
         playerView?.removeOnAttachStateChangeListener(this)
         isDisposed = true
     }
+}
+
+private fun PlayerView.contentFrameSubtitleRect(): SubtitleVideoRect? {
+    val frame = findViewById<AspectRatioFrameLayout>(
+        androidx.media3.ui.R.id.exo_content_frame
+    ) ?: return null
+    return displayedSubtitleContentFrameRect(
+        viewWidth = width,
+        viewHeight = height,
+        frameLeft = frame.left,
+        frameTop = frame.top,
+        frameWidth = frame.width,
+        frameHeight = frame.height,
+    )
 }
 
 internal fun resolveSubtitleUrl(serverUrl: String, url: String): String =

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
@@ -147,6 +147,49 @@ class SubtitleManagerAppearanceTest {
         assertEquals(SubtitleVideoRect(left = 0, top = 0, width = 1080, height = 2400), rect)
     }
 
+    @Test
+    fun contentFrameRectUsesSubtitleParentLocalBounds() {
+        val rect = displayedSubtitleContentFrameRect(
+            viewWidth = 1920,
+            viewHeight = 1080,
+            frameLeft = 0,
+            frameTop = 140,
+            frameWidth = 1920,
+            frameHeight = 800,
+        )
+
+        assertEquals(SubtitleVideoRect(left = 0, top = 0, width = 1920, height = 800), rect)
+    }
+
+    @Test
+    fun clippedContentFrameRectUsesSubtitleParentLocalIntersection() {
+        val rect = displayedSubtitleContentFrameRect(
+            viewWidth = 1920,
+            viewHeight = 1080,
+            frameLeft = -100,
+            frameTop = -50,
+            frameWidth = 2120,
+            frameHeight = 1180,
+        )
+
+        assertEquals(SubtitleVideoRect(left = 100, top = 50, width = 1920, height = 1080), rect)
+    }
+
+    @Test
+    fun invalidContentFrameRectFallsBackToComputedBounds() {
+        assertEquals(
+            null,
+            displayedSubtitleContentFrameRect(
+                viewWidth = 1920,
+                viewHeight = 1080,
+                frameLeft = 0,
+                frameTop = 0,
+                frameWidth = 0,
+                frameHeight = 0,
+            ),
+        )
+    }
+
     private fun captionStyleFor(appearance: SubtitleAppearance): CaptionStyleCompat {
         val method = SubtitleManager::class.java.getDeclaredMethod(
             "buildCaptionStyle",

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -17,7 +17,7 @@ if (file("google-services.json").isFile) {
 val siloVersionName = providers
     .gradleProperty("siloVersionName")
     .orElse(providers.environmentVariable("SILO_VERSION_NAME"))
-    .orElse("1.0.0")
+    .orElse("0.2.6")
 
 val siloVersionCode = providers
     .gradleProperty("siloVersionCode")
@@ -33,9 +33,9 @@ val siloVersionCode = providers
         }
         code
     }
-    // Bump this per release. base -> phone = base*2, TV = base*2+1. base 5 was
-    // the 10/11 build; base 6 -> phone 12, TV 13.
-    .orElse(6)
+    // Bump this per release. base -> phone = base*2, TV = base*2+1. base 6 was
+    // the 12/13 build; base 7 -> phone 14, TV 15.
+    .orElse(7)
 
 // APK ABI splits (below) are incompatible with the App Bundle build:
 // PerModuleBundleTask.getResourcesFile() expects a single processed-resources

--- a/androidTvApp/build.gradle.kts
+++ b/androidTvApp/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 val siloVersionName = providers
     .gradleProperty("siloVersionName")
     .orElse(providers.environmentVariable("SILO_VERSION_NAME"))
-    .orElse("1.0.0")
+    .orElse("0.2.6")
 
 val siloVersionCode = providers
     .gradleProperty("siloVersionCode")
@@ -24,9 +24,9 @@ val siloVersionCode = providers
         }
         code
     }
-    // Bump this per release. base -> phone = base*2, TV = base*2+1. base 5 was
-    // the 10/11 build; base 6 -> phone 12, TV 13.
-    .orElse(6)
+    // Bump this per release. base -> phone = base*2, TV = base*2+1. base 6 was
+    // the 12/13 build; base 7 -> phone 14, TV 15.
+    .orElse(7)
 
 // See androidApp/build.gradle.kts: APK ABI splits break the App Bundle build,
 // so disable them whenever a bundle task is invoked.

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadata.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadata.kt
@@ -43,7 +43,11 @@ internal object TvDetailMetadata {
     fun ratingChip(detail: ItemDetail): String? =
         detail.contentRating?.trim()?.takeIf { it.isNotEmpty() }
 
-    fun factsLine(detail: ItemDetail, preferredQuality: String? = null): List<TvHeroFactToken> {
+    fun factsLine(
+        detail: ItemDetail,
+        preferredQuality: String? = null,
+        selectedFileId: Int? = null,
+    ): List<TvHeroFactToken> {
         val tokens = mutableListOf<TvHeroFactToken>()
         if (detail.year > 0) tokens += TvHeroFactToken.TextToken(detail.year.toString())
         when {
@@ -57,7 +61,7 @@ internal object TvDetailMetadata {
         detail.ratingImdb?.let {
             tokens += TvHeroFactToken.TextToken("★ ${formatOneDecimal(it)}")
         }
-        tokens += qualityTokens(detail, preferredQuality)
+        tokens += qualityTokens(detail, preferredQuality, selectedFileId)
         return tokens
     }
 
@@ -125,8 +129,12 @@ internal object TvDetailMetadata {
         return "$whole.$tenths"
     }
 
-    private fun qualityTokens(detail: ItemDetail, preferredQuality: String?): List<TvHeroFactToken> {
-        val version = preferredVersion(detail, preferredQuality) ?: return emptyList()
+    private fun qualityTokens(
+        detail: ItemDetail,
+        preferredQuality: String?,
+        selectedFileId: Int?,
+    ): List<TvHeroFactToken> {
+        val version = preferredVersion(detail, preferredQuality, selectedFileId) ?: return emptyList()
         val tokens = mutableListOf<TvHeroFactToken>()
         resolutionLabel(version.resolution)?.let { tokens += TvHeroFactToken.Chip(it) }
         if (version.hdr) tokens += TvHeroFactToken.Chip(dolbyVisionLabel(version) ?: "HDR")
@@ -135,10 +143,14 @@ internal object TvDetailMetadata {
         return tokens
     }
 
-    private fun preferredVersion(detail: ItemDetail, preferredQuality: String?): FileVersion? {
+    private fun preferredVersion(
+        detail: ItemDetail,
+        preferredQuality: String?,
+        selectedFileId: Int?,
+    ): FileVersion? {
         return selectTvDetailDisplayVersion(
             versions = detail.versions,
-            selectedFileId = null,
+            selectedFileId = selectedFileId,
             lastFileId = detail.userData?.lastFileId,
             preferredQuality = preferredQuality,
         )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -194,6 +194,11 @@ private fun TvDetailContent(
             emptyList()
         }
     }
+    val heroSelectedFileId = if (detail.type == "series" || detail.type == "season") {
+        state.selectedNextUpFileId
+    } else {
+        state.selectedFileId
+    }
     var chaptersDialogOpen by remember(detail.contentId) { mutableStateOf(false) }
 
     // The first focusable body rail (episode rail, else cast). An Up press from
@@ -240,7 +245,11 @@ private fun TvDetailContent(
                             ratingChip = TvDetailMetadata.ratingChip(detail),
                             overview = detail.overview,
                             tagline = detail.tagline,
-                            factsLine = TvDetailMetadata.factsLine(detail, state.preferredQuality),
+                            factsLine = TvDetailMetadata.factsLine(
+                                detail = detail,
+                                preferredQuality = state.preferredQuality,
+                                selectedFileId = heroSelectedFileId,
+                            ),
                             starringText = TvDetailMetadata.starringText(detail),
                             actions = {
                                 HeroActionRow(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeScreen.kt
@@ -13,10 +13,8 @@ import org.siloserver.silo.model.section.ResolvedSection
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvLoadingScreen
 import org.siloserver.silo.tv.ui.components.TvMediaCardActions
-import org.siloserver.silo.tv.ui.components.TvRowStyle
 import org.siloserver.silo.tv.ui.components.TvSkylineSectionFeed
 import org.siloserver.silo.tv.ui.components.isTvProgressRow
-import org.siloserver.silo.tv.ui.util.visibleOnTv
 import org.siloserver.silo.viewmodel.HomeViewModel
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -36,7 +34,7 @@ fun TvHomeScreen(
     viewModel: HomeViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
-    val visibleSections = remember(state.sections) { state.sections.visibleOnTv() }
+    val visibleSections = remember(state.sections) { state.sections.normalizeTvHomeSections() }
 
     when {
         state.isLoading && state.sections.isEmpty() -> TvLoadingScreen(
@@ -93,7 +91,7 @@ private fun TvHomeContent(
             section.isTvProgressRow()
         },
         styleForSection = { section ->
-            if (section.isTvProgressRow()) TvRowStyle.Backdrop else TvRowStyle.Poster
+            section.tvHomeRowStyle()
         },
         cardActions = { section, item ->
             val isProgressRow = section.isTvProgressRow()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeSections.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeSections.kt
@@ -1,0 +1,47 @@
+package org.siloserver.silo.tv.ui.screens.home
+
+import org.siloserver.silo.model.section.ResolvedSection
+import org.siloserver.silo.tv.ui.components.TvRowStyle
+import org.siloserver.silo.tv.ui.components.isTvProgressRow
+import org.siloserver.silo.tv.ui.util.isAudiobookMediaType
+import org.siloserver.silo.tv.ui.util.visibleOnTv
+
+internal fun List<ResolvedSection>.normalizeTvHomeSections(): List<ResolvedSection> =
+    visibleOnTv().flatMap { section ->
+        if (section.isTvProgressRow()) section.splitAudioProgress() else listOf(section)
+    }
+
+internal fun ResolvedSection.isTvAudioProgressSection(): Boolean =
+    isTvProgressRow() && items.isNotEmpty() && items.all { isAudiobookMediaType(it.type) }
+
+internal fun ResolvedSection.tvHomeRowStyle(): TvRowStyle = when {
+    isTvAudioProgressSection() -> TvRowStyle.Poster
+    isTvProgressRow() -> TvRowStyle.Backdrop
+    else -> TvRowStyle.Poster
+}
+
+private fun ResolvedSection.splitAudioProgress(): List<ResolvedSection> {
+    val audioItems = items.filter { isAudiobookMediaType(it.type) }
+    if (audioItems.isEmpty()) return listOf(this)
+
+    val nonAudioItems = items.filterNot { isAudiobookMediaType(it.type) }
+    val listening = copy(
+        id = "$id-continue-listening",
+        sectionType = "continue_listening",
+        title = "Continue Listening",
+        totalCount = audioItems.size,
+        items = audioItems,
+    )
+
+    return buildList {
+        if (nonAudioItems.isNotEmpty()) {
+            add(
+                copy(
+                    totalCount = nonAudioItems.size,
+                    items = nonAudioItems,
+                )
+            )
+        }
+        add(listening)
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyAction.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyAction.kt
@@ -5,6 +5,8 @@ import android.view.KeyEvent
 internal enum class TvPlayerRemoteKeyAction {
     PlayPause,
     FocusTransport,
+    SkipBack,
+    SkipForward,
     OpenHud,
     // Unconsumed media-key events reach the system media-key fallback, which
     // toggles the Media3 session a second time — so both the UP half and any
@@ -29,9 +31,34 @@ internal fun tvPlayerRemoteKeyAction(
     KeyEvent.KEYCODE_DPAD_DOWN ->
         if (action == KeyEvent.ACTION_DOWN) TvPlayerRemoteKeyAction.FocusTransport else null
 
+    KeyEvent.KEYCODE_DPAD_LEFT ->
+        if (action == KeyEvent.ACTION_DOWN && repeatCount == 0) {
+            TvPlayerRemoteKeyAction.SkipBack
+        } else {
+            TvPlayerRemoteKeyAction.ConsumeOnly
+        }
+
+    KeyEvent.KEYCODE_DPAD_RIGHT ->
+        if (action == KeyEvent.ACTION_DOWN && repeatCount == 0) {
+            TvPlayerRemoteKeyAction.SkipForward
+        } else {
+            TvPlayerRemoteKeyAction.ConsumeOnly
+        }
+
     KeyEvent.KEYCODE_MENU,
     KeyEvent.KEYCODE_SETTINGS,
     -> if (action == KeyEvent.ACTION_UP) TvPlayerRemoteKeyAction.OpenHud else null
 
     else -> null
 }
+
+internal fun tvPlayerIdleOverlayRemoteKeyAction(
+    keyCode: Int,
+    action: Int,
+    repeatCount: Int,
+): TvPlayerRemoteKeyAction? =
+    tvPlayerRemoteKeyAction(
+        keyCode = keyCode,
+        action = action,
+        repeatCount = repeatCount,
+    )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -116,6 +116,7 @@ import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.model.settings.SubtitlePositionPreset
 import org.siloserver.silo.model.settings.legacyPosition
 import org.siloserver.silo.model.watchtogether.RoomPlaybackState
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.player.formatSubtitleTrackDisplayLabel
 import org.siloserver.silo.tv.R
 import org.siloserver.silo.tv.cast.TvSiloCastPlayerAdapter
@@ -434,14 +435,23 @@ fun TvPlayerScreen(
             onPlayNext(req.contentId, req.autoAdvanceCount, req.preferredQuality)
         }
     }
-    val applyTvSubtitleSelection: (Int, Boolean) -> Unit = { idx, dismiss ->
+    val applyTvSubtitleSelection: (Int, Boolean) -> Unit = selection@{ idx, dismiss ->
         val selectedTrack = state.subtitleTracks
             .firstOrNull { it.index == idx }
             ?.toVideoTrackEntry()
-        viewModel.onManualSubtitleSelectionIntent()
-        viewModel.onSubtitleSelectionApplied(idx)
-        if (dismiss) viewModel.closeSubtitleMenu()
-        if (videoBackend?.selectSubtitle(selectedTrack) == true) {
+        if (idx >= 0 && selectedTrack == null) {
+            Log.w(TAG, "Subtitle selection ignored: index=$idx not found")
+            return@selection
+        }
+        val backend = videoBackend
+        if (backend == null) {
+            Log.w(TAG, "Subtitle selection deferred or failed for index=$idx: backend unavailable")
+            return@selection
+        }
+        if (backend.selectSubtitle(selectedTrack)) {
+            viewModel.onManualSubtitleSelectionIntent()
+            viewModel.onSubtitleSelectionApplied(idx)
+            if (dismiss) viewModel.closeSubtitleMenu()
             viewModel.persistSubtitleSelection(idx)
         } else {
             Log.w(TAG, "Subtitle selection deferred or failed for index=$idx")
@@ -459,6 +469,31 @@ fun TvPlayerScreen(
             val soloTarget = viewModel.onSkipIntroNow() ?: return false
             mediaController?.seekTo((soloTarget * 1000).toLong())
         }
+        return true
+    }
+
+    fun performRelativeSeek(
+        deltaMs: Long,
+        snapshot: RoomSnapshot?,
+        revealControls: Boolean,
+    ): Boolean {
+        val controller = mediaController ?: return true
+        if (roomController != null &&
+            tvRoomTransportGate(snapshot, TvTransportIntent.Seek) != TransportGate.Send
+        ) {
+            return true
+        }
+        val duration = controller.duration
+        val upperBound = if (duration > 0L) duration else Long.MAX_VALUE
+        val target = (controller.currentPosition + deltaMs)
+            .coerceAtLeast(0L)
+            .coerceAtMost(upperBound)
+        if (roomController != null) {
+            roomController.onUserSeek(target / 1000.0)
+        } else {
+            controller.seekTo(target)
+        }
+        if (revealControls) viewModel.setControlsVisible(true)
         return true
     }
 
@@ -598,6 +633,10 @@ fun TvPlayerScreen(
                     transportFocusRequest++
                     true
                 }
+                TvPlayerRemoteKeyAction.SkipBack ->
+                    performRelativeSeek(-SKIP_BACK_MS, latestRoomSnapshot, revealControls = false)
+                TvPlayerRemoteKeyAction.SkipForward ->
+                    performRelativeSeek(SKIP_FORWARD_MS, latestRoomSnapshot, revealControls = false)
                 TvPlayerRemoteKeyAction.OpenHud -> {
                     requestedHudTab = HudTab.Info
                     viewModel.openHUD()
@@ -944,12 +983,14 @@ fun TvPlayerScreen(
     LaunchedEffect(videoBackend) {
         val backend = videoBackend ?: return@LaunchedEffect
         viewModel.subtitleSelectRequests.collect { idx ->
+            if (idx == -1) {
+                if (backend.selectSubtitle(null)) viewModel.onSubtitleSelectionApplied(idx)
+                return@collect
+            }
             val selectedTrack = viewModel.uiState.value.subtitleTracks
                 .firstOrNull { it.index == idx }
                 ?.toVideoTrackEntry()
-            // idx == -1 (disable) yields a null track, which selectSubtitle treats
-            // as "turn off"; an unknown idx also yields null and is a safe no-op.
-            if (backend.selectSubtitle(selectedTrack)) {
+            if (selectedTrack != null && backend.selectSubtitle(selectedTrack)) {
                 viewModel.onSubtitleSelectionApplied(idx)
             }
         }
@@ -1096,8 +1137,34 @@ fun TvPlayerScreen(
             .focusRequester(rootFocus)
             .focusable()
             .onPreviewKeyEvent { event ->
+                if (!state.showControls) {
+                    when (
+                        tvPlayerRemoteKeyAction(
+                            keyCode = event.nativeKeyEvent.keyCode,
+                            action = event.nativeKeyEvent.action,
+                            repeatCount = event.nativeKeyEvent.repeatCount,
+                        )
+                    ) {
+                        TvPlayerRemoteKeyAction.SkipBack ->
+                            return@onPreviewKeyEvent performRelativeSeek(
+                                -SKIP_BACK_MS,
+                                roomSnapshot,
+                                revealControls = false,
+                            )
+                        TvPlayerRemoteKeyAction.SkipForward ->
+                            return@onPreviewKeyEvent performRelativeSeek(
+                                SKIP_FORWARD_MS,
+                                roomSnapshot,
+                                revealControls = false,
+                            )
+                        TvPlayerRemoteKeyAction.ConsumeOnly -> return@onPreviewKeyEvent true
+                        else -> Unit
+                    }
+                }
                 if (event.nativeKeyEvent.action == KeyEvent.ACTION_DOWN &&
                     event.nativeKeyEvent.keyCode != KeyEvent.KEYCODE_BACK &&
+                    event.nativeKeyEvent.keyCode != KeyEvent.KEYCODE_DPAD_LEFT &&
+                    event.nativeKeyEvent.keyCode != KeyEvent.KEYCODE_DPAD_RIGHT &&
                     !state.showControls
                 ) {
                     viewModel.setControlsVisible(true)
@@ -1192,29 +1259,22 @@ fun TvPlayerScreen(
                         transportEnabled = canSeekInRoom,
                         playPauseEnabled = canPlayPauseInRoom,
                         onSkipBack = {
-                            val c = mediaController ?: return@TvPlayerIdleOverlay
-                            if (!canSeekInRoom) return@TvPlayerIdleOverlay
-                            val target = (c.currentPosition - SKIP_BACK_MS)
-                                .coerceAtLeast(0L)
-                            if (roomController != null) {
-                                roomController.onUserSeek(target / 1000.0)
-                            } else {
-                                c.seekTo(target)
+                            if (canSeekInRoom) {
+                                performRelativeSeek(
+                                    -SKIP_BACK_MS,
+                                    roomSnapshot,
+                                    revealControls = true,
+                                )
                             }
-                            viewModel.setControlsVisible(true)
                         },
                         onSkipForward = {
-                            val c = mediaController ?: return@TvPlayerIdleOverlay
-                            if (!canSeekInRoom) return@TvPlayerIdleOverlay
-                            val dur = c.duration.coerceAtLeast(0L)
-                            val target = (c.currentPosition + SKIP_FORWARD_MS)
-                                .coerceAtMost(dur)
-                            if (roomController != null) {
-                                roomController.onUserSeek(target / 1000.0)
-                            } else {
-                                c.seekTo(target)
+                            if (canSeekInRoom) {
+                                performRelativeSeek(
+                                    SKIP_FORWARD_MS,
+                                    roomSnapshot,
+                                    revealControls = true,
+                                )
                             }
-                            viewModel.setControlsVisible(true)
                         },
                         onBeginScrub = { viewModel.beginScrub() },
                         onUpdateScrub = { sec -> viewModel.updateScrubPreview(sec) },
@@ -1589,7 +1649,7 @@ private fun TvPlayerIdleOverlay(
             .fillMaxSize()
             .onPreviewKeyEvent { event ->
                 when (
-                    tvPlayerRemoteKeyAction(
+                    tvPlayerIdleOverlayRemoteKeyAction(
                         keyCode = event.nativeKeyEvent.keyCode,
                         action = event.nativeKeyEvent.action,
                         repeatCount = event.nativeKeyEvent.repeatCount,
@@ -1601,6 +1661,14 @@ private fun TvPlayerIdleOverlay(
                     }
                     TvPlayerRemoteKeyAction.FocusTransport -> {
                         runCatching { playPauseFocus.requestFocus() }
+                        true
+                    }
+                    TvPlayerRemoteKeyAction.SkipBack -> {
+                        onSkipBack()
+                        true
+                    }
+                    TvPlayerRemoteKeyAction.SkipForward -> {
+                        onSkipForward()
                         true
                     }
                     TvPlayerRemoteKeyAction.OpenHud -> {

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadataTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadataTest.kt
@@ -1,8 +1,10 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
 import org.siloserver.silo.model.audiobook.AudiobookMetadata
+import org.siloserver.silo.model.catalog.AudioTrack
 import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.catalog.ItemDetail
+import org.siloserver.silo.model.catalog.SubtitleTrack
 import org.siloserver.silo.model.ebook.MediaPerson
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -41,6 +43,43 @@ class TvDetailMetadataTest {
         assertEquals(
             listOf(TvHeroFactToken.Chip("HD")),
             TvDetailMetadata.factsLine(detail, preferredQuality = "1080p"),
+        )
+    }
+
+    @Test
+    fun factsLineUsesSelectedFileIdForVersionBadges() {
+        val detail = ItemDetail(
+            contentId = "m1",
+            type = "movie",
+            title = "Movie",
+            versions = listOf(
+                FileVersion(
+                    fileId = 1080,
+                    resolution = "1080p",
+                    audioTracks = listOf(AudioTrack(channels = 2, isDefault = true)),
+                ),
+                FileVersion(
+                    fileId = 2160,
+                    resolution = "2160p",
+                    hdr = true,
+                    audioTracks = listOf(AudioTrack(channels = 6, isDefault = true)),
+                    subtitleTracks = listOf(SubtitleTrack(language = "en")),
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                TvHeroFactToken.Chip("4K"),
+                TvHeroFactToken.Chip("HDR"),
+                TvHeroFactToken.Chip("5.1"),
+                TvHeroFactToken.Chip("CC"),
+            ),
+            TvDetailMetadata.factsLine(
+                detail = detail,
+                preferredQuality = "1080p",
+                selectedFileId = 2160,
+            ),
         )
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeSectionsTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeSectionsTest.kt
@@ -1,0 +1,55 @@
+package org.siloserver.silo.tv.ui.screens.home
+
+import org.siloserver.silo.model.section.ResolvedSection
+import org.siloserver.silo.model.section.SectionItem
+import org.siloserver.silo.tv.ui.components.TvRowStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TvHomeSectionsTest {
+    @Test
+    fun mixedContinueRowsSplitAudiobooksIntoContinueListening() {
+        val sections = listOf(
+            ResolvedSection(
+                id = "continue",
+                sectionType = "continue_watching",
+                title = "Continue Watching",
+                items = listOf(
+                    SectionItem(contentId = "m1", type = "movie", title = "Movie"),
+                    SectionItem(contentId = "a1", type = "audiobook", title = "Audio"),
+                    SectionItem(contentId = "e1", type = "ebook", title = "Book"),
+                ),
+            ),
+        )
+
+        val normalized = sections.normalizeTvHomeSections()
+
+        assertEquals(listOf("Continue Watching", "Continue Listening"), normalized.map { it.title })
+        assertEquals(listOf("m1"), normalized[0].items.map { it.contentId })
+        assertEquals(listOf("a1"), normalized[1].items.map { it.contentId })
+        assertTrue(normalized[1].isTvAudioProgressSection())
+        assertEquals(TvRowStyle.Poster, normalized[1].tvHomeRowStyle())
+    }
+
+    @Test
+    fun audiobookOnlyContinueRowIsRetitledAndKeptAsProgress() {
+        val sections = listOf(
+            ResolvedSection(
+                id = "continue",
+                sectionType = "continue_watching",
+                title = "Continue Watching",
+                items = listOf(
+                    SectionItem(contentId = "a1", type = "audiobook", title = "Audio"),
+                ),
+            ),
+        )
+
+        val normalized = sections.normalizeTvHomeSections()
+
+        assertEquals(listOf("Continue Listening"), normalized.map { it.title })
+        assertEquals("continue_listening", normalized.single().sectionType)
+        assertTrue(normalized.single().isTvAudioProgressSection())
+        assertEquals(TvRowStyle.Poster, normalized.single().tvHomeRowStyle())
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/PlayerTrackEntriesTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/PlayerTrackEntriesTest.kt
@@ -43,7 +43,7 @@ class PlayerTrackEntriesTest {
     }
 
     @Test
-    fun subtitleSelectionStateUpdatesOptimistically() {
+    fun subtitleSelectionStateMarksOnlyTheAppliedTrack() {
         val tracks = listOf(
             PlayerTrackEntry(index = 0, label = "English", language = "en", isSelected = false),
             PlayerTrackEntry(index = 1, label = "Dutch", language = "nl", isSelected = false),

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerControlsUsabilityTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerControlsUsabilityTest.kt
@@ -337,18 +337,36 @@ class TvPlayerControlsUsabilityTest {
     }
 
     @Test
-    fun subtitleSelectionUpdatesUiBeforeBackendTrackApply() {
+    fun subtitleSelectionUpdatesUiAfterBackendTrackApply() {
         val selectionBlock = screenSource
             .substringAfter("val applyTvSubtitleSelection")
             .substringBefore("DisposableEffect(context)")
         val uiUpdateIndex = selectionBlock.indexOf("viewModel.onSubtitleSelectionApplied(idx)")
-        val backendIndex = selectionBlock.indexOf("videoBackend?.selectSubtitle(selectedTrack)")
+        val backendIndex = selectionBlock.indexOf("backend.selectSubtitle(selectedTrack)")
+        val missingTrackGuardIndex = selectionBlock.indexOf("if (idx >= 0 && selectedTrack == null)")
 
-        assertTrue(uiUpdateIndex >= 0, "selection should optimistically update the checkmark")
+        assertTrue(missingTrackGuardIndex >= 0, "unknown positive subtitle indexes must not be treated as Off")
+        assertTrue(uiUpdateIndex >= 0, "selection should update the checkmark after the backend accepts it")
         assertTrue(backendIndex >= 0, "selection should still apply the Media3 subtitle track")
         assertTrue(
-            uiUpdateIndex < backendIndex,
-            "UI state must not wait for Media3 track selection to succeed",
+            backendIndex < uiUpdateIndex,
+            "UI state must not advance until Media3 accepts the same subtitle track",
+        )
+    }
+
+    @Test
+    fun hiddenLeftRightDpadSkipsInsteadOfRevealingOverlay() {
+        assertTrue(screenSource.contains("TvPlayerRemoteKeyAction.SkipBack"))
+        assertTrue(screenSource.contains("TvPlayerRemoteKeyAction.SkipForward"))
+        assertTrue(screenSource.contains("performRelativeSeek(-SKIP_BACK_MS"))
+        assertTrue(screenSource.contains("performRelativeSeek(SKIP_FORWARD_MS"))
+        assertTrue(
+            screenSource.contains("tvPlayerIdleOverlayRemoteKeyAction("),
+            "Visible idle overlay must use the tested remote-key mapping too.",
+        )
+        assertFalse(
+            screenSource.contains("event.nativeKeyEvent.keyCode != KeyEvent.KEYCODE_BACK &&\n                    !state.showControls"),
+            "Hidden controls must not treat every non-Back key as a chrome reveal; left/right are transport keys.",
         )
     }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyActionTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyActionTest.kt
@@ -84,6 +84,70 @@ class TvPlayerRemoteKeyActionTest {
     }
 
     @Test
+    fun leftAndRightSeekDuringPlaybackInsteadOfOpeningChrome() {
+        assertEquals(
+            TvPlayerRemoteKeyAction.SkipBack,
+            tvPlayerRemoteKeyAction(
+                keyCode = KeyEvent.KEYCODE_DPAD_LEFT,
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 0,
+            ),
+        )
+        assertEquals(
+            TvPlayerRemoteKeyAction.SkipForward,
+            tvPlayerRemoteKeyAction(
+                keyCode = KeyEvent.KEYCODE_DPAD_RIGHT,
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 0,
+            ),
+        )
+        assertEquals(
+            TvPlayerRemoteKeyAction.ConsumeOnly,
+            tvPlayerRemoteKeyAction(
+                keyCode = KeyEvent.KEYCODE_DPAD_LEFT,
+                action = KeyEvent.ACTION_UP,
+                repeatCount = 0,
+            ),
+        )
+        assertEquals(
+            TvPlayerRemoteKeyAction.ConsumeOnly,
+            tvPlayerRemoteKeyAction(
+                keyCode = KeyEvent.KEYCODE_DPAD_RIGHT,
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun visibleIdleOverlayLeftAndRightUseSkipActions() {
+        assertEquals(
+            TvPlayerRemoteKeyAction.SkipBack,
+            tvPlayerIdleOverlayRemoteKeyAction(
+                keyCode = KeyEvent.KEYCODE_DPAD_LEFT,
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 0,
+            ),
+        )
+        assertEquals(
+            TvPlayerRemoteKeyAction.SkipForward,
+            tvPlayerIdleOverlayRemoteKeyAction(
+                keyCode = KeyEvent.KEYCODE_DPAD_RIGHT,
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 0,
+            ),
+        )
+        assertEquals(
+            TvPlayerRemoteKeyAction.ConsumeOnly,
+            tvPlayerIdleOverlayRemoteKeyAction(
+                keyCode = KeyEvent.KEYCODE_DPAD_RIGHT,
+                action = KeyEvent.ACTION_UP,
+                repeatCount = 0,
+            ),
+        )
+    }
+
+    @Test
     fun nonMatchingActionsAndUnhandledKeysFallThrough() {
         assertNull(
             tvPlayerRemoteKeyAction(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreenStartPositionTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreenStartPositionTest.kt
@@ -56,7 +56,8 @@ class TvPlayerScreenStartPositionTest {
     @Test
     fun tvPlayerRoutesTrackSelectionThroughBackend() {
         assertTrue(
-            source.contains("videoBackend?.selectSubtitle("),
+            source.contains("backend.selectSubtitle(") ||
+                source.contains("videoBackend?.selectSubtitle("),
             "TV subtitle selection must go through the mounted backend",
         )
         assertTrue(


### PR DESCRIPTION
## Summary
- Fix TV subtitle quick-pick state so selections only advance after the backend applies the requested track, and unknown subtitle indexes no longer resolve to Off.
- Make TV D-pad left/right seek during playback instead of opening the HUD, including the visible idle-overlay path.
- Keep detail hero version chips in sync when the selected media version changes.
- Keep subtitles bounded to the actual video content frame during letterboxed playback without double-applying content-frame offsets.
- Split audiobook progress into a TV Home Continue Listening row instead of mixing it into Continue Watching.
- Set the default visible app version to 0.2.6 and bump the local Android version-code base to 7.

## Versioning
- Mobile: versionName 0.2.6, default versionCode 14.
- TV: versionName 0.2.6, default versionCode 15.
- CI can still override these via SILO_VERSION_NAME/SILO_VERSION_CODE or Gradle properties.

## Review follow-up
- Addressed the subtitle content-frame review by converting visible bounds back into the subtitle parent local coordinate space.
- Added tests for letterboxed/clipped subtitle frame bounds and visible-overlay D-pad skip behavior.
- Applied the home row-style `when` cleanup.
- Skipped the optional real PlayerView glue test because android-shared Robolectric unit tests cannot instantiate Media3 PlayerView reliably without packaged app style resources; the regression is covered by pure helper tests.

## Verification
- ./gradlew :android-shared:testDebugUnitTest --tests org.siloserver.silo.common.player.SubtitleManagerAppearanceTest
- ./gradlew :android-shared:testDebugUnitTest --tests org.siloserver.silo.common.player.SubtitleManagerAppearanceTest :androidTvApp:testDebugUnitTest --tests org.siloserver.silo.tv.ui.screens.player.TvPlayerRemoteKeyActionTest --tests org.siloserver.silo.tv.ui.screens.player.TvPlayerControlsUsabilityTest --tests org.siloserver.silo.tv.ui.screens.home.TvHomeSectionsTest
- ./gradlew :android-shared:testDebugUnitTest :androidTvApp:testDebugUnitTest :androidTvApp:assembleDebug :androidApp:assembleDebug
- generated manifests show versionName=0.2.6 for both apps
