### PR TITLE
Use a dedicated key-password secret for release signing

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -156,6 +156,7 @@ jobs:
         shell: bash
         env:
           SILO_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.SILO_RELEASE_KEYSTORE_PASSWORD }}
+          SILO_RELEASE_KEY_PASSWORD: ${{ secrets.SILO_RELEASE_KEY_PASSWORD }}
           SILO_RELEASE_KEY_ALIAS: ${{ secrets.SILO_RELEASE_KEY_ALIAS }}
         run: |
           set -euo pipefail

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -163,7 +163,10 @@ android {
                 storeFile = file(releaseKeystorePath!!)
                 storePassword = providers.environmentVariable("SILO_RELEASE_KEYSTORE_PASSWORD").orNull
                 keyAlias = providers.environmentVariable("SILO_RELEASE_KEY_ALIAS").orNull
-                keyPassword = providers.environmentVariable("SILO_RELEASE_KEYSTORE_PASSWORD").orNull
+                // The key password may differ from the keystore password; fall
+                // back to the keystore password when they're the same.
+                keyPassword = providers.environmentVariable("SILO_RELEASE_KEY_PASSWORD").orNull
+                    ?: providers.environmentVariable("SILO_RELEASE_KEYSTORE_PASSWORD").orNull
             }
         }
     }

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -166,6 +166,7 @@ android {
                 // The key password may differ from the keystore password; fall
                 // back to the keystore password when they're the same.
                 keyPassword = providers.environmentVariable("SILO_RELEASE_KEY_PASSWORD").orNull
+                    ?.takeIf { it.isNotBlank() }
                     ?: providers.environmentVariable("SILO_RELEASE_KEYSTORE_PASSWORD").orNull
             }
         }

--- a/androidTvApp/build.gradle.kts
+++ b/androidTvApp/build.gradle.kts
@@ -159,6 +159,7 @@ android {
                 // The key password may differ from the keystore password; fall
                 // back to the keystore password when they're the same.
                 keyPassword = providers.environmentVariable("SILO_RELEASE_KEY_PASSWORD").orNull
+                    ?.takeIf { it.isNotBlank() }
                     ?: providers.environmentVariable("SILO_RELEASE_KEYSTORE_PASSWORD").orNull
             }
         }

--- a/androidTvApp/build.gradle.kts
+++ b/androidTvApp/build.gradle.kts
@@ -156,7 +156,10 @@ android {
                 storeFile = file(releaseKeystorePath!!)
                 storePassword = providers.environmentVariable("SILO_RELEASE_KEYSTORE_PASSWORD").orNull
                 keyAlias = providers.environmentVariable("SILO_RELEASE_KEY_ALIAS").orNull
-                keyPassword = providers.environmentVariable("SILO_RELEASE_KEYSTORE_PASSWORD").orNull
+                // The key password may differ from the keystore password; fall
+                // back to the keystore password when they're the same.
+                keyPassword = providers.environmentVariable("SILO_RELEASE_KEY_PASSWORD").orNull
+                    ?: providers.environmentVariable("SILO_RELEASE_KEYSTORE_PASSWORD").orNull
             }
         }
     }


### PR DESCRIPTION
## Summary
The release keystore's **key password** can differ from its **keystore password**, but the CI signing config introduced in b702d4e8 used a single `SILO_RELEASE_KEYSTORE_PASSWORD` secret for both. With distinct passwords the release build fails to sign.

This wires `keyPassword` to a new `SILO_RELEASE_KEY_PASSWORD` env var in both apps, falling back to the keystore password when it's unset (so the same-password case keeps working), and passes the secret through the CI build step.

## Changes
- `androidApp/build.gradle.kts` — `keyPassword` reads `SILO_RELEASE_KEY_PASSWORD`, falls back to `SILO_RELEASE_KEYSTORE_PASSWORD`.
- `androidTvApp/build.gradle.kts` — same.
- `.github/workflows/android-build.yml` — expose `SILO_RELEASE_KEY_PASSWORD` to the Build release APK step.

## Required repo secret
Add a new Actions secret **`SILO_RELEASE_KEY_PASSWORD`** (the keystore's key password). No change needed if your key and keystore passwords are identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android release build signing so apps can use a separate password when needed, reducing release packaging issues.
  * Applied the same signing update across both Android app variants for more consistent release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->