### PR TITLE
test: cancel leaked viewModelScope coroutines before resetMain

### DIFF
--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibrarySubdestinationViewModelTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibrarySubdestinationViewModelTest.kt
@@ -9,8 +9,10 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -92,11 +94,19 @@ class TvLibrarySubdestinationViewModelTest {
         assertEquals(null, viewModel.uiState.value.selectedAudiobookGroup)
     }
 
+    private val createdViewModels = mutableListOf<androidx.lifecycle.ViewModel>()
+
     private fun runLibraryTest(block: suspend () -> Unit) = runTest {
         Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
         try {
             block()
         } finally {
+            // Cancel viewModelScope coroutines BEFORE resetting Main: they
+            // dispatch on Dispatchers.Main, and one still alive when a later
+            // test calls setMain throws IllegalStateException from
+            // TestMainDispatcher — the CI-only flake on this class.
+            createdViewModels.forEach { it.viewModelScope.cancel() }
+            createdViewModels.clear()
             Dispatchers.resetMain()
         }
     }
@@ -204,7 +214,7 @@ class TvLibrarySubdestinationViewModelTest {
             libraryId = 7,
             libraryTitle = "Library",
             libraryType = libraryType,
-        )
+        ).also { createdViewModels += it }
     }
 
     private fun MockRequestHandleScope.respondJson(body: String) = respond(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailViewModelTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailViewModelTest.kt
@@ -12,8 +12,10 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -31,7 +33,7 @@ class TvPersonDetailViewModelTest {
     @Test
     fun loadMoreAppendsSecondPageUsingSnapshotAndRawOffset() = runPersonTest {
         val queries = mutableListOf<Map<String, String?>>()
-        val viewModel = TvPersonDetailViewModel(repositoryFor(queries), personId = 7)
+        val viewModel = createViewModel(queries)
         awaitState(viewModel) { !it.isLoading && !it.isLoadingItems && it.items.size == 59 }
 
         viewModel.loadMoreIfNeeded()
@@ -50,7 +52,7 @@ class TvPersonDetailViewModelTest {
     @Test
     fun filterChangeResetsItemsSnapshotAndOffset() = runPersonTest {
         val queries = mutableListOf<Map<String, String?>>()
-        val viewModel = TvPersonDetailViewModel(repositoryFor(queries), personId = 7)
+        val viewModel = createViewModel(queries)
         awaitState(viewModel) { !it.isLoading && !it.isLoadingItems && it.items.size == 59 }
 
         viewModel.loadMoreIfNeeded()
@@ -69,7 +71,7 @@ class TvPersonDetailViewModelTest {
 
     @Test
     fun tvFiltersExcludeReadingSurface() = runPersonTest {
-        val viewModel = TvPersonDetailViewModel(repositoryFor(mutableListOf()), personId = 7)
+        val viewModel = createViewModel()
         awaitState(viewModel) { !it.isLoading && !it.isLoadingItems }
 
         assertEquals(
@@ -79,11 +81,25 @@ class TvPersonDetailViewModelTest {
         assertFalse(viewModel.uiState.value.availableFilters.any { it.title == "Reading" })
     }
 
+    private val createdViewModels = mutableListOf<androidx.lifecycle.ViewModel>()
+
+    private fun createViewModel(
+        queries: MutableList<Map<String, String?>> = mutableListOf(),
+    ): TvPersonDetailViewModel =
+        TvPersonDetailViewModel(repositoryFor(queries), personId = 7)
+            .also { createdViewModels += it }
+
     private fun runPersonTest(block: suspend () -> Unit) = runTest {
         Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
         try {
             block()
         } finally {
+            // Cancel viewModelScope coroutines BEFORE resetting Main: they
+            // dispatch on Dispatchers.Main, and one still alive when a later
+            // test calls setMain throws IllegalStateException from
+            // TestMainDispatcher — the CI-only flake on this class.
+            createdViewModels.forEach { it.viewModelScope.cancel() }
+            createdViewModels.clear()
             Dispatchers.resetMain()
         }
     }


### PR DESCRIPTION
## Problem

Main-branch CI failed on `TvLibrarySubdestinationViewModelTest.audiobookAuthorsAndSeriesDestinationsLoadGroupedRowsBeforeCatalogDrillIn` with `IllegalStateException` at `Dispatchers.setMain` (TestMainDispatcher contention) — a different failure mode than the awaitState timeout this class flaked with before.

## Root cause

Both this class and `TvPersonDetailViewModelTest` construct real ViewModels whose `viewModelScope` coroutines dispatch on `Dispatchers.Main` and are never cancelled. They leak past the test's `resetMain`; when a later test calls `setMain` while a leaked coroutine is mid-dispatch, TestMainDispatcher throws. The same leaked work competing for scheduler time is the likely driver behind the earlier timeout flake too — the 5s→30s bump treated a symptom.

## Fix

The test harnesses now track every constructed ViewModel and cancel its `viewModelScope` in the `finally`, before `Dispatchers.resetMain()`.

## Testing

- Both classes run 3× consecutively with `--rerun-tasks`: green each time
- Full `:androidTvApp:testDebugUnitTest`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of TV app test coverage by ensuring background tasks are cleaned up before the main thread is reset.
  * Reduced intermittent test failures in library and person detail flows, making validation more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->