### PR TITLE
Phone + TV QA sweep (2026-07-09/10): profile edit, playback, HDR, TV parity

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
@@ -13,6 +13,7 @@ import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
@@ -140,6 +141,26 @@ class SiloPlayerFactory(
         }.apply {
             setExtensionRendererMode(extensionMode)
             setEnableDecoderFallback(true)
+            // Force the HARDWARE HEVC decoder even when it reports "NoSupport" for
+            // an unusual profile/level. Some encodes (e.g. an odd-resolution 4K
+            // Main10 title) are rejected by the capability check yet decode fine in
+            // hardware — an NVIDIA Shield plays them, and so does the Pixel's Tensor
+            // decoder (`c2.google.hevc.decoder`, hardware-accelerated) once it's
+            // actually handed the stream. Without this, Media3 avoids the hardware
+            // decoder and falls to Android's software HEVC path, whose 10-bit HDR
+            // output is undisplayable (black). Handing the video renderer only the
+            // hardware-accelerated HEVC decoders makes it use that instead;
+            // decoder fallback stays on, and if no hardware decoder exists we hand
+            // back the full list so nothing regresses.
+            setMediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
+                val infos = MediaCodecSelector.DEFAULT
+                    .getDecoderInfos(mimeType, requiresSecureDecoder, requiresTunnelingDecoder)
+                if (mimeType == MimeTypes.VIDEO_H265) {
+                    infos.filter { it.hardwareAccelerated }.ifEmpty { infos }
+                } else {
+                    infos
+                }
+            }
         }
 
         val trackSelector = DefaultTrackSelector(context).apply {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/mpv/MpvPlayer.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/mpv/MpvPlayer.kt
@@ -208,7 +208,12 @@ class MpvPlayer(
         )
         mpv.setOptionString("profile", "fast")
         mpv.setOptionString("msg-level", "all=info")
-        mpv.setOptionString("vo", videoOutput)
+        // Start with NO video output; enable the real vo only once a surface is
+        // attached (attachVideoSurface/detachVideoSurface), mirroring mpv-android.
+        // Hard-setting vo up front means a surface-less start would make mpv open
+        // the GPU context with no surface ("Missing surface pointer"), fatal the
+        // video output, and drop video for the whole session.
+        mpv.setOptionString("vo", "null")
         mpv.setOptionString("ao", audioOutput)
         mpv.setOptionString("gpu-context", "android")
         mpv.setOptionString("opengl-es", "yes")
@@ -1464,6 +1469,10 @@ class MpvPlayer(
         currentSurface = surface
         mpv.attachSurface(surface)
         mpv.setOptionString("force-window", "yes")
+        // Enable the real video output now that a surface exists (mpv-android
+        // pattern). setPropertyString so it applies at runtime, letting video
+        // recover even after a surface-less start.
+        mpv.setPropertyString("vo", videoOutput)
         mpv.setOptionString("vid", "auto")
         applySurfaceFrameRate()
     }
@@ -1488,6 +1497,10 @@ class MpvPlayer(
     private fun detachVideoSurface(surface: Surface?) {
         if (surface != null && currentSurface != null && currentSurface != surface) return
 
+        // Disable the video output BEFORE releasing the surface (mpv-android
+        // pattern) so mpv doesn't keep a dangling GPU context.
+        mpv.setPropertyString("vo", "null")
+        mpv.setOptionString("force-window", "no")
         mpv.detachSurface()
         currentSurface = null
         resetVideoSurfaceSize()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
@@ -4,20 +4,28 @@ import org.siloserver.silo.common.player.Playability
 import org.siloserver.silo.model.playback.PlayMethod
 
 /**
- * Detects the gap between "Media3 accepted this direct file" and "playback
- * actually started." Preflight covers known unsupported tracks and player
- * errors; this covers startup sessions that stay in BUFFERING forever.
+ * Detects a playback session wedged in BUFFERING with no forward progress —
+ * both at STARTUP ("Media3 accepted this but playback never started") and
+ * MID-STREAM ("it was playing, then froze forever"). Preflight covers known
+ * unsupported tracks and player errors; this covers the silent buffer-forever
+ * case that never surfaces an error. Applies to ALL routes (direct, remux,
+ * transcode, HLS) — a wedged compatibility-route remux used to have no watchdog
+ * at all (TV QA 2026-07-10: some remuxes buffer indefinitely).
  */
 class PlaybackStartupStallDetector(
     private val startupGraceMs: Long = DEFAULT_STARTUP_GRACE_MS,
+    private val midStreamGraceMs: Long = DEFAULT_MID_STREAM_GRACE_MS,
     private val startedProgressMs: Long = DEFAULT_STARTED_PROGRESS_MS,
 ) {
     private var sessionKey: String? = null
-    private var playMethod: PlayMethod? = null
-    private var mountedAtMs: Long = 0L
     private var startPositionMs: Long = 0L
     private var started = false
     private var signaled = false
+    // Last time playback made forward progress (or the mount time before it
+    // starts). The stall is measured from here, so the same logic covers a
+    // never-started session and a mid-stream freeze.
+    private var lastProgressPositionMs: Long = 0L
+    private var lastProgressAtMs: Long = 0L
 
     fun onMounted(
         sessionKey: String,
@@ -27,11 +35,11 @@ class PlaybackStartupStallDetector(
     ) {
         if (this.sessionKey == sessionKey) return
         this.sessionKey = sessionKey
-        this.playMethod = playMethod
-        this.mountedAtMs = nowMs
         this.startPositionMs = startPositionMs.coerceAtLeast(0L)
         this.started = false
         this.signaled = false
+        this.lastProgressPositionMs = this.startPositionMs
+        this.lastProgressAtMs = nowMs
     }
 
     fun sample(
@@ -44,14 +52,22 @@ class PlaybackStartupStallDetector(
         bufferedPositionMs: Long,
     ): Playability.StartupStalled? {
         if (sessionKey != this.sessionKey) return null
-        if (isPlaying || currentPositionMs - startPositionMs >= startedProgressMs) {
+
+        // Forward progress (actively playing, or position advanced meaningfully)
+        // re-anchors the stall clock and latches "started".
+        if (isPlaying || currentPositionMs - lastProgressPositionMs >= startedProgressMs) {
+            lastProgressPositionMs = currentPositionMs
+            lastProgressAtMs = nowMs
             started = true
         }
-        if (started || signaled || playMethod != PlayMethod.DIRECT) return null
+
+        if (signaled) return null
         if (!playWhenReady || !isBuffering) return null
 
-        val stalledForMs = nowMs - mountedAtMs
-        if (stalledForMs <= startupGraceMs) return null
+        // Longer grace before playback ever starts (initial handshake/buffer)
+        // than for a mid-stream freeze once it has been playing.
+        val stalledForMs = nowMs - lastProgressAtMs
+        if (stalledForMs <= (if (started) midStreamGraceMs else startupGraceMs)) return null
 
         signaled = true
         return Playability.StartupStalled(
@@ -62,6 +78,7 @@ class PlaybackStartupStallDetector(
 
     companion object {
         const val DEFAULT_STARTUP_GRACE_MS: Long = 20_000L
+        const val DEFAULT_MID_STREAM_GRACE_MS: Long = 20_000L
         const val DEFAULT_STARTED_PROGRESS_MS: Long = 1_500L
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/mpv/MpvPlayerSourceTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/mpv/MpvPlayerSourceTest.kt
@@ -178,20 +178,24 @@ class MpvPlayerSourceTest {
     }
 
     @Test
-    fun mpvPlayerKeepsVideoOutputAliveAcrossSurfaceTransitions() {
+    fun mpvPlayerGatesVideoOutputOnSurface() {
+        // vo (video output) is gated on the surface, mirroring mpv-android: init
+        // starts with vo="null", the real vo is enabled only once a surface
+        // attaches, and it is nulled again on detach. Hard-setting vo up front made
+        // a surface-less start fatal the video output permanently.
         val text = source.readText()
         val attachBody = text.substringAfter("private fun attachVideoSurface(surface: Surface?)")
-            .substringBefore("private fun detachVideoSurface")
+            .substringBefore("private fun applySurfaceFrameRate")
         val detachBody = text.substringAfter("private fun detachVideoSurface(surface: Surface?)")
-            .substringBefore("private fun updateVideoSurfaceSize")
+            .substringBefore("private fun resetVideoSurfaceSize")
 
+        assertTrue(text.contains("setOptionString(\"vo\", \"null\")"))
         assertTrue(attachBody.contains("mpv.attachSurface(surface)"))
         assertTrue(attachBody.contains("setOptionString(\"force-window\", \"yes\")"))
-        assertTrue(!attachBody.contains("setOptionString(\"vo\", videoOutput)"))
+        assertTrue(attachBody.contains("setPropertyString(\"vo\", videoOutput)"))
+        assertTrue(detachBody.contains("setPropertyString(\"vo\", \"null\")"))
+        assertTrue(detachBody.contains("setOptionString(\"force-window\", \"no\")"))
         assertTrue(detachBody.contains("mpv.detachSurface()"))
-        assertTrue(!detachBody.contains("setOptionString(\"vid\", \"no\")"))
-        assertTrue(!detachBody.contains("setOptionString(\"vo\", \"null\")"))
-        assertTrue(!detachBody.contains("setOptionString(\"force-window\", \"no\")"))
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
@@ -4,6 +4,7 @@ import org.siloserver.silo.common.player.Playability
 import org.siloserver.silo.model.playback.PlayMethod
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class PlaybackStartupStallDetectorTest {
@@ -80,7 +81,9 @@ class PlaybackStartupStallDetectorTest {
     }
 
     @Test
-    fun nonDirectOrPausedStartupDoesNotTriggerFallback() {
+    fun nonDirectRouteStartupTriggersFallback() {
+        // Non-DIRECT routes (remux/transcode/HLS) that wedge at startup now
+        // trigger the fallback too (TV QA 2026-07-10: remuxes buffered forever).
         val detector = PlaybackStartupStallDetector(startupGraceMs = 10_000)
         detector.onMounted(
             sessionKey = "session-1",
@@ -89,7 +92,7 @@ class PlaybackStartupStallDetectorTest {
             nowMs = 0,
         )
 
-        assertNull(
+        assertNotNull(
             detector.sample(
                 sessionKey = "session-1",
                 nowMs = 20_000,
@@ -100,7 +103,12 @@ class PlaybackStartupStallDetectorTest {
                 bufferedPositionMs = 0,
             ),
         )
+    }
 
+    @Test
+    fun pausedStartupDoesNotTriggerFallback() {
+        // playWhenReady=false (user paused) never triggers, even past the grace.
+        val detector = PlaybackStartupStallDetector(startupGraceMs = 10_000)
         detector.onMounted(
             sessionKey = "session-2",
             playMethod = PlayMethod.DIRECT,
@@ -117,6 +125,58 @@ class PlaybackStartupStallDetectorTest {
                 isBuffering = true,
                 currentPositionMs = 0,
                 bufferedPositionMs = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun midStreamFreezeTriggersFallbackAfterStarted() {
+        // Playback starts and advances, then the position freezes while
+        // buffering → fires after the mid-stream grace, not before.
+        val detector = PlaybackStartupStallDetector(
+            startupGraceMs = 10_000,
+            midStreamGraceMs = 10_000,
+        )
+        detector.onMounted(
+            sessionKey = "session-3",
+            playMethod = PlayMethod.DIRECT,
+            startPositionMs = 0,
+            nowMs = 0,
+        )
+        // Progress: playing, position advanced — latches started + re-anchors.
+        assertNull(
+            detector.sample(
+                sessionKey = "session-3",
+                nowMs = 1_000,
+                playWhenReady = true,
+                isPlaying = true,
+                isBuffering = false,
+                currentPositionMs = 2_000,
+                bufferedPositionMs = 5_000,
+            ),
+        )
+        // Frozen (buffering, no progress) but still within the grace.
+        assertNull(
+            detector.sample(
+                sessionKey = "session-3",
+                nowMs = 5_000,
+                playWhenReady = true,
+                isPlaying = false,
+                isBuffering = true,
+                currentPositionMs = 2_000,
+                bufferedPositionMs = 2_000,
+            ),
+        )
+        // Still frozen past the mid-stream grace → fires.
+        assertNotNull(
+            detector.sample(
+                sessionKey = "session-3",
+                nowMs = 15_000,
+                playWhenReady = true,
+                isPlaying = false,
+                isBuffering = true,
+                currentPositionMs = 2_000,
+                bufferedPositionMs = 2_000,
             ),
         )
     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -312,6 +312,7 @@ val androidModule = module {
             get(), get(), get(),
             getOrNull<org.siloserver.silo.repository.port.UserItemStatePort>() ?: org.siloserver.silo.repository.port.NoOpUserItemStatePort,
             get(),
+            get<org.siloserver.silo.android.ui.screens.browse.BrowsePrefsStore>(),
         )
     }
     viewModel { ReadingHubViewModel(get(), get(), get()) }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaCard.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaCard.kt
@@ -28,7 +28,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import org.siloserver.silo.android.ui.navigation.heroSharedBounds
+import org.siloserver.silo.android.ui.navigation.LocalHeroSourceHandoff
+import org.siloserver.silo.android.ui.navigation.heroSharedKeyPrefix
+import org.siloserver.silo.android.ui.navigation.heroSource
+import java.util.UUID
 import org.siloserver.silo.common.overlays.CardOverlayVariant
 import org.siloserver.silo.common.overlays.CardOverlays
 import org.siloserver.silo.common.overlays.LocalCardOverlayUiState
@@ -75,12 +78,25 @@ fun MediaCard(
 ) {
     val overlayState = LocalCardOverlayUiState.current
     var menuExpanded by remember { mutableStateOf(false) }
+    // Unique per-placement hero key. Two placements of the same content id (e.g.
+    // Continue Watching + a genre row) get distinct keys, so they never collide
+    // in the shared-transition layout (the old flicker). Recomputed when this
+    // slot is recycled for a different item. Null when the card isn't a hero.
+    val heroHandoff = LocalHeroSourceHandoff.current
+    val heroKey = remember(sharedContentId) {
+        sharedContentId?.let { "${heroSharedKeyPrefix(it)}-${UUID.randomUUID()}" }
+    }
     // iOS MediaCard.swift: VStack(alignment: .leading, spacing: 4).
     Column(
         modifier = modifier
             .width(width)
             .combinedClickable(
-                onClick = onClick,
+                onClick = {
+                    // Record which exact placement was tapped so the detail hero
+                    // pairs with this card, not a duplicate elsewhere on screen.
+                    if (heroKey != null) heroHandoff?.pendingKey = heroKey
+                    onClick()
+                },
                 onLongClick = if (actions.isEmpty) null else { { menuExpanded = true } },
             ),
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -92,7 +108,7 @@ fun MediaCard(
                 .aspectRatio(artworkAspectRatio)
                 // Hero morph source. Must precede .clip() — sharedBounds renders
                 // into the transition overlay and clipping is applied to its child.
-                .heroSharedBounds(sharedContentId)
+                .heroSource(heroKey)
                 .clip(MaterialTheme.shapes.small),
         ) {
             ThumbhashImage(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
@@ -238,5 +238,8 @@ fun MediaRow(
 private class HorizontalBiasViewConfiguration(
     private val base: ViewConfiguration,
 ) : ViewConfiguration by base {
-    override val touchSlop: Float get() = base.touchSlop * 1.75f
+    // Bumped 1.75 -> 2.25 (Jim QA 2026-07-09: rows still too grabby on Pixel,
+    // vertical scroll getting hijacked by incidental horizontal activation).
+    // Governs only when horizontal scroll STARTS, not fling velocity.
+    override val touchSlop: Float get() = base.touchSlop * 2.25f
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
@@ -151,7 +151,13 @@ fun AppNavigation(
     // (a poster card, the detail hero) can opt in without threading it through
     // every composable signature in between.
     SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
-    CompositionLocalProvider(LocalSharedTransitionScope provides this) {
+    // One hand-off shared by every poster source and the detail hero target, so
+    // the tapped card's unique key reaches the backdrop (iOS pendingZoomSourceID).
+    val heroSourceHandoff = remember { HeroSourceHandoff() }
+    CompositionLocalProvider(
+        LocalSharedTransitionScope provides this,
+        LocalHeroSourceHandoff provides heroSourceHandoff,
+    ) {
     Box(modifier = Modifier.fillMaxSize()) {
     NavHost(
         navController = navController,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/SharedElementTransition.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/SharedElementTransition.kt
@@ -5,11 +5,10 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.SharedTransitionScope.ResizeMode
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 
 /**
@@ -17,14 +16,14 @@ import androidx.compose.ui.Modifier
  * on phone/tablet. [AppNavigation] wraps its NavHost in a `SharedTransitionLayout`
  * and publishes the [SharedTransitionScope] here; each animated destination
  * publishes its own [AnimatedVisibilityScope]. A poster card (source) and the
- * detail backdrop hero (target) then opt into a shared-bounds morph keyed on the
- * content id — so the thing you tapped visibly carries you into the detail page —
- * without threading either scope through every composable signature.
+ * detail backdrop hero (target) then opt into a shared-bounds morph — so the
+ * thing you tapped visibly carries you into the detail page — without threading
+ * either scope through every composable signature.
  *
  * Both locals are null wherever no `SharedTransitionLayout` / destination scope is
  * in play (previews, tests, screens not yet wired). Call sites MUST treat null as
- * "no shared transition" and fall back to a plain modifier — [heroSharedBounds]
- * does exactly that, so it is always safe to call.
+ * "no shared transition" and fall back to a plain modifier — [heroSource] and
+ * [heroTarget] do exactly that, so they are always safe to call.
  */
 @OptIn(ExperimentalSharedTransitionApi::class)
 val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { null }
@@ -37,118 +36,81 @@ val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { nu
 val LocalNavAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> { null }
 
 /**
- * Shared-element key for an item's hero artwork. The list poster and the detail
- * backdrop for the same content id MUST resolve to the same key to morph into one
- * another, so both ends route through this single helper.
+ * Base prefix for a poster's hero key. Each poster PLACEMENT appends a unique
+ * per-instance token (see [MediaCard]) so the same content id appearing in two
+ * rows at once — Continue Watching + a genre row — never resolves to the same
+ * shared key. Two live nodes under one key is exactly what made posters flicker
+ * and draw into the transition overlay while scrolling; unique per-placement
+ * keys make that collision impossible by construction (mirrors iOS's per-card
+ * `zoomInstanceID`).
  */
-fun heroSharedKey(contentId: String): String = "hero-$contentId"
+fun heroSharedKeyPrefix(contentId: String): String = "hero-$contentId"
 
 /**
- * Per-screen registry that lets only ONE visible node own a hero key at a
- * time. The same item can appear in several home rows at once (Continue
- * Watching + a genre row); if both register `sharedBounds` under the same key,
- * the transition machinery treats them as a match and "morphs" between two
- * live cards — posters flicker and draw into the overlay above everything
- * while scrolling. Screens that can show duplicates provide a registry; the
- * first composed instance claims the key and non-claimants render as plain
- * cards.
+ * Hand-off channel from the tapped poster to the detail hero target. The source
+ * card writes its own unique placement key here on tap, and the detail backdrop
+ * reads it to pair with THAT specific card rather than any duplicate of the same
+ * content id in another row. Mirrors iOS `router.pendingZoomSourceID`.
  *
- * Ownership is snapshot-backed ([mutableStateMapOf]), so composables that read
- * it via [ownerOf] recompose when the owner changes. This makes the claim
- * *re-offerable*: when the current claimant disposes (e.g. a LazyRow recycles
- * its card off-screen) it releases the key, the map change wakes the surviving
- * duplicates, and one of them re-claims — so the still-visible copy takes over
- * the morph instead of the key going dead until Home next recomposes.
- *
- * The detail screen provides no registry, so the hero target always registers
- * and pairs with whichever card currently holds the claim.
+ * Snapshot-backed so the detail target recomposes if it changes; in practice it
+ * is set once (synchronously, before navigation) and read once when the detail
+ * screen composes. A navigation that does not originate from a poster (deep
+ * link, search) leaves a stale or null key — harmless, because an unmatched key
+ * simply renders in place with no morph.
  */
-class HeroClaimRegistry {
-    private val owners = mutableStateMapOf<String, Any>()
-
-    /**
-     * Current owner token for [key], or null if unclaimed. Reading this inside
-     * composition subscribes the caller to ownership changes (snapshot map), so
-     * a released/reassigned key re-triggers the reading composable.
-     */
-    fun ownerOf(key: String): Any? = owners[key]
-
-    /**
-     * Atomically take [key] for [owner] if it is free, or confirm [owner]
-     * already holds it. Returns false when another owner holds the claim, so a
-     * duplicate never double-claims a key that is already spoken for.
-     */
-    fun tryClaim(key: String, owner: Any): Boolean {
-        val current = owners[key]
-        if (current == null) {
-            owners[key] = owner
-            return true
-        }
-        return current === owner
-    }
-
-    fun release(key: String, owner: Any) {
-        if (owners[key] === owner) owners.remove(key)
-    }
+class HeroSourceHandoff {
+    var pendingKey: String? by mutableStateOf(null)
 }
 
-val LocalHeroClaimRegistry = compositionLocalOf<HeroClaimRegistry?> { null }
+val LocalHeroSourceHandoff = compositionLocalOf<HeroSourceHandoff?> { null }
 
 /**
- * Tags this node as the hero shared element for [contentId]. When both the
- * shared-transition scope and a destination visibility scope are available, a
- * source (poster) and target (detail backdrop) carrying the same id animate their
- * bounds into one another, crossfading the differing artwork. Otherwise this is a
- * no-op, so it is safe to call unconditionally.
+ * Tags this node as the hero shared-element SOURCE under [key] (a unique
+ * per-placement key). When the shared-transition scope and a destination
+ * visibility scope are both available, this source and the detail target that
+ * pairs with the same key animate their bounds into one another. Null [key] (no
+ * hero) or a missing scope makes this a no-op, so it is always safe to call.
  *
  * `sharedBounds` renders into the scope overlay during the transition, so any
- * clipping/shaping MUST be applied AFTER this in the chain —
- * callers do `.heroSharedBounds(id).clip(shape)`.
- *
- * When a [HeroClaimRegistry] is provided (screens that can show the same item
- * in multiple rows), only the card holding the claim opts into the morph;
- * non-claimant duplicates render as plain cards. Note this does NOT mean a
- * non-claimant "navigates without a morph": if any claimant card is on screen,
- * the shared key is still matched, so the morph animates from that claimant
- * card — even when you tapped a different duplicate. The plain duplicate simply
- * isn't the visual source. The claim is snapshot-observed and re-taken whenever
- * the key falls free (see [HeroClaimRegistry]); the very first claim still lands
- * one frame after composition (the source card renders plain for that frame),
- * which is acceptable and unchanged.
+ * clipping/shaping MUST be applied AFTER this in the chain — callers do
+ * `.heroSource(key).clip(shape)`.
  */
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-fun Modifier.heroSharedBounds(contentId: String?): Modifier {
-    if (contentId.isNullOrBlank()) return this
+fun Modifier.heroSource(key: String?): Modifier {
+    if (key.isNullOrBlank()) return this
     val sharedScope = LocalSharedTransitionScope.current ?: return this
     val visibilityScope = LocalNavAnimatedVisibilityScope.current ?: return this
-    val registry = LocalHeroClaimRegistry.current
-    if (registry != null) {
-        val key = heroSharedKey(contentId)
-        val owner = remember { Any() }
-        // Observe live ownership; the snapshot map recomposes us when the owner
-        // changes, so a released key re-offers itself to survivors.
-        val currentOwner = registry.ownerOf(key)
-        val claimed = currentOwner === owner
-        // (Re-)claim whenever the key is unowned. This covers the initial claim
-        // AND re-offering after the previous claimant disposes (LazyRow
-        // recycling). tryClaim is atomic, so concurrent survivors can't
-        // double-own — losers see currentOwner become non-null and stay plain.
-        LaunchedEffect(key, currentOwner) {
-            if (currentOwner == null) registry.tryClaim(key, owner)
-        }
-        DisposableEffect(key, owner) {
-            onDispose { registry.release(key, owner) }
-        }
-        if (!claimed) return this
-    }
     return with(sharedScope) {
-        this@heroSharedBounds.sharedBounds(
-            sharedContentState = rememberSharedContentState(key = heroSharedKey(contentId)),
+        this@heroSource.sharedBounds(
+            sharedContentState = rememberSharedContentState(key = key),
             animatedVisibilityScope = visibilityScope,
             // Images respond well to being remeasured to the animated bounds, so the
             // artwork crop-fills the morphing rectangle (poster → wide hero) every
             // frame instead of scaling a single stable layout.
+            resizeMode = ResizeMode.RemeasureToBounds,
+        )
+    }
+}
+
+/**
+ * Tags this node as the hero shared-element TARGET (the detail backdrop). It
+ * pairs with whichever poster placement the user last tapped, read from
+ * [LocalHeroSourceHandoff]. With no recorded source (opened via deep link,
+ * search, etc.) or a missing scope this is a no-op — the backdrop just renders
+ * normally with no morph.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.heroTarget(): Modifier {
+    val key = LocalHeroSourceHandoff.current?.pendingKey
+    if (key.isNullOrBlank()) return this
+    val sharedScope = LocalSharedTransitionScope.current ?: return this
+    val visibilityScope = LocalNavAnimatedVisibilityScope.current ?: return this
+    return with(sharedScope) {
+        this@heroTarget.sharedBounds(
+            sharedContentState = rememberSharedContentState(key = key),
+            animatedVisibilityScope = visibilityScope,
             resizeMode = ResizeMode.RemeasureToBounds,
         )
     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/SharedElementTransition.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/SharedElementTransition.kt
@@ -5,9 +5,11 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.SharedTransitionScope.ResizeMode
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 
@@ -103,7 +105,15 @@ fun Modifier.heroSource(key: String?): Modifier {
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun Modifier.heroTarget(): Modifier {
-    val key = LocalHeroSourceHandoff.current?.pendingKey
+    val handoff = LocalHeroSourceHandoff.current
+    // Consume the key once for THIS target, then clear the app-wide hand-off so
+    // a later navigation that doesn't set a fresh key (back → search → open
+    // another item, with the source screen still composed in the back stack)
+    // can't reuse this stale key and morph the new hero from the wrong card.
+    // `remember` keeps our captured key for this target's lifetime, so clearing
+    // the hand-off doesn't disturb the current morph.
+    val key = remember(handoff) { handoff?.pendingKey }
+    LaunchedEffect(handoff) { handoff?.pendingKey = null }
     if (key.isNullOrBlank()) return this
     val sharedScope = LocalSharedTransitionScope.current ?: return this
     val visibilityScope = LocalNavAnimatedVisibilityScope.current ?: return this

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt
@@ -289,8 +289,6 @@ fun MainScreen(
                             onItemClick = { contentId ->
                                 navController.navigate(Route.ItemDetail(contentId).route)
                             },
-                            onWatchlistClick = { navController.navigate(Route.Watchlist.route) },
-                            onFavoritesClick = { navController.navigate(Route.Favorites.route) },
                             contentTopPadding = headerContentTop,
                         )
                     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/calendar/CalendarScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/calendar/CalendarScreen.kt
@@ -209,12 +209,28 @@ private fun PinnedHeader(
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.background)
-            .padding(vertical = SmallPadding),
+            // Only bottom padding: the floating top bar already provides the top
+            // breathing room, so a top gap here just stacked whitespace above the
+            // filter capsule in portrait (Jim QA 2026-07-09).
+            .padding(bottom = SmallPadding),
         verticalArrangement = Arrangement.spacedBy(SmallPadding),
     ) {
         CalendarFilterBar(
             selected = state.filter,
             onSelect = viewModel::setFilter,
+            modifier = Modifier.padding(horizontal = SafePadding),
+        )
+        // Left-aligned month/year header line above the day strip, matching iOS
+        // CalendarView (CalendarView.swift:105-113). Previously this lived inside
+        // the week-strip Row where portrait squeezed it to a vertical stack.
+        Text(
+            text = monthLabel(state.weekDates),
+            fontSize = 17.sp, // iOS monthLabel = 17 semibold
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.padding(horizontal = SafePadding),
         )
         CalendarWeekStrip(
@@ -336,6 +352,10 @@ private fun CalendarWeekStrip(
             contentDescription = "Next week",
             onClick = onNextWeek,
         )
+        // Month label intentionally NOT here — it lives as a left-aligned
+        // header line above the strip (see PinnedHeader), matching iOS
+        // CalendarView. Kept in this Row it was squeezed to ~0 width in
+        // portrait (chevrons + 7 day cells overflow) and stacked vertically.
 
         if (!isCurrentWeek) {
             Box(
@@ -357,17 +377,6 @@ private fun CalendarWeekStrip(
             }
         }
 
-        Spacer(Modifier.weight(1f))
-
-        Text(
-            text = monthLabel(weekDates),
-            fontSize = 13.sp, // iOS monthFont = 13 semibold
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            softWrap = false,
-            overflow = TextOverflow.Ellipsis,
-        )
     }
 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
@@ -62,7 +62,7 @@ import org.siloserver.silo.android.ui.theme.SiloBackground
 import org.siloserver.silo.android.ui.theme.SiloOnSurface
 import org.siloserver.silo.android.ui.theme.SiloSecondaryText
 import org.siloserver.silo.android.ui.theme.SiloSurfaceElevated
-import org.siloserver.silo.android.ui.navigation.heroSharedBounds
+import org.siloserver.silo.android.ui.navigation.heroTarget
 import org.siloserver.silo.android.ui.theme.PillShape
 import org.siloserver.silo.android.ui.util.playbackResumePosition
 import org.siloserver.silo.common.ui.components.ThumbhashImage
@@ -166,9 +166,10 @@ private fun Backdrop(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(heroHeight)
-                // Hero morph target — matches the tapped poster's shared key so
-                // the artwork bounds carry from the list card into this backdrop.
-                .heroSharedBounds(contentId),
+                // Hero morph target — pairs with the exact poster placement the
+                // user tapped (read from the hero hand-off) so the artwork bounds
+                // carry from that list card into this backdrop.
+                .heroTarget(),
         ) {
             ThumbhashImage(
                 url = backdropUrl,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
@@ -965,7 +965,8 @@ private fun buildDetailFacts(detail: ItemDetail): List<Pair<String, String>> = b
     if (detail.studios.isNotEmpty()) add("Studio" to detail.studios.joinToString(", "))
     if (detail.networks.isNotEmpty()) add("Network" to detail.networks.joinToString(", "))
     if (detail.countries.isNotEmpty()) add("Country" to detail.countries.joinToString(", "))
-    if (detail.genres.isNotEmpty()) add("Genres" to detail.genres.joinToString(", "))
+    // Genres are already carried by the hero facts line (HeroMetadata); iOS's
+    // detail facts list omits them, so listing them here duplicated them.
 }
 
 private fun runtimeText(minutes: Int): String {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -761,6 +761,12 @@ class ItemDetailViewModel(
             )
             if (subtitleOrdinal == null && audioOrdinal == null) return@launch
             _uiState.update {
+                // The ordinals were resolved against `version`; if the user
+                // switched versions while this suspended, they'd index into the
+                // wrong track list — leave the new version untouched.
+                if (it.detail?.versions?.getOrNull(it.selectedVersionIndex)?.fileId != version.fileId) {
+                    return@update it
+                }
                 // Don't clobber a pick the user already made this session.
                 it.copy(
                     selectedSubtitleIndex = if (it.hasExplicitSubtitleSelection) it.selectedSubtitleIndex

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -23,6 +23,11 @@ import org.siloserver.silo.repository.EbookReaderRepository
 import org.siloserver.silo.repository.PersonalDataRepository
 import org.siloserver.silo.viewmodel.applyLocalPlaybackProgress
 import org.siloserver.silo.model.download.DownloadQuality
+import org.siloserver.silo.playback.SUBTITLE_OFF_FINGERPRINT
+import org.siloserver.silo.playback.audioTrackFingerprint
+import org.siloserver.silo.playback.resolveAudioTrackOrdinal
+import org.siloserver.silo.playback.resolveSubtitleTrackOrdinal
+import org.siloserver.silo.playback.subtitleTrackFingerprint
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -283,6 +288,8 @@ class ItemDetailViewModel(
                             error = null,
                         )
                     }
+                    // Restore a persisted audio/subtitle override for this item.
+                    seedPersistedTrackSelection()
                     // For series, load seasons
                     if (detail.type == "series") {
                         loadSeasons(detail.contentId)
@@ -637,6 +644,8 @@ class ItemDetailViewModel(
                 hasExplicitSubtitleSelection = false,
             )
         }
+        // Restore any saved audio/subtitle override for the newly-selected file.
+        seedPersistedTrackSelection()
     }
 
     /** Back to Auto — clears the version override and, like [selectVersion],
@@ -652,6 +661,7 @@ class ItemDetailViewModel(
                 hasExplicitSubtitleSelection = false,
             )
         }
+        seedPersistedTrackSelection()
     }
 
     fun selectAudioTrack(index: Int) {
@@ -661,6 +671,7 @@ class ItemDetailViewModel(
                 hasExplicitAudioSelection = true,
             )
         }
+        persistTrackSelection()
     }
 
     /** Back to Auto — playback falls through to the file's default track. */
@@ -671,6 +682,7 @@ class ItemDetailViewModel(
                 hasExplicitAudioSelection = false,
             )
         }
+        persistTrackSelection()
     }
 
     fun selectSubtitle(index: Int) {
@@ -680,6 +692,7 @@ class ItemDetailViewModel(
                 hasExplicitSubtitleSelection = true,
             )
         }
+        persistTrackSelection()
     }
 
     /** Back to Auto — distinct from an explicit -1 ("Off") selection. */
@@ -689,6 +702,75 @@ class ItemDetailViewModel(
                 selectedSubtitleIndex = -1,
                 hasExplicitSubtitleSelection = false,
             )
+        }
+        persistTrackSelection()
+    }
+
+    /**
+     * Persist the current audio/subtitle override for the selected version's
+     * file, so it survives leaving and re-opening the detail page (and lines up
+     * with the player, which records the same fingerprints against the same
+     * port). Auto (no explicit pick) writes null to clear any prior override;
+     * an explicit "Off" writes the shared off sentinel; a concrete pick writes
+     * the catalog track's fingerprint. Keyed on (contentId, fileId) — different
+     * versions carry independent selections, matching [selectVersion]'s reset.
+     */
+    private fun persistTrackSelection() {
+        val state = _uiState.value
+        val detail = state.detail ?: return
+        val version = detail.versions.getOrNull(state.selectedVersionIndex) ?: return
+        val subtitleFingerprint = when {
+            !state.hasExplicitSubtitleSelection -> null
+            state.selectedSubtitleIndex == -1 -> SUBTITLE_OFF_FINGERPRINT
+            else -> version.subtitleTracks.orEmpty()
+                .getOrNull(state.selectedSubtitleIndex)
+                ?.let(::subtitleTrackFingerprint)
+        }
+        val audioFingerprint = when {
+            !state.hasExplicitAudioSelection -> null
+            else -> version.audioTracks.orEmpty()
+                .getOrNull(state.selectedAudioIndex)
+                ?.let(::audioTrackFingerprint)
+        }
+        viewModelScope.launch {
+            userItemState.recordSubtitleTrackSelection(detail.contentId, version.fileId, subtitleFingerprint)
+            userItemState.recordAudioTrackSelection(detail.contentId, version.fileId, audioFingerprint)
+        }
+    }
+
+    /**
+     * Seed the audio/subtitle selectors from a previously persisted override
+     * for the selected version's file, so re-opening the detail page restores
+     * what the user last chose. Fingerprints map back to the catalog list via
+     * the shared resolvers (Off -> -1). Only applies a dimension when a saved
+     * fingerprint actually matches a current track, leaving Auto otherwise.
+     */
+    private fun seedPersistedTrackSelection() {
+        val state = _uiState.value
+        val detail = state.detail ?: return
+        val version = detail.versions.getOrNull(state.selectedVersionIndex) ?: return
+        viewModelScope.launch {
+            val saved = userItemState.localTrackSelection(detail.contentId, version.fileId) ?: return@launch
+            val subtitleOrdinal = resolveSubtitleTrackOrdinal(
+                version.subtitleTracks.orEmpty(),
+                saved.subtitleFingerprint,
+            )
+            val audioOrdinal = resolveAudioTrackOrdinal(
+                version.audioTracks.orEmpty(),
+                saved.audioFingerprint,
+            )
+            if (subtitleOrdinal == null && audioOrdinal == null) return@launch
+            _uiState.update {
+                // Don't clobber a pick the user already made this session.
+                it.copy(
+                    selectedSubtitleIndex = if (it.hasExplicitSubtitleSelection) it.selectedSubtitleIndex
+                    else subtitleOrdinal ?: it.selectedSubtitleIndex,
+                    hasExplicitSubtitleSelection = it.hasExplicitSubtitleSelection || subtitleOrdinal != null,
+                    selectedAudioIndex = if (it.hasExplicitAudioSelection) it.selectedAudioIndex
+                    else audioOrdinal ?: it.selectedAudioIndex,
+                    hasExplicitAudioSelection = it.hasExplicitAudioSelection || audioOrdinal != null,
+                )
+            }
         }
     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MediaSelectors.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MediaSelectors.kt
@@ -369,14 +369,13 @@ fun formatVersionValueLabel(version: FileVersion?, isAuto: Boolean): String {
 }
 
 /**
- * Selector value for the Audio row, matching the iOS phone detail
- * (`DetailPlaybackFormatting.audioValueLabel` with `annotateAuto = false`):
- * the resolved track is named outright with no "Auto -" prefix, for both the
- * auto and the explicit case. Auto resolves to the server's effective track
- * ([effectiveIndex] = `FileVersion.effectiveAudioTrackIndex`), else the file's
- * default track, else the first — Apple parity: selected → effective →
- * default → first. [selectedIndex] null = Auto. (The annotated
- * "Auto - <track>" form is tvOS-only on Apple, so the phone omits it.)
+ * Selector value for the Audio row. Auto (no item-level override) previews
+ * what it resolves to with an "Auto - <track>" prefix, mirroring the Video row
+ * and the TV client's tvOS-style annotation (Jim 2026-07-09: apply "Auto -" to
+ * all three rows for consistency). Auto resolves to the server's effective
+ * track ([effectiveIndex] = `FileVersion.effectiveAudioTrackIndex`), else the
+ * file's default track, else the first — selected → effective → default →
+ * first. [selectedIndex] null = Auto; an explicit pick is named outright.
  */
 fun formatAudioValueLabel(
     tracks: List<AudioTrack>,
@@ -388,24 +387,27 @@ fun formatAudioValueLabel(
         ?: effectiveIndex?.takeIf { it in tracks.indices }
         ?: tracks.indexOfFirst { it.isDefault }.takeIf { it >= 0 }
         ?: 0
-    return formatAudioLabel(tracks[resolved])
+    val label = formatAudioLabel(tracks[resolved])
+    return if (selectedIndex == null) "Auto - $label" else label
 }
 
 /**
- * Selector value for the Subtitles row, matching the iOS phone detail
- * (`DetailPlaybackFormatting.subtitleValueLabel` with no `autoContext`).
+ * Selector value for the Subtitles row.
  *
- * [selectedIndex] null = Auto: the phone shows a bare "Auto". The player's
- * real subtitle resolver (preferred-language / audio-match / forced / SDH
- * rules in `resolveMobileAutoSubtitleSelection`) — never the catalog
- * `isDefault` flag — decides at playback, so previewing a concrete track from
- * `isDefault` could contradict what actually plays. A lone track is named
- * outright since Auto can only land there. -1 = Off.
+ * [selectedIndex] null = Auto. The player's real subtitle resolver
+ * (preferred-language / audio-match / forced / SDH rules in
+ * `resolveMobileAutoSubtitleSelection`) decides the concrete track at playback,
+ * and it needs profile prefs + the selected audio track that the detail page
+ * doesn't have — so a multi-track Auto stays a bare "Auto" (previewing a
+ * fabricated track could contradict what actually plays). When Auto can only
+ * land on one track (a lone track), we DO know the result, so we show it in the
+ * tvOS-style "Auto - <track>" form for consistency with the Video/Audio rows
+ * (Jim 2026-07-09). -1 = Off.
  */
 fun formatSubtitleValueLabel(tracks: List<SubtitleTrack>, selectedIndex: Int?): String {
     if (selectedIndex == null) {
         val single = tracks.singleOrNull() ?: return "Auto"
-        return formatSubtitleLabel(single)
+        return "Auto - ${formatSubtitleLabel(single)}"
     }
     if (selectedIndex == -1) return "Off"
     // A stale explicit index (the track list shrank under the selection) still

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
@@ -249,12 +249,14 @@ fun MovieDetailContent(
                                 onClick = { showAudioPicker = true },
                             )
                         }
-                        TrackSelectorRow(
-                            icon = Icons.Outlined.ClosedCaption,
-                            label = "Subtitles",
-                            value = formatSubtitleValueLabel(subtitleTracks, selectedSubtitleIndex),
-                            onClick = { showSubtitlePicker = true },
-                        )
+                        if (subtitleTracks.isNotEmpty()) {
+                            TrackSelectorRow(
+                                icon = Icons.Outlined.ClosedCaption,
+                                label = "Subtitles",
+                                value = formatSubtitleValueLabel(subtitleTracks, selectedSubtitleIndex),
+                                onClick = { showSubtitlePicker = true },
+                            )
+                        }
                     }
                 }
             }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
@@ -68,8 +68,6 @@ import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.profile.Profile
 import org.siloserver.silo.model.section.splitFeatured
 import org.siloserver.silo.viewmodel.HomeViewModel
-import org.siloserver.silo.android.ui.navigation.HeroClaimRegistry
-import org.siloserver.silo.android.ui.navigation.LocalHeroClaimRegistry
 import org.koin.compose.viewmodel.koinViewModel
 
 private const val ChromeFadeDistanceDp = 72f
@@ -131,11 +129,9 @@ fun HomeScreen(
         }
     }
 
-    // Home can show the same item in several rows at once; the claim registry
-    // ensures only one visible card owns the hero shared-element key (see
-    // HeroClaimRegistry) so duplicates don't morph into each other.
-    val heroClaims = remember { HeroClaimRegistry() }
-    CompositionLocalProvider(LocalHeroClaimRegistry provides heroClaims) {
+    // Home can show the same item in several rows at once. Each poster placement
+    // now carries a unique hero key (see MediaCard) so duplicates never collide
+    // in the shared-transition layout — no per-screen claim registry needed.
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -242,7 +238,6 @@ fun HomeScreen(
             onApprove = companionPairingViewModel::approveMatchCode,
             onCancel = companionPairingViewModel::cancelMatchCode,
         )
-    }
     }
 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
@@ -93,6 +93,7 @@ import org.siloserver.silo.android.ui.screens.home.FeaturedCarousel
 import org.siloserver.silo.android.ui.screens.home.HomeSectionRow
 import org.siloserver.silo.android.ui.screens.profiles.ProfileAvatar
 import org.siloserver.silo.android.ui.theme.SiloSurfaceElevated
+import org.siloserver.silo.android.ui.util.formatCardDate
 import org.siloserver.silo.android.ui.util.rememberDominantColor
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.catalog.BrowseItem
@@ -834,6 +835,7 @@ private fun BrowseTabContent(
             }
         }
 
+        // Sort chips on their own row.
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -849,6 +851,24 @@ private fun BrowseTabContent(
                     colors = libraryChipColors(state.browseSort == sort),
                 )
             }
+        }
+
+        // View-density on its own labelled row so it no longer reads as another
+        // sort option sitting beside the sort chips (Jim QA 2026-07-09). iOS
+        // phone has no density control; its FilterSheet groups it under "View".
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = "View",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
             CatalogViewDensity.entries.forEach { density ->
                 FilterChip(
                     selected = state.catalogDensity == density,
@@ -894,6 +914,13 @@ private fun BrowseTabContent(
                     hasMore = state.catalogHasMore,
                     onItemClick = onItemClick,
                     onLoadMore = onLoadMore,
+                    // Date sorts surface the sorted-by date under each card
+                    // (mirrors the standalone BrowseScreen), Jim QA 2026-07-09.
+                    cardSubtitle = when (state.browseSort.sortField) {
+                        "added_at" -> { item -> formatCardDate(item.addedAt) }
+                        "release_date" -> { item -> formatCardDate(item.releaseDate) }
+                        else -> null
+                    },
                     selectedNamePrefix = state.selectedNamePrefix,
                     onNamePrefixSelected = onNamePrefixChanged,
                     viewDensity = state.catalogDensity,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
@@ -703,7 +703,6 @@ fun LibrariesScreen(
                         onItemClick = onItemClick,
                         onPlayClick = onPlayClick,
                         onRetry = viewModel::retryCurrentTab,
-                        onSeeAllClick = viewModel::showBrowseFromRecommended,
                         onActiveBackdropChange = { url, thumbhash ->
                             heroBackdropUrl = url
                             heroBackdropThumbhash = thumbhash
@@ -758,7 +757,6 @@ private fun RecommendedTabContent(
     onItemClick: (String) -> Unit,
     onPlayClick: (String, Double?) -> Unit,
     onRetry: () -> Unit,
-    onSeeAllClick: () -> Unit,
     onActiveBackdropChange: (url: String?, thumbhash: String?) -> Unit,
 ) {
     when {
@@ -832,10 +830,11 @@ private fun RecommendedTabContent(
                     items = regularSections,
                     key = { section -> section.id },
                 ) { section ->
+                    // No "See All" — iOS has no such affordance (H3, Jim
+                    // 2026-07-10); the row omits it when onSeeAllClick is null.
                     HomeSectionRow(
                         section = section,
                         onItemClick = onItemClick,
-                        onSeeAllClick = { onSeeAllClick() },
                     )
                 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
@@ -228,9 +228,18 @@ class LibrariesViewModel(
                     val libraries = result.data
                         .filterNot(::isHiddenAudiobookLibrary)
                         .sortedBy { library -> library.sortOrder }
-                    val selectedLibraryId = _uiState.value.selectedLibraryId
+                    val previousLibraryId = _uiState.value.selectedLibraryId
+                    val selectedLibraryId = previousLibraryId
                         ?.takeIf { currentId -> libraries.any { it.id == currentId } }
                         ?: libraries.firstOrNull()?.id
+                    // When this resolves to a *new* library (first load, or the
+                    // prior one vanished), restore its saved browse filter +
+                    // preserve state — same as selectLibrary — so opening Browse
+                    // on the default library isn't an unfiltered grid for a
+                    // profile with saved filters. An unchanged selection keeps
+                    // whatever filters are already active.
+                    val restoreBrowsePrefs =
+                        selectedLibraryId != null && selectedLibraryId != previousLibraryId
 
                     _uiState.update {
                         it.copy(
@@ -238,6 +247,12 @@ class LibrariesViewModel(
                             libraries = libraries,
                             selectedLibraryId = selectedLibraryId,
                             librariesError = null,
+                            filterState = if (restoreBrowsePrefs)
+                                (browsePrefs?.savedState(selectedLibraryId) ?: CatalogFilterState())
+                            else it.filterState,
+                            preserveFilters = if (restoreBrowsePrefs)
+                                (browsePrefs?.preserveEnabled(selectedLibraryId) ?: true)
+                            else it.preserveFilters,
                         )
                     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
@@ -86,9 +86,23 @@ import org.siloserver.silo.android.ui.components.MediaGridDefaults
 import org.siloserver.silo.android.ui.components.MediaRowsSkeleton
 import org.siloserver.silo.android.ui.components.PosterGridSkeleton
 import org.siloserver.silo.android.ui.components.rememberShimmerProgress
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.IconButton
+import org.siloserver.silo.android.ui.screens.browse.BrowsePrefsStore
 import org.siloserver.silo.android.ui.screens.browse.CatalogGrid
 import org.siloserver.silo.android.ui.screens.browse.CatalogViewDensity
+import org.siloserver.silo.android.ui.screens.browse.FilterSheet
+import org.siloserver.silo.android.ui.screens.browse.facetValueLabel
 import org.siloserver.silo.android.ui.screens.browse.normalizeCatalogNamePrefix
+import org.siloserver.silo.catalog.filter.BrowseFacetMediaType
+import org.siloserver.silo.catalog.filter.CatalogFacet
+import org.siloserver.silo.catalog.filter.CatalogFilterQueryBuilder
+import org.siloserver.silo.catalog.filter.CatalogFilterState
+import org.siloserver.silo.model.catalog.CatalogFiltersResponse
+import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.android.ui.screens.home.FeaturedCarousel
 import org.siloserver.silo.android.ui.screens.home.HomeSectionRow
 import org.siloserver.silo.android.ui.screens.profiles.ProfileAvatar
@@ -144,8 +158,14 @@ data class LibrariesUiState(
     val catalogItems: List<BrowseItem> = emptyList(),
     val catalogTotal: Int = 0,
     val catalogHasMore: Boolean = false,
-    val browseGenres: List<String> = emptyList(),
-    val selectedBrowseGenre: String? = null,
+    // Full filter model shared with the standalone Browse screen: facets
+    // (genre/decade/rating/studio/language/series/...), match-all/any, and the
+    // available-filter vocabulary from the server. Genre is a Categories facet
+    // here — no more inline genre chip rail (L3).
+    val filterState: CatalogFilterState = CatalogFilterState(),
+    val availableFilters: CatalogFiltersResponse? = null,
+    val browseMediaType: BrowseFacetMediaType = BrowseFacetMediaType.Video,
+    val preserveFilters: Boolean = true,
     val selectedNamePrefix: String? = null,
     val catalogDensity: CatalogViewDensity = CatalogViewDensity.Normal,
     val browseSort: LibraryBrowseSort = LibraryBrowseSort.RecentlyAdded,
@@ -163,6 +183,7 @@ class LibrariesViewModel(
     private val userItemState: org.siloserver.silo.repository.port.UserItemStatePort =
         org.siloserver.silo.repository.port.NoOpUserItemStatePort,
     private val playerSettingsStore: org.siloserver.silo.common.settings.PlayerSettingsStore? = null,
+    private val browsePrefs: BrowsePrefsStore? = null,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(LibrariesUiState())
     val uiState: StateFlow<LibrariesUiState> = _uiState.asStateFlow()
@@ -261,8 +282,12 @@ class LibrariesViewModel(
                 catalogItems = emptyList(),
                 catalogTotal = 0,
                 catalogHasMore = false,
-                browseGenres = emptyList(),
-                selectedBrowseGenre = null,
+                // Restore this library's persisted filter/preserve state (iOS
+                // parity) so a preserved selection doesn't flash the unfiltered
+                // grid; default to a clean filter when nothing is saved.
+                filterState = browsePrefs?.savedState(libraryId) ?: CatalogFilterState(),
+                availableFilters = null,
+                preserveFilters = browsePrefs?.preserveEnabled(libraryId) ?: true,
                 selectedNamePrefix = null,
                 catalogError = null,
                 collections = emptyList(),
@@ -278,16 +303,27 @@ class LibrariesViewModel(
         _uiState.value.selectedLibraryId?.let { loadCurrentTab(it, force = false) }
     }
 
-    fun selectBrowseGenre(genre: String?) {
+    /** Apply a new facet/match filter selection, persist it (when preserve is
+     *  on), and reload the catalog. Mirrors BrowseViewModel.applyFilterState. */
+    fun applyFilterState(state: CatalogFilterState) {
+        if (state == _uiState.value.filterState) return
         _uiState.update {
             it.copy(
-                selectedBrowseGenre = genre,
+                filterState = state,
                 catalogItems = emptyList(),
                 catalogTotal = 0,
                 catalogHasMore = false,
             )
         }
+        browsePrefs?.saveState(_uiState.value.selectedLibraryId, state)
         _uiState.value.selectedLibraryId?.let { loadCatalog(it, reset = true, force = true) }
+    }
+
+    fun setPreserveFilters(enabled: Boolean) {
+        val libraryId = _uiState.value.selectedLibraryId
+        browsePrefs?.setPreserveEnabled(libraryId, enabled)
+        _uiState.update { it.copy(preserveFilters = enabled) }
+        if (enabled) browsePrefs?.saveState(libraryId, _uiState.value.filterState)
     }
 
     fun selectBrowseSort(sort: LibraryBrowseSort) {
@@ -398,11 +434,14 @@ class LibrariesViewModel(
             val state = _uiState.value
             val offset = if (reset) 0 else state.catalogItems.size
 
-            if (reset && state.browseGenres.isEmpty()) {
+            if (reset && state.availableFilters == null) {
                 launch {
-                    when (val filters = catalogRepository.getFilters(libraryId)) {
+                    // includeTechnical: resolution + audio/subtitle-language facets
+                    // are only fetched on request (iOS parity). Keep the FULL
+                    // response so the filter sheet has every facet, not just genres.
+                    when (val filters = catalogRepository.getFilters(libraryId, includeTechnical = true)) {
                         is ApiResult.Success -> {
-                            _uiState.update { it.copy(browseGenres = filters.data.genres) }
+                            _uiState.update { it.copy(availableFilters = filters.data) }
                         }
                         else -> Unit
                     }
@@ -427,17 +466,30 @@ class LibrariesViewModel(
             when (
                 val result = catalogRepository.browse(
                     libraryId = libraryId,
-                    genre = state.selectedBrowseGenre,
                     sort = state.browseSort.sortField,
                     order = state.browseSort.sortOrder,
                     offset = offset,
                     limit = pageSize,
                     namePrefix = state.selectedNamePrefix,
+                    // Full facet filtering (genre/decade/rating/studio/language/...)
+                    // via the shared query builder — replaces the single-genre param.
+                    queryGroups = CatalogFilterQueryBuilder.buildGroups(state.filterState),
+                    match = CatalogFilterQueryBuilder.matchParam(state.filterState)
+                        .takeIf { state.filterState.hasActiveFilters },
                 )
             ) {
                 is ApiResult.Success -> {
                     // Overlay local optimistic watched/favorite (mirrors Home/Browse).
                     val overlaid = overlayLocalState(result.data.items)
+                    // Audiobook libraries expose book-native facets
+                    // (author/narrator/series) — detected from the first item.
+                    val detectedMediaType = overlaid.firstOrNull()?.let { first ->
+                        if (isAudiobookItemType(first.type)) {
+                            BrowseFacetMediaType.Audiobook
+                        } else {
+                            BrowseFacetMediaType.Video
+                        }
+                    }
                     _uiState.update {
                         it.copy(
                             isLoadingCatalog = false,
@@ -445,6 +497,7 @@ class LibrariesViewModel(
                             catalogItems = if (reset) overlaid else it.catalogItems + overlaid,
                             catalogTotal = result.data.total,
                             catalogHasMore = result.data.hasMore,
+                            browseMediaType = detectedMediaType ?: it.browseMediaType,
                             catalogError = null,
                         )
                     }
@@ -661,10 +714,11 @@ fun LibrariesScreen(
                         onItemClick = onItemClick,
                         onRetry = viewModel::retryCurrentTab,
                         onLoadMore = viewModel::loadMoreCatalog,
-                        onGenreChanged = viewModel::selectBrowseGenre,
                         onSortChanged = viewModel::selectBrowseSort,
                         onNamePrefixChanged = viewModel::selectNamePrefix,
                         onDensityChanged = viewModel::selectViewDensity,
+                        onApplyFilter = viewModel::applyFilterState,
+                        onSetPreserve = viewModel::setPreserveFilters,
                     )
                     LibrariesSubtab.Collections -> CollectionsTabContent(
                         state = state,
@@ -799,83 +853,78 @@ private fun BrowseTabContent(
     onItemClick: (String) -> Unit,
     onRetry: () -> Unit,
     onLoadMore: () -> Unit,
-    onGenreChanged: (String?) -> Unit,
     onSortChanged: (LibraryBrowseSort) -> Unit,
     onNamePrefixChanged: (String?) -> Unit,
     onDensityChanged: (CatalogViewDensity) -> Unit,
+    onApplyFilter: (CatalogFilterState) -> Unit,
+    onSetPreserve: (Boolean) -> Unit,
 ) {
+    var showFilterSheet by remember { mutableStateOf(false) }
     Column(
         modifier = Modifier
             .fillMaxSize()
             .windowInsetsPadding(WindowInsets.statusBars)
             .padding(top = LibrariesChromeContentHeight),
     ) {
-        if (state.browseGenres.isNotEmpty()) {
+        // Sort chips + a Filter button that opens the shared FilterSheet. Genre
+        // is now a Categories facet inside the sheet (no inline genre rail, L3),
+        // and view-density moved into the sheet's "View" section (L4).
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState())
-                    .padding(horizontal = 16.dp),
+                    .weight(1f)
+                    .horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                FilterChip(
-                    selected = state.selectedBrowseGenre == null,
-                    onClick = { onGenreChanged(null) },
-                    label = { Text("All") },
-                    colors = libraryChipColors(state.selectedBrowseGenre == null),
-                )
-                state.browseGenres.forEach { genre ->
+                LibraryBrowseSort.entries.forEach { sort ->
                     FilterChip(
-                        selected = state.selectedBrowseGenre == genre,
-                        onClick = { onGenreChanged(genre) },
-                        label = { Text(genre) },
-                        colors = libraryChipColors(state.selectedBrowseGenre == genre),
+                        selected = state.browseSort == sort,
+                        onClick = { onSortChanged(sort) },
+                        label = { Text(sort.label) },
+                        colors = libraryChipColors(state.browseSort == sort),
+                    )
+                }
+            }
+            BadgedBox(
+                badge = {
+                    if (state.filterState.activeFacetCount > 0) {
+                        Badge { Text("${state.filterState.activeFacetCount}") }
+                    }
+                },
+            ) {
+                IconButton(onClick = { showFilterSheet = true }) {
+                    Icon(
+                        imageVector = Icons.Default.FilterList,
+                        contentDescription = "Filters",
                     )
                 }
             }
         }
 
-        // Sort chips on their own row.
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            LibraryBrowseSort.entries.forEach { sort ->
-                FilterChip(
-                    selected = state.browseSort == sort,
-                    onClick = { onSortChanged(sort) },
-                    label = { Text(sort.label) },
-                    colors = libraryChipColors(state.browseSort == sort),
-                )
-            }
-        }
-
-        // View-density on its own labelled row so it no longer reads as another
-        // sort option sitting beside the sort chips (Jim QA 2026-07-09). iOS
-        // phone has no density control; its FilterSheet groups it under "View".
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(bottom = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Text(
-                text = "View",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            CatalogViewDensity.entries.forEach { density ->
-                FilterChip(
-                    selected = state.catalogDensity == density,
-                    onClick = { onDensityChanged(density) },
-                    label = { Text(density.label) },
-                    colors = libraryChipColors(state.catalogDensity == density),
-                )
+        // Active filter chips — removable capsules, one per selected facet value.
+        if (state.filterState.hasActiveFilters) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                CatalogFacet.available(state.browseMediaType).forEach { facet ->
+                    state.filterState.valuesFor(facet).sorted().forEach { value ->
+                        LibraryActiveFilterChip(
+                            label = facetValueLabel(facet, value),
+                            onRemove = { onApplyFilter(state.filterState.toggle(facet, value)) },
+                        )
+                    }
+                }
             }
         }
 
@@ -928,6 +977,54 @@ private fun BrowseTabContent(
                 )
             }
         }
+    }
+
+    if (showFilterSheet) {
+        FilterSheet(
+            viewDensity = state.catalogDensity,
+            onSelectDensity = onDensityChanged,
+            currentFilters = state.filterState,
+            availableFilters = state.availableFilters,
+            mediaType = state.browseMediaType,
+            preserveFilters = state.preserveFilters,
+            onCommit = onApplyFilter,
+            onSetPreserve = onSetPreserve,
+            onDismiss = { showFilterSheet = false },
+        )
+    }
+}
+
+/**
+ * Removable active-filter capsule chip for the Libraries browse tab (mirrors the
+ * standalone Browse screen's private chip). Removing a chip toggles that one
+ * facet value off.
+ */
+@Composable
+private fun LibraryActiveFilterChip(
+    label: String,
+    onRemove: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = 10.dp, vertical = 5.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Icon(
+            imageVector = Icons.Filled.Cancel,
+            contentDescription = "Remove filter",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .size(14.dp)
+                .clickable(onClick = onRemove),
+        )
     }
 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/EditProfileViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/EditProfileViewModel.kt
@@ -43,6 +43,14 @@ class EditProfileViewModel(
     private var existingProfiles: List<Profile> = emptyList()
 
     /**
+     * Whether the loaded profile already had a PIN. Needed to distinguish
+     * "remove the existing PIN" (send an explicit empty string) from "there was
+     * never a PIN" (omit the field). The shared Json uses explicitNulls=false,
+     * so a null pin is dropped from the PUT and the server keeps the old value.
+     */
+    private var loadedHasPin: Boolean = false
+
+    /**
      * Loads the profile by ID. Called once from the composable via LaunchedEffect.
      * We fetch the full list and find the matching profile because the repository
      * API does not expose a getProfile(id) method.
@@ -56,6 +64,7 @@ class EditProfileViewModel(
                     existingProfiles = result.data
                     val profile = result.data.find { it.id == profileId }
                     if (profile != null) {
+                        loadedHasPin = profile.hasPin
                         _uiState.update {
                             it.copy(
                                 isLoading = false,
@@ -138,7 +147,10 @@ class EditProfileViewModel(
 
     fun onSubtitleModeSelected(mode: String) {
         _uiState.update {
-            it.copy(subtitleMode = if (mode == "Off") null else mode.lowercase().replace(" ", "_"))
+            // "Off" must go over the wire as the explicit "off" value, not null:
+            // explicitNulls=false drops a null subtitle_mode so the server would
+            // keep the previous mode instead of switching subtitles off.
+            it.copy(subtitleMode = if (mode == "Off") "off" else mode.lowercase().replace(" ", "_"))
         }
     }
 
@@ -158,13 +170,24 @@ class EditProfileViewModel(
             return
         }
 
+        // Map the PIN state onto the wire value the server expects:
+        //  - a freshly entered 4-digit PIN sets/replaces the PIN;
+        //  - turning a PIN off on a profile that had one sends an explicit ""
+        //    so the server clears it (a null would be omitted and ignored);
+        //  - otherwise omit the field (null) to leave the PIN unchanged.
+        val pinValue = when {
+            current.pinEnabled && current.pin.isNotEmpty() -> current.pin
+            !current.pinEnabled && loadedHasPin -> ""
+            else -> null
+        }
+
         viewModelScope.launch {
             _uiState.update { it.copy(isSaving = true, error = null) }
 
             val request = UpdateProfileRequest(
                 name = current.name,
                 avatar = current.selectedAvatar,
-                pin = if (current.pinEnabled && current.pin.isNotEmpty()) current.pin else null,
+                pin = pinValue,
                 isChild = current.isChild,
                 maxContentRating = current.maxContentRating,
                 qualityPreference = current.qualityPreference,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reading/ReadingHubScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reading/ReadingHubScreen.kt
@@ -112,7 +112,6 @@ fun ReadingHubScreen(
             },
             onRetry = viewModel::retryCurrentTab,
             onRefreshLibraries = viewModel::refresh,
-            onShowBrowse = viewModel::showBrowseFromRecommended,
             onLoadMore = viewModel::loadMoreCatalog,
             onGenreChanged = viewModel::selectBrowseGenre,
             onSortChanged = viewModel::selectBrowseSort,
@@ -278,7 +277,6 @@ private fun ReadingHubContent(
     onCollectionClick: (String) -> Unit,
     onRetry: () -> Unit,
     onRefreshLibraries: () -> Unit,
-    onShowBrowse: () -> Unit,
     onLoadMore: () -> Unit,
     onGenreChanged: (String?) -> Unit,
     onSortChanged: (LibraryBrowseSort) -> Unit,
@@ -330,7 +328,6 @@ private fun ReadingHubContent(
                         state = state,
                         onItemClick = onItemClick,
                         onRetry = onRetry,
-                        onShowBrowse = onShowBrowse,
                     )
                     LibrariesSubtab.Browse -> ReadingBrowseTab(
                         state = state,
@@ -375,7 +372,6 @@ private fun ReadingRecommendedTab(
     state: ReadingHubUiState,
     onItemClick: (String) -> Unit,
     onRetry: () -> Unit,
-    onShowBrowse: () -> Unit,
 ) {
     when {
         state.isLoadingSections && state.sections.isEmpty() -> {
@@ -407,10 +403,10 @@ private fun ReadingRecommendedTab(
                     key = { section -> section.id },
                     contentType = { "reading-section-row" },
                 ) { section ->
+                    // No "See All" — iOS parity (H3, Jim 2026-07-10).
                     HomeSectionRow(
                         section = section.readingFriendlySection(),
                         onItemClick = onItemClick,
-                        onSeeAllClick = { onShowBrowse() },
                     )
                 }
             }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/recommendations/RecommendationsScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/recommendations/RecommendationsScreen.kt
@@ -66,8 +66,6 @@ import org.koin.compose.viewmodel.koinViewModel
 fun RecommendationsScreen(
     onItemClick: (String) -> Unit,
     contentTopPadding: Dp = 0.dp,
-    onWatchlistClick: () -> Unit = {},
-    onFavoritesClick: () -> Unit = {},
     viewModel: RecommendationsViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
@@ -178,41 +176,64 @@ fun RecommendationsScreen(
         }
 
         else -> {
-            PullToRefreshBox(
-                isRefreshing = state.isRefreshing,
-                onRefresh = { viewModel.refresh() },
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    // Keep room for the floating bottom nav while preserving iOS
-                    // section rhythm inside the list.
-                    contentPadding = PaddingValues(bottom = 96.dp),
-                    // iOS sectionSpacing (phone) = largePadding (24).
-                    verticalArrangement = Arrangement.spacedBy(24.dp),
-                ) {
-                    item {
-                        Spacer(modifier = Modifier.height(contentTopPadding + 8.dp))
-                    }
-
-                    // iOS renders the SavedShortcutsRow above the sections at all
-                    // times (it is not gated on having recommendations).
-                    item {
-                        SavedShortcutsRow(
-                            onWatchlistClick = onWatchlistClick,
-                            onFavoritesClick = onFavoritesClick,
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                        )
-                    }
-
-                    items(
-                        items = state.sections,
-                        key = { it.id },
-                    ) { section ->
-                        HomeSectionRow(
-                            section = section,
-                            onItemClick = onItemClick,
-                        )
+            // Watchlist / Favorites toggle IN PLACE over the recommendations feed
+            // instead of navigating to a separate page (Jim 2026-07-09 — a
+            // deliberate divergence from iOS, which navigates when recs exist).
+            // The pill row is pinned above the content so it is always reachable;
+            // null selection shows the recommendation sections, and re-tapping the
+            // active pill returns to them.
+            var savedListSelection by rememberSaveable { mutableStateOf<SavedList?>(null) }
+            Column(modifier = Modifier.fillMaxSize()) {
+                Spacer(modifier = Modifier.height(contentTopPadding + 8.dp))
+                SavedShortcutsRow(
+                    onWatchlistClick = {
+                        savedListSelection =
+                            if (savedListSelection == SavedList.Watchlist) null else SavedList.Watchlist
+                    },
+                    onFavoritesClick = {
+                        savedListSelection =
+                            if (savedListSelection == SavedList.Favorites) null else SavedList.Favorites
+                    },
+                    selection = savedListSelection,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                when (savedListSelection) {
+                    SavedList.Watchlist -> WatchlistGridContent(
+                        onItemClick = onItemClick,
+                        modifier = Modifier.weight(1f),
+                        contentPadding = PaddingValues(bottom = 96.dp),
+                    )
+                    SavedList.Favorites -> FavoritesGridContent(
+                        onItemClick = onItemClick,
+                        modifier = Modifier.weight(1f),
+                        contentPadding = PaddingValues(bottom = 96.dp),
+                    )
+                    null -> PullToRefreshBox(
+                        isRefreshing = state.isRefreshing,
+                        onRefresh = { viewModel.refresh() },
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                    ) {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            // Keep room for the floating bottom nav while preserving
+                            // iOS section rhythm inside the list.
+                            contentPadding = PaddingValues(bottom = 96.dp),
+                            // iOS sectionSpacing (phone) = largePadding (24).
+                            verticalArrangement = Arrangement.spacedBy(24.dp),
+                        ) {
+                            items(
+                                items = state.sections,
+                                key = { it.id },
+                            ) { section ->
+                                HomeSectionRow(
+                                    section = section,
+                                    onItemClick = onItemClick,
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/MobileAppleParitySourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/MobileAppleParitySourceTest.kt
@@ -53,13 +53,21 @@ class MobileAppleParitySourceTest {
             recommendations.contains("SavedShortcutsRow("),
             "For You should expose iOS's saved Watchlist/Favorites shortcut row before recommendations.",
         )
+        // For You Watchlist/Favorites toggle the saved list IN PLACE over the feed
+        // rather than navigating to a separate page — a deliberate divergence from
+        // iOS chosen by Jim (2026-07-09). The saved-list routes still exist and are
+        // reachable from Settings (asserted below), just not from these shortcuts.
         assertTrue(
-            mainScreen.contains("onWatchlistClick = { navController.navigate(Route.Watchlist.route) }"),
-            "The For You Watchlist shortcut should navigate to the existing Watchlist route.",
+            recommendations.contains(
+                "if (savedListSelection == SavedList.Watchlist) null else SavedList.Watchlist",
+            ),
+            "The For You Watchlist shortcut should toggle the saved list in place, not navigate.",
         )
         assertTrue(
-            mainScreen.contains("onFavoritesClick = { navController.navigate(Route.Favorites.route) }"),
-            "The For You Favorites shortcut should navigate to the existing Favorites route.",
+            recommendations.contains(
+                "if (savedListSelection == SavedList.Favorites) null else SavedList.Favorites",
+            ),
+            "The For You Favorites shortcut should toggle the saved list in place, not navigate.",
         )
         assertTrue(
             settings.contains("SettingsSectionHeader(title = \"Library\")"),

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/MobileSharedElementSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/MobileSharedElementSourceTest.kt
@@ -37,10 +37,12 @@ class MobileSharedElementSourceTest {
     fun sharedScopesArePublishedFromTheHost() {
         assertTrue(
             appNavigation.contains("SharedTransitionLayout(modifier = Modifier.fillMaxSize())") &&
-                appNavigation.contains("CompositionLocalProvider(LocalSharedTransitionScope provides this)") &&
+                appNavigation.contains("LocalSharedTransitionScope provides this") &&
+                appNavigation.contains("LocalHeroSourceHandoff provides heroSourceHandoff") &&
                 appNavigation.contains("CompositionLocalProvider(LocalNavAnimatedVisibilityScope provides this)"),
             "AppNavigation must wrap the NavHost in a SharedTransitionLayout and publish " +
-                "both the shared-transition scope and the per-destination visibility scope.",
+                "the shared-transition scope, the per-destination visibility scope, and the " +
+                "hero source hand-off.",
         )
     }
 
@@ -49,10 +51,12 @@ class MobileSharedElementSourceTest {
         assertTrue(
             sharedElement.contains("val LocalSharedTransitionScope") &&
                 sharedElement.contains("val LocalNavAnimatedVisibilityScope") &&
-                sharedElement.contains("fun Modifier.heroSharedBounds(") &&
+                sharedElement.contains("class HeroSourceHandoff") &&
+                sharedElement.contains("fun Modifier.heroSource(") &&
+                sharedElement.contains("fun Modifier.heroTarget(") &&
                 sharedElement.contains("ResizeMode.RemeasureToBounds"),
-            "SharedElementTransition must expose both scope locals and a heroSharedBounds " +
-                "modifier that remeasures artwork to the animated bounds.",
+            "SharedElementTransition must expose both scope locals, the source hand-off, and " +
+                "heroSource/heroTarget modifiers that remeasure artwork to the animated bounds.",
         )
     }
 
@@ -60,8 +64,13 @@ class MobileSharedElementSourceTest {
     fun posterCardsEnrollAsHeroSources() {
         assertTrue(
             mediaCard.contains("sharedContentId: String? = null") &&
-                mediaCard.contains(".heroSharedBounds(sharedContentId)"),
-            "MediaCard must accept a sharedContentId and tag its poster as the hero source.",
+                mediaCard.contains(".heroSource(heroKey)") &&
+                // Unique per-placement key so duplicate content ids in different
+                // rows never collide (the flicker fix).
+                mediaCard.contains("UUID.randomUUID()") &&
+                mediaCard.contains("heroHandoff?.pendingKey = heroKey"),
+            "MediaCard must derive a unique per-placement hero key, publish it on tap, and " +
+                "tag its poster as the hero source.",
         )
         assertTrue(
             mediaRow.contains("sharedContentId = item.contentId"),
@@ -77,8 +86,9 @@ class MobileSharedElementSourceTest {
     fun detailBackdropIsTheHeroTarget() {
         assertTrue(
             detailShared.contains("contentId = detail.contentId") &&
-                detailShared.contains(".heroSharedBounds(contentId)"),
-            "The detail backdrop must tag itself as the hero target keyed on the content id.",
+                detailShared.contains(".heroTarget()"),
+            "The detail backdrop must tag itself as the hero target that pairs with the " +
+                "tapped poster via the source hand-off.",
         )
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAuroraBackdrop.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAuroraBackdrop.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.tv.ui.components
 
+import android.graphics.Bitmap
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -14,6 +15,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageShader
+import androidx.compose.ui.graphics.ShaderBrush
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.drawscope.withTransform
@@ -66,6 +72,14 @@ fun TvAuroraBackdrop(
         val rng = Random(0x5110)
         List(90) { Triple(rng.nextFloat(), rng.nextFloat() * 0.62f, 0.25f + rng.nextFloat() * 0.55f) }
     }
+
+    // Deterministic dither grain. These plum-night gradients quantize into
+    // visible 8-bit bands on the Shield (Android 11, no RenderEffect blur to
+    // smear them). A tiled tile of per-pixel ±luminance noise at ~4% alpha,
+    // painted over the final composite, is ordered dithering: it nudges each
+    // pixel randomly across the band boundary so the eye stops seeing steps,
+    // with no perceptible texture (Jim TV QA TS3, 2026-07-10).
+    val grain = remember { buildDitherGrain() }
 
     Box(modifier = modifier.fillMaxSize().background(NightBottom)) {
         // Glow layer: night gradient + additive bloom + additive aurora glows.
@@ -173,7 +187,37 @@ fun TvAuroraBackdrop(
                     Brush.verticalGradient(listOf(NightBottom.copy(alpha = 0.66f), Color.Transparent)),
                 ),
         )
+
+        // Dither grain on top of everything, so it breaks up the banding of the
+        // final composite (glows, vignette, and scrims all band on 8-bit). Tiled
+        // 1:1 in pixels so the grain stays sub-pixel-fine at any resolution.
+        Canvas(Modifier.matchParentSize()) {
+            drawRect(
+                brush = ShaderBrush(ImageShader(grain, TileMode.Repeated, TileMode.Repeated)),
+                size = size,
+            )
+        }
     }
+}
+
+/**
+ * A small square of monochrome dither noise: each pixel is fully black or fully
+ * white at a low, constant alpha, so painting it (SrcOver) over a gradient
+ * randomly pushes each covered pixel slightly lighter or darker — dithering the
+ * 8-bit banding. Kept tiny and tiled ([TileMode.Repeated]) so it costs one small
+ * bitmap regardless of screen size and stays grain-fine when tiled 1:1.
+ */
+private fun buildDitherGrain(): ImageBitmap {
+    val dim = 160
+    val alpha = 10 // ~4% — enough to cross a band step, below visible-texture.
+    val rng = Random(0x6261)
+    val pixels = IntArray(dim * dim) {
+        val channel = if (rng.nextBoolean()) 0xFF else 0x00
+        (alpha shl 24) or (channel shl 16) or (channel shl 8) or channel
+    }
+    return Bitmap.createBitmap(dim, dim, Bitmap.Config.ARGB_8888)
+        .apply { setPixels(pixels, 0, dim, 0, 0, dim, dim) }
+        .asImageBitmap()
 }
 
 /**

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt
@@ -138,17 +138,12 @@ fun TvServerSetupScreen(
     }
     LaunchedEffect(isActivePairing) {
         if (!isActivePairing) {
-            // First sign-in (no URL yet): land on the SETUP WITH PHONE card so
-            // the viewer decides between the two paths instead of being
-            // dropped into the URL field. Returning users (URL pre-filled
-            // after a sign-out) keep the field focused.
-            runCatching {
-                if (viewModel.uiState.value.serverUrl.isBlank()) {
-                    phoneSetupFocus.requestFocus()
-                } else {
-                    focusRequester.requestFocus()
-                }
-            }
+            // Always land on the server-address field, matching tvOS
+            // (TVServerSetupView `.defaultFocus(.host)`). The user chooses "Set
+            // up with phone" by navigating to it — we don't pre-select it for
+            // them (Jim TV QA 2026-07-10). Returning users keep the pre-filled
+            // field focused too.
+            runCatching { focusRequester.requestFocus() }
         }
     }
     LaunchedEffect(pairingStatus) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -428,8 +428,10 @@ class TvItemDetailViewModel(
             it.copy(selectedFileId = fileId, selectedAudioIndex = null, selectedSubtitleIndex = null)
         }
         TvDetailTrackSelectionSession.remember(contentId, fileId, audio = null, subtitle = null)
-        persistTrackSelection()
-        // Restore any durable override saved for the newly-selected file.
+        // Do NOT persist here: a version switch resets the indexes to null, and
+        // persisting null clears the durable row — which would wipe the newly
+        // selected file's saved override before seedPersistedTrackSelection can
+        // restore it. Only explicit audio/subtitle picks persist.
         _uiState.value.detail?.let(::seedPersistedTrackSelection)
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -6,10 +6,16 @@ import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.model.catalog.CastMember
 import org.siloserver.silo.model.catalog.EpisodeListItem
+import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.catalog.Season
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.catalog.sortedForDisplay
+import org.siloserver.silo.playback.SUBTITLE_OFF_FINGERPRINT
+import org.siloserver.silo.playback.audioTrackFingerprint
+import org.siloserver.silo.playback.resolveAudioTrackOrdinal
+import org.siloserver.silo.playback.resolveSubtitleTrackOrdinal
+import org.siloserver.silo.playback.subtitleTrackFingerprint
 import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.CatalogRepository
@@ -239,6 +245,8 @@ class TvItemDetailViewModel(
                             error = null,
                         )
                     }
+                    // Restore a durably-persisted audio/subtitle override (TM4).
+                    seedPersistedTrackSelection(detail)
                     when (detail.type.lowercase()) {
                         "series" -> loadSeasons(seriesContentId = detail.contentId)
                         "season",
@@ -420,6 +428,9 @@ class TvItemDetailViewModel(
             it.copy(selectedFileId = fileId, selectedAudioIndex = null, selectedSubtitleIndex = null)
         }
         TvDetailTrackSelectionSession.remember(contentId, fileId, audio = null, subtitle = null)
+        persistTrackSelection()
+        // Restore any durable override saved for the newly-selected file.
+        _uiState.value.detail?.let(::seedPersistedTrackSelection)
     }
 
     /** Pre-select an audio track for the next Play (index into the version's audioTracks). */
@@ -427,6 +438,7 @@ class TvItemDetailViewModel(
         _uiState.update { it.copy(selectedAudioIndex = index) }
         val state = _uiState.value
         TvDetailTrackSelectionSession.remember(contentId, state.selectedFileId, index, state.selectedSubtitleIndex)
+        persistTrackSelection()
     }
 
     /** Pre-select a subtitle track for the next Play (-1 = Off, null = auto). */
@@ -434,6 +446,67 @@ class TvItemDetailViewModel(
         _uiState.update { it.copy(selectedSubtitleIndex = index) }
         val state = _uiState.value
         TvDetailTrackSelectionSession.remember(contentId, state.selectedFileId, state.selectedAudioIndex, index)
+        persistTrackSelection()
+    }
+
+    /** The version behind [TvItemDetailUiState.selectedFileId], or the default
+     *  (first) version when nothing is explicitly selected. */
+    private fun selectedVersionFor(state: TvItemDetailUiState, detail: ItemDetail): FileVersion? {
+        val fileId = state.selectedFileId
+        return if (fileId != null) detail.versions.firstOrNull { it.fileId == fileId }
+        else detail.versions.firstOrNull()
+    }
+
+    /**
+     * Durably persist the current audio/subtitle override for the selected
+     * version's file, so it survives leaving/re-opening the page AND the process
+     * (the in-memory [TvDetailTrackSelectionSession] only covers this process).
+     * Mirrors the phone I7 fix and tvOS TrackSelectionPersistence: record the
+     * catalog track's fingerprint against the shared UserItemStatePort keyed on
+     * (contentId, fileId); Auto (null) clears, explicit Off writes the off
+     * sentinel.
+     */
+    private fun persistTrackSelection() {
+        val state = _uiState.value
+        val detail = state.detail ?: return
+        val version = selectedVersionFor(state, detail) ?: return
+        val subtitleFingerprint = when (val idx = state.selectedSubtitleIndex) {
+            null -> null
+            -1 -> SUBTITLE_OFF_FINGERPRINT
+            else -> version.subtitleTracks.orEmpty().getOrNull(idx)?.let(::subtitleTrackFingerprint)
+        }
+        val audioFingerprint = when (val idx = state.selectedAudioIndex) {
+            null -> null
+            else -> version.audioTracks.orEmpty().getOrNull(idx)?.let(::audioTrackFingerprint)
+        }
+        viewModelScope.launch {
+            userItemState.recordSubtitleTrackSelection(contentId, version.fileId, subtitleFingerprint)
+            userItemState.recordAudioTrackSelection(contentId, version.fileId, audioFingerprint)
+        }
+    }
+
+    /**
+     * Seed the audio/subtitle selection from a previously persisted override for
+     * the selected version's file. Skips when a selection is already set (the
+     * in-memory session recall or the current pick wins), and only applies a
+     * dimension when a saved fingerprint matches a current track.
+     */
+    private fun seedPersistedTrackSelection(detail: ItemDetail) {
+        val state = _uiState.value
+        if (state.selectedSubtitleIndex != null || state.selectedAudioIndex != null) return
+        val version = selectedVersionFor(state, detail) ?: return
+        viewModelScope.launch {
+            val saved = userItemState.localTrackSelection(contentId, version.fileId) ?: return@launch
+            val subOrdinal = resolveSubtitleTrackOrdinal(version.subtitleTracks.orEmpty(), saved.subtitleFingerprint)
+            val audOrdinal = resolveAudioTrackOrdinal(version.audioTracks.orEmpty(), saved.audioFingerprint)
+            if (subOrdinal == null && audOrdinal == null) return@launch
+            _uiState.update {
+                it.copy(
+                    selectedSubtitleIndex = it.selectedSubtitleIndex ?: subOrdinal,
+                    selectedAudioIndex = it.selectedAudioIndex ?: audOrdinal,
+                )
+            }
+        }
     }
 
     fun onSeasonSelected(seasonNumber: Int) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -503,6 +503,10 @@ class TvItemDetailViewModel(
             val audOrdinal = resolveAudioTrackOrdinal(version.audioTracks.orEmpty(), saved.audioFingerprint)
             if (subOrdinal == null && audOrdinal == null) return@launch
             _uiState.update {
+                // The ordinals were resolved against `version`; if the user
+                // switched versions while this suspended, they'd index into the
+                // wrong track list — leave the new version untouched.
+                if (selectedVersionFor(it, detail)?.fileId != version.fileId) return@update it
                 it.copy(
                     selectedSubtitleIndex = it.selectedSubtitleIndex ?: subOrdinal,
                     selectedAudioIndex = it.selectedAudioIndex ?: audOrdinal,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt
@@ -858,7 +858,10 @@ private fun HudVideoPane(
                     )
                 }
 
-                val hasQualityChoice = videoQualities.size > 2
+                // The server-transcode quality ladder always offers at least
+                // Auto + Original (plus downscale rungs below the source), so the
+                // row is enabled whenever there is more than one option.
+                val hasQualityChoice = videoQualities.size > 1
                 val selectedQuality = videoQualities.firstOrNull { it.isSelected }
                 val qualityValue = selectedQuality?.label ?: "Auto"
                 HudFocusedSettingRow(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -898,8 +898,9 @@ fun TvPlayerScreen(
                     val audio = extractTrackEntries(tracks, C.TRACK_TYPE_AUDIO)
                     val subtitle = extractTrackEntries(tracks, C.TRACK_TYPE_TEXT)
                     val video = extractTrackEntries(tracks, C.TRACK_TYPE_VIDEO)
-                    val videoQualities = extractVideoQualityOptions(tracks)
-                    viewModel.onTracksChanged(audio, subtitle, video, videoQualities)
+                    // Quality is a server-transcode ladder built by the VM at
+                    // session load (tvOS parity), not the adaptive variants.
+                    viewModel.onTracksChanged(audio, subtitle, video)
                 }
                 override fun onVideoSizeChanged(videoSize: VideoSize) {
                     // MediaController doesn't expose ExoPlayer's `videoFormat`
@@ -1515,17 +1516,9 @@ fun TvPlayerScreen(
                                 }
                             },
                             onSelectVideoQuality = { id ->
-                                // Real Media3 video track override: clears the
-                                // override for Auto, otherwise pins the chosen
-                                // resolution/bitrate variant within the video group.
-                                mediaController?.let {
-                                    if (selectVideoQuality(it, id)) {
-                                        val resolution = state.videoQualities
-                                            .firstOrNull { option -> option.id == id }
-                                            ?.resolution
-                                        viewModel.onVideoQualitySelectionApplied(resolution)
-                                    }
-                                }
+                                // Server-transcode quality ladder (tvOS parity):
+                                // re-request the session at the chosen rung.
+                                viewModel.switchQuality(id)
                             },
                             onSelectSubtitle = { idx -> applyTvSubtitleSelection(idx, false) },
                             onVideoFillModeChanged = viewModel::onVideoFillModeChanged,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -2019,7 +2019,21 @@ class TvPlayerViewModel(
         _uiState.update {
             it.copy(videoQualities = transcodeQualityLadder(it.selectedFileResolution, wireValue))
         }
-        loadContent(startPositionOverride = _uiState.value.position, suppressResumeRewind = true)
+        val resumeAt = _uiState.value.position.takeIf { it > 0.0 }
+        val staleSessionId = _uiState.value.sessionId
+        // A quality change restarts the session, exactly like onSelectFileVersion
+        // and retry — so share their single-flight guard: supersede any in-flight
+        // switch/retry and stop the old server session first, or loadContent's
+        // adoptActiveSession leaves the previous session orphaned until timeout
+        // and two load pipelines can race.
+        versionSwitchJob?.cancel()
+        versionSwitchJob = viewModelScope.launch {
+            if (staleSessionId != null) {
+                runCatching { playbackSessionManager.stopSession(staleSessionId) }
+            }
+            coroutineContext.ensureActive()
+            loadContent(startPositionOverride = resumeAt, suppressResumeRewind = true)
+        }
     }
 
     /**

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -5,6 +5,7 @@ package org.siloserver.silo.tv.ui.screens.player
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import org.siloserver.silo.tv.data.preferences.PlaybackQuality
 import org.siloserver.silo.common.player.PlaybackAnalyticsListener
 import org.siloserver.silo.common.player.PlaybackCapabilityDetector
 import org.siloserver.silo.common.player.PlaybackRecoveryAction
@@ -529,6 +530,11 @@ class TvPlayerViewModel(
      */
     private val preferredFileId: Int? = launchArgs.preferredFileId
     private val preferredQuality: String? = launchArgs.preferredQuality
+    // Session-level video-quality override chosen in the player's Quality menu
+    // (a server transcode ladder, tvOS ApplePlaybackQuality parity). Null =
+    // fall back to the profile/launch preference. Wire values match
+    // [PlaybackQuality]: "auto"/"original"/"2160p"/"1080p"/"720p"/"480p".
+    private var qualityOverride: String? = null
     private val roomId: String? = launchArgs.roomId
     private val resumePositionOverride: Double? = launchArgs.resumePositionOverride
 
@@ -943,7 +949,7 @@ class TvPlayerViewModel(
                         resumePositionOverride = startPositionOverride,
                         audioTrackIndex = initialAudioTrackIndex,
                         subtitleTrackIndex = pendingInitialSubtitleIndex,
-                        preferredQualityOverride = preferredQuality,
+                        preferredQualityOverride = qualityOverride ?: preferredQuality,
                         suppressResumeRewind = suppressResumeRewind,
                     ),
                 )
@@ -986,6 +992,12 @@ class TvPlayerViewModel(
                                 selectedFileId = result.fileId,
                                 fileVersions = result.versions,
                                 selectedFileResolution = result.fileResolution,
+                                // Server-transcode quality ladder for this source
+                                // (tvOS parity) — replaces adaptive-variant options.
+                                videoQualities = transcodeQualityLadder(
+                                    result.fileResolution,
+                                    qualityOverride ?: preferredQuality ?: PlaybackQuality.Auto.wireValue,
+                                ),
                                 mediaFileId = result.mediaFileId,
                                 startPosition = result.startPositionSeconds,
                                 position = result.startPositionSeconds,
@@ -1724,14 +1736,15 @@ class TvPlayerViewModel(
         audio: List<PlayerTrackEntry>,
         subtitle: List<PlayerTrackEntry>,
         video: List<PlayerTrackEntry>,
-        videoQualities: List<VideoQualityOption> = emptyList(),
     ) {
+        // videoQualities is the server-transcode ladder built at session load
+        // (see loadContent) — NOT derived from the mounted adaptive variants, so
+        // it is intentionally not touched here.
         _uiState.update {
             it.copy(
                 audioTracks = audio,
                 subtitleTracks = subtitle,
                 videoTracks = video,
-                videoQualities = videoQualities,
             )
         }
         // The detail-page explicit pick resolves FIRST so a resolved pick can
@@ -1991,6 +2004,56 @@ class TvPlayerViewModel(
 
     fun onVideoQualitySelectionApplied(resolution: String?) {
         _uiState.update { it.copy(selectedFileResolution = resolution) }
+    }
+
+    /**
+     * Switch the in-player video quality (tvOS ApplePlaybackQuality parity): pin
+     * a session-level [qualityOverride] and re-request the session at the current
+     * position so the server transcodes to the chosen rung (or returns to
+     * Auto/Original). [wireValue] is a [PlaybackQuality] wire value.
+     */
+    fun switchQuality(wireValue: String) {
+        val current = qualityOverride ?: preferredQuality ?: PlaybackQuality.Auto.wireValue
+        if (wireValue == current) return
+        qualityOverride = wireValue
+        _uiState.update {
+            it.copy(videoQualities = transcodeQualityLadder(it.selectedFileResolution, wireValue))
+        }
+        loadContent(startPositionOverride = _uiState.value.position, suppressResumeRewind = true)
+    }
+
+    /**
+     * The server-transcode quality ladder for the current source: Auto + Original
+     * always, plus each downscale rung whose height is below the source (never
+     * offer an upscale). Wire values / labels come from [PlaybackQuality].
+     */
+    private fun transcodeQualityLadder(
+        sourceResolution: String?,
+        selectedWire: String,
+    ): List<VideoQualityOption> {
+        val sourceHeight = sourceResolution?.filter { it.isDigit() }?.toIntOrNull() ?: Int.MAX_VALUE
+        val rungs = listOf(
+            PlaybackQuality.P4K,
+            PlaybackQuality.P1080,
+            PlaybackQuality.P720,
+            PlaybackQuality.P480,
+        ).filter { tierHeight(it) < sourceHeight }
+        return (listOf(PlaybackQuality.Auto, PlaybackQuality.Original) + rungs).map {
+            VideoQualityOption(
+                id = it.wireValue,
+                label = it.label,
+                isSelected = it.wireValue == selectedWire,
+                resolution = it.wireValue,
+            )
+        }
+    }
+
+    private fun tierHeight(q: PlaybackQuality): Int = when (q) {
+        PlaybackQuality.P4K -> 2160
+        PlaybackQuality.P1080 -> 1080
+        PlaybackQuality.P720 -> 720
+        PlaybackQuality.P480 -> 480
+        else -> Int.MAX_VALUE
     }
 
     /**

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -1055,6 +1055,11 @@ fun TvMainShell(
                             navigateToSecondary(TvMainRoute.Favorites.route)
                             moveFocusToContent(TvMainRoute.Favorites.route)
                         },
+                        onRecommendations = {
+                            focusState.closePanel(false)
+                            navigateToSecondary(TvMainRoute.ForYou.route)
+                            moveFocusToContent(TvMainRoute.ForYou.route)
+                        },
                     )
                 }
             }
@@ -1318,6 +1323,7 @@ private fun TvForYouDropdown(
     focusEntryToken: Int,
     onWatchlist: () -> Unit,
     onFavorites: () -> Unit,
+    onRecommendations: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val firstFocus = remember { FocusRequester() }
@@ -1342,6 +1348,13 @@ private fun TvForYouDropdown(
             onClick = onWatchlist,
         )
         ProfileDropdownRow(label = "Favorites", icon = Icons.Filled.Favorite, onClick = onFavorites)
+        // tvOS parity: the For You dropdown's third row (sparkles) returns to the
+        // recommendations feed (Jim TV QA 2026-07-10).
+        ProfileDropdownRow(
+            label = "Recommendations",
+            icon = Icons.Filled.AutoAwesome,
+            onClick = onRecommendations,
+        )
     }
 }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvAuthFocusSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvAuthFocusSourceTest.kt
@@ -24,10 +24,12 @@ class TvAuthFocusSourceTest {
         assertTrue(serverSetupSource.contains(".imePadding()"))
         assertTrue(serverSetupSource.contains("keyboardController?.show()"))
         assertTrue(serverSetupSource.contains("LaunchedEffect(isActivePairing)"))
-        // First sign-in anchors on the SETUP WITH PHONE card; a pre-filled URL
-        // (returning user) keeps the field focus. Both are crash-guarded.
-        assertTrue(serverSetupSource.contains("phoneSetupFocus.requestFocus()"))
-        assertTrue(serverSetupSource.contains("focusRequester.requestFocus()"))
+        // Initial focus always anchors on the server-address field (tvOS
+        // .defaultFocus(.host)); the user chooses "Set up with phone" by
+        // navigating to it — it is NOT auto-focused (Jim TV QA 2026-07-10).
+        // Crash-guarded via runCatching.
+        assertTrue(serverSetupSource.contains("runCatching { focusRequester.requestFocus() }"))
+        assertFalse(serverSetupSource.contains("phoneSetupFocus.requestFocus()"))
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerControlsUsabilityTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerControlsUsabilityTest.kt
@@ -275,21 +275,18 @@ class TvPlayerControlsUsabilityTest {
     }
 
     @Test
-    fun qualityRowAppliesRealVideoTrackOverrideAndDisablesWhenNoChoice() {
-        // Quality must be a genuine Media3 video-track override, not a silent
-        // no-op that just closes the dialog. The screen wires onSelectVideoQuality
-        // to selectVideoQuality on the live player, which sets/clears an override.
-        assertTrue(screenSource.contains("selectVideoQuality(it, id)"))
-        assertTrue(screenSource.contains("viewModel.onVideoQualitySelectionApplied("))
-        assertTrue(screenSource.contains("setOverrideForType("))
-        assertTrue(screenSource.contains("clearOverridesOfType(C.TRACK_TYPE_VIDEO)"))
-        // The old no-op onSelectVideo wiring is gone.
-        assertFalse(screenSource.contains("but no-op on tap"))
-        // Quality options come from the real per-format variants (resolution /
-        // bitrate), and the row disables when there is no genuine choice.
-        assertTrue(screenSource.contains("fun extractVideoQualityOptions("))
-        assertTrue(screenSource.contains("fun formatVideoQualityLabel("))
-        assertTrue(hudSource.contains("val hasQualityChoice = videoQualities.size > 2"))
+    fun qualityRowOffersServerTranscodeLadder() {
+        // Quality is a server-transcode ladder (tvOS ApplePlaybackQuality parity):
+        // selecting a rung re-requests the session at that quality rather than
+        // pinning a Media3 adaptive-variant override.
+        assertTrue(screenSource.contains("viewModel.switchQuality(id)"))
+        // The ladder is built by the VM from the source resolution + selected
+        // quality, offering at least Auto + Original (plus downscale rungs).
+        assertTrue(viewModelSource.contains("fun transcodeQualityLadder("))
+        assertTrue(viewModelSource.contains("PlaybackQuality.Auto, PlaybackQuality.Original"))
+        // Row is enabled whenever more than one option exists (always ≥ 2), so a
+        // single-file movie is no longer stuck with a disabled Quality row.
+        assertTrue(hudSource.contains("val hasQualityChoice = videoQualities.size > 1"))
         assertTrue(hudSource.contains("enabled = enabled && hasQualityChoice"))
         // Quality is no longer keyed off the group-level videoTracks.size count.
         assertFalse(hudSource.contains("videoTracks.size > 1"))
@@ -524,7 +521,10 @@ class TvPlayerControlsUsabilityTest {
         assertTrue(routeSource.contains("if (quality != null) add(\"quality=\${quality.routeEncode()}\")"))
         assertTrue(navigationSource.contains("TvRoute.Player(contentId = nextContentId, quality = nextQuality"))
         assertTrue(navigationSource.contains("preferredQuality = preferredQuality"))
-        assertTrue(viewModelSource.contains("preferredQualityOverride = preferredQuality"))
+        // In-player Quality menu can pin a session override that wins over the
+        // launch/profile preference (TP3 transcode ladder).
+        assertTrue(viewModelSource.contains("preferredQualityOverride = qualityOverride ?: preferredQuality"))
+        assertTrue(viewModelSource.contains("fun switchQuality(wireValue: String)"))
     }
 
     @Test


### PR DESCRIPTION
Consolidated QA sweep across the phone (`androidApp`) and TV (`androidTvApp`) clients from Jim's on-device passes on 2026-07-09/10, mirroring silo-apple (iOS↔phone, tvOS↔TV). Supersedes #51 (its profile fix is included here as `06cb58f1`).

## Phone
- **Profile edit** — can now clear a PIN and set subtitles to Off (`06cb58f1`); duplicate-name pre-check + real server errors in forms.
- **Detail** — correct audio/subtitle track labels, subtitle-row gating, genre dedupe; persist per-item audio/subtitle overrides (I7); scroll-slop fix.
- **Libraries** — full filter sheet on the browse tab (L2/L3); removed "See All" from Libraries + Reading rows (H3); date subtitles + density/sort separation.
- **Calendar / For You** — month header + top padding; For You toggle applies in-place.
- **Posters** — per-placement hero keys eliminate poster flicker on shared-element transitions.

## Playback (shared)
- **HDR black screen** — force the hardware HEVC decoder via `MediaCodecSelector` so Media3 can't fall back to the software path that rendered black on Pixel Tensor. (`58d3ef7b`)
- **Stall watchdog** — now covers all playback routes (not just DIRECT) and catches mid-stream freezes, feeding the recovery planner. (TP7)

## TV
- **Sign-in** — server address field takes initial focus (TS4).
- **Detail** — durable audio/subtitle track persistence, ported from phone I7 (TM4).
- **Player** — in-player video quality selector backed by the server transcode ladder (TP3).
- **For You** — added the tvOS "Recommendations" dropdown row (TT2).
- **Aurora backdrop** — dither grain overlay to kill 8-bit gradient banding on the Shield (TS3).

## Verification
- `./gradlew :androidApp:assembleDebug :androidTvApp:assembleDebug test` — BUILD SUCCESSFUL, tests pass.
- Not yet installed on the Shield; device-retest items (TS1, TS5, TSet1, TP1, TCal1) are fixed in code and awaiting a fresh build on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advanced Browse filters, filter chips, active-filter counts, and filter preservation in Libraries.
  * Added in-place Watchlist and Favorites switching within Recommendations.
  * Added TV playback quality selection with server-based quality options.
  * Saved audio and subtitle selections now persist per media file.
  * Improved poster-to-detail transitions, calendar headers, and TV backdrop appearance.

* **Bug Fixes**
  * Improved playback startup-stall detection across playback methods.
  * Prevented subtitle controls from appearing when no subtitles are available.
  * Improved video surface handling and HEVC hardware decoder selection.
  * Fixed profile PIN and subtitle-off settings updates.
  * Improved TV setup focus and quality-control availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->