### PR TITLE
fix(audiobook): align chapters across alternate parts

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudiobookPlayerViewModel.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudiobookPlayerViewModel.kt
@@ -298,6 +298,7 @@ class AudiobookPlayerViewModel(
                     val builtTimeline = buildAudiobookTimeline(
                         versions = d.versions,
                         serverTotalSeconds = d.audiobook?.totalDurationSeconds?.toDouble(),
+                        preferredFileId = selectedVersion.fileId,
                     )
                     val wholeBookDuration = builtTimeline?.totalSeconds
                         ?: d.audiobook?.totalDurationSeconds?.toDouble()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudiobookPlayerViewModel.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudiobookPlayerViewModel.kt
@@ -759,6 +759,7 @@ class AudiobookPlayerViewModel(
             buildAudiobookTimeline(
                 versions = cached.versions,
                 serverTotalSeconds = cached.audiobook?.totalDurationSeconds?.toDouble(),
+                preferredFileId = media.fileId,
             )
         }?.takeIf { !it.isSingle }
         val offlinePart = cachedTimeline?.tracks?.firstOrNull { it.fileId == media.fileId }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AudiobookPlayerStartPositionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AudiobookPlayerStartPositionTest.kt
@@ -26,6 +26,18 @@ class AudiobookPlayerStartPositionTest {
     }
 
     @Test
+    fun offlineCachedTimelinePrefersDownloadedFile() {
+        val offlineBody = source
+            .substringAfter("private suspend fun loadOfflineOnly")
+            .substringBefore("fun onPositionChanged")
+
+        assertTrue(
+            offlineBody.contains("preferredFileId = media.fileId"),
+            "offline cached timeline must select the downloaded presentation variant",
+        )
+    }
+
+    @Test
     fun stopPlaybackSessionClearsPlayableStateEvenWithoutRemoteSession() {
         val stopBody = source
             .substringAfter("fun stopPlaybackSession()")

--- a/docs/superpowers/plans/2026-07-22-audiobook-coherent-variant-fallback.md
+++ b/docs/superpowers/plans/2026-07-22-audiobook-coherent-variant-fallback.md
@@ -1,0 +1,236 @@
+# Audiobook Coherent Variant Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish Android PR #75 by choosing a complete audiobook presentation variant when the preferred variant is incomplete and by preserving the downloaded-file preference during offline resume mapping.
+
+**Architecture:** Keep variant selection inside `audioParts`, where logical parts are already grouped. Resolve one complete presentation key before selecting files, then pass the downloaded file ID into the existing cached-timeline builder so offline playback uses the same selection contract.
+
+**Tech Stack:** Kotlin Multiplatform, Kotlin/JVM tests, Gradle.
+
+## Global Constraints
+
+- Prefer the selected file's presentation variant only when it covers every indexed logical part.
+- Otherwise select the first complete presentation variant in deterministic candidate order.
+- If no complete variant exists, retain deterministic per-part fallback behavior.
+- Do not add a new playback error or change server APIs, downloads, persistence, or online session behavior.
+- Do not trigger remote CI or release builds.
+
+---
+
+### Task 1: Reject incomplete preferred presentation variants
+
+**Files:**
+- Modify: `shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt`
+- Modify: `shared/src/commonMain/kotlin/org/siloserver/silo/audiobook/AudiobookTimeline.kt:208-227`
+
+**Interfaces:**
+- Consumes: `audioParts(versions: List<FileVersion>, preferredFileId: Int? = null): List<FileVersion>` and `FileVersion.presentationVariantKey(): String`.
+- Produces: a deterministic list containing one file per indexed logical part, using a complete presentation key whenever one exists.
+
+- [ ] **Step 1: Add the failing incomplete-preference regression test**
+
+Add this test after `fallback keeps one presentation variant across all parts`:
+
+```kotlin
+@Test
+fun `incomplete preferred variant falls back to a complete variant`() {
+    val versions = listOf(
+        part(fileId = 401, duration = 100.0, partIndex = 0)
+            .copy(presentationGroupKey = "lossless"),
+        part(fileId = 402, duration = 100.0, partIndex = 0)
+            .copy(presentationGroupKey = "compressed"),
+        part(fileId = 403, duration = 200.0, partIndex = 1)
+            .copy(presentationGroupKey = "compressed"),
+    )
+
+    val timeline = buildAudiobookTimeline(
+        versions = versions,
+        serverTotalSeconds = null,
+        preferredFileId = 401,
+    )!!
+
+    assertEquals(listOf(402, 403), timeline.tracks.map { it.fileId })
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+./gradlew :shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.audiobook.AudiobookTimelineTest'
+```
+
+Expected: FAIL because the current selector returns file IDs `[401, 403]`.
+
+- [ ] **Step 3: Select the preferred key only when it is complete**
+
+Replace the indexed selection block in `audioParts` with:
+
+```kotlin
+val selected = if (indexed.isNotEmpty()) {
+    val byPart = indexed
+        .groupBy { it.presentationPartIndex }
+        .toSortedMap(compareBy(nullsLast()) { it })
+    val candidateKeys = candidates
+        .map { it.presentationVariantKey() }
+        .distinct()
+    fun isCompleteVariant(key: String): Boolean = byPart.values.all { partVersions ->
+        partVersions.any { it.presentationVariantKey() == key }
+    }
+    val selectedKey = preferredKey
+        ?.takeIf(::isCompleteVariant)
+        ?: candidateKeys.firstOrNull(::isCompleteVariant)
+
+    byPart.values.mapNotNull { partVersions ->
+        selectedKey?.let { key ->
+            partVersions.firstOrNull { it.presentationVariantKey() == key }
+        } ?: partVersions.firstOrNull { it.fileId == preferredFileId }
+            ?: partVersions.firstOrNull()
+    }
+} else {
+    listOf(
+        preferred
+            ?: preferredKey?.let { key -> candidates.firstOrNull { it.presentationVariantKey() == key } }
+            ?: candidates.first(),
+    )
+}
+```
+
+- [ ] **Step 4: Run the focused timeline suite and verify GREEN**
+
+Run:
+
+```bash
+./gradlew :shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.audiobook.AudiobookTimelineTest'
+```
+
+Expected: PASS, including the existing complete-preferred and coherent-fallback tests.
+
+- [ ] **Step 5: Commit the timeline fix**
+
+```bash
+git add \
+  shared/src/commonMain/kotlin/org/siloserver/silo/audiobook/AudiobookTimeline.kt \
+  shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt
+git commit -m "fix(audiobook): require complete preferred variants [skip ci]"
+```
+
+### Task 2: Preserve the downloaded-file preference offline
+
+**Files:**
+- Modify: `android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AudiobookPlayerStartPositionTest.kt`
+- Modify: `android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudiobookPlayerViewModel.kt:758-763`
+
+**Interfaces:**
+- Consumes: `buildAudiobookTimeline(versions: List<FileVersion>, serverTotalSeconds: Double?, preferredFileId: Int? = null)` and `OfflineMedia.fileId` exposed as `media.fileId`.
+- Produces: a cached offline timeline built with `preferredFileId = media.fileId`, allowing `offlinePart` lookup to map whole-book resume time into part-local time.
+
+- [ ] **Step 1: Add the failing offline wiring regression test**
+
+Add this test to `AudiobookPlayerStartPositionTest`:
+
+```kotlin
+@Test
+fun offlineCachedTimelinePrefersDownloadedFile() {
+    val offlineBody = source
+        .substringAfter("private suspend fun loadOfflineOnly")
+        .substringBefore("fun onPositionChanged")
+
+    assertTrue(
+        offlineBody.contains("preferredFileId = media.fileId"),
+        "offline cached timeline must select the downloaded presentation variant",
+    )
+}
+```
+
+- [ ] **Step 2: Run the focused Android test and verify RED**
+
+Run:
+
+```bash
+./gradlew :android-shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.common.player.AudiobookPlayerStartPositionTest'
+```
+
+Expected: FAIL with `offline cached timeline must select the downloaded presentation variant`.
+
+- [ ] **Step 3: Pass the downloaded file ID to timeline construction**
+
+Update the cached timeline call in `loadOfflineOnly` to:
+
+```kotlin
+val cachedTimeline = catalogRepository.getCachedItemDetail(contentId)?.let { cached ->
+    buildAudiobookTimeline(
+        versions = cached.versions,
+        serverTotalSeconds = cached.audiobook?.totalDurationSeconds?.toDouble(),
+        preferredFileId = media.fileId,
+    )
+}?.takeIf { !it.isSingle }
+```
+
+- [ ] **Step 4: Run the focused Android test and verify GREEN**
+
+Run:
+
+```bash
+./gradlew :android-shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.common.player.AudiobookPlayerStartPositionTest'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the offline wiring fix**
+
+```bash
+git add \
+  android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudiobookPlayerViewModel.kt \
+  android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AudiobookPlayerStartPositionTest.kt
+git commit -m "fix(audiobook): preserve offline variant selection [skip ci]"
+```
+
+### Task 3: Verify the complete PR update
+
+**Files:**
+- Verify: `shared/src/commonMain/kotlin/org/siloserver/silo/audiobook/AudiobookTimeline.kt`
+- Verify: `shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt`
+- Verify: `android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudiobookPlayerViewModel.kt`
+- Verify: `android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AudiobookPlayerStartPositionTest.kt`
+
+**Interfaces:**
+- Consumes: the two completed fixes.
+- Produces: a reviewable PR #75 head with focused test evidence and no remote workflow run.
+
+- [ ] **Step 1: Run both focused suites together**
+
+```bash
+./gradlew :shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.audiobook.AudiobookTimelineTest'
+./gradlew :android-shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.common.player.AudiobookPlayerStartPositionTest'
+```
+
+Expected: `BUILD SUCCESSFUL` with both test classes passing.
+
+- [ ] **Step 2: Verify patch hygiene and scope**
+
+```bash
+git diff --check origin/pr-75-review..HEAD
+git diff --stat origin/pr-75-review..HEAD
+git status --short --branch
+```
+
+Expected: no whitespace errors; only the approved design, plan, two production files, and two test files differ from the prior PR head; working tree is clean.
+
+- [ ] **Step 3: Update the PR head without running CI**
+
+Push the commits, whose messages all contain `[skip ci]`, to PR #75's existing head branch:
+
+```bash
+git push <pr-head-remote> HEAD:fix/audiobook-chapters-pr
+```
+
+Expected: PR #75 updates to the verified head; GitHub Actions records no new workflow run for that SHA.

--- a/docs/superpowers/plans/2026-07-22-audiobook-coherent-variant-fallback.md
+++ b/docs/superpowers/plans/2026-07-22-audiobook-coherent-variant-fallback.md
@@ -225,12 +225,12 @@ git status --short --branch
 
 Expected: no whitespace errors; only the approved design, plan, two production files, and two test files differ from the prior PR head; working tree is clean.
 
-- [ ] **Step 3: Update the PR head without running CI**
+- [ ] **Step 3: Offer the verified PR update for maintainer approval**
 
-Push the commits, whose messages all contain `[skip ci]`, to PR #75's existing head branch:
+After verifying the repository's workflow triggers, ask the maintainer to approve updating PR #75's existing head branch. If approved, push the verified commits:
 
 ```bash
 git push <pr-head-remote> HEAD:fix/audiobook-chapters-pr
 ```
 
-Expected: PR #75 updates to the verified head; GitHub Actions records no new workflow run for that SHA.
+Expected: PR #75 updates to the verified head. Check every configured CI provider after the push and report any workflow that starts; do not assume `[skip ci]` suppresses non-GitHub providers.

--- a/docs/superpowers/specs/2026-07-22-audiobook-coherent-variant-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-22-audiobook-coherent-variant-fallback-design.md
@@ -1,0 +1,36 @@
+# Audiobook Coherent Variant Fallback Design
+
+## Goal
+
+Complete Android PR #75 so audiobook timelines never stitch alternate encodings as sequential or mixed logical parts, while preserving correct offline resume mapping for a downloaded file.
+
+## Variant Selection
+
+Group playable, indexed audiobook files by `presentationPartIndex`. A presentation variant is complete only when its `presentationGroupKey` is represented in every indexed logical part.
+
+Selection follows this order:
+
+1. Use the preferred file's presentation variant when that variant is complete.
+2. Otherwise use the first complete presentation variant in deterministic candidate order.
+3. If no complete variant exists, retain the existing deterministic per-part fallback so malformed or legacy catalog data remains playable.
+
+This preserves the selected variant when it can represent the entire book and prevents an incomplete preferred variant from causing an avoidable mixture when a complete alternative exists.
+
+## Offline Resume Mapping
+
+When rebuilding a cached timeline for offline-only playback, pass the downloaded media file ID as `preferredFileId`. This lets the timeline include the downloaded variant when it is complete and allows the existing whole-book-to-part-local resume conversion to find the matching track.
+
+No changes are made to persistence, download selection, server APIs, or online playback session behavior.
+
+## Tests
+
+Add focused regression coverage for:
+
+- an incomplete preferred variant falling back to another variant that covers every part;
+- the offline cached-timeline call passing the downloaded file ID as the preference.
+
+The existing complete-preferred-variant and no-preference coherent-fallback tests remain authoritative for normal selection.
+
+## Error Handling
+
+Incomplete catalog metadata does not become a new playback error. If no presentation variant spans every logical part, selection falls back deterministically to one playable file per part, matching the current tolerance for legacy data.

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/audiobook/AudiobookTimeline.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/audiobook/AudiobookTimeline.kt
@@ -172,9 +172,13 @@ fun buildAudiobookTimeline(
     // reports nothing, the cumulative offset is the whole-book length.
     val total = maxOf(serverTotalSeconds ?: 0.0, offset)
 
+    val sortedChapters = chapters
+        .sortedBy { it.startSeconds }
+        .mapIndexed { index, chapter -> chapter.copy(index = index) }
+
     return AudiobookTimeline(
         tracks = tracks,
-        chapters = chapters.sortedBy { it.startSeconds },
+        chapters = sortedChapters,
         totalSeconds = total,
     )
 }
@@ -205,13 +209,20 @@ internal fun audioParts(versions: List<FileVersion>, preferredFileId: Int? = nul
     val preferredKey = preferred?.presentationVariantKey()
     val indexed = candidates.filter { it.presentationPartIndex != null }
     val selected = if (indexed.isNotEmpty()) {
-        indexed
+        val byPart = indexed
             .groupBy { it.presentationPartIndex }
             .toSortedMap(compareBy(nullsLast()) { it })
-            .values
-            .mapNotNull { partVersions ->
+        val selectedKey = preferredKey ?: candidates
+            .map { it.presentationVariantKey() }
+            .distinct()
+            .firstOrNull { key ->
+                byPart.values.all { partVersions ->
+                    partVersions.any { it.presentationVariantKey() == key }
+                }
+            }
+        byPart.values.mapNotNull { partVersions ->
                 partVersions.firstOrNull { it.fileId == preferredFileId }
-                    ?: preferredKey?.let { key -> partVersions.firstOrNull { it.presentationVariantKey() == key } }
+                    ?: selectedKey?.let { key -> partVersions.firstOrNull { it.presentationVariantKey() == key } }
                     ?: partVersions.firstOrNull()
             }
     } else {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/audiobook/AudiobookTimeline.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/audiobook/AudiobookTimeline.kt
@@ -212,19 +212,22 @@ internal fun audioParts(versions: List<FileVersion>, preferredFileId: Int? = nul
         val byPart = indexed
             .groupBy { it.presentationPartIndex }
             .toSortedMap(compareBy(nullsLast()) { it })
-        val selectedKey = preferredKey ?: candidates
+        val candidateKeys = candidates
             .map { it.presentationVariantKey() }
             .distinct()
-            .firstOrNull { key ->
-                byPart.values.all { partVersions ->
-                    partVersions.any { it.presentationVariantKey() == key }
-                }
-            }
+        fun isCompleteVariant(key: String): Boolean = byPart.values.all { partVersions ->
+            partVersions.any { it.presentationVariantKey() == key }
+        }
+        val selectedKey = preferredKey
+            ?.takeIf(::isCompleteVariant)
+            ?: candidateKeys.firstOrNull(::isCompleteVariant)
+
         byPart.values.mapNotNull { partVersions ->
-                partVersions.firstOrNull { it.fileId == preferredFileId }
-                    ?: selectedKey?.let { key -> partVersions.firstOrNull { it.presentationVariantKey() == key } }
-                    ?: partVersions.firstOrNull()
-            }
+            selectedKey?.let { key ->
+                partVersions.firstOrNull { it.presentationVariantKey() == key }
+            } ?: partVersions.firstOrNull { it.fileId == preferredFileId }
+                ?: partVersions.firstOrNull()
+        }
     } else {
         listOf(
             preferred

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/audiobook/AudiobookTimeline.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/audiobook/AudiobookTimeline.kt
@@ -124,8 +124,9 @@ private const val AUDIOBOOK_PART_KIND = "audiobook_part"
 fun buildAudiobookTimeline(
     versions: List<FileVersion>,
     serverTotalSeconds: Double?,
+    preferredFileId: Int? = null,
 ): AudiobookTimeline? {
-    val parts = audioParts(versions)
+    val parts = audioParts(versions, preferredFileId)
     if (parts.isEmpty()) return null
 
     val tracks = ArrayList<AudioPlaybackTrack>(parts.size)
@@ -152,7 +153,10 @@ fun buildAudiobookTimeline(
         for (chapter in part.chapters.orEmpty()) {
             chapters.add(
                 AudioPlaybackChapter(
-                    index = chapter.index,
+                    // File chapter indexes restart at zero for every part.
+                    // The player exposes one book-wide list, so its index must
+                    // be the merged ordinal rather than the file-local value.
+                    index = chapters.size,
                     title = chapter.title,
                     startSeconds = offset + chapter.startSeconds,
                     endSeconds = offset + chapter.endSeconds,
@@ -176,26 +180,54 @@ fun buildAudiobookTimeline(
 }
 
 /**
- * The playable audio parts of [versions], in book order. A version is a part
- * when it is tagged `audiobook_part`, or (fallback for un-tagged libraries) when
- * it carries an audio codec or a positive duration. Sorted by
- * `presentationPartIndex` ascending (parts without one sort last), tie-broken by
- * `fileId` for a stable order.
+ * Selects one playable file for each ordered audiobook part. A version is
+ * playable when it is tagged `audiobook_part`, or (fallback for un-tagged
+ * libraries) when it carries an audio codec or a positive duration. Alternate
+ * files in the same part are reduced to the variant matching [preferredFileId]
+ * so their durations and chapters cannot be stitched into the book twice.
  *
  * Mirrors Apple `AudiobookPlaybackContext.audioParts(of:)` (AudiobookPlaybackContext.swift:89-101).
  */
-internal fun audioParts(versions: List<FileVersion>): List<FileVersion> =
-    versions
+internal fun audioParts(versions: List<FileVersion>, preferredFileId: Int? = null): List<FileVersion> {
+    val candidates = versions
         .filter { version ->
             if (version.presentationKind == AUDIOBOOK_PART_KIND) return@filter true
             version.codecAudio != null || version.duration > 0.0
         }
-        .sortedWith(
-            compareBy(
-                { it.presentationPartIndex ?: Int.MAX_VALUE },
-                { it.fileId },
-            )
+
+    if (candidates.isEmpty()) return emptyList()
+
+    // Detail responses contain alternate files for each logical audiobook
+    // part. Pick one coherent variant across all parts; treating every file as
+    // a sequential part shifts chapter offsets by the duration/chapter count
+    // of each alternate file.
+    val preferred = preferredFileId?.let { id -> candidates.firstOrNull { it.fileId == id } }
+    val preferredKey = preferred?.presentationVariantKey()
+    val indexed = candidates.filter { it.presentationPartIndex != null }
+    val selected = if (indexed.isNotEmpty()) {
+        indexed
+            .groupBy { it.presentationPartIndex }
+            .toSortedMap(compareBy(nullsLast()) { it })
+            .values
+            .mapNotNull { partVersions ->
+                partVersions.firstOrNull { it.fileId == preferredFileId }
+                    ?: preferredKey?.let { key -> partVersions.firstOrNull { it.presentationVariantKey() == key } }
+                    ?: partVersions.firstOrNull()
+            }
+    } else {
+        listOf(
+            preferred
+                ?: preferredKey?.let { key -> candidates.firstOrNull { it.presentationVariantKey() == key } }
+                ?: candidates.first(),
         )
+    }
+
+    return selected.sortedWith(compareBy({ it.presentationPartIndex ?: Int.MAX_VALUE }, { it.fileId }))
+}
+
+private fun FileVersion.presentationVariantKey(): String =
+    listOf(presentationKind.orEmpty(), presentationGroupKey.orEmpty())
+        .joinToString("\u0000")
 
 /**
  * Duration of a part: the probed [FileVersion.duration] when finite and

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/catalog/CatalogModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/catalog/CatalogModels.kt
@@ -258,6 +258,7 @@ data class FileVersion(
     // `presentation_part_index` (pre-sorted by index). The client stitches these parts
     // into one virtual whole-book timeline. Defaults keep single-file items unchanged.
     @SerialName("presentation_kind") val presentationKind: String? = null,
+    @SerialName("presentation_group_key") val presentationGroupKey: String? = null,
     @SerialName("presentation_part_index") val presentationPartIndex: Int? = null,
     @SerialName("presentation_part_total") val presentationPartTotal: Int? = null
 )

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt
@@ -111,7 +111,7 @@ class AudiobookTimelineTest {
     }
 
     @Test
-    fun `one version per ordered part is stitched when parts have alternate files`() {
+    fun oneVersionPerOrderedPartIsStitchedWhenPartsHaveAlternateFiles() {
         val versions = listOf(
             part(
                 fileId = 201,
@@ -152,7 +152,7 @@ class AudiobookTimelineTest {
     }
 
     @Test
-    fun `fallback keeps one presentation variant across all parts`() {
+    fun fallbackKeepsOnePresentationVariantAcrossAllParts() {
         val versions = listOf(
             part(fileId = 301, duration = 100.0, partIndex = 0)
                 .copy(presentationGroupKey = "lossless"),
@@ -172,7 +172,7 @@ class AudiobookTimelineTest {
     }
 
     @Test
-    fun `incomplete preferred variant falls back to a complete variant`() {
+    fun incompletePreferredVariantFallsBackToACompleteVariant() {
         val versions = listOf(
             part(fileId = 401, duration = 100.0, partIndex = 0)
                 .copy(presentationGroupKey = "lossless"),
@@ -192,7 +192,7 @@ class AudiobookTimelineTest {
     }
 
     @Test
-    fun `chapter indexes follow globally sorted chapter order`() {
+    fun chapterIndexesFollowGloballySortedChapterOrder() {
         val versions = listOf(
             part(
                 fileId = 310,
@@ -333,8 +333,9 @@ class AudiobookTimelineTest {
     }
 
     @Test
-    fun `parts sort by presentation index then file id`() {
-        // Provided out of order; missing index sorts last, tie-broken by fileId.
+    fun indexedPartsExcludeUnindexedFallbackCandidates() {
+        // Once indexed logical parts exist, unindexed candidates are excluded;
+        // indexed parts remain ordered by presentation index then file ID.
         val versions = listOf(
             part(fileId = 73, duration = 10.0, partIndex = null),
             part(fileId = 71, duration = 10.0, partIndex = 1),

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt
@@ -172,6 +172,26 @@ class AudiobookTimelineTest {
     }
 
     @Test
+    fun `incomplete preferred variant falls back to a complete variant`() {
+        val versions = listOf(
+            part(fileId = 401, duration = 100.0, partIndex = 0)
+                .copy(presentationGroupKey = "lossless"),
+            part(fileId = 402, duration = 100.0, partIndex = 0)
+                .copy(presentationGroupKey = "compressed"),
+            part(fileId = 403, duration = 200.0, partIndex = 1)
+                .copy(presentationGroupKey = "compressed"),
+        )
+
+        val timeline = buildAudiobookTimeline(
+            versions = versions,
+            serverTotalSeconds = null,
+            preferredFileId = 401,
+        )!!
+
+        assertEquals(listOf(402, 403), timeline.tracks.map { it.fileId })
+    }
+
+    @Test
     fun `chapter indexes follow globally sorted chapter order`() {
         val versions = listOf(
             part(

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt
@@ -97,16 +97,58 @@ class AudiobookTimelineTest {
         assertEquals(4, timeline.chapters.size)
 
         // Part-2's first chapter (local start 0) sits at part2 offset (100).
-        val part2First = timeline.chapters.first { it.trackIndex == 1 && it.index == 0 }
+        val part2First = timeline.chapters.first { it.trackIndex == 1 && it.startSeconds == 100.0 }
         assertEquals(100.0, part2First.startSeconds)   // part2Offset(100) + localStart(0)
         assertEquals(190.0, part2First.endSeconds)     // part2Offset(100) + localEnd(90)
 
         // Part-2's second chapter: 100 + 90 = 190 start.
-        val part2Second = timeline.chapters.first { it.trackIndex == 1 && it.index == 1 }
+        val part2Second = timeline.chapters.first { it.trackIndex == 1 && it.startSeconds == 190.0 }
         assertEquals(190.0, part2Second.startSeconds)
 
         // Global sort order (ascending by startSeconds).
         assertEquals(listOf(0.0, 60.0, 100.0, 190.0), timeline.chapters.map { it.startSeconds })
+        assertEquals(listOf(0, 1, 2, 3), timeline.chapters.map { it.index })
+    }
+
+    @Test
+    fun `one version per ordered part is stitched when parts have alternate files`() {
+        val versions = listOf(
+            part(
+                fileId = 201,
+                duration = 100.0,
+                partIndex = 1,
+                chapters = listOf(chapter(0, 0.0, 60.0), chapter(1, 60.0, 100.0)),
+            ).copy(presentationGroupKey = "lossless"),
+            part(
+                fileId = 202,
+                duration = 100.0,
+                partIndex = 1,
+                chapters = listOf(chapter(0, 0.0, 55.0), chapter(1, 55.0, 100.0)),
+            ).copy(presentationGroupKey = "compressed"),
+            part(
+                fileId = 203,
+                duration = 200.0,
+                partIndex = 2,
+                chapters = listOf(chapter(0, 0.0, 90.0), chapter(1, 90.0, 200.0)),
+            ).copy(presentationGroupKey = "lossless"),
+            part(
+                fileId = 204,
+                duration = 200.0,
+                partIndex = 2,
+                chapters = listOf(chapter(0, 0.0, 80.0), chapter(1, 80.0, 200.0)),
+            ).copy(presentationGroupKey = "compressed"),
+        )
+
+        val timeline = buildAudiobookTimeline(
+            versions = versions,
+            serverTotalSeconds = null,
+            preferredFileId = 201,
+        )!!
+
+        assertEquals(listOf(201, 203), timeline.tracks.map { it.fileId })
+        assertEquals(listOf(0.0, 100.0), timeline.tracks.map { it.startOffsetSeconds })
+        assertEquals(listOf(0.0, 60.0, 100.0, 190.0), timeline.chapters.map { it.startSeconds })
+        assertEquals(listOf(0, 1, 2, 3), timeline.chapters.map { it.index })
     }
 
     @Test
@@ -240,6 +282,6 @@ class AudiobookTimelineTest {
             part(fileId = 70, duration = 10.0, partIndex = 0),
         )
         val timeline = buildAudiobookTimeline(versions, serverTotalSeconds = null)!!
-        assertEquals(listOf(70, 71, 72, 73), timeline.tracks.map { it.fileId })
+        assertEquals(listOf(70, 71), timeline.tracks.map { it.fileId })
     }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/audiobook/AudiobookTimelineTest.kt
@@ -152,6 +152,46 @@ class AudiobookTimelineTest {
     }
 
     @Test
+    fun `fallback keeps one presentation variant across all parts`() {
+        val versions = listOf(
+            part(fileId = 301, duration = 100.0, partIndex = 0)
+                .copy(presentationGroupKey = "lossless"),
+            part(fileId = 302, duration = 100.0, partIndex = 0)
+                .copy(presentationGroupKey = "compressed"),
+            // Reverse the alternate order for part two. Selecting firstOrNull
+            // independently would combine lossless part one with compressed part two.
+            part(fileId = 304, duration = 200.0, partIndex = 1)
+                .copy(presentationGroupKey = "compressed"),
+            part(fileId = 303, duration = 200.0, partIndex = 1)
+                .copy(presentationGroupKey = "lossless"),
+        )
+
+        val timeline = buildAudiobookTimeline(versions, serverTotalSeconds = null)!!
+
+        assertEquals(listOf(301, 303), timeline.tracks.map { it.fileId })
+    }
+
+    @Test
+    fun `chapter indexes follow globally sorted chapter order`() {
+        val versions = listOf(
+            part(
+                fileId = 310,
+                duration = 100.0,
+                partIndex = 0,
+                chapters = listOf(
+                    chapter(1, 60.0, 100.0),
+                    chapter(0, 0.0, 60.0),
+                ),
+            ),
+        )
+
+        val timeline = buildAudiobookTimeline(versions, serverTotalSeconds = null)!!
+
+        assertEquals(listOf(0.0, 60.0), timeline.chapters.map { it.startSeconds })
+        assertEquals(listOf(0, 1), timeline.chapters.map { it.index })
+    }
+
+    @Test
     fun `single part book behaves like today`() {
         val versions = listOf(
             part(


### PR DESCRIPTION
## Summary

Fix audiobook chapter navigation when the server exposes multiple files for the same logical audiobook part.

The previous client timeline treated alternate encodings/versions as sequential audiobook parts. That caused chapter lists and chapter selection to drift from the actual audiobook, with some books offset by one chapter and others by many chapters.

## Changes

- Add the server-provided `presentation_group_key` to the shared `FileVersion` model.
- Group alternate files belonging to the same audiobook presentation part.
- Select one consistent variant for the timeline, preferring the currently selected file version.
- Preserve the correct order of indexed audiobook parts and avoid stitching alternate encodings together.
- Keep chapter indexes global across the selected audiobook timeline.
- Pass the selected file id from the audiobook player into timeline construction.
- Add regression coverage for alternate files per part and updated timeline index behavior.

## Validation

- `./gradlew :shared:testDebugUnitTest --tests 'org.siloserver.silo.audiobook.AudiobookTimelineTest'`
- `./gradlew :androidApp:testDebugUnitTest :androidTvApp:testDebugUnitTest :androidApp:assembleDebug :androidTvApp:assembleDebug`
- `git diff --check`

This branch is based directly on the current `upstream/main` and contains only the four files required for this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audiobook stitching to prioritize the user-selected audio across multi-part books, producing more consistent playback timelines.
  * Corrected stitched chapter numbering so indices match the globally ordered whole-book chapter sequence.
  * Enhanced variant selection for multi-part audiobooks to keep playback tracks coherent, with deterministic fallback when metadata is incomplete.
  * Improved offline resume by preferring the downloaded audio variant when rebuilding the cached timeline.
* **Tests**
  * Updated and expanded audiobook timeline tests and offline start-position tests to verify coherent variant selection, global chapter ordering, and downloaded-file preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->