### PR TITLE
Player: gate swipe-dismiss during load + guard exit from grey NavHost

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt
@@ -89,6 +89,11 @@ fun PlayerGestureHandler(
     // fill/stretch), false = pinch-in (step back toward fit).
     onPinchVideoGravity: (Boolean) -> Unit = {},
     onDismiss: () -> Unit = {},
+    // Swipe-down-to-dismiss is suppressed until playback is actually established.
+    // During the initial open the media is still loading, and a downward volume/
+    // brightness swipe that drifts inward would otherwise be read as "close the
+    // player" — which then strands the user (Jim, Fold).
+    dismissEnabled: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -228,7 +233,7 @@ fun PlayerGestureHandler(
                         }
                     },
                     onDragEnd = {
-                        if (mode == VerticalDragMode.DismissCandidate) {
+                        if (dismissEnabled && mode == VerticalDragMode.DismissCandidate) {
                             val dy = totalDrag.y
                             val dx = totalDrag.x
                             if (dy > DismissDragThresholdDp.dp.toPx() &&

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt
@@ -105,6 +105,10 @@ fun PlayerGestureHandler(
     val currentPosition by rememberUpdatedState(position)
     val currentDuration by rememberUpdatedState(duration)
     val currentSeekEnabled by rememberUpdatedState(seekEnabled)
+    // Same reason as seekEnabled: the vertical-drag coroutine is created once
+    // (keyed on Unit), so read the latest dismiss gate through rememberUpdatedState
+    // — otherwise a value captured while buffering would stick after playback.
+    val currentDismissEnabled by rememberUpdatedState(dismissEnabled)
 
     // Live scrub feedback shown while a seek drag is in progress (direction +
     // delta + target time); null when not seeking.
@@ -233,7 +237,7 @@ fun PlayerGestureHandler(
                         }
                     },
                     onDragEnd = {
-                        if (dismissEnabled && mode == VerticalDragMode.DismissCandidate) {
+                        if (currentDismissEnabled && mode == VerticalDragMode.DismissCandidate) {
                             val dy = totalDrag.y
                             val dx = totalDrag.x
                             if (dy > DismissDragThresholdDp.dp.toPx() &&

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerOverlay.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerOverlay.kt
@@ -167,6 +167,10 @@ fun PlayerOverlay(
                 onFastForwardHold = gatedFastForwardHold,
                 onPinchVideoGravity = stepVideoGravity,
                 onDismiss = handleBack,
+                // Only allow swipe-down-to-dismiss once playback is established —
+                // during the initial load a stray volume swipe must not close the
+                // player.
+                dismissEnabled = state.isPlaying || state.isPaused,
                 modifier = Modifier.zIndex(0f),
             )
         }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -206,7 +206,10 @@ fun PlayerScreen(
         viewModel.remoteStopRequests.collect {
             exitRequested = true
             viewModel.onExit()
-            navController.popBackStack()
+            // Nothing behind the player (launcher/deep-link/notification open) →
+            // popBackStack can't land anywhere and leaves a blank NavHost, then
+            // system back exits from a grey screen. Finish cleanly instead.
+            if (!navController.popBackStack()) activity?.finish()
         }
     }
 
@@ -215,7 +218,10 @@ fun PlayerScreen(
         if (roomClosedReason != null && roomController != null) {
             exitRequested = true
             viewModel.onExit()
-            navController.popBackStack()
+            // Nothing behind the player (launcher/deep-link/notification open) →
+            // popBackStack can't land anywhere and leaves a blank NavHost, then
+            // system back exits from a grey screen. Finish cleanly instead.
+            if (!navController.popBackStack()) activity?.finish()
         }
     }
 
@@ -911,7 +917,11 @@ fun PlayerScreen(
                         exitRequested = true
                         roomController?.leave(closeRoom = roomSnapshot?.isHost == true)
                         viewModel.onExit()
-                        navController.popBackStack()
+                        // Nothing behind the player (launcher/deep-link/notification
+                        // open) → popBackStack can't land anywhere and leaves a blank
+                        // NavHost, then system back exits from a grey screen. Finish
+                        // cleanly instead.
+                        if (!navController.popBackStack()) activity?.finish()
                     },
                     onPlayPause = {
                         // In a room, route through transport_request (gated to


### PR DESCRIPTION
Jim's report (phone/Fold): while adjusting volume on initial open, a swipe-down sometimes **closes the media** instead, and it can land in a **grey hanging state** where the back button just closes Silo.

## Root cause (confirmed in code)
1. **Accidental dismiss.** Gestures split by drag-start zone: left/right **88dp** edges = brightness/volume, everything else = a "dismiss candidate". Any center swipe-down over **140dp** closes the player. On a wide Fold screen a downward *volume* swipe that drifts inward of that 88dp strip is read as "close" — especially during the initial open. (`PlayerGestureHandler.kt`)
2. **Grey hang.** The exit path called `navController.popBackStack()` **unguarded**. When the player has nothing behind it (launcher / deep link / notification open), the pop lands nowhere → blank NavHost (grey), and system back then exits the app from that grey screen. (`PlayerScreen.kt`)

Neither is from the recent swipe-seek work — the volume/dismiss/exit logic was untouched and pre-existing.

## Fix
1. Add `dismissEnabled` to the gesture handler, wired to `state.isPlaying || state.isPaused` — swipe-dismiss is suppressed until playback is actually established, so a stray volume swipe during the initial-load window can't close the player.
2. Guard all three exit paths: `if (!navController.popBackStack()) activity?.finish()` — a dismiss/back can never strand the app on a blank NavHost; it finishes cleanly instead.

## Verification
- `./gradlew :androidApp:assembleDebug` — BUILD SUCCESSFUL.
- Gesture/nav change; the exact grey-screen trigger (which launch path) still warrants a live confirm on the Fold, but the guard removes the failure mode regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented swipe-down dismissal while the player is still loading.
  * Improved player exit behavior when no navigation history is available, preventing a blank or gray screen.
  * Ensured remote stops, room closures, server errors, and back actions close the player correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->