### PR TITLE
feat(push): handle relay silo_delivery_id and silo_mode data keys

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/push/PushNotificationPresenter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/push/PushNotificationPresenter.kt
@@ -63,6 +63,12 @@ class PushNotificationPresenter(
         }
     }
 
+    // sync refreshes the inbox for a background_wake push without posting a
+    // visible notification.
+    suspend fun sync() {
+        runCatching { notificationsRepository.refresh() }
+    }
+
     private suspend fun fetch(deliveryId: String): NotificationRow? =
         when (val direct = notificationsRepository.get(deliveryId)) {
             is ApiResult.Success -> direct.data

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/push/SiloFirebaseMessagingService.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/push/SiloFirebaseMessagingService.kt
@@ -18,6 +18,12 @@ class PushMessageHandler(
         fallbackBody: String? = null,
     ): Boolean {
         val deliveryId = deliveryIdFrom(data) ?: return false
+        // The relay's background_wake mode is a silent sync signal: refresh the
+        // inbox so content is ready, but never surface a visible notification.
+        if (data[MODE_KEY]?.trim() == MODE_BACKGROUND_WAKE) {
+            presenter.sync()
+            return true
+        }
         presenter.present(
             deliveryId = deliveryId,
             fallbackTitle = fallbackTitle ?: data["title"],
@@ -32,8 +38,14 @@ class PushMessageHandler(
         }
 
     companion object {
+        // The Silo push relay sends data-only messages carrying exactly
+        // silo_delivery_id and silo_mode; the legacy keys stay as fallbacks.
+        const val SILO_DELIVERY_ID_KEY = "silo_delivery_id"
         const val DELIVERY_ID_KEY = "delivery_id"
-        private val DELIVERY_ID_KEYS = listOf(DELIVERY_ID_KEY, "deliveryId", "deliveryID", "id")
+        const val MODE_KEY = "silo_mode"
+        const val MODE_BACKGROUND_WAKE = "background_wake"
+        private val DELIVERY_ID_KEYS =
+            listOf(SILO_DELIVERY_ID_KEY, DELIVERY_ID_KEY, "deliveryId", "deliveryID", "id")
     }
 }
 

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/push/AndroidPushSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/push/AndroidPushSourceTest.kt
@@ -36,6 +36,10 @@ class AndroidPushSourceTest {
         assertTrue(service.contains("onMessageReceived"))
         assertTrue(service.contains("onNewToken"))
         assertTrue(service.contains("delivery_id"))
+        // The relay's fixed content-private data payload carries exactly these keys.
+        assertTrue(service.contains("silo_delivery_id"))
+        assertTrue(service.contains("silo_mode"))
+        assertTrue(service.contains("background_wake"))
         assertTrue(manifest.contains("SiloFirebaseMessagingService"))
         assertTrue(app.contains("AndroidPushRegistrationStarter"))
         assertTrue(presenter.contains("notificationContentFor"))


### PR DESCRIPTION
## Summary

The Silo push relay's FCM payload is a fixed content-private data message carrying exactly `silo_delivery_id` and `silo_mode`. The existing `PushMessageHandler` only looked for `delivery_id`-style keys and ignored mode entirely, so relay pushes would have been dropped.

- `silo_delivery_id` is now the primary delivery-id key (legacy `delivery_id`/`deliveryId`/`id` remain as fallbacks).
- `silo_mode=background_wake` triggers a silent inbox refresh (`PushNotificationPresenter.sync()`) instead of posting a visible notification; `private_alert` (or absent mode) keeps the existing fetch-then-present flow.
- `AndroidPushSourceTest` now pins the relay contract keys.

Pairs with the server PR that enables FCM delivery (`Silo-Server/silo-server` feat/android-fcm-push) and the already-deployed relay `/v1/fcm/send` endpoint. No registration, manifest, DI, or permission changes needed — that wiring already existed.

## Commands run

- `./gradlew :androidApp:testDebugUnitTest :shared:testDebugUnitTest` (BUILD SUCCESSFUL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for background wake messages that refresh the notifications inbox without displaying a notification.
  * Expanded message delivery ID recognition to support additional relay payload formats.

* **Bug Fixes**
  * Background notification synchronization now safely handles refresh failures without interrupting message processing.

* **Tests**
  * Added coverage for the new background wake and delivery payload fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->