### PR TITLE
Fix resume loss (0-position clobber) + phone Continue Watching? dialog

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -78,7 +78,14 @@ class RoomUserItemStateRepository(
     ) {
         // Reject values that would enqueue invalid JSON and poison the drain
         // (a NaN/Infinity/negative would parse-fail after claim and retry forever).
-        if (contentId.isBlank() || !positionSeconds.isFinite() || positionSeconds < 0.0) return
+        // Reject 0 too: a resume row is only readable when positionSeconds > 0, so
+        // writing 0 can't help resume — it can only HARM it. On player teardown the
+        // final recordPosition snapshots _uiState.position, which is 0 in the race
+        // where the player was already reset/released; without this guard that stale
+        // 0 overwrites a good resume locally AND syncs SET_POSITION=0 to the server,
+        // so re-entering the detail shows "Play" instead of "Resume" (Jim TV/phone
+        // QA 2026-07-10). Legit resets go through markUnwatched, not this path.
+        if (contentId.isBlank() || !positionSeconds.isFinite() || positionSeconds <= 0.0) return
         val safeDuration = durationSeconds?.takeIf { it.isFinite() && it > 0.0 }
 
         val snapshot = snapshotProvider() ?: return

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -205,6 +205,21 @@ class RoomUserItemStateRepositoryTest {
     }
 
     @Test
+    fun recordPositionZeroDoesNotClobberAnExistingResume() = runTest {
+        // A good resume point is recorded during playback...
+        repo.recordPosition("c1", fileId = 7, positionSeconds = 1200.0, durationSeconds = 3600.0)
+        // ...then a player-teardown race snapshots position as 0. That stale 0 must
+        // NOT overwrite the resume locally or sync SET_POSITION=0 to the server,
+        // else re-entering the detail would show "Play" instead of "Resume".
+        repo.recordPosition("c1", fileId = 7, positionSeconds = 0.0, durationSeconds = 3600.0)
+
+        assertEquals(1200.0, repo.localPosition("c1", fileId = 7))
+        // Only the original 1200s op is queued; the 0 produced no new/overwriting op.
+        val op = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 2000L, limit = 10).single()
+        assertEquals(1200.0, OutboxOperation.decodePositionPayload(op.payloadJson).first)
+    }
+
+    @Test
     fun handleCarriesScopeForInlinePinning() = runTest {
         val handle = repo.recordFavorite("c1", favorite = true)
         assertEquals("s1", handle.scope?.serverId)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
@@ -39,7 +39,9 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -64,7 +66,6 @@ import org.siloserver.silo.android.ui.theme.SiloSecondaryText
 import org.siloserver.silo.android.ui.theme.SiloSurfaceElevated
 import org.siloserver.silo.android.ui.navigation.heroTarget
 import org.siloserver.silo.android.ui.theme.PillShape
-import org.siloserver.silo.android.ui.util.playbackResumePosition
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.catalog.Season
@@ -639,7 +640,13 @@ fun HeroActionStack(
     onVersionClick: (() -> Unit)? = null,
     overflow: (@Composable (dismiss: () -> Unit) -> Unit)? = null,
     downloadSlot: (@Composable () -> Unit)? = null,
+    // When non-null there is resume progress: tapping the primary button opens
+    // the "Continue Watching?" dialog (Resume / Play from Beginning) instead of
+    // resuming immediately, matching iOS. Null → the button plays directly.
+    onPlayFromBeginning: (() -> Unit)? = null,
+    resumeStoppedAtLabel: String? = null,
 ) {
+    var showResumeDialog by remember { mutableStateOf(false) }
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -648,7 +655,7 @@ fun HeroActionStack(
         PrimaryPillButton(
             icon = Icons.Filled.PlayArrow,
             label = primaryLabel,
-            onClick = onPlay,
+            onClick = { if (onPlayFromBeginning != null) showResumeDialog = true else onPlay() },
         )
         Row(
             horizontalArrangement = Arrangement.spacedBy(14.dp),
@@ -697,6 +704,31 @@ fun HeroActionStack(
                 onClick = onVersionClick,
             )
         }
+    }
+
+    if (showResumeDialog && onPlayFromBeginning != null) {
+        val stoppedAt = resumeStoppedAtLabel
+        AlertDialog(
+            onDismissRequest = { showResumeDialog = false },
+            title = { Text("Continue Watching?") },
+            text = if (stoppedAt != null) {
+                { Text("You stopped at $stoppedAt.") }
+            } else {
+                null
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showResumeDialog = false
+                    onPlay()
+                }) { Text("Resume") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showResumeDialog = false
+                    onPlayFromBeginning()
+                }) { Text("Play from Beginning") }
+            },
+        )
     }
 }
 
@@ -870,24 +902,17 @@ object HeroMetadata {
 
 // ── Play label helper ─────────────────────────────────────────
 
+// iOS parity: the play-button label stays neutral ("Play" / "Play S·E") even
+// when there's resume progress. The resume-vs-restart choice is offered in the
+// "Continue Watching?" dialog on tap (see HeroActionStack), not baked into the
+// label — mirrors silo-apple MovieDetailContent.swift +
+// ViewExtensions.continuumResumePlaybackAlert (Jim phone QA 2026-07-10).
 fun computePlayLabel(
     detail: ItemDetail,
     nextEpisodeLabel: String? = null,
 ): String {
     if (detail.type == "series" && nextEpisodeLabel != null) {
         return "Play $nextEpisodeLabel"
-    }
-    val pos = playbackResumePosition(detail.userData)
-    if (pos != null) {
-        val totalSec = pos.toInt()
-        val h = totalSec / 3600
-        val m = (totalSec % 3600) / 60
-        val s = totalSec % 60
-        return if (h > 0) {
-            "Resume %d:%02d:%02d".format(h, m, s)
-        } else {
-            "Resume %d:%02d".format(m, s)
-        }
     }
     if (detail.type == "episode") {
         val s = detail.seasonNumber
@@ -897,6 +922,15 @@ fun computePlayLabel(
         }
     }
     return "Play"
+}
+
+/** Clock for the "Continue Watching?" dialog's "You stopped at …" line. */
+fun formatResumeStoppedAt(positionSeconds: Double): String {
+    val totalSec = positionSeconds.toInt().coerceAtLeast(0)
+    val h = totalSec / 3600
+    val m = (totalSec % 3600) / 60
+    val s = totalSec % 60
+    return if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
 }
 
 // ── Details list (key/value facts) ────────────────────────────

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
@@ -492,8 +492,17 @@ fun ItemDetailScreen(
                             }
                         }
 
-                        val seriesResume = nextEpisode?.let { playbackResumePosition(it) }
-                            ?: playbackResumePosition(detail.userData)
+                        // Key the dialog off the SAME source the Resume action uses
+                        // below: whenever nextEpisode exists, Resume launches it with
+                        // its own progress. Don't fall back to series-level progress
+                        // when nextEpisode has none, or the dialog would show a
+                        // "stopped at" time that Resume won't honor (both buttons
+                        // would start the episode at 0).
+                        val seriesResume = if (nextEpisode != null) {
+                            playbackResumePosition(nextEpisode)
+                        } else {
+                            playbackResumePosition(detail.userData)
+                        }
                         SeriesDetailContent(
                             translation = translationSlot,
                             detail = detail,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
@@ -492,6 +492,8 @@ fun ItemDetailScreen(
                             }
                         }
 
+                        val seriesResume = nextEpisode?.let { playbackResumePosition(it) }
+                            ?: playbackResumePosition(detail.userData)
                         SeriesDetailContent(
                             translation = translationSlot,
                             detail = detail,
@@ -513,6 +515,14 @@ fun ItemDetailScreen(
                                     playbackResumePosition(detail.userData),
                                 )
                             },
+                            onPlayFromBeginning = seriesResume?.let {
+                                {
+                                    nextEpisode?.let { ep ->
+                                        onPlayClick(ep.contentId, null, null, null, 0.0)
+                                    } ?: onPlayClick(detail.contentId, null, null, null, 0.0)
+                                }
+                            },
+                            resumeStoppedAtLabel = seriesResume?.let { formatResumeStoppedAt(it) },
                             onEpisodePlayClick = { contentId, resumePositionSeconds ->
                                 onPlayClick(contentId, null, null, null, resumePositionSeconds)
                             },
@@ -638,6 +648,7 @@ fun ItemDetailScreen(
                             hasLocalMedia = selectedVersion?.let { selectedLocalDownload != null },
                         )
 
+                        val movieResume = playbackResumePosition(detail.userData)
                         MovieDetailContent(
                             translation = translationSlot,
                             detail = detail,
@@ -653,9 +664,21 @@ fun ItemDetailScreen(
                                     playbackFileId,
                                     explicitAudioIndex,
                                     explicitSubtitleIndex,
-                                    playbackResumePosition(detail.userData),
+                                    movieResume,
                                 )
                             },
+                            onPlayFromBeginning = movieResume?.let {
+                                {
+                                    onPlayClick(
+                                        detail.contentId,
+                                        playbackFileId,
+                                        explicitAudioIndex,
+                                        explicitSubtitleIndex,
+                                        0.0,
+                                    )
+                                }
+                            },
+                            resumeStoppedAtLabel = movieResume?.let { formatResumeStoppedAt(it) },
                             onFavoriteClick = { viewModel.toggleFavorite() },
                             onWatchlistClick = { viewModel.toggleWatchlist() },
                             onToggleWatched = { viewModel.toggleWatched() },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
@@ -63,6 +63,8 @@ fun MovieDetailContent(
     selectedAudioIndex: Int?,
     selectedSubtitleIndex: Int?,
     onPlayClick: () -> Unit,
+    onPlayFromBeginning: (() -> Unit)? = null,
+    resumeStoppedAtLabel: String? = null,
     onFavoriteClick: () -> Unit,
     onWatchlistClick: () -> Unit,
     onToggleWatched: () -> Unit,
@@ -139,6 +141,8 @@ fun MovieDetailContent(
                 HeroActionStack(
                     primaryLabel = computePlayLabel(detail),
                     onPlay = onPlayClick,
+                    onPlayFromBeginning = onPlayFromBeginning,
+                    resumeStoppedAtLabel = resumeStoppedAtLabel,
                     isFavorite = isFavorite,
                     isInWatchlist = isInWatchlist,
                     isWatched = detail.userData?.played == true,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
@@ -52,6 +52,8 @@ fun SeriesDetailContent(
     isInWatchlist: Boolean,
     nextEpisodeLabel: String?,
     onPlayClick: () -> Unit,
+    onPlayFromBeginning: (() -> Unit)? = null,
+    resumeStoppedAtLabel: String? = null,
     onEpisodePlayClick: (String, Double?) -> Unit,
     onEpisodeDetailClick: (String) -> Unit,
     onSeasonSelected: (Int) -> Unit,
@@ -109,6 +111,8 @@ fun SeriesDetailContent(
                 HeroActionStack(
                     primaryLabel = computePlayLabel(detail, nextEpisodeLabel),
                     onPlay = onPlayClick,
+                    onPlayFromBeginning = onPlayFromBeginning,
+                    resumeStoppedAtLabel = resumeStoppedAtLabel,
                     isFavorite = isFavorite,
                     isInWatchlist = isInWatchlist,
                     isWatched = detail.userData?.played == true,

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailPlayLabelTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailPlayLabelTest.kt
@@ -8,7 +8,9 @@ import kotlin.test.assertEquals
 class DetailPlayLabelTest {
 
     @Test
-    fun episodeWithProgressShowsResumeLabelBeforeSeasonEpisodeLabel() {
+    fun episodeWithProgressShowsNeutralSeasonEpisodeLabel() {
+        // iOS parity: the label stays neutral even with progress; the resume-vs-
+        // restart choice is offered in the "Continue Watching?" dialog on tap.
         val detail = ItemDetail(
             contentId = "episode-1",
             type = "episode",
@@ -22,11 +24,11 @@ class DetailPlayLabelTest {
             ),
         )
 
-        assertEquals("Resume 5:18", computePlayLabel(detail))
+        assertEquals("Play S6·E4", computePlayLabel(detail))
     }
 
     @Test
-    fun playedEpisodeWithRewatchProgressShowsResumeLabel() {
+    fun playedEpisodeWithRewatchProgressShowsNeutralLabel() {
         val detail = ItemDetail(
             contentId = "episode-1",
             type = "episode",
@@ -41,7 +43,7 @@ class DetailPlayLabelTest {
             ),
         )
 
-        assertEquals("Resume 5:18", computePlayLabel(detail))
+        assertEquals("Play S6·E4", computePlayLabel(detail))
     }
 
     @Test


### PR DESCRIPTION
Two item-detail playback fixes from Jim's on-device QA (2026-07-10).

## ① Resume loss — phone + TV (root-cause fix)
`RoomUserItemStateRepository.recordPosition` accepted a `0.0` position and blindly upserted it (fresh `clientUpdatedAtMs`, no monotonic guard), overwriting a good resume row **locally** and enqueuing `SET_POSITION=0` to the **server**. On player teardown the final `recordPosition` snapshots `_uiState.position`, which is `0` in the race where the player was already reset/released — so backing out of a title and returning showed **"Play"** instead of **"Resume."**

Fix: reject `positionSeconds <= 0` on the progress path. Reads already treat `0` as "no resume," and real resets go through `markUnwatched` (a separate API), so nothing legitimate breaks. One shared-store change fixes both clients. Added a regression test that a `0` write can't wipe a good resume.

## ② Phone "Continue Watching?" dialog — iOS parity
The phone detail hero had a single Resume button that always resumed, with **no way to start over**. iOS offers a resume-vs-restart dialog; ported it:
- Play label is now neutral (**"Play" / "Play S·E"**), matching iOS.
- When there's resume progress, tapping it opens a **"Continue Watching?"** dialog (**Resume** / **Play from Beginning**, with "You stopped at 12:34.").
- Mirrors silo-apple `ViewExtensions.continuumResumePlaybackAlert` + `MovieDetailContent.swift`.

(Android TV already had a dedicated "Start Over" button — unchanged.)

Deviation from iOS: the dialog uses Material3's two-button form (Resume / Play from Beginning) with cancel via tap-outside/back, rather than an explicit Cancel button — the idiomatic Android pattern.

## Verification
- `./gradlew :androidApp:assembleDebug :androidTvApp:assembleDebug test` — BUILD SUCCESSFUL, tests pass (incl. new `recordPositionZeroDoesNotClobberAnExistingResume` and updated `DetailPlayLabelTest`).
- Not yet installed on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Continue Watching?” prompt when resuming movies or episodes.
  - Users can choose to resume playback or play from the beginning.
  - The prompt displays where playback was last stopped.

- **Bug Fixes**
  - Prevented zero-second progress updates from overwriting valid resume positions.
  - Updated playback buttons to use neutral “Play” labels while offering resume choices separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->