### PR TITLE
Fix startup crash on oversized home/catalog cache rows (SQLite CursorWindow)

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/db/dao/CatalogCacheDao.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/db/dao/CatalogCacheDao.kt
@@ -14,4 +14,7 @@ interface CatalogCacheDao {
 
     @Query("SELECT * FROM catalog_cache WHERE serverId = :serverId AND profileId = :profileId AND cacheKey = :cacheKey")
     suspend fun get(serverId: String, profileId: String, cacheKey: String): CatalogCacheEntity?
+
+    @Query("DELETE FROM catalog_cache WHERE serverId = :serverId AND profileId = :profileId AND cacheKey = :cacheKey")
+    suspend fun delete(serverId: String, profileId: String, cacheKey: String)
 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomCatalogCacheRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomCatalogCacheRepository.kt
@@ -66,6 +66,13 @@ class RoomCatalogCacheRepository(
     private suspend fun put(cacheKey: String, jsonStr: String) {
         val snapshot = snapshotProvider() ?: return
         val profileId = snapshot.profileId ?: return
+        // A Room row must fit SQLite's ~2MB CursorWindow or the *read* throws
+        // SQLiteBlobTooBigException. Big library pages can exceed it, so don't
+        // store an unreadable row — drop any prior row for this key and skip.
+        if (jsonStr.encodeToByteArray().size > MAX_CACHE_BYTES) {
+            runCatching { dao.delete(snapshot.serverId, profileId, cacheKey) }
+            return
+        }
         dao.upsert(
             CatalogCacheEntity(
                 serverId = snapshot.serverId,
@@ -80,10 +87,18 @@ class RoomCatalogCacheRepository(
     private suspend fun get(cacheKey: String): String? {
         val snapshot = snapshotProvider() ?: return null
         val profileId = snapshot.profileId ?: return null
-        return dao.get(snapshot.serverId, profileId, cacheKey)?.json
+        // An oversized legacy row throws SQLiteBlobTooBigException on read; purge
+        // it so it can't keep crashing the browse screen, and serve online.
+        return runCatching { dao.get(snapshot.serverId, profileId, cacheKey) }
+            .getOrElse {
+                runCatching { dao.delete(snapshot.serverId, profileId, cacheKey) }
+                null
+            }?.json
     }
 
     private companion object {
+        // Stay well under SQLite's ~2MB CursorWindow.
+        const val MAX_CACHE_BYTES = 1_500_000
         const val KEY_LIBRARIES = "libraries"
         fun libraryKey(libraryId: Int) = "library:$libraryId"
         fun librarySectionsKey(libraryId: Int) = "library-sections:$libraryId"

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomHomeCacheRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomHomeCacheRepository.kt
@@ -28,11 +28,20 @@ class RoomHomeCacheRepository(
     override suspend fun cacheHome(sections: List<ResolvedSection>) {
         val snapshot = snapshotProvider() ?: return
         val profileId = snapshot.profileId ?: return
+        val sectionsJson = json.encodeToString(sections)
+        // A Room row must fit SQLite's ~2MB CursorWindow or the *read* throws
+        // SQLiteBlobTooBigException. Large reorganized home layouts can exceed
+        // that, so don't cache an unreadable row — drop any prior row (which may
+        // itself be an oversized poison) and just serve the home online.
+        if (sectionsJson.encodeToByteArray().size > MAX_CACHE_BYTES) {
+            runCatching { dao.delete(snapshot.serverId, profileId) }
+            return
+        }
         dao.upsert(
             HomeCacheEntity(
                 serverId = snapshot.serverId,
                 profileId = profileId,
-                sectionsJson = json.encodeToString(sections),
+                sectionsJson = sectionsJson,
                 cachedAtMs = now(),
             ),
         )
@@ -41,10 +50,23 @@ class RoomHomeCacheRepository(
     override suspend fun getCachedHome(): HomeCacheSnapshot? {
         val snapshot = snapshotProvider() ?: return null
         val profileId = snapshot.profileId ?: return null
-        val row = dao.get(snapshot.serverId, profileId) ?: return null
+        // An oversized legacy row (written before the cap) throws
+        // SQLiteBlobTooBigException on read; purge it so it can't crash the home
+        // screen again, and fall through to an online load.
+        val row = runCatching { dao.get(snapshot.serverId, profileId) }
+            .getOrElse {
+                runCatching { dao.delete(snapshot.serverId, profileId) }
+                null
+            } ?: return null
         val sections = runCatching {
             json.decodeFromString<List<ResolvedSection>>(row.sectionsJson)
         }.getOrNull() ?: return null
         return HomeCacheSnapshot(sections = sections, cachedAtMs = row.cachedAtMs)
+    }
+
+    private companion object {
+        // Stay well under SQLite's ~2MB CursorWindow (row must include other
+        // columns + overhead), so a cached row is always readable.
+        const val MAX_CACHE_BYTES = 1_500_000
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomHomeCacheRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomHomeCacheRepositoryTest.kt
@@ -52,6 +52,31 @@ class RoomHomeCacheRepositoryTest {
     }
 
     @Test
+    fun oversizedHomeIsNotCachedAndDropsPriorRow() = runTest {
+        // A good small cache exists first.
+        repo.cacheHome(listOf(section("s-cw", "c1")))
+        assertEquals(1, repo.getCachedHome()?.sections?.size)
+
+        // An oversized layout (> ~1.5MB serialized) must NOT be stored — a row
+        // that big overflows SQLite's ~2MB CursorWindow and throws
+        // SQLiteBlobTooBigException on the next read. It should be skipped and
+        // the prior row dropped, so getCachedHome cleanly returns null.
+        val bigTitle = "x".repeat(2_000)
+        val huge = listOf(
+            ResolvedSection(
+                id = "big",
+                sectionType = "row",
+                title = "Big",
+                items = (0 until 1_000).map {
+                    SectionItem(contentId = "c$it", type = "movie", title = bigTitle)
+                },
+            ),
+        )
+        repo.cacheHome(huge)
+        assertNull(repo.getCachedHome())
+    }
+
+    @Test
     fun cacheIsScopedAndNoOpWithoutScope() = runTest {
         repo.cacheHome(listOf(section("s-cw", "c1")))
         // Different scope → no cached home.


### PR DESCRIPTION
**Crash report** (Pixel 9 Pro Fold, phone v0.3.8 / 6016):
```
android.database.sqlite.SQLiteBlobTooBigException: Row too big to fit into CursorWindow requiredPos=0, totalRows=1
```
Fires ~4.7s after launch (home cache read on startup).

## Root cause
`home_cache` and `catalog_cache` store an entire serialized API response as **one JSON string per row** (`HomeCacheEntity.sectionsJson` = whole home layout; `CatalogCacheEntity.json` = whole library page). SQLite caps a single row at ~2MB (the `CursorWindow`). A large reorganized home layout pushed `sectionsJson` past 2MB, so `dao.get()` throws on the cursor read — **before** the existing decode-guard (`runCatching` around `decodeFromString`) ever runs. Not device- or version-specific; purely data size crossing the limit.

## Fix (both repos)
- **Cap writes**: if the serialized JSON exceeds ~1.5MB, skip caching and drop any prior row — a row that can't be read back is worse than a cache miss; the screen just serves online.
- **Guard reads**: wrap `dao.get()` so an oversized *legacy* row (already on-device) becomes a clean cache miss instead of a crash, and purge the poison row so it self-heals on first launch of the fixed build.

Adds `CatalogCacheDao.delete(key)` and a write-cap regression test (`oversizedHomeIsNotCachedAndDropsPriorRow`).

## Verification
- `./gradlew :androidApp:assembleDebug :androidTvApp:assembleDebug test` — BUILD SUCCESSFUL, tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented oversized cached home and catalog data from breaking local database reads.
  * Automatically removes invalid or oversized cache entries and falls back to online data.
  * Prevented new cache entries from exceeding the safe storage limit.

* **Tests**
  * Added coverage verifying oversized home data is not retained and prior cache entries are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->