### PR TITLE
fix(tv): No background row toggles off again

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt
@@ -1270,7 +1270,14 @@ private fun HudSubtitlesPane(
                 enabled = enabled,
                 leftFocusRequester = subtitleTrackFocus,
                 onActivate = {
-                    onAppearanceChanged(appearance.copy(backgroundStyle = SubtitleBackgroundStylePreset.None))
+                    // Toggle: turning it back off restores the default Box
+                    // background (Apple parity) rather than staying stuck on None.
+                    val target = if (appearance.backgroundStyle == SubtitleBackgroundStylePreset.None) {
+                        SubtitleBackgroundStylePreset.Box
+                    } else {
+                        SubtitleBackgroundStylePreset.None
+                    }
+                    onAppearanceChanged(appearance.copy(backgroundStyle = target))
                 },
             )
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerControlsUsabilityTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerControlsUsabilityTest.kt
@@ -238,7 +238,10 @@ class TvPlayerControlsUsabilityTest {
     @Test
     fun subtitlePaneShowsDirectNoBackgroundControlAndReadableWhiteSelection() {
         assertTrue(hudSource.contains("label = \"No background\""))
-        assertTrue(hudSource.contains("appearance.copy(backgroundStyle = SubtitleBackgroundStylePreset.None)"))
+        // Must be a real toggle: On sets None, Off restores the default Box
+        // background (a one-way None assignment left users stuck on On).
+        assertTrue(hudSource.contains("SubtitleBackgroundStylePreset.Box"))
+        assertTrue(hudSource.contains("appearance.copy(backgroundStyle = target)"))
         assertTrue(hudSource.contains("val isLightSwatch ="))
         assertTrue(hudSource.contains("Icons.Filled.Check"))
         assertTrue(hudSource.contains("checkTint"))


### PR DESCRIPTION
## Problem

In the TV player's subtitle pane, the "No background" quick control could be switched On but never back Off — activating it unconditionally set `backgroundStyle = None`.

## Fix

The row is now a real toggle: activating while On restores the default **Box** background (the Apple-parity default, per #31); activating while Off sets None as before. Source-guard test updated to pin the toggle behavior.

Reported on-device on the Shield (v0.3.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The subtitle “No background” option now acts as a toggle, letting you switch between no background and the default box background.
  * Subtitle appearance updates now correctly preserve and restore the chosen background style instead of only turning it off.
  * Updated behavior in the on-screen controls to match the new toggle logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->