### PR TITLE
fix(profiles): phone profile edit can clear PIN and turn subtitles off

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/EditProfileViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/EditProfileViewModel.kt
@@ -43,6 +43,14 @@ class EditProfileViewModel(
     private var existingProfiles: List<Profile> = emptyList()
 
     /**
+     * Whether the loaded profile already had a PIN. Needed to distinguish
+     * "remove the existing PIN" (send an explicit empty string) from "there was
+     * never a PIN" (omit the field). The shared Json uses explicitNulls=false,
+     * so a null pin is dropped from the PUT and the server keeps the old value.
+     */
+    private var loadedHasPin: Boolean = false
+
+    /**
      * Loads the profile by ID. Called once from the composable via LaunchedEffect.
      * We fetch the full list and find the matching profile because the repository
      * API does not expose a getProfile(id) method.
@@ -56,6 +64,7 @@ class EditProfileViewModel(
                     existingProfiles = result.data
                     val profile = result.data.find { it.id == profileId }
                     if (profile != null) {
+                        loadedHasPin = profile.hasPin
                         _uiState.update {
                             it.copy(
                                 isLoading = false,
@@ -138,7 +147,10 @@ class EditProfileViewModel(
 
     fun onSubtitleModeSelected(mode: String) {
         _uiState.update {
-            it.copy(subtitleMode = if (mode == "Off") null else mode.lowercase().replace(" ", "_"))
+            // "Off" must go over the wire as the explicit "off" value, not null:
+            // explicitNulls=false drops a null subtitle_mode so the server would
+            // keep the previous mode instead of switching subtitles off.
+            it.copy(subtitleMode = if (mode == "Off") "off" else mode.lowercase().replace(" ", "_"))
         }
     }
 
@@ -158,13 +170,24 @@ class EditProfileViewModel(
             return
         }
 
+        // Map the PIN state onto the wire value the server expects:
+        //  - a freshly entered 4-digit PIN sets/replaces the PIN;
+        //  - turning a PIN off on a profile that had one sends an explicit ""
+        //    so the server clears it (a null would be omitted and ignored);
+        //  - otherwise omit the field (null) to leave the PIN unchanged.
+        val pinValue = when {
+            current.pinEnabled && current.pin.isNotEmpty() -> current.pin
+            !current.pinEnabled && loadedHasPin -> ""
+            else -> null
+        }
+
         viewModelScope.launch {
             _uiState.update { it.copy(isSaving = true, error = null) }
 
             val request = UpdateProfileRequest(
                 name = current.name,
                 avatar = current.selectedAvatar,
-                pin = if (current.pinEnabled && current.pin.isNotEmpty()) current.pin else null,
+                pin = pinValue,
                 isChild = current.isChild,
                 maxContentRating = current.maxContentRating,
                 qualityPreference = current.qualityPreference,


### PR DESCRIPTION
The phone `EditProfileViewModel` carried the same `explicitNulls=false` trap that PR #50 fixed on the TV app but never ported to phone. Two edit-flow bugs:

- **Can't clear a PIN.** Disabling a PIN sent `pin = null`, which SiloJson omits from the PUT, so the server kept the old PIN. Now tracks `loadedHasPin` and sends an explicit `""` to clear (server treats `""` as clear, `null`/omitted as unchanged).
- **Can't turn subtitles off.** Selecting subtitle mode "Off" mapped to `null`, likewise omitted, so the previous mode stuck. Now sends the literal `"off"`.

Both are straight ports of `TvEditProfileViewModel`'s already-correct handling (the `loadedHasPin → ""` PIN mapping and the `"off"` subtitle mapping). Create and delete flows were already correct on both platforms and are untouched.

Gated on `:androidApp:assembleDebug` + `./gradlew test` (debug + release unit suites) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile updates so PIN changes are saved correctly when enabling, disabling, or leaving a PIN unchanged.
  * Improved subtitle settings so turning subtitles off now applies reliably instead of being treated as an unset value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->