### PR TITLE
test(tv): cancel auth-test ViewModel scopes before resetting Main

### DIFF
--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvAuthSingleFlightTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvAuthSingleFlightTest.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -47,19 +49,33 @@ class TvAuthSingleFlightTest {
 
     @AfterTest
     fun tearDown() {
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
         Dispatchers.resetMain()
     }
+
+    // Cancel viewModelScope coroutines BEFORE resetting Main: a coroutine
+    // still parked on Dispatchers.Main when a later test class calls
+    // setMain throws IllegalStateException from TestMainDispatcher — the
+    // CI-only cross-class flake that failed the v0.3.4 tag build.
+    private val createdViewModels = mutableListOf<androidx.lifecycle.ViewModel>()
+
+    private fun <T : androidx.lifecycle.ViewModel> track(viewModel: T): T {
+        createdViewModels += viewModel
+        return viewModel
+    }
+
 
     @Test
     fun loginSubmitIgnoresSecondClickWhileLoading() = runTest(dispatcher) {
         val release = CompletableDeferred<Unit>()
         val recorder = AuthRequestRecorder("/api/v1/auth/login", release)
         val tokenManager = SingleFlightTokenManager()
-        val viewModel = TvLoginViewModel(
+        val viewModel = track(TvLoginViewModel(
             authRepository = AuthRepository(AuthApi(recorder.client(tokenManager)), tokenManager),
             tokenManager = tokenManager,
             deviceLogin = DeviceLoginRepository(NeverCompletingDeviceLoginApi),
-        )
+        ))
         advanceUntilIdle()
 
         viewModel.onUsernameChanged("jim")
@@ -77,9 +93,9 @@ class TvAuthSingleFlightTest {
     fun setupSubmitIgnoresSecondClickWhileLoading() = runTest(dispatcher) {
         val release = CompletableDeferred<Unit>()
         val recorder = AuthRequestRecorder("/api/v1/auth/setup", release)
-        val viewModel = TvSetupViewModel(
+        val viewModel = track(TvSetupViewModel(
             AuthRepository(AuthApi(recorder.client(SingleFlightTokenManager())), SingleFlightTokenManager()),
-        )
+        ))
 
         viewModel.onUsernameChanged("jim")
         viewModel.onEmailChanged("jim@example.com")
@@ -97,9 +113,9 @@ class TvAuthSingleFlightTest {
     fun signupSubmitIgnoresSecondClickWhileLoading() = runTest(dispatcher) {
         val release = CompletableDeferred<Unit>()
         val recorder = AuthRequestRecorder("/api/v1/auth/signup", release)
-        val viewModel = TvSignupViewModel(
+        val viewModel = track(TvSignupViewModel(
             AuthRepository(AuthApi(recorder.client(SingleFlightTokenManager())), SingleFlightTokenManager()),
-        )
+        ))
 
         viewModel.onUsernameChanged("jim")
         viewModel.onEmailChanged("jim@example.com")

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvLoginViewModelRaceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvLoginViewModelRaceTest.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -47,8 +49,22 @@ class TvLoginViewModelRaceTest {
 
     @AfterTest
     fun tearDown() {
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
         Dispatchers.resetMain()
     }
+
+    // Cancel viewModelScope coroutines BEFORE resetting Main: a coroutine
+    // still parked on Dispatchers.Main when a later test class calls
+    // setMain throws IllegalStateException from TestMainDispatcher — the
+    // CI-only cross-class flake that failed the v0.3.4 tag build.
+    private val createdViewModels = mutableListOf<androidx.lifecycle.ViewModel>()
+
+    private fun <T : androidx.lifecycle.ViewModel> track(viewModel: T): T {
+        createdViewModels += viewModel
+        return viewModel
+    }
+
 
     @Test
     fun credentialCompletionAfterQrApprovalDoesNotOverwriteQrTokens() = runTest(dispatcher) {
@@ -56,14 +72,14 @@ class TvLoginViewModelRaceTest {
         val releaseCredentialLogin = CompletableDeferred<Unit>()
         val credentialLoginStarted = CompletableDeferred<Unit>()
         val deviceApi = ControlledDeviceLoginApi()
-        val viewModel = TvLoginViewModel(
+        val viewModel = track(TvLoginViewModel(
             authRepository = AuthRepository(
                 authApi = AuthApi(loginClient(tokenManager, releaseCredentialLogin, credentialLoginStarted)),
                 tokenManager = tokenManager,
             ),
             tokenManager = tokenManager,
             deviceLogin = DeviceLoginRepository(deviceApi),
-        )
+        ))
         advanceUntilIdle()
 
         viewModel.onUsernameChanged("jim")

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupPersistenceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupPersistenceTest.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -34,8 +36,22 @@ class TvServerSetupPersistenceTest {
 
     @AfterTest
     fun tearDown() {
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
         Dispatchers.resetMain()
     }
+
+    // Cancel viewModelScope coroutines BEFORE resetting Main: a coroutine
+    // still parked on Dispatchers.Main when a later test class calls
+    // setMain throws IllegalStateException from TestMainDispatcher — the
+    // CI-only cross-class flake that failed the v0.3.4 tag build.
+    private val createdViewModels = mutableListOf<androidx.lifecycle.ViewModel>()
+
+    private fun <T : androidx.lifecycle.ViewModel> track(viewModel: T): T {
+        createdViewModels += viewModel
+        return viewModel
+    }
+
 
     @Test
     fun failedProbeDoesNotReplacePreviouslyActiveServerUrl() = runTest(dispatcher) {
@@ -54,7 +70,7 @@ class TvServerSetupPersistenceTest {
             ),
             tokenManager = tokenManager,
         )
-        val viewModel = TvServerSetupViewModel(repository)
+        val viewModel = track(TvServerSetupViewModel(repository))
 
         viewModel.onServerUrlChanged("bad.silo")
         viewModel.onConnectClick()


### PR DESCRIPTION
The v0.3.4 tag build failed on `TvLibrarySubdestinationViewModelTest` with `IllegalStateException` from `TestMainDispatcher.setMain` — the cross-class Main-dispatcher leak this repo fixed once before (PR #41), resurfacing from a different source.

The three auth test classes (`TvLoginViewModelRaceTest`, `TvServerSetupPersistenceTest`, `TvAuthSingleFlightTest`) set Main but created ViewModels without ever cancelling their scopes — the race test even parks a login in-flight on a `CompletableDeferred` by design. A coroutine still parked on `Dispatchers.Main` when the *next* class calls `setMain` throws, so the failure lands on an innocent class and only reproduces under CI's test ordering.

All three now track created ViewModels and cancel their scopes before `resetMain`, matching the pattern already in `TvLibrarySubdestinationViewModelTest` and `TvPersonDetailViewModelTest`. TV suite passes 3× consecutive forced reruns locally.

(The v0.3.4 tag build itself was unblocked with a rerun; this prevents the next occurrence.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)