### PR TITLE
fix: profile workflow QA — list refresh, honest deletes, primary badge, TV manage mode, duplicate names

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/CreateProfileViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/CreateProfileViewModel.kt
@@ -3,7 +3,9 @@ package org.siloserver.silo.android.ui.screens.profiles
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.model.profile.CreateProfileRequest
+import org.siloserver.silo.model.profile.Profile
 import org.siloserver.silo.model.profile.canonicalProfileQualityPreference
+import org.siloserver.silo.model.profile.hasProfileNamed
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.ProfileRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,6 +45,18 @@ class CreateProfileViewModel(
 
     private val _uiState = MutableStateFlow(CreateProfileUiState())
     val uiState: StateFlow<CreateProfileUiState> = _uiState.asStateFlow()
+
+    /** Existing profiles, loaded for the duplicate-name pre-check. Best
+     *  effort: if the load fails the server still enforces the rule. */
+    private var existingProfiles: List<Profile> = emptyList()
+
+    init {
+        viewModelScope.launch {
+            (profileRepository.listProfiles() as? ApiResult.Success)?.let {
+                existingProfiles = it.data
+            }
+        }
+    }
 
     fun onNameChanged(value: String) {
         _uiState.update { it.copy(name = value, error = null) }
@@ -103,6 +117,10 @@ class CreateProfileViewModel(
             _uiState.update { it.copy(error = "Profile name is required") }
             return
         }
+        if (existingProfiles.hasProfileNamed(current.name)) {
+            _uiState.update { it.copy(error = "A profile with this name already exists") }
+            return
+        }
         if (current.pinEnabled && current.pin.length != 4) {
             _uiState.update { it.copy(error = "PIN must be 4 digits") }
             return
@@ -123,14 +141,19 @@ class CreateProfileViewModel(
                 subtitleMode = current.subtitleMode,
             )
 
-            when (profileRepository.createProfile(request)) {
+            when (val result = profileRepository.createProfile(request)) {
                 is ApiResult.Success -> {
                     _uiState.update { it.copy(isLoading = false, createSuccess = true) }
                 }
 
                 is ApiResult.Error -> {
+                    // Surface the server's explanation (e.g. the account's
+                    // profile limit) instead of a generic failure.
                     _uiState.update {
-                        it.copy(isLoading = false, error = "Failed to create profile")
+                        it.copy(
+                            isLoading = false,
+                            error = result.message.ifBlank { "Failed to create profile" },
+                        )
                     }
                 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/EditProfileViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/EditProfileViewModel.kt
@@ -2,8 +2,10 @@ package org.siloserver.silo.android.ui.screens.profiles
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import org.siloserver.silo.model.profile.Profile
 import org.siloserver.silo.model.profile.UpdateProfileRequest
 import org.siloserver.silo.model.profile.canonicalProfileQualityPreference
+import org.siloserver.silo.model.profile.hasProfileNamed
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.ProfileRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,6 +39,9 @@ class EditProfileViewModel(
     private val _uiState = MutableStateFlow(EditProfileUiState())
     val uiState: StateFlow<EditProfileUiState> = _uiState.asStateFlow()
 
+    /** All profiles from [loadProfile], kept for the rename duplicate check. */
+    private var existingProfiles: List<Profile> = emptyList()
+
     /**
      * Loads the profile by ID. Called once from the composable via LaunchedEffect.
      * We fetch the full list and find the matching profile because the repository
@@ -48,6 +53,7 @@ class EditProfileViewModel(
 
             when (val result = profileRepository.listProfiles()) {
                 is ApiResult.Success -> {
+                    existingProfiles = result.data
                     val profile = result.data.find { it.id == profileId }
                     if (profile != null) {
                         _uiState.update {
@@ -143,6 +149,10 @@ class EditProfileViewModel(
             _uiState.update { it.copy(error = "Profile name is required") }
             return
         }
+        if (existingProfiles.hasProfileNamed(current.name, excludeId = current.profileId)) {
+            _uiState.update { it.copy(error = "A profile with this name already exists") }
+            return
+        }
         if (current.pinEnabled && current.pin.isNotEmpty() && current.pin.length != 4) {
             _uiState.update { it.copy(error = "PIN must be 4 digits") }
             return
@@ -163,14 +173,19 @@ class EditProfileViewModel(
                 subtitleMode = current.subtitleMode,
             )
 
-            when (profileRepository.updateProfile(current.profileId, request)) {
+            when (val result = profileRepository.updateProfile(current.profileId, request)) {
                 is ApiResult.Success -> {
                     _uiState.update { it.copy(isSaving = false, saveSuccess = true) }
                 }
 
                 is ApiResult.Error -> {
+                    // Surface the server's explanation (e.g. a name conflict)
+                    // instead of a generic failure.
                     _uiState.update {
-                        it.copy(isSaving = false, error = "Failed to update profile")
+                        it.copy(
+                            isSaving = false,
+                            error = result.message.ifBlank { "Failed to update profile" },
+                        )
                     }
                 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Eco
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.WorkspacePremium
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -33,9 +34,13 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -76,6 +81,18 @@ fun ProfileSelectionScreen(
     viewModel: ProfileSelectionViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
+
+    // Reload on resume so a profile created/edited on a pushed screen is
+    // reflected when we return (the VM otherwise only loads in init) — the
+    // TvProfileSelectionScreen pattern.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) viewModel.loadProfiles()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     // Navigate after a profile is selected.
     LaunchedEffect(state.selectedProfileId) {
@@ -287,20 +304,24 @@ private fun ProfileCard(
                 )
             }
 
-            IconButton(
-                onClick = onDelete,
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .size(28.dp)
-                    .clip(CircleShape)
-                    .background(AuthColors.Error),
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Close,
-                    contentDescription = "Delete profile",
-                    tint = Color.White,
-                    modifier = Modifier.size(16.dp),
-                )
+            // The server never deletes the primary profile (409
+            // primary_profile_protected), so don't offer it.
+            if (!profile.isPrimary) {
+                IconButton(
+                    onClick = onDelete,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(AuthColors.Error),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = "Delete profile",
+                        tint = Color.White,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
             }
         }
     }
@@ -364,14 +385,17 @@ private fun ProfileTileBody(profile: Profile, tint: Color) {
             )
         }
 
-        // Child / lock badges ride the top-right corner.
-        if (profile.hasPin || profile.isChild) {
+        // Primary / child / lock badges ride the top-right corner.
+        if (profile.isPrimary || profile.hasPin || profile.isChild) {
             Row(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(12.dp),
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
+                if (profile.isPrimary) {
+                    TileBadge(Icons.Filled.WorkspacePremium, contentDescription = "Primary profile")
+                }
                 if (profile.isChild) {
                     TileBadge(Icons.Filled.Eco)
                 }
@@ -384,7 +408,10 @@ private fun ProfileTileBody(profile: Profile, tint: Color) {
 }
 
 @Composable
-private fun TileBadge(icon: androidx.compose.ui.graphics.vector.ImageVector) {
+private fun TileBadge(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    contentDescription: String? = null,
+) {
     Box(
         modifier = Modifier
             .clip(CircleShape)
@@ -394,7 +421,7 @@ private fun TileBadge(icon: androidx.compose.ui.graphics.vector.ImageVector) {
     ) {
         Icon(
             imageVector = icon,
-            contentDescription = null,
+            contentDescription = contentDescription,
             tint = Color.White,
             modifier = Modifier.size(16.dp),
         )

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModel.kt
@@ -40,9 +40,14 @@ class ProfileSelectionViewModel(
         loadProfiles()
     }
 
-    fun loadProfiles() {
+    /**
+     * @param clearError false keeps an existing error banner (e.g. a failed
+     * delete's explanation) visible across the follow-up list refresh, which
+     * would otherwise silently swallow it.
+     */
+    fun loadProfiles(clearError: Boolean = true) {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, error = null) }
+            _uiState.update { it.copy(isLoading = true, error = if (clearError) null else it.error) }
 
             val activeId = profileRepository.getActiveProfileId()
             when (val result = profileRepository.listProfiles()) {
@@ -156,19 +161,26 @@ class ProfileSelectionViewModel(
         val profile = _uiState.value.deleteDialogProfile ?: return
         _uiState.update { it.copy(deleteDialogProfile = null) }
         viewModelScope.launch {
-            // Deleting the signed-in profile invalidates its profile token
-            // server-side; clear the local selection FIRST so the follow-up
-            // profile list reload doesn't ride dead credentials (previously
-            // this errored and rendered an empty list — "all profiles gone").
-            if (profile.id == _uiState.value.activeProfileId) {
-                profileRepository.clearProfile()
-                _uiState.update { it.copy(activeProfileId = null) }
-            }
-            when (profileRepository.deleteProfile(profile.id)) {
-                is ApiResult.Success -> loadProfiles()
-                is ApiResult.Error -> {
-                    _uiState.update { it.copy(error = "Failed to delete profile") }
+            // Order matters: the DELETE itself is authorized by the signed-in
+            // profile's X-Profile-Id/X-Profile-Token headers, so credentials
+            // must stay intact until the server has answered. Only after a
+            // successful delete of the signed-in profile do we clear the local
+            // selection — BEFORE reloading, so the list refresh doesn't ride
+            // the now-invalidated profile token (previously that errored and
+            // rendered an empty list — "all profiles gone").
+            when (val result = profileRepository.deleteProfile(profile.id)) {
+                is ApiResult.Success -> {
+                    if (profile.id == _uiState.value.activeProfileId) {
+                        profileRepository.clearProfile()
+                        _uiState.update { it.copy(activeProfileId = null) }
+                    }
                     loadProfiles()
+                }
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(error = result.message.ifBlank { "Failed to delete profile" })
+                    }
+                    loadProfiles(clearError = false)
                 }
                 is ApiResult.NetworkError -> {
                     _uiState.update { it.copy(error = "Network error") }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvCreateProfileViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvCreateProfileViewModel.kt
@@ -3,7 +3,9 @@ package org.siloserver.silo.tv.ui.screens.profiles
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.model.profile.CreateProfileRequest
+import org.siloserver.silo.model.profile.Profile
 import org.siloserver.silo.model.profile.canonicalProfileQualityPreference
+import org.siloserver.silo.model.profile.hasProfileNamed
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.ProfileRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,6 +41,18 @@ class TvCreateProfileViewModel(
 
     private val _uiState = MutableStateFlow(TvCreateProfileUiState())
     val uiState: StateFlow<TvCreateProfileUiState> = _uiState.asStateFlow()
+
+    /** Existing profiles, loaded for the duplicate-name pre-check. Best
+     *  effort: if the load fails the server still enforces the rule. */
+    private var existingProfiles: List<Profile> = emptyList()
+
+    init {
+        viewModelScope.launch {
+            (profileRepository.listProfiles() as? ApiResult.Success)?.let {
+                existingProfiles = it.data
+            }
+        }
+    }
 
     fun onNameChanged(value: String) {
         _uiState.update { it.copy(name = value, error = null) }
@@ -122,6 +136,10 @@ class TvCreateProfileViewModel(
             _uiState.update { it.copy(error = "Profile name is required") }
             return
         }
+        if (existingProfiles.hasProfileNamed(current.name)) {
+            _uiState.update { it.copy(error = "A profile with this name already exists") }
+            return
+        }
         if (current.pinEnabled && current.pin.length != 4) {
             _uiState.update { it.copy(error = "PIN must be 4 digits") }
             return
@@ -140,14 +158,19 @@ class TvCreateProfileViewModel(
                 subtitleMode = current.subtitleMode,
             )
 
-            when (profileRepository.createProfile(request)) {
+            when (val result = profileRepository.createProfile(request)) {
                 is ApiResult.Success -> {
                     _uiState.update { it.copy(isLoading = false, createSuccess = true) }
                 }
 
                 is ApiResult.Error -> {
+                    // Surface the server's explanation (e.g. the account's
+                    // profile limit) instead of a generic failure.
                     _uiState.update {
-                        it.copy(isLoading = false, error = "Failed to create profile")
+                        it.copy(
+                            isLoading = false,
+                            error = result.message.ifBlank { "Failed to create profile" },
+                        )
                     }
                 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvEditProfileViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvEditProfileViewModel.kt
@@ -2,8 +2,10 @@ package org.siloserver.silo.tv.ui.screens.profiles
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import org.siloserver.silo.model.profile.Profile
 import org.siloserver.silo.model.profile.UpdateProfileRequest
 import org.siloserver.silo.model.profile.canonicalProfileQualityPreference
+import org.siloserver.silo.model.profile.hasProfileNamed
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.ProfileRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,6 +46,9 @@ class TvEditProfileViewModel(
     private val _uiState = MutableStateFlow(TvEditProfileUiState(profileId = profileId))
     val uiState: StateFlow<TvEditProfileUiState> = _uiState.asStateFlow()
 
+    /** All profiles from [loadProfile], kept for the rename duplicate check. */
+    private var existingProfiles: List<Profile> = emptyList()
+
     init {
         loadProfile()
     }
@@ -54,6 +59,7 @@ class TvEditProfileViewModel(
 
             when (val result = profileRepository.listProfiles()) {
                 is ApiResult.Success -> {
+                    existingProfiles = result.data
                     val profile = result.data.find { it.id == profileId }
                     if (profile != null) {
                         val preset = TvProfileAvatarPresets.parseRef(profile.avatar)
@@ -173,6 +179,10 @@ class TvEditProfileViewModel(
             _uiState.update { it.copy(error = "Profile name is required") }
             return
         }
+        if (existingProfiles.hasProfileNamed(current.name, excludeId = current.profileId)) {
+            _uiState.update { it.copy(error = "A profile with this name already exists") }
+            return
+        }
         if (current.pinEnabled && current.pin.isNotEmpty() && current.pin.length != 4) {
             _uiState.update { it.copy(error = "PIN must be 4 digits") }
             return
@@ -191,14 +201,19 @@ class TvEditProfileViewModel(
                 subtitleMode = current.subtitleMode,
             )
 
-            when (profileRepository.updateProfile(current.profileId, request)) {
+            when (val result = profileRepository.updateProfile(current.profileId, request)) {
                 is ApiResult.Success -> {
                     _uiState.update { it.copy(isSaving = false, saveSuccess = true) }
                 }
 
                 is ApiResult.Error -> {
+                    // Surface the server's explanation (e.g. a name conflict)
+                    // instead of a generic failure.
                     _uiState.update {
-                        it.copy(isSaving = false, error = "Failed to update profile")
+                        it.copy(
+                            isSaving = false,
+                            error = result.message.ifBlank { "Failed to update profile" },
+                        )
                     }
                 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.Dns
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Logout
+import androidx.compose.material.icons.filled.WorkspacePremium
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -195,8 +196,20 @@ fun TvProfileSelectionScreen(
                     ProfileTileGrid(
                         profiles = state.profiles,
                         firstCardFocus = firstCardFocus,
+                        isManageMode = state.isManageMode,
                         onProfileSelected = viewModel::onProfileSelected,
+                        onEditProfile = { onEditProfile(it.id) },
+                        onDeleteProfile = viewModel::requestDelete,
                         onAddProfile = onAddProfile,
+                    )
+
+                    Spacer(modifier = Modifier.height(28.dp))
+
+                    TvHeroActionPill(
+                        label = if (state.isManageMode) "Done" else "Manage Profiles",
+                        icon = Icons.Filled.Edit,
+                        variant = TvPillVariant.Ghost,
+                        onClick = viewModel::toggleManageMode,
                     )
 
                     if (state.error != null) {
@@ -251,7 +264,10 @@ fun TvProfileSelectionScreen(
 private fun ProfileTileGrid(
     profiles: List<Profile>,
     firstCardFocus: FocusRequester,
+    isManageMode: Boolean,
     onProfileSelected: (Profile) -> Unit,
+    onEditProfile: (Profile) -> Unit,
+    onDeleteProfile: (Profile) -> Unit,
     onAddProfile: () -> Unit,
 ) {
     val itemCount = profiles.size + 1
@@ -274,9 +290,15 @@ private fun ProfileTileGrid(
                                 val profile = profiles[itemIndex]
                                 TvProfileCard(
                                     profile = profile,
-                                    manageMode = false,
-                                    onClick = { onProfileSelected(profile) },
-                                    onDelete = {},
+                                    manageMode = isManageMode,
+                                    onClick = {
+                                        if (isManageMode) {
+                                            onEditProfile(profile)
+                                        } else {
+                                            onProfileSelected(profile)
+                                        }
+                                    },
+                                    onDelete = { onDeleteProfile(profile) },
                                     modifier = if (itemIndex == 0) {
                                         Modifier.focusRequester(firstCardFocus)
                                     } else {
@@ -385,15 +407,17 @@ private fun TvProfileCard(
                     )
                 }
 
-                // Child (leaf) + PIN (lock) indicator badges, top-trailing — tvOS
-                // ProfileTile surfaces these so a household reads at a glance.
-                if (profile.isChild || profile.hasPin) {
+                // Primary (crown) + child (leaf) + PIN (lock) indicator badges,
+                // top-trailing — tvOS ProfileTile surfaces these so a household
+                // reads at a glance.
+                if (profile.isPrimary || profile.isChild || profile.hasPin) {
                     Row(
                         modifier = Modifier
                             .align(Alignment.TopEnd)
                             .padding(12.dp),
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                     ) {
+                        if (profile.isPrimary) ProfileBadge(Icons.Filled.WorkspacePremium, "Primary profile")
                         if (profile.isChild) ProfileBadge(Icons.Filled.ChildCare, "Child profile")
                         if (profile.hasPin) ProfileBadge(Icons.Filled.Lock, "PIN protected")
                     }
@@ -425,7 +449,9 @@ private fun TvProfileCard(
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.88f),
         )
-        if (manageMode) {
+        // The server never deletes the primary profile (409
+        // primary_profile_protected), so don't offer it.
+        if (manageMode && !profile.isPrimary) {
             Spacer(modifier = Modifier.height(8.dp))
             TvHeroActionPill(
                 label = "Delete",

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionViewModel.kt
@@ -163,8 +163,15 @@ class TvProfileSelectionViewModel(
         val profile = _uiState.value.deleteCandidate ?: return
         _uiState.update { it.copy(isDeleting = true) }
         viewModelScope.launch {
-            when (profileRepository.deleteProfile(profile.id)) {
+            when (val result = profileRepository.deleteProfile(profile.id)) {
                 is ApiResult.Success -> {
+                    // Deleting the signed-in profile invalidates its profile
+                    // token server-side; drop the local selection BEFORE the
+                    // list reload so it doesn't ride dead credentials and
+                    // render an empty grid ("all profiles gone").
+                    if (profile.id == profileRepository.getActiveProfileId()) {
+                        profileRepository.clearProfile()
+                    }
                     _uiState.update { it.copy(isDeleting = false, deleteCandidate = null) }
                     loadProfiles()
                 }
@@ -172,7 +179,7 @@ class TvProfileSelectionViewModel(
                     it.copy(
                         isDeleting = false,
                         deleteCandidate = null,
-                        error = "Failed to delete profile",
+                        error = result.message.ifBlank { "Failed to delete profile" },
                     )
                 }
                 is ApiResult.NetworkError -> _uiState.update {

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionScreenSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionScreenSourceTest.kt
@@ -19,9 +19,12 @@ class TvProfileSelectionScreenSourceTest {
         )
         assertTrue(source.contains("\"Change Server\""))
         assertTrue(source.contains("\"Sign Out\""))
-        assertFalse(
+        // Deliberate deviation from tvOS: Android TV wires profile edit/delete
+        // through a manage mode on the picker (there is no other entry point),
+        // toggled by a Manage Profiles pill under the grid.
+        assertTrue(
             source.contains("\"Manage Profiles\""),
-            "tvOS profile picker exposes Change Server and Sign Out, not a Manage Profiles button.",
+            "Android TV's picker is the entry point for profile management.",
         )
     }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/profile/ProfileModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/profile/ProfileModels.kt
@@ -27,6 +27,17 @@ data class Profile(
     @SerialName("updated_at") val updatedAt: String? = null
 )
 
+/**
+ * True when a profile other than [excludeId] already uses [name], comparing
+ * trimmed forms case-insensitively ("Laura" ≡ " laura "). Mirrors the server's
+ * per-account `name_conflict` rule so forms can fail fast before the network
+ * round-trip (and against servers that predate the rule).
+ */
+fun List<Profile>.hasProfileNamed(name: String, excludeId: String? = null): Boolean {
+    val trimmed = name.trim()
+    return any { it.id != excludeId && it.name.trim().equals(trimmed, ignoreCase = true) }
+}
+
 @Serializable
 data class CreateProfileRequest(
     val name: String,

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/profile/ProfileNameConflictTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/profile/ProfileNameConflictTest.kt
@@ -1,0 +1,32 @@
+package org.siloserver.silo.model.profile
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProfileNameConflictTest {
+    private val profiles = listOf(
+        Profile(id = "p1", name = "Main", isPrimary = true),
+        Profile(id = "p2", name = "Laura"),
+    )
+
+    @Test
+    fun matchesCaseInsensitivelyAndTrimmed() {
+        assertTrue(profiles.hasProfileNamed("laura"))
+        assertTrue(profiles.hasProfileNamed(" LAURA "))
+        assertTrue(profiles.hasProfileNamed("Main"))
+    }
+
+    @Test
+    fun distinctNameDoesNotConflict() {
+        assertFalse(profiles.hasProfileNamed("Ed"))
+    }
+
+    @Test
+    fun renameExcludesTheProfileItself() {
+        // Re-saving p2 under its own name is not a conflict...
+        assertFalse(profiles.hasProfileNamed("Laura", excludeId = "p2"))
+        // ...but renaming p2 to another profile's name is.
+        assertTrue(profiles.hasProfileNamed("Main", excludeId = "p2"))
+    }
+}


### PR DESCRIPTION
## Problem

Four issues from the 2026-07-08 phone QA pass on the profile workflow, plus what the investigation turned up on TV:

1. **Created profiles didn't appear** until leaving and re-entering the picker — the mobile VM only loads in `init` and survives the push/pop to Create/Edit. (TV already had the ON_RESUME reload; mobile never got it.)
2. **Deleting the signed-in profile claimed it would delete watch history, then silently did nothing.** Two stacked causes: the previous fix cleared local profile credentials *before* the DELETE, but those very headers authorize profile management server-side, so the delete always 403'd (and the local selection was wiped anyway); and the error the VM set was immediately nulled by the follow-up `loadProfiles()`, so the user saw nothing. Additionally the server never deletes the *primary* profile (409 `primary_profile_protected`), so the dialog promised something impossible.
3. **No indicator for the primary profile.**
4. **Unlimited identically-named profiles** — no validation anywhere in the stack.
5. (Found along the way) **TV's profile manage mode was dead code** — the pencil/delete UI and VM state existed, but nothing ever rendered tiles with `manageMode = true`, so edit/delete were unreachable on TV. TV also still had the original "all profiles gone" bug: no credential clear after a successful signed-in delete.

## Changes (one commit per concern)

- **`fix(mobile)` picker QA** — ON_RESUME reload (TV pattern); delete-then-clear ordering with the clear still preceding the reload; server error messages surfaced and kept visible across the reload; crown badge (`WorkspacePremium`) on the primary tile and no delete affordance for it in manage mode.
- **`feat(tv)` manage mode + parity** — Manage Profiles / Done pill under the grid; managing routes tile clicks to edit and shows the delete pill on non-primary tiles; clear-after-successful-delete of the signed-in profile before the reload; server messages surfaced; crown badge. Deliberate tvOS deviation (tvOS has no Manage Profiles button) since the picker is Android TV's only profile-management entry point — the screen source test now pins the pill instead of forbidding it.
- **`feat(profiles)` duplicate names** — client half of Silo-Server/silo-server#342: shared `hasProfileNamed` (trimmed, case-insensitive, excludes self on rename) pre-checks in create/edit on both platforms, and those forms now surface server messages (`name_conflict`, `profile_limit_reached`) instead of generic failures. Works against older servers too, where the pre-check is the only guard.

## Testing

- `:androidApp:assembleDebug`, `:androidTvApp:assembleDebug` build clean.
- Full unit-test suite passes (includes new `ProfileNameConflictTest` for the shared helper and the updated TV picker source test).
- Server-side counterpart merged separately as Silo-Server/silo-server#342; store-level atomicity follow-up tracked in Silo-Server/silo-server#343.

## Risks / follow-up

- The Manage Profiles pill is a visible TV UI change; if strict tvOS parity is preferred, management would need a different entry point (e.g. Settings).
- Non-primary signed-in profiles attempting manage actions get the server's 403 explanation verbatim; iOS's "borrow primary context with PIN" flow is not ported.

## AI-use disclosure

Implemented with Claude Code (Claude Fable 5); build- and test-verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)