### PR TITLE
Phone swipe-to-seek: live feedback + inner-80% safe-box

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt
@@ -9,10 +9,12 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.horizontalDrag
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,8 +34,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableDoubleStateOf
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,6 +44,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -100,12 +101,6 @@ fun PlayerGestureHandler(
     val currentDuration by rememberUpdatedState(duration)
     val currentSeekEnabled by rememberUpdatedState(seekEnabled)
 
-    var seekDragStartPosition by remember { mutableDoubleStateOf(0.0) }
-    var seekDragAccumulator by remember { mutableFloatStateOf(0f) }
-    // True when a horizontal drag started in the outer edge band (or seek is
-    // gated off): that gesture is left alone so an edge swipe stays a back-swipe
-    // instead of scrubbing (Jim: inner-~80% safe-box).
-    var seekGestureIgnored by remember { mutableStateOf(false) }
     // Live scrub feedback shown while a seek drag is in progress (direction +
     // delta + target time); null when not seeking.
     var seekPreview by remember { mutableStateOf<SeekPreview?>(null) }
@@ -259,47 +254,58 @@ fun PlayerGestureHandler(
                 )
             }
             .pointerInput(Unit) {
-                detectHorizontalDragGestures(
-                    onDragStart = { start ->
-                        // Safe-box: only scrub when the drag starts in the inner
-                        // ~80%. A drag beginning in the outer edge band is left
-                        // unconsumed so it can be a system back-swipe, not a seek.
-                        val edge = size.width * SeekEdgeExclusionFraction
-                        seekGestureIgnored = !currentSeekEnabled ||
-                            start.x < edge || start.x > size.width - edge
-                        if (!seekGestureIgnored) {
-                            seekDragStartPosition = currentPosition
-                            seekDragAccumulator = 0f
-                        }
-                    },
-                    onDragEnd = {
-                        if (!seekGestureIgnored) {
-                            val dur = currentDuration
-                            val seekAmount =
-                                (seekDragAccumulator / size.width.toFloat()) * dur.toFloat() * 0.5f
-                            val newPosition = (seekDragStartPosition + seekAmount).coerceIn(0.0, dur)
-                            onSeek(newPosition)
-                        }
-                        seekDragAccumulator = 0f
-                        seekGestureIgnored = false
-                        seekPreview = null
-                    },
-                    onHorizontalDrag = { change, dragAmount ->
-                        // Ignored (edge) drags: don't consume, so the gesture can
-                        // fall through to the system back-swipe.
-                        if (seekGestureIgnored) return@detectHorizontalDragGestures
+                // Low-level loop instead of detectHorizontalDragGestures: that
+                // detector reports onDragStart only AFTER crossing (and consuming)
+                // horizontal slop, so the start position is post-slop and the edge
+                // event is already claimed — too late to (a) honor the safe-box on
+                // the true down position, or (b) leave an edge swipe for the system
+                // back gesture. Here we read the raw down, apply the safe-box
+                // BEFORE consuming anything, and only then claim the drag.
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    val edge = size.width * SeekEdgeExclusionFraction
+                    // Safe-box: a drag beginning in the outer band (or with seek
+                    // gated off) is left entirely unconsumed so it can be a system
+                    // back-swipe, not a scrub.
+                    if (!currentSeekEnabled ||
+                        down.position.x < edge ||
+                        down.position.x > size.width - edge
+                    ) {
+                        return@awaitEachGesture
+                    }
+                    // Claim only once the motion is actually horizontal (lets taps,
+                    // vertical brightness/volume/dismiss drags win otherwise).
+                    var accumulator = 0f
+                    val slopChange = awaitHorizontalTouchSlopOrCancellation(down.id) { change, overSlop ->
                         change.consume()
-                        seekDragAccumulator += dragAmount
+                        accumulator += overSlop
+                    } ?: return@awaitEachGesture
+
+                    val startPosition = currentPosition
+                    fun publishPreview() {
                         val dur = currentDuration
-                        val seekAmount =
-                            (seekDragAccumulator / size.width.toFloat()) * dur.toFloat() * 0.5f
-                        val target = (seekDragStartPosition + seekAmount).coerceIn(0.0, dur)
+                        val seekAmount = (accumulator / size.width.toFloat()) * dur.toFloat() * 0.5f
+                        val target = (startPosition + seekAmount).coerceIn(0.0, dur)
                         seekPreview = SeekPreview(
-                            deltaSeconds = target - seekDragStartPosition,
+                            deltaSeconds = target - startPosition,
                             targetSeconds = target,
                         )
-                    },
-                )
+                    }
+                    slopChange.consume()
+                    publishPreview()
+
+                    horizontalDrag(down.id) { change ->
+                        accumulator += change.positionChange().x
+                        change.consume()
+                        publishPreview()
+                    }
+
+                    // Released: commit the seek to the previewed target.
+                    val dur = currentDuration
+                    val seekAmount = (accumulator / size.width.toFloat()) * dur.toFloat() * 0.5f
+                    onSeek((startPosition + seekAmount).coerceIn(0.0, dur))
+                    seekPreview = null
+                }
             },
     ) {
         // Double-tap skip flash badge — vertically centered in the tapped

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt
@@ -16,11 +16,15 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.FastRewind
 import androidx.compose.material.icons.filled.Forward10
 import androidx.compose.material.icons.filled.Replay10
 import androidx.compose.material3.Icon
@@ -98,6 +102,13 @@ fun PlayerGestureHandler(
 
     var seekDragStartPosition by remember { mutableDoubleStateOf(0.0) }
     var seekDragAccumulator by remember { mutableFloatStateOf(0f) }
+    // True when a horizontal drag started in the outer edge band (or seek is
+    // gated off): that gesture is left alone so an edge swipe stays a back-swipe
+    // instead of scrubbing (Jim: inner-~80% safe-box).
+    var seekGestureIgnored by remember { mutableStateOf(false) }
+    // Live scrub feedback shown while a seek drag is in progress (direction +
+    // delta + target time); null when not seeking.
+    var seekPreview by remember { mutableStateOf<SeekPreview?>(null) }
     var suppressTapAfterFastForwardHold by remember { mutableStateOf(false) }
 
     // Double-tap skip feedback (iOS MobilePlayerGestureLayer skipFlash parity):
@@ -249,20 +260,44 @@ fun PlayerGestureHandler(
             }
             .pointerInput(Unit) {
                 detectHorizontalDragGestures(
-                    onDragStart = {
-                        seekDragStartPosition = currentPosition
-                        seekDragAccumulator = 0f
+                    onDragStart = { start ->
+                        // Safe-box: only scrub when the drag starts in the inner
+                        // ~80%. A drag beginning in the outer edge band is left
+                        // unconsumed so it can be a system back-swipe, not a seek.
+                        val edge = size.width * SeekEdgeExclusionFraction
+                        seekGestureIgnored = !currentSeekEnabled ||
+                            start.x < edge || start.x > size.width - edge
+                        if (!seekGestureIgnored) {
+                            seekDragStartPosition = currentPosition
+                            seekDragAccumulator = 0f
+                        }
                     },
                     onDragEnd = {
-                        val dur = currentDuration
-                        val seekAmount = (seekDragAccumulator / size.width.toFloat()) * dur.toFloat() * 0.5f
-                        val newPosition = (seekDragStartPosition + seekAmount).coerceIn(0.0, dur)
-                        onSeek(newPosition)
+                        if (!seekGestureIgnored) {
+                            val dur = currentDuration
+                            val seekAmount =
+                                (seekDragAccumulator / size.width.toFloat()) * dur.toFloat() * 0.5f
+                            val newPosition = (seekDragStartPosition + seekAmount).coerceIn(0.0, dur)
+                            onSeek(newPosition)
+                        }
                         seekDragAccumulator = 0f
+                        seekGestureIgnored = false
+                        seekPreview = null
                     },
                     onHorizontalDrag = { change, dragAmount ->
+                        // Ignored (edge) drags: don't consume, so the gesture can
+                        // fall through to the system back-swipe.
+                        if (seekGestureIgnored) return@detectHorizontalDragGestures
                         change.consume()
                         seekDragAccumulator += dragAmount
+                        val dur = currentDuration
+                        val seekAmount =
+                            (seekDragAccumulator / size.width.toFloat()) * dur.toFloat() * 0.5f
+                        val target = (seekDragStartPosition + seekAmount).coerceIn(0.0, dur)
+                        seekPreview = SeekPreview(
+                            deltaSeconds = target - seekDragStartPosition,
+                            targetSeconds = target,
+                        )
                     },
                 )
             },
@@ -284,7 +319,65 @@ fun PlayerGestureHandler(
                 SkipFlashBadge(forward = flash.forward)
             }
         }
+
+        // Live scrub feedback while a horizontal seek drag is in progress.
+        val preview = seekPreview
+        if (preview != null) {
+            SeekPreviewBadge(preview, modifier = Modifier.align(Alignment.Center))
+        }
     }
+}
+
+/**
+ * Live scrubbing HUD shown during a horizontal seek drag: a direction glyph,
+ * the signed delta from the drag's start position, and the target time. No
+ * animation — it tracks the finger and vanishes on release.
+ */
+@Composable
+private fun SeekPreviewBadge(preview: SeekPreview, modifier: Modifier = Modifier) {
+    val forward = preview.deltaSeconds >= 0
+    Row(
+        modifier = modifier
+            .background(color = Color.Black.copy(alpha = 0.6f), shape = RoundedCornerShape(14.dp))
+            .padding(horizontal = 18.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = if (forward) Icons.Filled.FastForward else Icons.Filled.FastRewind,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(24.dp),
+        )
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = formatSeekDelta(preview.deltaSeconds),
+                color = Color.White,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = formatSeekClock(preview.targetSeconds),
+                color = Color.White.copy(alpha = 0.7f),
+                fontSize = 12.sp,
+            )
+        }
+    }
+}
+
+private data class SeekPreview(val deltaSeconds: Double, val targetSeconds: Double)
+
+private fun formatSeekClock(seconds: Double): String {
+    val s = seconds.toInt().coerceAtLeast(0)
+    val h = s / 3600
+    val m = (s % 3600) / 60
+    val sec = s % 60
+    return if (h > 0) "%d:%02d:%02d".format(h, m, sec) else "%d:%02d".format(m, sec)
+}
+
+private fun formatSeekDelta(deltaSeconds: Double): String {
+    val sign = if (deltaSeconds >= 0) "+" else "−"
+    return sign + formatSeekClock(kotlin.math.abs(deltaSeconds))
 }
 
 /**
@@ -320,6 +413,13 @@ private const val PinchGravityThreshold = 1.08f
 
 /** iOS skipZoneFraction: outer double-tap bands (35% each side) skip ±10s. */
 private const val SkipZoneFraction = 0.35f
+
+/**
+ * Horizontal seek safe-box: a drag must START within the inner 80% (this much
+ * excluded on each side) to scrub. Drags beginning in the outer band are left
+ * unconsumed so an edge swipe stays a system back-swipe, not a rewind (Jim).
+ */
+private const val SeekEdgeExclusionFraction = 0.1f
 
 /** iOS skip flash hold before the fade-out begins. */
 private const val SkipFlashHoldMs = 700L


### PR DESCRIPTION
Jim's phone (Fold) feedback on the video player's horizontal swipe-to-seek:
> The slide to rewind/forward gives no feedback. Idk if it's rewinding or forwarding and how much. Also a safe box would be nice so the feature only activates in the inner ~80% of the screen. Sometimes I just want to swipe back not rewind.

## Changes (`PlayerGestureHandler.kt`, phone only — TV has no swipe)
1. **Live scrub feedback** — the horizontal seek drag previously only applied on release with no on-screen indication. Added a live HUD centered on screen: a rewind/forward glyph, the signed delta from the drag's start (`+1:23` / `−0:45`), and the target time. Tracks the finger during the drag, vanishes on release.
2. **Inner-80% safe-box** — the seek fired across the full width, so an edge swipe scrubbed instead of navigating back. Now a seek only starts when the drag begins in the inner ~80% (`SeekEdgeExclusionFraction = 0.1` each side); a drag starting in the outer band is left **unconsumed** so it can fall through to a system back-swipe.

## Needs on-device verification
Whether an outer-band drag actually triggers the **system back gesture** depends on the device's gesture-nav zone — the unconsumed passthrough is the right approach in-code, but it should be confirmed on the Fold. The scrub HUD + the "outer band no longer scrubs" behavior are deterministic.

## Verification
- `./gradlew :androidApp:assembleDebug` — BUILD SUCCESSFUL.
- UI/gesture change; not yet felt on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an on-screen seek preview showing rewind/fast-forward direction, time adjustment, and target playback time while scrubbing.
  * Improved horizontal seeking with a safe area that prevents accidental conflicts with system back-swipe gestures.

* **Bug Fixes**
  * Horizontal drags beginning near the player’s outer edges no longer trigger unintended seeking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->