### PR TITLE
Ease TV page cross-fade to 500ms

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -72,8 +72,12 @@ private val preMainAuthRoutes: Set<String> = setOf(
     TvRoute.EditProfile.ROUTE,
 )
 
-/** Page-to-page cross-fade duration (ms); snappier than Compose Nav's 700ms default. */
-private const val TvPageFadeDurationMs = 200
+/**
+ * Page-to-page cross-fade duration (ms). A middle ground between Compose Nav's
+ * sluggish 700ms default and a phone-snappy 200ms — a touch more deliberate for
+ * the 10-foot view so focus settles, without the old drag (Jim, TV feel).
+ */
+private const val TvPageFadeDurationMs = 500
 
 @Composable
 fun TvAppNavigation(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -661,11 +661,12 @@ fun TvMainShell(
                 navController = nestedNav,
                 startDestination = firstTvRoute(),
                 modifier = Modifier.fillMaxSize(),
-                // Snappier than Compose Nav's 700ms default cross-fade between tabs.
-                enterTransition = { fadeIn(tween(200)) },
-                exitTransition = { fadeOut(tween(200)) },
-                popEnterTransition = { fadeIn(tween(200)) },
-                popExitTransition = { fadeOut(tween(200)) },
+                // Middle ground between the 700ms default and phone-snappy 200ms
+                // for tab-content switches (matches TvPageFadeDurationMs = 500).
+                enterTransition = { fadeIn(tween(500)) },
+                exitTransition = { fadeOut(tween(500)) },
+                popEnterTransition = { fadeIn(tween(500)) },
+                popExitTransition = { fadeOut(tween(500)) },
             ) {
                 composable(TvMainRoute.Video.route) {
                     TvHomeScreen(


### PR DESCRIPTION
Follow-up tuning to the TV page fade. 200ms felt too fast in the 10-foot view; the 700ms Compose Nav default felt sluggish. Settle on **500ms** on both TV NavHosts (`TvAppNavigation` + the nested `TvMainShell` tab host) so D-pad focus has time to land without dragging. Phone stays at 200ms.

Verified: `./gradlew :androidTvApp:assembleDebug test` — BUILD SUCCESSFUL.

Note: this will be cut as a re-release of **v0.3.9** (same versionCode) per request — sideload-only, so `adb install -r` updates in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)