### PR TITLE
Page library-collection items via the catalog resolver (Apple parity)

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/collections/CollectionDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/collections/CollectionDetailViewModel.kt
@@ -129,13 +129,19 @@ class CollectionDetailViewModel(
                 }
             }
 
-            when (val result = sectionRepository.getLibraryCollectionItems(libraryId, collectionId)) {
+            when (
+                val result = sectionRepository.getLibraryCollectionItems(
+                    collectionId,
+                    offset = 0,
+                    limit = pageSize,
+                )
+            ) {
                 is ApiResult.Success -> {
                     _uiState.update {
                         it.copy(
                             items = result.data.items,
                             total = result.data.total,
-                            hasMore = false,
+                            hasMore = result.data.hasMore,
                             isLoading = false,
                             error = null,
                         )
@@ -162,17 +168,27 @@ class CollectionDetailViewModel(
     }
 
     fun loadMore() {
-        if (libraryId != null) return
         val current = _uiState.value
         if (current.isLoadingMore || !current.hasMore) return
 
         viewModelScope.launch {
             _uiState.update { it.copy(isLoadingMore = true) }
-            when (val result = collectionRepository.getItems(
-                collectionId,
-                offset = current.items.size,
-                limit = pageSize,
-            )) {
+            // Library collections page through the catalog resolver (like
+            // silo-apple); user collections keep their own paged endpoint.
+            val result = if (libraryId != null) {
+                sectionRepository.getLibraryCollectionItems(
+                    collectionId,
+                    offset = current.items.size,
+                    limit = pageSize,
+                )
+            } else {
+                collectionRepository.getItems(
+                    collectionId,
+                    offset = current.items.size,
+                    limit = pageSize,
+                )
+            }
+            when (result) {
                 is ApiResult.Success -> {
                     _uiState.update {
                         it.copy(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryCollectionDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryCollectionDetailScreen.kt
@@ -76,10 +76,10 @@ fun TvLibraryCollectionDetailScreen(
             )
             else -> TvCatalogGrid(
                 items = state.items,
-                isLoading = false,
-                hasMore = false,
+                isLoading = state.isLoadingMore,
+                hasMore = state.hasMore,
                 onItemClick = onItemClick,
-                onLoadMore = {},
+                onLoadMore = viewModel::loadMore,
                 fixedColumnCount = 6,
                 contentPadding = androidx.compose.foundation.layout.PaddingValues(
                     start = Spacing.safeArea,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryCollectionDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryCollectionDetailViewModel.kt
@@ -21,7 +21,9 @@ class TvLibraryCollectionDetailViewModel(
 
     data class UiState(
         val isLoading: Boolean = true,
+        val isLoadingMore: Boolean = false,
         val items: List<BrowseItem> = emptyList(),
+        val hasMore: Boolean = false,
         val error: String? = null,
     )
 
@@ -39,13 +41,23 @@ class TvLibraryCollectionDetailViewModel(
     private fun load() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            when (val result = sectionRepository.getLibraryCollectionItems(libraryId, collectionId)) {
-                is ApiResult.Success -> _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        items = result.data.items.visibleOnTv(),
-                        error = null,
-                    )
+            when (
+                val result = sectionRepository.getLibraryCollectionItems(
+                    collectionId,
+                    offset = 0,
+                    limit = PAGE_SIZE,
+                )
+            ) {
+                is ApiResult.Success -> {
+                    fetchedCount = result.data.items.size
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            items = result.data.items.visibleOnTv(),
+                            hasMore = result.data.hasMore,
+                            error = null,
+                        )
+                    }
                 }
                 is ApiResult.Error -> _uiState.update {
                     it.copy(
@@ -61,5 +73,46 @@ class TvLibraryCollectionDetailViewModel(
                 }
             }
         }
+    }
+
+    /**
+     * Offsets track RAW fetched count, not the rendered list size — the TV
+     * grid filters reading items out via [visibleOnTv], so paging by
+     * `items.size` would re-fetch overlapping windows on book-heavy
+     * collections.
+     */
+    private var fetchedCount = 0
+
+    fun loadMore() {
+        val current = _uiState.value
+        if (current.isLoading || current.isLoadingMore || !current.hasMore) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingMore = true) }
+            when (
+                val result = sectionRepository.getLibraryCollectionItems(
+                    collectionId,
+                    offset = fetchedCount,
+                    limit = PAGE_SIZE,
+                )
+            ) {
+                is ApiResult.Success -> {
+                    fetchedCount += result.data.items.size
+                    _uiState.update {
+                        it.copy(
+                            isLoadingMore = false,
+                            items = it.items + result.data.items.visibleOnTv(),
+                            hasMore = result.data.hasMore,
+                        )
+                    }
+                }
+                is ApiResult.Error, is ApiResult.NetworkError -> {
+                    _uiState.update { it.copy(isLoadingMore = false) }
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val PAGE_SIZE = 60
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryCollectionDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryCollectionDetailViewModel.kt
@@ -41,23 +41,15 @@ class TvLibraryCollectionDetailViewModel(
     private fun load() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            when (
-                val result = sectionRepository.getLibraryCollectionItems(
-                    collectionId,
-                    offset = 0,
-                    limit = PAGE_SIZE,
-                )
-            ) {
-                is ApiResult.Success -> {
-                    fetchedCount = result.data.items.size
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            items = result.data.items.visibleOnTv(),
-                            hasMore = result.data.hasMore,
-                            error = null,
-                        )
-                    }
+            fetchedCount = 0
+            when (val result = fetchVisiblePage(fromOffset = 0)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        items = result.data.items,
+                        hasMore = result.data.hasMore,
+                        error = null,
+                    )
                 }
                 is ApiResult.Error -> _uiState.update {
                     it.copy(
@@ -75,6 +67,40 @@ class TvLibraryCollectionDetailViewModel(
         }
     }
 
+    private data class VisiblePage(val items: List<BrowseItem>, val hasMore: Boolean)
+
+    /**
+     * Fetches pages starting at [fromOffset] until one yields at least one
+     * TV-visible item or the collection is exhausted. Reading/ebook entries
+     * are filtered out per page ([visibleOnTv]); without draining, a page
+     * that filters to empty with `hasMore=true` would strand the grid —
+     * TvCatalogGrid skips pagination while its list is empty, so a
+     * book-fronted collection would wrongly render as empty (Codex).
+     * Advances [fetchedCount] by RAW page sizes as it goes.
+     */
+    private suspend fun fetchVisiblePage(fromOffset: Int): ApiResult<VisiblePage> {
+        var offset = fromOffset
+        while (true) {
+            when (val result = sectionRepository.getLibraryCollectionItems(
+                collectionId,
+                offset = offset,
+                limit = PAGE_SIZE,
+            )) {
+                is ApiResult.Success -> {
+                    fetchedCount = offset + result.data.items.size
+                    val visible = result.data.items.visibleOnTv()
+                    val hasMore = result.data.hasMore && result.data.items.isNotEmpty()
+                    if (visible.isNotEmpty() || !hasMore) {
+                        return ApiResult.Success(VisiblePage(visible, hasMore))
+                    }
+                    offset = fetchedCount
+                }
+                is ApiResult.Error -> return ApiResult.Error(result.code, result.error, result.message)
+                is ApiResult.NetworkError -> return ApiResult.NetworkError(result.exception)
+            }
+        }
+    }
+
     /**
      * Offsets track RAW fetched count, not the rendered list size — the TV
      * grid filters reading items out via [visibleOnTv], so paging by
@@ -88,22 +114,13 @@ class TvLibraryCollectionDetailViewModel(
         if (current.isLoading || current.isLoadingMore || !current.hasMore) return
         viewModelScope.launch {
             _uiState.update { it.copy(isLoadingMore = true) }
-            when (
-                val result = sectionRepository.getLibraryCollectionItems(
-                    collectionId,
-                    offset = fetchedCount,
-                    limit = PAGE_SIZE,
-                )
-            ) {
-                is ApiResult.Success -> {
-                    fetchedCount += result.data.items.size
-                    _uiState.update {
-                        it.copy(
-                            isLoadingMore = false,
-                            items = it.items + result.data.items.visibleOnTv(),
-                            hasMore = result.data.hasMore,
-                        )
-                    }
+            when (val result = fetchVisiblePage(fromOffset = fetchedCount)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        isLoadingMore = false,
+                        items = it.items + result.data.items,
+                        hasMore = result.data.hasMore,
+                    )
                 }
                 is ApiResult.Error, is ApiResult.NetworkError -> {
                     _uiState.update { it.copy(isLoadingMore = false) }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryCollectionDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryCollectionDetailViewModel.kt
@@ -71,7 +71,7 @@ class TvLibraryCollectionDetailViewModel(
 
     /**
      * Fetches pages starting at [fromOffset] until one yields at least one
-     * TV-visible item or the collection is exhausted. Reading/ebook entries
+     * TV-visible item or the collection is exhausted. Book-type entries
      * are filtered out per page ([visibleOnTv]); without draining, a page
      * that filters to empty with `hasMore=true` would strand the grid —
      * TvCatalogGrid skips pagination while its list is empty, so a

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/SectionApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/SectionApi.kt
@@ -4,7 +4,7 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import org.siloserver.silo.model.catalog.BrowseResponse
+import org.siloserver.silo.model.catalog.CatalogResponse
 import org.siloserver.silo.model.section.*
 import org.siloserver.silo.network.ApiErrorBody
 import org.siloserver.silo.network.ApiResult
@@ -65,11 +65,25 @@ class SectionApi(private val client: HttpClient) {
         }
     }
 
+    /**
+     * Library-collection items via the paginated catalog resolver
+     * (`source=library_collection`), matching silo-apple's
+     * `libraryCollectionItems`. The raw
+     * `/library/{id}/collections/{id}/items` route serves full membership
+     * in one response — a 10k-item language collection in a single body —
+     * and is being phased out client-side so the server can bound it.
+     */
     suspend fun getLibraryCollectionItems(
-        libraryId: Int,
-        collectionId: String
-    ): ApiResult<BrowseResponse> = safeApiCall {
-        client.get("/api/v1/library/$libraryId/collections/$collectionId/items")
+        collectionId: String,
+        offset: Int = 0,
+        limit: Int = 60,
+    ): ApiResult<CatalogResponse> = safeApiCall {
+        client.get("/api/v1/catalog") {
+            parameter("source", "library_collection")
+            parameter("collection_id", collectionId)
+            parameter("offset", offset)
+            parameter("limit", limit)
+        }
     }
 
     private fun parseLibraryCollectionsResponse(body: String): LibraryCollectionsResponse {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/SectionRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/SectionRepository.kt
@@ -1,6 +1,6 @@
 package org.siloserver.silo.repository
 
-import org.siloserver.silo.model.catalog.BrowseResponse
+import org.siloserver.silo.model.catalog.CatalogResponse
 import org.siloserver.silo.model.section.HomeLayoutResponse
 import org.siloserver.silo.model.section.HomeSectionItemsResponse
 import org.siloserver.silo.model.section.LibraryCollection
@@ -61,9 +61,11 @@ class SectionRepository(
         sectionApi.getLibraryCollections(libraryId)
 
     /** Fetches items within a library collection. */
+    /** Pages a library collection's items via the catalog resolver. */
     suspend fun getLibraryCollectionItems(
-        libraryId: Int,
         collectionId: String,
-    ): ApiResult<BrowseResponse> =
-        sectionApi.getLibraryCollectionItems(libraryId, collectionId)
+        offset: Int = 0,
+        limit: Int = 60,
+    ): ApiResult<CatalogResponse> =
+        sectionApi.getLibraryCollectionItems(collectionId, offset, limit)
 }


### PR DESCRIPTION
Companion to silo-server#340. The phone and TV collection detail screens loaded through the raw `/api/v1/library/{id}/collections/{id}/items` endpoint, which serves **full membership in one response** — opening a 10k-item language collection materialized every record in a single body (the ktor-client hits visible in prod logs). Android was also the only client keeping the server from bounding that endpoint.

Both screens now page through `GET /api/v1/catalog?source=library_collection&collection_id=…&offset&limit` — the same resolver silo-apple's `libraryCollectionItems` has always used — 60 per page with infinite scroll.

- `SectionApi` / `SectionRepository.getLibraryCollectionItems` → paginated catalog call returning `CatalogResponse`; the raw items route is no longer referenced by any client code
- Phone `CollectionDetailViewModel`: the library path pages exactly like the user-collections path already did; `loadMore` branches per source
- TV `TvLibraryCollectionDetailViewModel`: paged load + `loadMore` wired to `TvCatalogGrid`'s existing (previously no-op) hook; paging offsets track the **raw fetched count**, not the rendered list size, because `visibleOnTv()` filters reading items and size-based offsets would re-fetch overlapping windows on book-heavy collections

Once this ships, the server's raw items endpoint can be bounded in a follow-up without truncating anything on Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collection detail pages now support paginated loading, letting users browse more items without reloading the full page.
  * TV collection details now show loading progress and “load more” behavior based on the current content state.

* **Bug Fixes**
  * Improved item loading for library collections so additional items are fetched correctly as users scroll or request more content.
  * Fixed collection detail loading behavior on TV to use the same live pagination state as the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->