### PR TITLE
Use the phone profile for remote TV playback

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/cast/SiloCastNsdBrowser.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/cast/SiloCastNsdBrowser.kt
@@ -17,6 +17,9 @@ data class SiloCastTarget(
     val host: String,
     val port: Int,
     val version: Int,
+    val serverId: String? = null,
+    val serverName: String? = null,
+    val playing: Boolean = false,
     /** The mDNS instance name (may carry conflict decorations like " (2)").
      *  onServiceLost only reports this, so removal must match on it — the
      *  display name comes from the TXT record and can collide/diverge. */
@@ -104,7 +107,10 @@ class SiloCastNsdBrowser(context: Context) {
         val name = attributes.string("name") ?: serviceName
         val mdnsName = serviceName
         val deviceId = attributes.string("deviceId") ?: attributes.string("id") ?: "$host:$port"
-        val version = attributes.string("v")?.toIntOrNull() ?: SiloCastProtocol.version
+        val version = attributes.string("v")?.toIntOrNull() ?: 1
+        val serverId = attributes.string("server")
+        val serverName = attributes.string("serverName")
+        val playing = attributes.string("playing") == "1"
         return SiloCastTarget(
             serviceName = mdnsName,
             deviceId = deviceId,
@@ -112,6 +118,9 @@ class SiloCastNsdBrowser(context: Context) {
             host = host,
             port = port,
             version = version,
+            serverId = serverId,
+            serverName = serverName,
+            playing = playing,
         )
     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastController.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastController.kt
@@ -2,7 +2,9 @@ package org.siloserver.silo.android.cast
 
 import android.util.Log
 import java.io.OutputStream
+import java.util.UUID
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -15,10 +17,15 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import org.siloserver.silo.cast.SiloCastControlCommand
 import org.siloserver.silo.cast.SiloCastHello
+import org.siloserver.silo.cast.SiloCastHandoffCancel
+import org.siloserver.silo.cast.SiloCastHandoffChallenge
+import org.siloserver.silo.cast.SiloCastHandoffOffer
+import org.siloserver.silo.cast.SiloCastHandoffReady
 import org.siloserver.silo.cast.SiloCastLaunchRequest
 import org.siloserver.silo.cast.SiloCastMessage
 import org.siloserver.silo.cast.SiloCastPeerRole
@@ -32,12 +39,17 @@ import org.siloserver.silo.common.cast.SiloCastTarget
 import org.siloserver.silo.common.lan.SiloCastTls
 import org.siloserver.silo.common.lan.SiloCastTlsClientSession
 import org.siloserver.silo.network.ServerRegistry
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.getOrThrow
+import org.siloserver.silo.network.api.DeviceLoginApi
+import org.siloserver.silo.repository.ProfileRepository
 
 data class SiloCastControllerState(
     val targets: List<SiloCastTarget> = emptyList(),
     val connectedTarget: SiloCastTarget? = null,
     val playbackState: SiloCastPlaybackState? = null,
     val isConnecting: Boolean = false,
+    val isPreparingIdentity: Boolean = false,
     val error: String? = null,
 ) {
     val isConnected: Boolean get() = connectedTarget != null
@@ -54,6 +66,9 @@ data class SiloCastControllerState(
 class SiloCastController(
     private val browser: SiloCastNsdBrowser,
     private val serverRegistry: ServerRegistry,
+    private val tokenManager: TokenManager,
+    private val deviceLoginApi: DeviceLoginApi,
+    private val profileRepository: ProfileRepository,
     private val deviceNameProvider: () -> String,
     private val deviceIdProvider: () -> String,
 ) {
@@ -68,6 +83,7 @@ class SiloCastController(
     // targets otherwise interleave connect/teardown across IO coroutines and
     // tear the session vars.
     private val connectionMutex = Mutex()
+    private val launchMutex = Mutex()
     private val clock = SiloCastPlaybackClock()
 
     private val _state = MutableStateFlow(SiloCastControllerState())
@@ -76,6 +92,11 @@ class SiloCastController(
     private var session: SiloCastTlsClientSession? = null
     private var output: OutputStream? = null
     private var readJob: Job? = null
+    private var negotiatedVersion: Int? = null
+    private var helloDeferred: CompletableDeferred<Int>? = null
+    private var pendingHandoffRequestId: String? = null
+    private var challengeDeferred: CompletableDeferred<SiloCastHandoffChallenge>? = null
+    private var readyDeferred: CompletableDeferred<SiloCastHandoffReady>? = null
 
     init {
         scope.launch {
@@ -96,13 +117,115 @@ class SiloCastController(
     fun launchOnTarget(target: SiloCastTarget, request: SiloCastLaunchRequest) {
         scope.launch {
             runCatching {
-                ensureConnected(target)
-                send(SiloCastMessage.Launch(request))
+                launchMutex.withLock {
+                    launchWithPhoneIdentity(target, request)
+                }
             }.onFailure { error ->
                 if (error !is CancellationException) {
-                    _state.update { it.copy(isConnecting = false, error = error.message ?: "Unable to cast.") }
+                    _state.update {
+                        it.copy(
+                            isConnecting = false,
+                            isPreparingIdentity = false,
+                            error = error.message ?: "Unable to cast.",
+                        )
+                    }
                 }
             }
+        }
+    }
+
+    private suspend fun launchWithPhoneIdentity(
+        target: SiloCastTarget,
+        request: SiloCastLaunchRequest,
+    ) {
+        require(target.version >= 2) { "Update Silo on this TV to use your profile." }
+        val captured = tokenManager.snapshotCurrentScope()
+            ?: error("Choose a signed-in Silo server before playing on TV.")
+        val profileId = captured.profileId
+            ?.takeIf { it.isNotBlank() }
+            ?: error("Choose a profile before playing on TV.")
+        val profileName = profileRepository.getActiveProfile()?.name
+        require(request.serverId == captured.serverId) { "The active server changed. Try again." }
+
+        val version = ensureConnected(target)
+        require(version >= 2) { "Update Silo on this TV to use your profile." }
+
+        val requestId = UUID.randomUUID().toString()
+        pendingHandoffRequestId = requestId
+        challengeDeferred = CompletableDeferred()
+        readyDeferred = CompletableDeferred()
+        _state.update { it.copy(isPreparingIdentity = true, error = null) }
+        var userCode: String? = null
+
+        try {
+            send(
+                SiloCastMessage.HandoffOffer(
+                    SiloCastHandoffOffer(
+                        requestId = requestId,
+                        serverId = captured.serverId,
+                        serverURL = captured.serverUrl,
+                        serverName = serverRegistry.activeEntry.value?.displayName,
+                        profileId = profileId,
+                        profileName = profileName,
+                    ),
+                ),
+            )
+            val challenge = withTimeout(HANDOFF_TIMEOUT_MS) {
+                challengeDeferred?.await() ?: error("Profile handoff was cancelled.")
+            }
+            userCode = challenge.userCode
+            val lookup = deviceLoginApi.lookupRemotePlayback(challenge.userCode, captured).getOrThrow()
+            require(lookup.clientPurpose == "remote_playback" && lookup.temporary == true) {
+                "The TV requested an unsupported sign-in."
+            }
+            require(lookup.matchCode == challenge.matchCode) {
+                "The TV profile verification code did not match."
+            }
+            requireCurrentScope(captured.serverId, profileId)
+            deviceLoginApi.approveRemotePlayback(
+                token = null,
+                code = challenge.userCode,
+                scope = captured,
+            ).getOrThrow()
+
+            val ready = withTimeout(HANDOFF_TIMEOUT_MS) {
+                readyDeferred?.await() ?: error("Profile handoff was cancelled.")
+            }
+            require(
+                ready.requestId == requestId &&
+                    ready.serverId == captured.serverId &&
+                    ready.profileId == profileId,
+            ) { "The TV activated a different profile." }
+            requireCurrentScope(captured.serverId, profileId)
+            send(SiloCastMessage.Launch(request))
+            _state.update { it.copy(isPreparingIdentity = false, error = null) }
+        } catch (t: Throwable) {
+            userCode?.let { code ->
+                runCatching { deviceLoginApi.denyRemotePlayback(code, captured) }
+            }
+            runCatching {
+                send(
+                    SiloCastMessage.HandoffCancel(
+                        SiloCastHandoffCancel(
+                            requestId = requestId,
+                            reason = "controller_cancelled",
+                            message = null,
+                        ),
+                    ),
+                )
+            }
+            throw t
+        } finally {
+            pendingHandoffRequestId = null
+            challengeDeferred = null
+            readyDeferred = null
+        }
+    }
+
+    private suspend fun requireCurrentScope(serverId: String, profileId: String) {
+        val current = tokenManager.snapshotCurrentScope()
+        require(current?.serverId == serverId && current.profileId == profileId) {
+            "The active server or profile changed. Try again."
         }
     }
 
@@ -154,8 +277,10 @@ class SiloCastController(
         }
     }
 
-    private suspend fun ensureConnected(target: SiloCastTarget) = connectionMutex.withLock {
-        if (_state.value.connectedTarget?.deviceId == target.deviceId && session?.isConnected == true) return@withLock
+    private suspend fun ensureConnected(target: SiloCastTarget): Int = connectionMutex.withLock {
+        if (_state.value.connectedTarget?.deviceId == target.deviceId && session?.isConnected == true) {
+            return@withLock negotiatedVersion ?: error("The TV has not finished connecting.")
+        }
         closeConnectionLocked()
         _state.update { it.copy(isConnecting = true, error = null) }
         val newSession = withContext(Dispatchers.IO) {
@@ -163,10 +288,12 @@ class SiloCastController(
         }
         session = newSession
         output = newSession.output
+        val hello = CompletableDeferred<Int>()
+        helloDeferred = hello
         _state.update { it.copy(connectedTarget = target, isConnecting = false, error = null) }
-        send(SiloCastMessage.Hello(makeHello()))
         readJob = scope.launch { readLoop(newSession) }
-        Unit
+        send(SiloCastMessage.Hello(makeHello()))
+        withTimeout(HELLO_TIMEOUT_MS) { hello.await() }
     }
 
     private fun makeHello(): SiloCastHello {
@@ -177,7 +304,7 @@ class SiloCastController(
             deviceId = deviceIdProvider(),
             serverId = server?.id,
             serverName = server?.displayName,
-            supportedVersions = listOf(SiloCastProtocol.version),
+            supportedVersions = SiloCastProtocol.supportedVersions,
         )
     }
 
@@ -212,7 +339,31 @@ class SiloCastController(
 
     private suspend fun handleMessage(message: SiloCastMessage) {
         when (message) {
-            is SiloCastMessage.Hello -> Unit // receiver identity; nothing to act on
+            is SiloCastMessage.Hello -> {
+                val version = SiloCastProtocol.negotiatedVersion(message.hello.supportedVersions)
+                    ?: error("Update Silo on both devices to continue.")
+                negotiatedVersion = version
+                helloDeferred?.complete(version)
+            }
+            is SiloCastMessage.HandoffChallenge -> {
+                if (message.handoffChallenge.requestId == pendingHandoffRequestId) {
+                    challengeDeferred?.complete(message.handoffChallenge)
+                }
+            }
+            is SiloCastMessage.HandoffReady -> {
+                if (message.handoffReady.requestId == pendingHandoffRequestId) {
+                    readyDeferred?.complete(message.handoffReady)
+                }
+            }
+            is SiloCastMessage.HandoffCancel -> {
+                if (message.handoffCancel.requestId == pendingHandoffRequestId) {
+                    val error = IllegalStateException(
+                        message.handoffCancel.message ?: "Profile handoff was cancelled.",
+                    )
+                    challengeDeferred?.completeExceptionally(error)
+                    readyDeferred?.completeExceptionally(error)
+                }
+            }
             is SiloCastMessage.State -> {
                 clock.ingest(message.state, nowMs())
                 _state.update { it.copy(playbackState = message.state, error = null) }
@@ -242,9 +393,22 @@ class SiloCastController(
         runCatching { session?.close() }
         session = null
         output = null
+        val closed = IllegalStateException("The TV disconnected during profile handoff.")
+        helloDeferred?.completeExceptionally(closed)
+        challengeDeferred?.completeExceptionally(closed)
+        readyDeferred?.completeExceptionally(closed)
+        helloDeferred = null
+        negotiatedVersion = null
         readJob?.cancel()
         readJob = null
-        _state.update { it.copy(connectedTarget = null, playbackState = null, isConnecting = false) }
+        _state.update {
+            it.copy(
+                connectedTarget = null,
+                playbackState = null,
+                isConnecting = false,
+                isPreparingIdentity = false,
+            )
+        }
     }
 
     fun close() {
@@ -258,5 +422,7 @@ class SiloCastController(
     private companion object {
         const val TAG = "SiloCastController"
         const val CONNECT_TIMEOUT_MS = 5_000
+        const val HELLO_TIMEOUT_MS = 5_000L
+        const val HANDOFF_TIMEOUT_MS = 90_000L
     }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -178,6 +178,9 @@ val androidModule = module {
         SiloCastController(
             browser = get(),
             serverRegistry = get(),
+            tokenManager = get(),
+            deviceLoginApi = get(),
+            profileRepository = get(),
             deviceNameProvider = {
                 android.os.Build.MODEL?.trim()?.ifBlank { null } ?: "Android Phone"
             },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/cast/SiloCastTargetPickerSheet.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/cast/SiloCastTargetPickerSheet.kt
@@ -75,9 +75,20 @@ fun SiloCastTargetPickerSheet(
                 )
             } else {
                 state.targets.forEach { target ->
+                    val supportsIdentityHandoff = target.version >= 2
                     ListItem(
                         headlineContent = { Text(target.name) },
-                        supportingContent = { Text("${target.host}:${target.port}") },
+                        supportingContent = {
+                            Text(
+                                when {
+                                    !supportsIdentityHandoff ->
+                                        "Update Silo on this TV to use your profile."
+                                    target.serverId != launchRequest.serverId ->
+                                        "Temporarily use your phone's server and profile"
+                                    else -> "Use your phone profile"
+                                },
+                            )
+                        },
                         leadingContent = { Icon(Icons.Outlined.Cast, contentDescription = null) },
                         trailingContent = {
                             TextButton(
@@ -85,6 +96,7 @@ fun SiloCastTargetPickerSheet(
                                     controller.launchOnTarget(target, launchRequest)
                                     onDismiss()
                                 },
+                                enabled = supportsIdentityHandoff,
                             ) {
                                 Text("Play")
                             }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/cast/RemotePlaybackIdentityManager.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/cast/RemotePlaybackIdentityManager.kt
@@ -1,0 +1,258 @@
+package org.siloserver.silo.tv.cast
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import java.net.URI
+import java.time.Instant
+import java.util.UUID
+import kotlinx.coroutines.delay
+import org.siloserver.silo.cast.SiloCastHandoffChallenge
+import org.siloserver.silo.cast.SiloCastHandoffOffer
+import org.siloserver.silo.cast.SiloCastHandoffReady
+import org.siloserver.silo.cast.SiloCastProtocol
+import org.siloserver.silo.common.settings.LibraryPlaybackPrefsStore
+import org.siloserver.silo.common.settings.OverlayPrefsStore
+import org.siloserver.silo.model.auth.DeviceLoginCapabilityResponse
+import org.siloserver.silo.model.auth.DeviceLoginPollRequest
+import org.siloserver.silo.model.auth.DeviceLoginPollResponse
+import org.siloserver.silo.model.auth.DeviceLoginStartRequest
+import org.siloserver.silo.model.auth.DeviceLoginStartResponse
+import org.siloserver.silo.model.auth.DeviceLoginStatus
+import org.siloserver.silo.network.AndroidServerRegistry
+import org.siloserver.silo.network.ServerRegistry
+import org.siloserver.silo.network.TemporaryAuthScope
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.skipSiloAuth
+import org.siloserver.silo.tv.watchnext.WatchNextSeeder
+
+data class RemotePlaybackIdentity(
+    val generationId: String,
+    val serverId: String,
+    val serverUrl: String,
+    val serverName: String?,
+    val profileId: String,
+    val profileName: String?,
+    val controllerDeviceId: String,
+    val controllerDeviceName: String?,
+    val usesDifferentServer: Boolean,
+    val sessionExpiresAtEpochMs: Long,
+)
+
+/** Owns Android TV's playback-scoped, process-only phone identity. */
+class RemotePlaybackIdentityManager(
+    private val tokenManager: TokenManager,
+    private val serverRegistry: ServerRegistry,
+    private val authenticatedClient: HttpClient,
+    private val overlayPrefsStore: OverlayPrefsStore,
+    private val libraryPlaybackPrefsStore: LibraryPlaybackPrefsStore,
+    private val watchNextSeeder: WatchNextSeeder,
+    private val deviceNameProvider: () -> String,
+) {
+    @Volatile
+    var activeIdentity: RemotePlaybackIdentity? = null
+        private set
+
+    private val transport = ExplicitDeviceLoginTransport(authenticatedClient)
+
+    val effectiveServerId: String?
+        get() = activeIdentity?.serverId ?: serverRegistry.activeServerId.value
+
+    val effectiveServerName: String?
+        get() = activeIdentity?.serverName ?: serverRegistry.activeEntry.value?.displayName
+
+    fun matches(offer: SiloCastHandoffOffer, controllerDeviceId: String): Boolean =
+        activeIdentity?.let {
+            it.serverId == offer.serverId &&
+                it.profileId == offer.profileId &&
+                it.controllerDeviceId == controllerDeviceId
+        } == true
+
+    suspend fun prepare(
+        offer: SiloCastHandoffOffer,
+        controllerDeviceId: String,
+        controllerDeviceName: String?,
+        onChallenge: suspend (SiloCastHandoffChallenge) -> Unit,
+    ): SiloCastHandoffReady {
+        val normalizedUrl = validateOffer(offer)
+        activeIdentity?.takeIf { matches(offer, controllerDeviceId) }?.let { identity ->
+            return SiloCastHandoffReady(
+                requestId = offer.requestId,
+                serverId = identity.serverId,
+                profileId = identity.profileId,
+                sessionExpiresAt = Instant.ofEpochMilli(identity.sessionExpiresAtEpochMs).toString(),
+                reused = true,
+            )
+        }
+
+        val capability = transport.capability(normalizedUrl)
+        require(capability.remotePlaybackHandoff && SiloCastProtocol.version in capability.protocolVersions) {
+            "Update the phone's Silo server to use profile handoff."
+        }
+        val started = transport.start(normalizedUrl, deviceNameProvider())
+        require(started.clientPurpose == "remote_playback" && started.temporary == true) {
+            "The server does not support temporary profile handoff."
+        }
+        onChallenge(
+            SiloCastHandoffChallenge(
+                requestId = offer.requestId,
+                userCode = started.userCode,
+                matchCode = started.matchCode,
+                expiresAt = started.expiresAt,
+            ),
+        )
+
+        val deadline = System.currentTimeMillis() + started.expiresIn * 1_000L
+        while (System.currentTimeMillis() < deadline) {
+            val poll = transport.poll(normalizedUrl, started.deviceCode)
+            when (DeviceLoginStatus.fromWire(poll.status)) {
+                DeviceLoginStatus.Approved -> {
+                    val access = poll.accessToken?.takeIf { it.isNotBlank() }
+                        ?: error("The handoff response did not include an access token.")
+                    val refresh = poll.refreshToken?.takeIf { it.isNotBlank() }
+                        ?: error("The handoff response did not include a refresh token.")
+                    val profileToken = poll.profileToken?.takeIf { it.isNotBlank() }
+                        ?: error("The handoff response did not include a profile token.")
+                    require(poll.temporary == true && poll.profileId == offer.profileId) {
+                        "The server activated a different profile."
+                    }
+                    val expiresAt = poll.sessionExpiresAt
+                        ?.let { runCatching { Instant.parse(it).toEpochMilli() }.getOrNull() }
+                        ?: (System.currentTimeMillis() + MAX_SESSION_MS)
+                    if (activeIdentity != null) {
+                        end()
+                    }
+                    activate(
+                        identity = RemotePlaybackIdentity(
+                            generationId = UUID.randomUUID().toString(),
+                            serverId = offer.serverId,
+                            serverUrl = normalizedUrl,
+                            serverName = offer.serverName,
+                            profileId = offer.profileId,
+                            profileName = offer.profileName,
+                            controllerDeviceId = controllerDeviceId,
+                            controllerDeviceName = controllerDeviceName,
+                            usesDifferentServer = offer.serverId != serverRegistry.activeServerId.value,
+                            sessionExpiresAtEpochMs = expiresAt,
+                        ),
+                        accessToken = access,
+                        refreshToken = refresh,
+                        profileToken = profileToken,
+                    )
+                    return SiloCastHandoffReady(
+                        requestId = offer.requestId,
+                        serverId = offer.serverId,
+                        profileId = offer.profileId,
+                        sessionExpiresAt = Instant.ofEpochMilli(expiresAt).toString(),
+                        reused = false,
+                    )
+                }
+                DeviceLoginStatus.Denied -> error("Profile handoff was denied.")
+                DeviceLoginStatus.Expired,
+                DeviceLoginStatus.Consumed,
+                -> error("Profile handoff expired.")
+                DeviceLoginStatus.Pending,
+                DeviceLoginStatus.Unknown,
+                -> delay(((poll.pollAfter ?: started.interval).coerceAtLeast(1)) * 1_000L)
+            }
+        }
+        error("Profile handoff expired.")
+    }
+
+    suspend fun end() {
+        if (tokenManager.getTemporaryScope() == null && activeIdentity == null) return
+        runCatching { authenticatedClient.post("/api/v1/auth/logout") }
+        tokenManager.endTemporaryScope()
+        activeIdentity = null
+        clearIdentityCaches()
+    }
+
+    private suspend fun activate(
+        identity: RemotePlaybackIdentity,
+        accessToken: String,
+        refreshToken: String,
+        profileToken: String,
+    ) {
+        clearIdentityCaches()
+        tokenManager.beginTemporaryScope(
+            TemporaryAuthScope(
+                serverId = identity.serverId,
+                serverUrl = identity.serverUrl,
+                accessToken = accessToken,
+                refreshToken = refreshToken,
+                profileId = identity.profileId,
+                profileToken = profileToken,
+                controllerDeviceId = identity.controllerDeviceId,
+                expiresAtEpochMs = identity.sessionExpiresAtEpochMs,
+            ),
+        )
+        activeIdentity = identity
+    }
+
+    private fun validateOffer(offer: SiloCastHandoffOffer): String {
+        val normalized = AndroidServerRegistry.normalizeUrl(offer.serverURL)
+        val uri = runCatching { URI(normalized) }.getOrNull()
+        require(
+            normalized.isNotBlank() &&
+                uri != null &&
+                uri.scheme?.lowercase() in setOf("http", "https") &&
+                !uri.host.isNullOrBlank() &&
+                uri.userInfo == null &&
+                offer.profileId.isNotBlank() &&
+                AndroidServerRegistry.idFor(normalized) == offer.serverId,
+        ) { "The phone sent an invalid server or profile." }
+        return normalized
+    }
+
+    private fun clearIdentityCaches() {
+        overlayPrefsStore.clear()
+        libraryPlaybackPrefsStore.clear()
+        watchNextSeeder.clear()
+    }
+
+    private companion object {
+        const val MAX_SESSION_MS = 24 * 60 * 60 * 1_000L
+    }
+}
+
+/** Public start/poll transport pinned to the offered origin and carrying no TV credentials. */
+private class ExplicitDeviceLoginTransport(
+    private val client: HttpClient,
+) {
+
+    suspend fun capability(serverUrl: String): DeviceLoginCapabilityResponse =
+        client.get("$serverUrl/api/v1/auth/device/capability") {
+            skipSiloAuth()
+        }.checkedBody()
+
+    suspend fun start(serverUrl: String, deviceName: String): DeviceLoginStartResponse =
+        client.post("$serverUrl/api/v1/auth/device/start") {
+            skipSiloAuth()
+            contentType(ContentType.Application.Json)
+            setBody(
+                DeviceLoginStartRequest(
+                    deviceName = deviceName,
+                    devicePlatform = "android-tv",
+                    clientPurpose = "remote_playback",
+                    temporary = true,
+                ),
+            )
+        }.checkedBody()
+
+    suspend fun poll(serverUrl: String, deviceCode: String): DeviceLoginPollResponse =
+        client.post("$serverUrl/api/v1/auth/device/poll") {
+            skipSiloAuth()
+            contentType(ContentType.Application.Json)
+            setBody(DeviceLoginPollRequest(deviceCode))
+        }.checkedBody()
+
+    private suspend inline fun <reified T> io.ktor.client.statement.HttpResponse.checkedBody(): T {
+        check(status.isSuccess()) { "The phone's Silo server returned HTTP ${status.value}." }
+        return body()
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/cast/TvSiloCastReceiver.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/cast/TvSiloCastReceiver.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import org.siloserver.silo.cast.SiloCastError
 import org.siloserver.silo.cast.SiloCastHello
+import org.siloserver.silo.cast.SiloCastHandoffCancel
 import org.siloserver.silo.cast.SiloCastLaunchRequest
 import org.siloserver.silo.cast.SiloCastMessage
 import org.siloserver.silo.cast.SiloCastPeerRole
@@ -32,6 +33,7 @@ import org.siloserver.silo.common.cast.SiloCastNsdAdvertiser
 import org.siloserver.silo.common.lan.SiloCastTls
 import org.siloserver.silo.common.lan.SiloCastTlsSession
 import org.siloserver.silo.network.ServerRegistry
+import org.siloserver.silo.network.TokenManager
 
 /**
  * TV-side SiloCast receiver, session-semantics-compatible with silo-apple's
@@ -57,6 +59,8 @@ import org.siloserver.silo.network.ServerRegistry
 class TvSiloCastReceiver(
     private val advertiser: SiloCastNsdAdvertiser,
     private val serverRegistry: ServerRegistry,
+    private val tokenManager: TokenManager,
+    private val identityManager: RemotePlaybackIdentityManager,
     private val deviceNameProvider: () -> String,
     private val deviceIdProvider: () -> String,
 ) {
@@ -74,6 +78,7 @@ class TvSiloCastReceiver(
      *  register — they belong to the previous epoch. */
     private var sessionEpoch: Long = 0
     private var activePlayer: ActivePlayer? = null
+    private var pendingPlayerGeneration: String? = null
     private var launchHandler: ((SiloCastLaunchRequest) -> Unit)? = null
 
     @Synchronized
@@ -83,11 +88,10 @@ class TvSiloCastReceiver(
         scope = newScope
         newScope.launch {
             val socket = ServerSocket(0).also { serverSocket = it }
-            val server = serverRegistry.activeEntry.value
             advertiser.start(
                 port = socket.localPort,
-                serverId = server?.id,
-                serverName = server?.displayName,
+                serverId = identityManager.effectiveServerId,
+                serverName = identityManager.effectiveServerName,
                 playing = activePlayer != null,
             )
             Log.i(TAG, "SiloCast listening on ${socket.localPort} for ${SiloCastProtocol.serviceType}")
@@ -100,6 +104,7 @@ class TvSiloCastReceiver(
         // drive playback on the new one.
         newScope.launch {
             serverRegistry.activeEntry.drop(1).collect { entry ->
+                if (identityManager.activeIdentity != null) return@collect
                 closePreviousController()
                 val port = synchronized(this@TvSiloCastReceiver) { serverSocket?.localPort }
                 if (port != null) {
@@ -110,6 +115,11 @@ class TvSiloCastReceiver(
                         playing = activePlayer != null,
                     )
                 }
+            }
+        }
+        newScope.launch {
+            tokenManager.temporarySessionExpired.collect {
+                handleTemporarySessionExpired()
             }
         }
     }
@@ -141,14 +151,29 @@ class TvSiloCastReceiver(
         adapter: TvSiloCastPlayerAdapter,
         stateProvider: () -> SiloCastPlaybackState,
     ): Closeable {
-        val player = ActivePlayer(adapter = adapter, stateProvider = stateProvider)
+        val player = ActivePlayer(
+            adapter = adapter,
+            stateProvider = stateProvider,
+            handoffGeneration = pendingPlayerGeneration,
+        )
+        pendingPlayerGeneration = null
         activePlayer = player
+        activeSession?.readyTimeoutJob?.cancel()
+        activeSession?.readyTimeoutJob = null
         advertiser.updatePlaying(true)
         return Closeable {
             synchronized(this) {
                 if (activePlayer === player) {
                     activePlayer = null
                     advertiser.updatePlaying(false)
+                    if (player.handoffGeneration != null &&
+                        identityManager.activeIdentity?.generationId == player.handoffGeneration
+                    ) {
+                        scope?.launch {
+                            identityManager.end()
+                            refreshAdvertisement()
+                        }
+                    }
                 }
             }
         }
@@ -225,13 +250,15 @@ class TvSiloCastReceiver(
             coroutineScope {
                 session.job = coroutineContext[Job]
 
-                // TV speaks first: hello + current state, like tvOS.
+                // TV speaks first. State is withheld until the controller is
+                // authorized; a cross-server v2 peer gets only the handoff lane.
                 session.send(SiloCastMessage.Hello(makeHello()))
-                session.send(SiloCastMessage.State(currentState()))
 
                 val stateJob = launch {
                     while (isActive) {
-                        session.send(SiloCastMessage.State(currentState()))
+                        if (session.isAuthorized) {
+                            session.send(SiloCastMessage.State(currentState()))
+                        }
                         delay(STATE_INTERVAL_MS)
                     }
                 }
@@ -249,8 +276,8 @@ class TvSiloCastReceiver(
                 }
                 val authWatchdog = launch {
                     delay(AUTH_GRACE_MS)
-                    if (!session.isAuthorized) {
-                        Log.i(TAG, "SiloCast controller never authorized; closing")
+                    if (!session.didReceiveHello) {
+                        Log.i(TAG, "SiloCast controller never completed hello; closing")
                         session.goodbyeAndClose()
                     }
                 }
@@ -280,9 +307,30 @@ class TvSiloCastReceiver(
     private suspend fun handleMessage(session: ControllerSession, message: SiloCastMessage): Boolean {
         when (message) {
             is SiloCastMessage.Hello -> {
-                val activeServerId = serverRegistry.activeServerId.value
+                val version = SiloCastProtocol.negotiatedVersion(message.hello.supportedVersions)
+                if (message.hello.role != SiloCastPeerRole.Phone || version == null) {
+                    session.send(
+                        SiloCastMessage.Error(
+                            SiloCastError(
+                                code = "version_unsupported",
+                                message = "Update Silo on both devices to continue.",
+                            ),
+                        ),
+                    )
+                    session.goodbyeAndClose()
+                    return false
+                }
+                session.didReceiveHello = true
+                session.negotiatedVersion = version
+                session.controllerDeviceId = message.hello.deviceId
+                session.controllerDeviceName = message.hello.deviceName
+                session.controllerServerId = message.hello.serverId
+                val activeServerId = identityManager.effectiveServerId
                 val offered = message.hello.serverId
-                if (offered.isNullOrEmpty() || activeServerId == null || offered != activeServerId) {
+                if (!offered.isNullOrEmpty() && activeServerId != null && offered == activeServerId) {
+                    session.isAuthorized = true
+                    session.send(SiloCastMessage.State(currentState()))
+                } else if (version < 2) {
                     session.send(
                         SiloCastMessage.Error(
                             SiloCastError(
@@ -294,11 +342,46 @@ class TvSiloCastReceiver(
                     session.goodbyeAndClose()
                     return false
                 }
-                session.isAuthorized = true
+            }
+            is SiloCastMessage.HandoffOffer -> {
+                val controllerDeviceId = session.controllerDeviceId
+                if (session.negotiatedVersion != 2 || controllerDeviceId.isNullOrBlank()) {
+                    session.send(
+                        SiloCastMessage.HandoffCancel(
+                            SiloCastHandoffCancel(
+                                requestId = message.handoffOffer.requestId,
+                                reason = "version_unsupported",
+                                message = "Update Silo on both devices to continue.",
+                            ),
+                        ),
+                    )
+                    return true
+                }
+                beginHandoff(session, message.handoffOffer, controllerDeviceId)
+            }
+            is SiloCastMessage.HandoffCancel -> {
+                if (message.handoffCancel.requestId == session.pendingHandoffRequestId) {
+                    session.handoffJob?.cancel()
+                    session.handoffJob = null
+                    session.pendingHandoffRequestId = null
+                }
             }
             is SiloCastMessage.Launch -> {
                 if (!requireAuthorized(session)) return true
-                if (message.launch.serverId != serverRegistry.activeServerId.value) {
+                if (session.negotiatedVersion == 2 &&
+                    (!session.remoteIdentityReady || identityManager.activeIdentity == null)
+                ) {
+                    session.send(
+                        SiloCastMessage.Error(
+                            SiloCastError(
+                                code = "handoff_required",
+                                message = "Prepare the phone profile before playing.",
+                            ),
+                        ),
+                    )
+                    return true
+                }
+                if (message.launch.serverId != identityManager.effectiveServerId) {
                     session.send(
                         SiloCastMessage.Error(
                             SiloCastError(
@@ -311,6 +394,7 @@ class TvSiloCastReceiver(
                 }
                 val handler = launchHandler
                 if (handler != null) {
+                    pendingPlayerGeneration = identityManager.activeIdentity?.generationId
                     handler.invoke(message.launch)
                 } else {
                     // No launch handler is wired (setLaunchHandler is never
@@ -345,9 +429,119 @@ class TvSiloCastReceiver(
             is SiloCastMessage.Ping -> session.send(SiloCastMessage.Pong())
             is SiloCastMessage.Pong -> session.missedHeartbeats = 0
             is SiloCastMessage.Close -> return false
-            is SiloCastMessage.State, is SiloCastMessage.Error -> Unit
+            is SiloCastMessage.State,
+            is SiloCastMessage.Error,
+            is SiloCastMessage.HandoffChallenge,
+            is SiloCastMessage.HandoffReady,
+            -> Unit
         }
         return true
+    }
+
+    private fun beginHandoff(
+        session: ControllerSession,
+        offer: org.siloserver.silo.cast.SiloCastHandoffOffer,
+        controllerDeviceId: String,
+    ) {
+        session.handoffJob?.cancel()
+        session.pendingHandoffRequestId = offer.requestId
+        session.remoteIdentityReady = false
+        val owner = scope ?: return
+        session.handoffJob = owner.launch {
+            runCatching {
+                val ready = identityManager.prepare(
+                    offer,
+                    controllerDeviceId,
+                    session.controllerDeviceName,
+                ) { challenge ->
+                    if (activeSession !== session || session.pendingHandoffRequestId != offer.requestId) {
+                        throw CancellationException("Stale handoff")
+                    }
+                    session.send(SiloCastMessage.HandoffChallenge(challenge))
+                }
+                if (activeSession !== session || session.pendingHandoffRequestId != offer.requestId) {
+                    if (!ready.reused) identityManager.end()
+                    return@launch
+                }
+                session.pendingHandoffRequestId = null
+                session.handoffJob = null
+                session.isAuthorized = true
+                session.remoteIdentityReady = true
+                refreshAdvertisement()
+                session.send(SiloCastMessage.HandoffReady(ready))
+                armReadyTimeout(session)
+            }.onFailure { error ->
+                if (error is CancellationException || activeSession !== session) return@onFailure
+                runCatching {
+                    session.send(
+                        SiloCastMessage.HandoffCancel(
+                            SiloCastHandoffCancel(
+                                requestId = offer.requestId,
+                                reason = "handoff_failed",
+                                message = error.message ?: "Profile handoff failed.",
+                            ),
+                        ),
+                    )
+                }
+                session.pendingHandoffRequestId = null
+                session.handoffJob = null
+            }
+        }
+    }
+
+    private fun armReadyTimeout(session: ControllerSession) {
+        session.readyTimeoutJob?.cancel()
+        session.readyTimeoutJob = scope?.launch {
+            delay(READY_TIMEOUT_MS)
+            if (activeSession === session && session.remoteIdentityReady && activePlayer == null) {
+                identityManager.end()
+                session.remoteIdentityReady = false
+                pendingPlayerGeneration = null
+                session.isAuthorized = session.controllerServerId == identityManager.effectiveServerId
+                refreshAdvertisement()
+                runCatching {
+                    session.send(
+                        SiloCastMessage.Error(
+                            SiloCastError(
+                                code = "launch_timeout",
+                                message = "No content was launched, so the TV profile was restored.",
+                            ),
+                        ),
+                    )
+                }
+                session.goodbyeAndClose()
+            }
+        }
+    }
+
+    private fun refreshAdvertisement() {
+        val port = synchronized(this) { serverSocket?.localPort } ?: return
+        advertiser.start(
+            port = port,
+            serverId = identityManager.effectiveServerId,
+            serverName = identityManager.effectiveServerName,
+            playing = activePlayer != null,
+        )
+    }
+
+    private suspend fun handleTemporarySessionExpired() {
+        synchronized(this) { activePlayer?.adapter }?.handle(
+            org.siloserver.silo.cast.SiloCastControlCommand.stop(),
+        )
+        identityManager.end()
+        refreshAdvertisement()
+        activeSession?.let { session ->
+            runCatching {
+                session.send(
+                    SiloCastMessage.Error(
+                        SiloCastError(
+                            code = "temporary_session_expired",
+                            message = "The phone profile session expired.",
+                        ),
+                    ),
+                )
+            }
+        }
     }
 
     private suspend fun requireAuthorized(session: ControllerSession): Boolean {
@@ -379,14 +573,13 @@ class TvSiloCastReceiver(
     }
 
     private fun makeHello(): SiloCastHello {
-        val server = serverRegistry.activeEntry.value
         return SiloCastHello(
             role = SiloCastPeerRole.Tv,
             deviceName = deviceNameProvider(),
             deviceId = deviceIdProvider(),
-            serverId = server?.id,
-            serverName = server?.displayName,
-            supportedVersions = listOf(SiloCastProtocol.version),
+            serverId = identityManager.effectiveServerId,
+            serverName = identityManager.effectiveServerName,
+            supportedVersions = SiloCastProtocol.supportedVersions,
         )
     }
 
@@ -433,8 +626,31 @@ class TvSiloCastReceiver(
         var isAuthorized: Boolean = false
 
         @Volatile
+        var didReceiveHello: Boolean = false
+
+        @Volatile
+        var negotiatedVersion: Int? = null
+
+        @Volatile
+        var controllerDeviceId: String? = null
+
+        @Volatile
+        var controllerDeviceName: String? = null
+
+        @Volatile
+        var controllerServerId: String? = null
+
+        @Volatile
+        var pendingHandoffRequestId: String? = null
+
+        @Volatile
+        var remoteIdentityReady: Boolean = false
+
+        @Volatile
         var missedHeartbeats: Int = 0
         var job: Job? = null
+        var handoffJob: Job? = null
+        var readyTimeoutJob: Job? = null
 
         suspend fun send(message: SiloCastMessage) {
             val payload = json.encodeToString(SiloCastMessage.serializer(), message).encodeToByteArray()
@@ -466,6 +682,8 @@ class TvSiloCastReceiver(
         }
 
         fun close() {
+            handoffJob?.cancel()
+            readyTimeoutJob?.cancel()
             tls.close()
             runCatching { socket.close() }
             job?.cancel()
@@ -475,6 +693,7 @@ class TvSiloCastReceiver(
     private data class ActivePlayer(
         val adapter: TvSiloCastPlayerAdapter,
         val stateProvider: () -> SiloCastPlaybackState,
+        val handoffGeneration: String?,
     )
 
     private companion object {
@@ -486,5 +705,6 @@ class TvSiloCastReceiver(
         const val MAX_MISSED_HEARTBEATS = 3
         const val AUTH_GRACE_MS = 5_000L
         const val GOODBYE_TIMEOUT_MS = 1_000L
+        const val READY_TIMEOUT_MS = 60_000L
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -27,6 +27,7 @@ import org.siloserver.silo.common.cast.SiloCastNsdAdvertiser
 import org.siloserver.silo.common.player.video.VideoPlaybackSessionCoordinator
 import org.siloserver.silo.common.player.video.VideoPlaybackStarter
 import org.siloserver.silo.tv.cast.TvSiloCastReceiver
+import org.siloserver.silo.tv.cast.RemotePlaybackIdentityManager
 import org.siloserver.silo.tv.ui.screens.player.TvPlayerLaunchArgs
 import org.siloserver.silo.tv.ui.screens.auth.TvLoginViewModel
 import org.siloserver.silo.tv.ui.screens.auth.TvServerSetupViewModel
@@ -293,16 +294,55 @@ val androidTvModule = module {
     }
     single { SiloCastNsdAdvertiser(androidContext()) }
     single {
+        RemotePlaybackIdentityManager(
+            tokenManager = get(),
+            serverRegistry = get(),
+            authenticatedClient = get(),
+            overlayPrefsStore = get(),
+            libraryPlaybackPrefsStore = get(),
+            watchNextSeeder = get(),
+            deviceNameProvider = {
+                android.os.Build.MODEL?.trim()?.ifBlank { null } ?: "Android TV"
+            },
+        )
+    }
+    single {
         TvSiloCastReceiver(
             advertiser = get(),
             serverRegistry = get(),
+            tokenManager = get(),
+            identityManager = get(),
             deviceNameProvider = {
                 android.os.Build.MODEL?.trim()?.ifBlank { null } ?: "Android TV"
             },
             deviceIdProvider = {
                 org.siloserver.silo.common.pairing.PairingDeviceId.stable(androidContext())
             },
-        )
+        ).also { receiver ->
+            receiver.setLaunchHandler { request ->
+                val uri = android.net.Uri.Builder()
+                    .scheme("silo")
+                    .authority("play")
+                    .appendPath(request.playback.contentId)
+                    .apply {
+                        request.playback.fileId?.let { appendQueryParameter("fileId", it.toString()) }
+                        request.playback.audioTrackIndex?.let {
+                            appendQueryParameter("audioTrackIndex", it.toString())
+                        }
+                        request.playback.subtitleTrackIndex?.let {
+                            appendQueryParameter("subtitleTrackIndex", it.toString())
+                        }
+                        val resume = if (request.playback.startFromBeginning) {
+                            0.0
+                        } else {
+                            request.playback.resumePosition
+                        }
+                        resume?.let { appendQueryParameter("resumePosition", it.toString()) }
+                    }
+                    .build()
+                get<MutableStateFlow<Uri?>>(named("pendingDeepLink")).value = uri
+            }
+        }
     }
 
     // Auth ViewModels

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -147,13 +147,25 @@ fun TvAppNavigation(
                     // and falls through to [TvRoute.Player], preserving today's
                     // behavior for movie/episode tiles.
                     val itemType = uri.getQueryParameter("type")
-                    navController.navigate(
-                        tvPlayDestinationFor(
-                            itemType = itemType,
-                            contentId = contentId,
-                            fileId = null,
-                        ),
-                    )
+                    if (itemType.equals("audiobook", ignoreCase = true)) {
+                        navController.navigate(
+                            TvRoute.AudiobookPlayer(
+                                contentId = contentId,
+                                fileId = uri.getQueryParameter("fileId")?.toIntOrNull(),
+                                startPositionSeconds = uri.getQueryParameter("resumePosition")?.toDoubleOrNull(),
+                            ).route,
+                        )
+                    } else {
+                        navController.navigate(
+                            TvRoute.Player(
+                                contentId = contentId,
+                                fileId = uri.getQueryParameter("fileId")?.toIntOrNull(),
+                                resumePositionSeconds = uri.getQueryParameter("resumePosition")?.toDoubleOrNull(),
+                                audioTrackIndex = uri.getQueryParameter("audioTrackIndex")?.toIntOrNull(),
+                                subtitleTrackIndex = uri.getQueryParameter("subtitleTrackIndex")?.toIntOrNull(),
+                            ).route,
+                        )
+                    }
                 }
             }
             pendingDeepLink.value = null

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/RemotePlaybackIdentityNotice.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/RemotePlaybackIdentityNotice.kt
@@ -1,0 +1,64 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import org.siloserver.silo.tv.cast.RemotePlaybackIdentity
+
+@Composable
+internal fun RemotePlaybackIdentityNotice(identity: RemotePlaybackIdentity) {
+    val profile = identity.profileName?.trim()?.takeIf { it.isNotEmpty() }
+        ?: "your phone's profile"
+    val device = identity.controllerDeviceName?.trim()?.takeIf { it.isNotEmpty() }
+        ?: "your phone"
+    val server = identity.serverName?.trim()?.takeIf { it.isNotEmpty() }
+    val source = if (identity.usesDifferentServer && server != null) {
+        "From $device · $server"
+    } else {
+        "From $device"
+    }
+
+    Column(
+        modifier = Modifier
+            .widthIn(max = 720.dp)
+            .semantics { liveRegion = LiveRegionMode.Polite }
+            .background(
+                color = Color.Black.copy(alpha = 0.84f),
+                shape = RoundedCornerShape(16.dp),
+            )
+            .border(
+                width = 1.dp,
+                color = Color.White.copy(alpha = 0.16f),
+                shape = RoundedCornerShape(16.dp),
+            )
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+    ) {
+        Text(
+            text = "Playing as $profile",
+            color = Color.White,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = source,
+            color = Color.White.copy(alpha = 0.72f),
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -123,6 +123,7 @@ import org.siloserver.silo.player.formatSubtitleTrackDisplayLabel
 import org.siloserver.silo.tv.R
 import org.siloserver.silo.tv.cast.TvSiloCastPlayerAdapter
 import org.siloserver.silo.tv.cast.TvSiloCastReceiver
+import org.siloserver.silo.tv.cast.RemotePlaybackIdentityManager
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvLoadingScreen
 import com.google.common.util.concurrent.MoreExecutors
@@ -207,8 +208,18 @@ fun TvPlayerScreen(
     pictureInPictureCoordinator: SiloPictureInPictureCoordinator = koinInject(),
     playerSettingsStore: org.siloserver.silo.common.settings.PlayerSettingsStore = koinInject(),
     siloCastReceiver: TvSiloCastReceiver = koinInject(),
+    remotePlaybackIdentityManager: RemotePlaybackIdentityManager = koinInject(),
 ) {
     val state by viewModel.uiState.collectAsState()
+    var remoteIdentityNotice by remember(contentId) {
+        mutableStateOf(remotePlaybackIdentityManager.activeIdentity)
+    }
+    LaunchedEffect(remoteIdentityNotice?.generationId) {
+        if (remoteIdentityNotice != null) {
+            delay(REMOTE_IDENTITY_NOTICE_MS)
+            remoteIdentityNotice = null
+        }
+    }
     val pictureInPictureEnabled by playerSettingsStore.pictureInPictureEnabledFlow.collectAsState(initial = true)
     val isInPictureInPictureMode by pictureInPictureCoordinator.isInPictureInPictureMode.collectAsState()
     // The real session player (ExoPlayer/MpvPlayer) the service publishes. The
@@ -1673,7 +1684,7 @@ fun TvPlayerScreen(
 
         // Remote-control "display_message" toast (top-center), shown a few
         // seconds regardless of controls visibility.
-        if (!isInPictureInPictureMode) remoteMessage?.let { message ->
+        if (!isInPictureInPictureMode && remoteIdentityNotice == null) remoteMessage?.let { message ->
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -1694,6 +1705,20 @@ fun TvPlayerScreen(
                         color = Color.White,
                         style = MaterialTheme.typography.titleMedium,
                     )
+                }
+            }
+        }
+
+        if (!isInPictureInPictureMode) {
+            remoteIdentityNotice?.let { identity ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = 48.dp)
+                        .zIndex(9f),
+                    contentAlignment = Alignment.TopCenter,
+                ) {
+                    RemotePlaybackIdentityNotice(identity)
                 }
             }
         }
@@ -1795,6 +1820,8 @@ fun TvPlayerScreen(
         }
     }
 }
+
+private const val REMOTE_IDENTITY_NOTICE_MS = 6_000L
 
 /**
  * Idle controls overlay — bottom-anchored gradient scrim with title + time +

--- a/shared/src/androidMain/kotlin/org/siloserver/silo/network/EncryptedTokenManagerImpl.kt
+++ b/shared/src/androidMain/kotlin/org/siloserver/silo/network/EncryptedTokenManagerImpl.kt
@@ -46,6 +46,7 @@ class EncryptedTokenManagerImpl(
     private var tokenExpiryEpochMs: Long? = null
     private var profileId: String? = null
     private var profileToken: String? = null
+    private var temporaryScope: TemporaryAuthScope? = null
 
     private val _sessionExpired = MutableSharedFlow<Unit>(
         replay = 0,
@@ -53,6 +54,12 @@ class EncryptedTokenManagerImpl(
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     override val sessionExpired: SharedFlow<Unit> = _sessionExpired.asSharedFlow()
+    private val _temporarySessionExpired = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    override val temporarySessionExpired: SharedFlow<Unit> = _temporarySessionExpired.asSharedFlow()
 
     init {
         // Load initial cache for whichever server the registry made active
@@ -79,11 +86,11 @@ class EncryptedTokenManagerImpl(
 
     override suspend fun getAccessToken(): String? = mutex.withLock {
         ensureCacheMatchesRegistryLocked()
-        accessToken
+        if (temporaryScope != null) temporaryScope?.accessToken else accessToken
     }
     override suspend fun getRefreshToken(): String? = mutex.withLock {
         ensureCacheMatchesRegistryLocked()
-        refreshToken
+        if (temporaryScope != null) temporaryScope?.refreshToken else refreshToken
     }
 
     /**
@@ -105,6 +112,10 @@ class EncryptedTokenManagerImpl(
 
     override suspend fun saveTokens(accessToken: String, refreshToken: String, expiresIn: Long) {
         mutex.withLock {
+            temporaryScope?.let {
+                temporaryScope = it.copy(accessToken = accessToken, refreshToken = refreshToken)
+                return@withLock
+            }
             val serverId = activeServerId ?: return  // No active server — drop on the floor.
             this.accessToken = accessToken
             this.refreshToken = refreshToken
@@ -120,6 +131,10 @@ class EncryptedTokenManagerImpl(
 
     override suspend fun clearTokens() {
         mutex.withLock {
+            if (temporaryScope != null) {
+                temporaryScope = null
+                return@withLock
+            }
             val serverId = activeServerId
             accessToken = null
             refreshToken = null
@@ -139,17 +154,31 @@ class EncryptedTokenManagerImpl(
     }
 
     override suspend fun invalidateSession() {
+        val temporary = mutex.withLock {
+            if (temporaryScope == null) false else {
+                temporaryScope = null
+                true
+            }
+        }
+        if (temporary) {
+            _temporarySessionExpired.tryEmit(Unit)
+            return
+        }
         clearTokens()
         _sessionExpired.tryEmit(Unit)
     }
 
     override suspend fun getProfileId(): String? = mutex.withLock {
         ensureCacheMatchesRegistryLocked()
-        profileId
+        if (temporaryScope != null) temporaryScope?.profileId else profileId
     }
 
     override suspend fun setProfileId(profileId: String?) {
         mutex.withLock {
+            temporaryScope?.let {
+                temporaryScope = it.copy(profileId = profileId)
+                return@withLock
+            }
             val serverId = activeServerId ?: return
             if (this.profileId == profileId) return
             this.profileId = profileId
@@ -162,11 +191,15 @@ class EncryptedTokenManagerImpl(
 
     override suspend fun getProfileToken(): String? = mutex.withLock {
         ensureCacheMatchesRegistryLocked()
-        profileToken
+        if (temporaryScope != null) temporaryScope?.profileToken else profileToken
     }
 
     override suspend fun setProfileToken(token: String?) {
         mutex.withLock {
+            temporaryScope?.let {
+                temporaryScope = it.copy(profileToken = token)
+                return@withLock
+            }
             val serverId = activeServerId ?: return
             if (this.profileToken == token) return
             this.profileToken = token
@@ -177,8 +210,9 @@ class EncryptedTokenManagerImpl(
         }
     }
 
-    override suspend fun getServerUrl(): String =
-        registry.activeEntry.value?.url.orEmpty()
+    override suspend fun getServerUrl(): String = mutex.withLock {
+        temporaryScope?.serverUrl ?: registry.activeEntry.value?.url.orEmpty()
+    }
 
     /**
      * Adds-or-updates [url] in the registry and switches to it. Used by the
@@ -197,7 +231,9 @@ class EncryptedTokenManagerImpl(
 
     // ---- Multi-server controls ----
 
-    override suspend fun getCurrentServerId(): String? = mutex.withLock { activeServerId }
+    override suspend fun getCurrentServerId(): String? = mutex.withLock {
+        temporaryScope?.serverId ?: activeServerId
+    }
 
     override suspend fun switchActiveServer(serverId: String?) {
         mutex.withLock {
@@ -211,9 +247,29 @@ class EncryptedTokenManagerImpl(
         clearTokens()
     }
 
+    override suspend fun beginTemporaryScope(scope: TemporaryAuthScope) {
+        mutex.withLock {
+            temporaryScope = scope.copy(serverUrl = scope.serverUrl.trimEnd('/'))
+        }
+    }
+
+    override suspend fun endTemporaryScope(): TemporaryAuthScope? = mutex.withLock {
+        temporaryScope.also { temporaryScope = null }
+    }
+
+    override suspend fun getTemporaryScope(): TemporaryAuthScope? = mutex.withLock { temporaryScope }
+
     // ---- Scoped auth (pinned background requests) ----
 
     override suspend fun snapshotCurrentScope(): AuthScopeSnapshot? = mutex.withLock {
+        temporaryScope?.let { scope ->
+            return@withLock AuthScopeSnapshot(
+                serverId = scope.serverId,
+                profileId = scope.profileId,
+                serverUrl = scope.serverUrl,
+                profileToken = scope.profileToken,
+            )
+        }
         val serverId = activeServerId ?: return@withLock null
         // Resolve the URL for *this* serverId from the registry entries so the
         // snapshot is internally consistent. Do NOT fall back to activeEntry —
@@ -231,12 +287,14 @@ class EncryptedTokenManagerImpl(
     }
 
     override suspend fun getAccessTokenForScope(serverId: String): String? = mutex.withLock {
-        if (serverId == activeServerId) accessToken
+        if (serverId == temporaryScope?.serverId) temporaryScope?.accessToken
+        else if (serverId == activeServerId) accessToken
         else prefs.getString(serverScopedKey(serverId, KEY_ACCESS_TOKEN), null)
     }
 
     override suspend fun getRefreshTokenForScope(serverId: String): String? = mutex.withLock {
-        if (serverId == activeServerId) refreshToken
+        if (serverId == temporaryScope?.serverId) temporaryScope?.refreshToken
+        else if (serverId == activeServerId) refreshToken
         else prefs.getString(serverScopedKey(serverId, KEY_REFRESH_TOKEN), null)
     }
 
@@ -247,6 +305,10 @@ class EncryptedTokenManagerImpl(
         expiresIn: Long,
     ) {
         mutex.withLock {
+            temporaryScope?.takeIf { it.serverId == serverId }?.let {
+                temporaryScope = it.copy(accessToken = accessToken, refreshToken = refreshToken)
+                return@withLock
+            }
             val expiryEpochMs = System.currentTimeMillis() + expiresIn * 1000L
             prefs.edit()
                 .putString(serverScopedKey(serverId, KEY_ACCESS_TOKEN), accessToken)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/cast/SiloCastMessage.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/cast/SiloCastMessage.kt
@@ -31,6 +31,34 @@ sealed class SiloCastMessage {
     ) : SiloCastMessage()
 
     @Serializable
+    @SerialName("handoff_offer")
+    data class HandoffOffer(
+        val handoffOffer: SiloCastHandoffOffer,
+        @EncodeDefault(EncodeDefault.Mode.ALWAYS) override val v: Int = SiloCastProtocol.version,
+    ) : SiloCastMessage()
+
+    @Serializable
+    @SerialName("handoff_challenge")
+    data class HandoffChallenge(
+        val handoffChallenge: SiloCastHandoffChallenge,
+        @EncodeDefault(EncodeDefault.Mode.ALWAYS) override val v: Int = SiloCastProtocol.version,
+    ) : SiloCastMessage()
+
+    @Serializable
+    @SerialName("handoff_ready")
+    data class HandoffReady(
+        val handoffReady: SiloCastHandoffReady,
+        @EncodeDefault(EncodeDefault.Mode.ALWAYS) override val v: Int = SiloCastProtocol.version,
+    ) : SiloCastMessage()
+
+    @Serializable
+    @SerialName("handoff_cancel")
+    data class HandoffCancel(
+        val handoffCancel: SiloCastHandoffCancel,
+        @EncodeDefault(EncodeDefault.Mode.ALWAYS) override val v: Int = SiloCastProtocol.version,
+    ) : SiloCastMessage()
+
+    @Serializable
     @SerialName("launch")
     data class Launch(
         val launch: SiloCastLaunchRequest,
@@ -116,6 +144,41 @@ data class SiloCastPlaybackRequest(
 data class SiloCastLaunchRequest(
     val serverId: String,
     val playback: SiloCastPlaybackRequest,
+)
+
+@Serializable
+data class SiloCastHandoffOffer(
+    val requestId: String,
+    val serverId: String,
+    val serverURL: String,
+    val serverName: String? = null,
+    val profileId: String,
+    /** Display-only label for the verified profile ID. Older peers omit it. */
+    val profileName: String? = null,
+)
+
+@Serializable
+data class SiloCastHandoffChallenge(
+    val requestId: String,
+    val userCode: String,
+    val matchCode: String,
+    val expiresAt: String,
+)
+
+@Serializable
+data class SiloCastHandoffReady(
+    val requestId: String,
+    val serverId: String,
+    val profileId: String,
+    val sessionExpiresAt: String,
+    val reused: Boolean,
+)
+
+@Serializable
+data class SiloCastHandoffCancel(
+    val requestId: String,
+    val reason: String,
+    val message: String? = null,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/cast/SiloCastProtocol.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/cast/SiloCastProtocol.kt
@@ -1,6 +1,10 @@
 package org.siloserver.silo.cast
 
 object SiloCastProtocol {
-    const val version: Int = 1
+    const val version: Int = 2
+    val supportedVersions: List<Int> = listOf(1, 2)
     const val serviceType: String = "_silocast._tcp"
+
+    fun negotiatedVersion(peerVersions: List<Int>): Int? =
+        supportedVersions.filter(peerVersions::contains).maxOrNull()
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/auth/DeviceLoginModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/auth/DeviceLoginModels.kt
@@ -7,6 +7,8 @@ import kotlinx.serialization.Serializable
 data class DeviceLoginStartRequest(
     @SerialName("device_name") val deviceName: String? = null,
     @SerialName("device_platform") val devicePlatform: String? = null,
+    @SerialName("client_purpose") val clientPurpose: String? = null,
+    val temporary: Boolean? = null,
 )
 
 /**
@@ -26,6 +28,8 @@ data class DeviceLoginStartResponse(
     val interval: Int,
     @SerialName("device_name") val deviceName: String,
     @SerialName("device_platform") val devicePlatform: String,
+    @SerialName("client_purpose") val clientPurpose: String? = null,
+    val temporary: Boolean? = null,
 )
 
 @Serializable
@@ -49,6 +53,10 @@ data class DeviceLoginPollResponse(
     @SerialName("refresh_token") val refreshToken: String? = null,
     @SerialName("expires_in") val expiresIn: Long? = null,
     val user: User? = null,
+    @SerialName("profile_id") val profileId: String? = null,
+    @SerialName("profile_token") val profileToken: String? = null,
+    val temporary: Boolean? = null,
+    @SerialName("session_expires_at") val sessionExpiresAt: String? = null,
 )
 
 @Serializable
@@ -60,6 +68,14 @@ data class DeviceLoginLookupResponse(
     @SerialName("device_platform") val devicePlatform: String? = null,
     @SerialName("ip_address_hint") val ipAddressHint: String? = null,
     @SerialName("expires_at") val expiresAt: String? = null,
+    @SerialName("client_purpose") val clientPurpose: String? = null,
+    val temporary: Boolean? = null,
+)
+
+@Serializable
+data class DeviceLoginCapabilityResponse(
+    @SerialName("remote_playback_handoff") val remotePlaybackHandoff: Boolean,
+    @SerialName("protocol_versions") val protocolVersions: List<Int> = emptyList(),
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/TokenManager.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/TokenManager.kt
@@ -1,6 +1,20 @@
 package org.siloserver.silo.network
 
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+/** Process-only auth used by a TV for one phone-owned playback session. */
+data class TemporaryAuthScope(
+    val serverId: String,
+    val serverUrl: String,
+    val accessToken: String? = null,
+    val refreshToken: String? = null,
+    val profileId: String? = null,
+    val profileToken: String? = null,
+    val controllerDeviceId: String,
+    val expiresAtEpochMs: Long? = null,
+)
 
 /**
  * Manages JWT access and refresh tokens.
@@ -38,6 +52,9 @@ interface TokenManager {
      */
     val sessionExpired: SharedFlow<Unit>
 
+    /** Emits when only a temporary remote-playback identity expires. */
+    val temporarySessionExpired: Flow<Unit> get() = emptyFlow()
+
     suspend fun getProfileId(): String?
     suspend fun setProfileId(profileId: String?)
     suspend fun getProfileToken(): String?
@@ -72,6 +89,16 @@ interface TokenManager {
 
     /** Wipe just the active server's tokens + profile state, keeping the registry entry. */
     suspend fun signOutCurrentServer()
+
+    // ----- Temporary remote-playback identity -----
+
+    /** Installs or replaces a process-only scope without touching persistent slots. */
+    suspend fun beginTemporaryScope(scope: TemporaryAuthScope) {}
+
+    /** Removes the process-only scope and exposes the saved TV identity again. */
+    suspend fun endTemporaryScope(): TemporaryAuthScope? = null
+
+    suspend fun getTemporaryScope(): TemporaryAuthScope? = null
 
     // ----- Scoped auth (Track B outbox replay; see [AuthScopeSnapshot]) -----
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/TokenManagerImpl.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/TokenManagerImpl.kt
@@ -32,6 +32,7 @@ class TokenManagerImpl : TokenManager {
     private var profileToken: String? = null
 
     private var serverUrl: String = "http://localhost:8090"
+    private var temporaryScope: TemporaryAuthScope? = null
 
     // extraBufferCapacity=1 + DROP_OLDEST makes `tryEmit` from a non-suspend
     // caller always succeed without backpressure — we never care about
@@ -43,17 +44,27 @@ class TokenManagerImpl : TokenManager {
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     override val sessionExpired: SharedFlow<Unit> = _sessionExpired.asSharedFlow()
+    private val _temporarySessionExpired = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    override val temporarySessionExpired: SharedFlow<Unit> = _temporarySessionExpired.asSharedFlow()
 
     override suspend fun getAccessToken(): String? = mutex.withLock {
-        accessToken
+        temporaryScope?.accessToken ?: accessToken
     }
 
     override suspend fun getRefreshToken(): String? = mutex.withLock {
-        refreshToken
+        temporaryScope?.refreshToken ?: refreshToken
     }
 
     override suspend fun saveTokens(accessToken: String, refreshToken: String, expiresIn: Long) {
         mutex.withLock {
+            temporaryScope?.let {
+                temporaryScope = it.copy(accessToken = accessToken, refreshToken = refreshToken)
+                return@withLock
+            }
             this.accessToken = accessToken
             this.refreshToken = refreshToken
             this.tokenExpiry = timeSource.markNow() + expiresIn.seconds
@@ -71,6 +82,16 @@ class TokenManagerImpl : TokenManager {
     }
 
     override suspend fun invalidateSession() {
+        val temporary = mutex.withLock {
+            if (temporaryScope == null) false else {
+                temporaryScope = null
+                true
+            }
+        }
+        if (temporary) {
+            _temporarySessionExpired.tryEmit(Unit)
+            return
+        }
         clearTokens()
         // Non-suspending emit so this method can be called from anywhere
         // without caller cooperation. DROP_OLDEST buffer means a rapid
@@ -80,27 +101,35 @@ class TokenManagerImpl : TokenManager {
     }
 
     override suspend fun getProfileId(): String? = mutex.withLock {
-        profileId
+        temporaryScope?.profileId ?: profileId
     }
 
     override suspend fun setProfileId(profileId: String?) {
         mutex.withLock {
+            temporaryScope?.let {
+                temporaryScope = it.copy(profileId = profileId)
+                return@withLock
+            }
             this.profileId = profileId
         }
     }
 
     override suspend fun getProfileToken(): String? = mutex.withLock {
-        profileToken
+        temporaryScope?.profileToken ?: profileToken
     }
 
     override suspend fun setProfileToken(token: String?) {
         mutex.withLock {
+            temporaryScope?.let {
+                temporaryScope = it.copy(profileToken = token)
+                return@withLock
+            }
             this.profileToken = token
         }
     }
 
     override suspend fun getServerUrl(): String = mutex.withLock {
-        serverUrl
+        temporaryScope?.serverUrl ?: serverUrl
     }
 
     override suspend fun setServerUrl(url: String) {
@@ -112,9 +141,19 @@ class TokenManagerImpl : TokenManager {
     // The in-memory impl is single-server; multi-server methods are no-ops.
     // The Android impl ([org.siloserver.silo.network.EncryptedTokenManagerImpl])
     // is what the apps actually run with.
-    override suspend fun getCurrentServerId(): String? = null
+    override suspend fun getCurrentServerId(): String? = mutex.withLock { temporaryScope?.serverId }
     override suspend fun switchActiveServer(serverId: String?) { /* no-op */ }
     override suspend fun signOutCurrentServer() {
         clearTokens()
     }
+
+    override suspend fun beginTemporaryScope(scope: TemporaryAuthScope) {
+        mutex.withLock { temporaryScope = scope.copy(serverUrl = scope.serverUrl.trimEnd('/')) }
+    }
+
+    override suspend fun endTemporaryScope(): TemporaryAuthScope? = mutex.withLock {
+        temporaryScope.also { temporaryScope = null }
+    }
+
+    override suspend fun getTemporaryScope(): TemporaryAuthScope? = mutex.withLock { temporaryScope }
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/DeviceLoginApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/DeviceLoginApi.kt
@@ -7,7 +7,10 @@ import org.siloserver.silo.model.auth.DeviceLoginDecisionResponse
 import org.siloserver.silo.model.auth.DeviceLoginLookupResponse
 import org.siloserver.silo.model.auth.DeviceLoginStartRequest
 import org.siloserver.silo.model.auth.DeviceLoginStartResponse
+import org.siloserver.silo.model.auth.DeviceLoginCapabilityResponse
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.authScope
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -26,6 +29,9 @@ import io.ktor.http.contentType
  * is [DefaultDeviceLoginApi].
  */
 interface DeviceLoginApi {
+
+    suspend fun remotePlaybackCapability(): ApiResult<DeviceLoginCapabilityResponse> =
+        ApiResult.Error(501, "unsupported", "Remote playback handoff is unavailable.")
 
     suspend fun startDeviceLogin(
         deviceName: String?,
@@ -53,6 +59,31 @@ interface DeviceLoginApi {
         token: String?,
         code: String?,
     ): ApiResult<DeviceLoginDecisionResponse>
+
+    suspend fun startRemotePlayback(
+        deviceName: String?,
+        devicePlatform: String?,
+    ): ApiResult<DeviceLoginStartResponse> =
+        ApiResult.Error(501, "unsupported", "Remote playback handoff is unavailable.")
+
+    suspend fun approveRemotePlayback(
+        token: String?,
+        code: String?,
+        scope: AuthScopeSnapshot? = null,
+    ): ApiResult<DeviceLoginDecisionResponse> =
+        ApiResult.Error(501, "unsupported", "Remote playback handoff is unavailable.")
+
+    suspend fun lookupRemotePlayback(
+        code: String,
+        scope: AuthScopeSnapshot,
+    ): ApiResult<DeviceLoginLookupResponse> =
+        ApiResult.Error(501, "unsupported", "Remote playback handoff is unavailable.")
+
+    suspend fun denyRemotePlayback(
+        code: String,
+        scope: AuthScopeSnapshot,
+    ): ApiResult<DeviceLoginDecisionResponse> =
+        ApiResult.Error(501, "unsupported", "Remote playback handoff is unavailable.")
 }
 
 /**
@@ -61,6 +92,10 @@ interface DeviceLoginApi {
  */
 class DefaultDeviceLoginApi(private val client: HttpClient) : DeviceLoginApi {
 
+    override suspend fun remotePlaybackCapability(): ApiResult<DeviceLoginCapabilityResponse> = safeApiCall {
+        client.get("/api/v1/auth/device/capability")
+    }
+
     override suspend fun startDeviceLogin(
         deviceName: String?,
         devicePlatform: String?,
@@ -68,6 +103,23 @@ class DefaultDeviceLoginApi(private val client: HttpClient) : DeviceLoginApi {
         client.post("/api/v1/auth/device/start") {
             contentType(ContentType.Application.Json)
             setBody(DeviceLoginStartRequest(deviceName, devicePlatform))
+        }
+    }
+
+    override suspend fun startRemotePlayback(
+        deviceName: String?,
+        devicePlatform: String?,
+    ): ApiResult<DeviceLoginStartResponse> = safeApiCall {
+        client.post("/api/v1/auth/device/start") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                DeviceLoginStartRequest(
+                    deviceName = deviceName,
+                    devicePlatform = devicePlatform,
+                    clientPurpose = "remote_playback",
+                    temporary = true,
+                ),
+            )
         }
     }
 
@@ -95,6 +147,39 @@ class DefaultDeviceLoginApi(private val client: HttpClient) : DeviceLoginApi {
         client.post("/api/v1/auth/device/approve") {
             contentType(ContentType.Application.Json)
             setBody(DeviceLoginDecisionRequest(token = token, code = code))
+        }
+    }
+
+    override suspend fun approveRemotePlayback(
+        token: String?,
+        code: String?,
+        scope: AuthScopeSnapshot?,
+    ): ApiResult<DeviceLoginDecisionResponse> = safeApiCall {
+        client.post("/api/v1/auth/device/approve-handoff") {
+            scope?.let { authScope(it) }
+            contentType(ContentType.Application.Json)
+            setBody(DeviceLoginDecisionRequest(token = token, code = code))
+        }
+    }
+
+    override suspend fun lookupRemotePlayback(
+        code: String,
+        scope: AuthScopeSnapshot,
+    ): ApiResult<DeviceLoginLookupResponse> = safeApiCall {
+        client.get("/api/v1/auth/device") {
+            authScope(scope)
+            parameter("code", code)
+        }
+    }
+
+    override suspend fun denyRemotePlayback(
+        code: String,
+        scope: AuthScopeSnapshot,
+    ): ApiResult<DeviceLoginDecisionResponse> = safeApiCall {
+        client.post("/api/v1/auth/device/deny") {
+            authScope(scope)
+            contentType(ContentType.Application.Json)
+            setBody(DeviceLoginDecisionRequest(code = code))
         }
     }
 

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/cast/SiloCastMessageTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/cast/SiloCastMessageTest.kt
@@ -28,13 +28,13 @@ class SiloCastMessageTest {
     fun helloMatchesAppleEnvelopeAndFields() {
         assertWireEquals(
             """
-            {"type":"hello","v":1,"hello":{
+            {"type":"hello","v":2,"hello":{
                 "role":"phone",
                 "deviceName":"Pixel 9",
                 "deviceId":"android-abc",
                 "serverId":"srv-1",
                 "serverName":"Home",
-                "supportedVersions":[1]
+                "supportedVersions":[1,2]
             }}
             """,
             SiloCastMessage.Hello(
@@ -44,7 +44,7 @@ class SiloCastMessageTest {
                     deviceId = "android-abc",
                     serverId = "srv-1",
                     serverName = "Home",
-                    supportedVersions = listOf(SiloCastProtocol.version),
+                    supportedVersions = SiloCastProtocol.supportedVersions,
                 ),
             ),
         )
@@ -66,7 +66,7 @@ class SiloCastMessageTest {
     fun launchNestsPlaybackRequestLikeApple() {
         assertWireEquals(
             """
-            {"type":"launch","v":1,"launch":{
+            {"type":"launch","v":2,"launch":{
                 "serverId":"srv-1",
                 "playback":{
                     "contentId":"movie-42",
@@ -96,23 +96,23 @@ class SiloCastMessageTest {
     @Test
     fun controlCommandsUseAppleNamesAndFields() {
         assertWireEquals(
-            """{"type":"control","v":1,"control":{"name":"play_pause"}}""",
+            """{"type":"control","v":2,"control":{"name":"play_pause"}}""",
             SiloCastMessage.Control(SiloCastControlCommand.playPause()),
         )
         assertWireEquals(
-            """{"type":"control","v":1,"control":{"name":"set_quality","value":"hd-1080"}}""",
+            """{"type":"control","v":2,"control":{"name":"set_quality","value":"hd-1080"}}""",
             SiloCastMessage.Control(SiloCastControlCommand.setQuality("hd-1080")),
         )
         assertWireEquals(
-            """{"type":"control","v":1,"control":{"name":"select_audio_track","trackId":3}}""",
+            """{"type":"control","v":2,"control":{"name":"select_audio_track","trackId":3}}""",
             SiloCastMessage.Control(SiloCastControlCommand.selectAudioTrack(3L)),
         )
         assertWireEquals(
-            """{"type":"control","v":1,"control":{"name":"set_subtitle_sync_ms","milliseconds":-250}}""",
+            """{"type":"control","v":2,"control":{"name":"set_subtitle_sync_ms","milliseconds":-250}}""",
             SiloCastMessage.Control(SiloCastControlCommand.setSubtitleSyncMs(-250)),
         )
         assertWireEquals(
-            """{"type":"control","v":1,"control":{"name":"play_next"}}""",
+            """{"type":"control","v":2,"control":{"name":"play_next"}}""",
             SiloCastMessage.Control(SiloCastControlCommand.playNext()),
         )
     }
@@ -121,7 +121,7 @@ class SiloCastMessageTest {
     fun subtitleOffOmitsTrackIdLikeApple() {
         val message = SiloCastMessage.Control(SiloCastControlCommand.selectSubtitleTrack(null))
         assertWireEquals(
-            """{"type":"control","v":1,"control":{"name":"select_subtitle_track"}}""",
+            """{"type":"control","v":2,"control":{"name":"select_subtitle_track"}}""",
             message,
         )
         val decoded = json.decodeFromString(
@@ -133,9 +133,9 @@ class SiloCastMessageTest {
 
     @Test
     fun pingPongCloseCarryNoPayload() {
-        assertWireEquals("""{"type":"ping","v":1}""", SiloCastMessage.Ping())
-        assertWireEquals("""{"type":"pong","v":1}""", SiloCastMessage.Pong())
-        assertWireEquals("""{"type":"close","v":1}""", SiloCastMessage.Close())
+        assertWireEquals("""{"type":"ping","v":2}""", SiloCastMessage.Ping())
+        assertWireEquals("""{"type":"pong","v":2}""", SiloCastMessage.Pong())
+        assertWireEquals("""{"type":"close","v":2}""", SiloCastMessage.Close())
         // Apple's decoder reads only `type` for these kinds.
         assertIs<SiloCastMessage.Ping>(
             json.decodeFromString(SiloCastMessage.serializer(), """{"type":"ping","v":1}"""),
@@ -175,14 +175,50 @@ class SiloCastMessageTest {
     @Test
     fun errorMatchesAppleShape() {
         assertWireEquals(
-            """{"type":"error","v":1,"error":{"code":"server_mismatch","message":"wrong server"}}""",
+            """{"type":"error","v":2,"error":{"code":"server_mismatch","message":"wrong server"}}""",
             SiloCastMessage.Error(SiloCastError(code = "server_mismatch", message = "wrong server")),
         )
     }
 
     @Test
     fun protocolConstantsMatchApple() {
-        assertEquals(1, SiloCastProtocol.version)
+        assertEquals(2, SiloCastProtocol.version)
+        assertEquals(listOf(1, 2), SiloCastProtocol.supportedVersions)
+        assertEquals(2, SiloCastProtocol.negotiatedVersion(listOf(1, 2)))
+        assertEquals(1, SiloCastProtocol.negotiatedVersion(listOf(1)))
+        assertNull(SiloCastProtocol.negotiatedVersion(listOf(3)))
         assertEquals("_silocast._tcp", SiloCastProtocol.serviceType)
+    }
+
+    @Test
+    fun handoffMessagesMatchAppleV2WireShape() {
+        assertWireEquals(
+            """{"type":"handoff_offer","v":2,"handoffOffer":{"requestId":"r1","serverId":"s1","serverURL":"https://silo.example","serverName":"Home","profileId":"p1","profileName":"Alex"}}""",
+            SiloCastMessage.HandoffOffer(
+                SiloCastHandoffOffer("r1", "s1", "https://silo.example", "Home", "p1", "Alex"),
+            ),
+        )
+        assertWireEquals(
+            """{"type":"handoff_challenge","v":2,"handoffChallenge":{"requestId":"r1","userCode":"ABCD-EFGH","matchCode":"WXYZ","expiresAt":"2026-07-09T20:00:00Z"}}""",
+            SiloCastMessage.HandoffChallenge(
+                SiloCastHandoffChallenge("r1", "ABCD-EFGH", "WXYZ", "2026-07-09T20:00:00Z"),
+            ),
+        )
+        assertWireEquals(
+            """{"type":"handoff_ready","v":2,"handoffReady":{"requestId":"r1","serverId":"s1","profileId":"p1","sessionExpiresAt":"2026-07-10T20:00:00Z","reused":false}}""",
+            SiloCastMessage.HandoffReady(
+                SiloCastHandoffReady("r1", "s1", "p1", "2026-07-10T20:00:00Z", false),
+            ),
+        )
+        assertWireEquals(
+            """{"type":"handoff_cancel","v":2,"handoffCancel":{"requestId":"r1","reason":"denied","message":"No"}}""",
+            SiloCastMessage.HandoffCancel(SiloCastHandoffCancel("r1", "denied", "No")),
+        )
+
+        val legacyOffer = json.decodeFromString(
+            SiloCastMessage.serializer(),
+            """{"type":"handoff_offer","v":2,"handoffOffer":{"requestId":"r2","serverId":"s1","serverURL":"https://silo.example","profileId":"p1"}}""",
+        )
+        assertNull(assertIs<SiloCastMessage.HandoffOffer>(legacyOffer).handoffOffer.profileName)
     }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/TemporaryAuthScopeTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/TemporaryAuthScopeTest.kt
@@ -1,0 +1,43 @@
+package org.siloserver.silo.network
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TemporaryAuthScopeTest {
+    @Test
+    fun temporaryReadsAndRefreshWritesDoNotOverwritePersistentIdentity() = runTest {
+        val manager = TokenManagerImpl()
+        manager.setServerUrl("https://tv.example")
+        manager.saveTokens("tv-access", "tv-refresh", 3_600)
+        manager.setProfileId("tv-profile")
+        manager.setProfileToken("tv-profile-token")
+
+        manager.beginTemporaryScope(
+            TemporaryAuthScope(
+                serverId = "phone-server",
+                serverUrl = "https://phone.example",
+                accessToken = "phone-access",
+                refreshToken = "phone-refresh",
+                profileId = "phone-profile",
+                profileToken = "phone-profile-token",
+                controllerDeviceId = "phone-1",
+            ),
+        )
+
+        assertEquals("phone-access", manager.getAccessToken())
+        assertEquals("phone-profile", manager.getProfileId())
+        assertEquals("https://phone.example", manager.getServerUrl())
+        manager.saveTokens("rotated-access", "rotated-refresh", 3_600)
+        assertEquals("rotated-access", manager.getAccessToken())
+
+        manager.endTemporaryScope()
+        assertEquals("tv-access", manager.getAccessToken())
+        assertEquals("tv-refresh", manager.getRefreshToken())
+        assertEquals("tv-profile", manager.getProfileId())
+        assertEquals("tv-profile-token", manager.getProfileToken())
+        assertEquals("https://tv.example", manager.getServerUrl())
+        assertNull(manager.getTemporaryScope())
+    }
+}


### PR DESCRIPTION
## Summary

- add Silo Cast protocol-v2 identity handoff on Android phone and TV
- acquire a process-only TV session for the phone's server and selected profile
- retain the TV's saved identity and restore it after remotely launched playback ends
- keep existing-playback control TV-owned and make v1 targets control-only
- wire remote launches through TV navigation and bind cleanup to the launched player generation
- show the same six-second, non-focusable “Playing as …” phone/profile notice as tvOS

## User impact

Launching content from an Android phone now uses that phone's active server, account, and profile for permissions, resume state, progress, and preferences. No temporary handoff credentials are persisted by Android TV.

The notice names the active phone profile and originating device, and includes the server for cross-server launches.

## Dependencies and parity

- Server API: [Silo-Server/silo-server#360](https://github.com/Silo-Server/silo-server/pull/360)
- Apple implementation/wire parity: [Silo-Server/silo-apple#82](https://github.com/Silo-Server/silo-apple/pull/82)

## Validation

- `:androidApp:compileDebugKotlinAndroid`
- `:androidTvApp:compileDebugKotlinAndroid`
- `:shared:testDebugUnitTest`
- `:androidApp:testDebugUnitTest`
- `:androidTvApp:testDebugUnitTest`
- `git diff --check`