### PR TITLE
feat(player): resume progressive direct play transparently after mid-stream transport failures

### DIFF
--- a/android-shared/build.gradle.kts
+++ b/android-shared/build.gradle.kts
@@ -112,6 +112,9 @@ kotlin {
             // stubs provide. androidx-test-core supplies ApplicationProvider.
             implementation(libs.androidx.test.core)
             implementation(libs.robolectric)
+            implementation(libs.media3.test.utils)
+            implementation(libs.media3.test.utils.robolectric)
+            implementation(libs.okhttp.mockwebserver)
 
             // SyncEngine tests drive a real PersonalDataApi over a MockEngine
             // HttpClient to exercise the outbox drain end-to-end.

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt
@@ -12,6 +12,7 @@ import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.TransferListener
 import org.siloserver.silo.common.player.subtitle.normalizeSubripPayloadIfNeeded
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -62,6 +63,8 @@ internal class RefreshingHttpDataSource(
     private val transferListeners = mutableListOf<TransferListener>()
     private val requestProperties = linkedMapOf<String, String>()
     private var active: HttpDataSource? = null
+    private var entityUri: Uri? = null
+    private var entityEtag: String? = null
 
     override fun addTransferListener(transferListener: TransferListener) {
         transferListeners += transferListener
@@ -69,11 +72,12 @@ internal class RefreshingHttpDataSource(
     }
 
     override fun open(dataSpec: DataSpec): Long {
+        prepareEntityGuard(dataSpec.uri)
         val failedSnapshot = runBlocking { authSession.snapshot() }
         val first = newDataSource()
         active = first
         return try {
-            first.open(dataSpec.withAuthHeaders(failedSnapshot))
+            first.openWithGuards(dataSpec, failedSnapshot)
         } catch (error: HttpDataSource.InvalidResponseCodeException) {
             if (error.responseCode != 401 || !runBlocking { authSession.refreshIfStale(failedSnapshot) }) {
                 throw error
@@ -81,7 +85,7 @@ internal class RefreshingHttpDataSource(
             first.close()
             val retry = newDataSource()
             active = retry
-            retry.open(dataSpec.withAuthHeaders(runBlocking { authSession.snapshot() }))
+            retry.openWithGuards(dataSpec, runBlocking { authSession.snapshot() })
         }
     }
 
@@ -120,6 +124,41 @@ internal class RefreshingHttpDataSource(
         transferListeners.forEach(dataSource::addTransferListener)
     }
 
+    private fun prepareEntityGuard(openedUri: Uri) {
+        if (openedUri != entityUri) {
+            entityUri = openedUri
+            entityEtag = null
+        }
+    }
+
+    private fun HttpDataSource.openWithGuards(
+        dataSpec: DataSpec,
+        snapshot: MediaAuthSnapshot,
+    ): Long {
+        val guardedDataSpec = dataSpec
+            .withIfRangeHeader()
+            .withAuthHeaders(snapshot)
+        val length = open(guardedDataSpec)
+        val responseEtag = responseHeaders.headerValue("ETag")
+        val previousEtag = entityEtag
+        if (previousEtag != null && responseEtag != null && responseEtag != previousEtag) {
+            runCatching(::close)
+            throw EntityChangedException()
+        }
+        if (responseEtag != null) {
+            entityEtag = responseEtag
+        }
+        return length
+    }
+
+    private fun DataSpec.withIfRangeHeader(): DataSpec {
+        val etag = entityEtag
+        if (position <= 0L || etag == null) return this
+        return buildUpon()
+            .setHttpRequestHeaders(httpRequestHeaders.withHeader("If-Range", etag))
+            .build()
+    }
+
     private fun DataSpec.withAuthHeaders(snapshot: MediaAuthSnapshot): DataSpec = buildUpon()
         // A V3 plan may carry a stream-scoped credential (for example, a
         // signed CDN Authorization value). Treat those explicit DataSpec
@@ -130,6 +169,23 @@ internal class RefreshingHttpDataSource(
         )
         .build()
 }
+
+internal class EntityChangedException :
+    IOException("HTTP entity changed during ranged resume")
+
+private fun Map<String, List<String>>.headerValue(name: String): String? =
+    entries.firstOrNull { (key, _) -> key.equals(name, ignoreCase = true) }
+        ?.value
+        ?.firstOrNull()
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+
+private fun Map<String, String>.withHeader(name: String, value: String): Map<String, String> =
+    buildMap {
+        putAll(this@withHeader)
+        keys.firstOrNull { it.equals(name, ignoreCase = true) }?.let(::remove)
+        put(name, value)
+    }
 
 internal fun mergeSessionAuthHeaders(
     sessionHeaders: Map<String, String>,

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt
@@ -33,10 +33,15 @@ class AuthenticatedDataSourceFactory(
     private val authSession: MediaAuthSession,
     private val serverUrlProvider: () -> String,
     private val requestHeadersProvider: (Uri) -> Map<String, String> = { emptyMap() },
+    private val isResumableDirectPlayUri: (Uri) -> Boolean = { false },
 ) : DataSource.Factory {
 
     override fun createDataSource(): DataSource {
-        val http = RefreshingHttpDataSource(httpDataSourceFactory, authSession)
+        val http = RefreshingHttpDataSource(
+            factory = httpDataSourceFactory,
+            authSession = authSession,
+            isResumableDirectPlayUri = isResumableDirectPlayUri,
+        )
         val file = FileDataSource()
         val content = ContentDataSource(context)
         return RoutedDataSource(
@@ -59,6 +64,7 @@ class AuthenticatedDataSourceFactory(
 internal class RefreshingHttpDataSource(
     private val factory: HttpDataSource.Factory,
     private val authSession: MediaAuthSession,
+    private val isResumableDirectPlayUri: (Uri) -> Boolean = { false },
 ) : HttpDataSource {
     private val transferListeners = mutableListOf<TransferListener>()
     private val requestProperties = linkedMapOf<String, String>()
@@ -72,12 +78,15 @@ internal class RefreshingHttpDataSource(
     }
 
     override fun open(dataSpec: DataSpec): Long {
-        prepareEntityGuard(dataSpec.uri)
+        val guardEnabled = isResumableDirectPlayUri(dataSpec.uri)
+        if (guardEnabled) {
+            prepareEntityGuard(dataSpec.uri)
+        }
         val failedSnapshot = runBlocking { authSession.snapshot() }
         val first = newDataSource()
         active = first
         return try {
-            first.openWithGuards(dataSpec, failedSnapshot)
+            first.openWithGuards(dataSpec, failedSnapshot, guardEnabled)
         } catch (error: HttpDataSource.InvalidResponseCodeException) {
             if (error.responseCode != 401 || !runBlocking { authSession.refreshIfStale(failedSnapshot) }) {
                 throw error
@@ -85,7 +94,7 @@ internal class RefreshingHttpDataSource(
             first.close()
             val retry = newDataSource()
             active = retry
-            retry.openWithGuards(dataSpec, runBlocking { authSession.snapshot() })
+            retry.openWithGuards(dataSpec, runBlocking { authSession.snapshot() }, guardEnabled)
         }
     }
 
@@ -134,16 +143,25 @@ internal class RefreshingHttpDataSource(
     private fun HttpDataSource.openWithGuards(
         dataSpec: DataSpec,
         snapshot: MediaAuthSnapshot,
+        guardEnabled: Boolean,
     ): Long {
+        if (!guardEnabled) {
+            return open(dataSpec.withAuthHeaders(snapshot))
+        }
+
+        val previousEtag = entityEtag
         val guardedDataSpec = dataSpec
             .withIfRangeHeader()
             .withAuthHeaders(snapshot)
         val length = open(guardedDataSpec)
         val responseEtag = responseHeaders.headerValue("ETag")
-        val previousEtag = entityEtag
-        if (previousEtag != null && responseEtag != null && responseEtag != previousEtag) {
-            runCatching(::close)
-            throw EntityChangedException()
+        if (previousEtag != null && dataSpec.position > 0L) {
+            if (responseEtag != null && responseEtag != previousEtag) {
+                failEntityChanged()
+            }
+            if (responseCode == 200 && responseEtag != previousEtag) {
+                failEntityChanged()
+            }
         }
         if (responseEtag != null) {
             entityEtag = responseEtag
@@ -153,10 +171,16 @@ internal class RefreshingHttpDataSource(
 
     private fun DataSpec.withIfRangeHeader(): DataSpec {
         val etag = entityEtag
-        if (position <= 0L || etag == null) return this
+        if (position <= 0L || etag == null || !etag.isStrongEtagValidator()) return this
         return buildUpon()
             .setHttpRequestHeaders(httpRequestHeaders.withHeader("If-Range", etag))
             .build()
+    }
+
+    private fun HttpDataSource.failEntityChanged(): Nothing {
+        runCatching(::close)
+        active = null
+        throw EntityChangedException()
     }
 
     private fun DataSpec.withAuthHeaders(snapshot: MediaAuthSnapshot): DataSpec = buildUpon()
@@ -179,6 +203,9 @@ private fun Map<String, List<String>>.headerValue(name: String): String? =
         ?.firstOrNull()
         ?.trim()
         ?.takeIf(String::isNotEmpty)
+
+private fun String.isStrongEtagValidator(): Boolean =
+    !startsWith("W/", ignoreCase = true)
 
 private fun Map<String, String>.withHeader(name: String, value: String): Map<String, String> =
     buildMap {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicy.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicy.kt
@@ -1,38 +1,126 @@
 package org.siloserver.silo.common.player
 
+import android.util.Log
 import androidx.media3.common.C
+import androidx.media3.common.ParserException
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
+import java.io.EOFException
 import java.net.ConnectException
 import java.net.ProtocolException
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.util.concurrent.ConcurrentHashMap
+import okhttp3.internal.http2.ConnectionShutdownException
+import okhttp3.internal.http2.StreamResetException
 
 /**
- * Keeps HLS manifest/segment loads alive across short server restarts.
+ * Keeps transient HLS loads alive and resumes eligible progressive direct play
+ * after mid-body transport failures.
  *
- * The server can reconstruct transcode sessions after restart, but only if the
- * client keeps retrying instead of letting Media3's short default retry budget
- * turn the outage into a fatal PlaybackException.
+ * HLS retains its existing server-restart retries. Original-file progressive
+ * loads additionally reopen only after real byte progress, allowing Media3 to
+ * continue at its current extraction position without surfacing a player error.
  */
 @UnstableApi
-internal class SiloMediaLoadErrorHandlingPolicy : DefaultLoadErrorHandlingPolicy() {
+internal class SiloMediaLoadErrorHandlingPolicy(
+    private val isResumableProgressiveDirectPlay: () -> Boolean = { false },
+) : DefaultLoadErrorHandlingPolicy() {
+    private val attemptBytesTracker = MediaLoadAttemptBytesTracker()
 
     override fun getRetryDelayMsFor(loadErrorInfo: LoadErrorHandlingPolicy.LoadErrorInfo): Long {
         val invalidResponse = loadErrorInfo.exception as? HttpDataSource.InvalidResponseCodeException
-        return siloMediaLoadRetryDelayMs(
+        val cumulativeBytesLoaded = loadErrorInfo.loadEventInfo.bytesLoaded
+        val bytesLoaded = attemptBytesTracker.bytesLoadedForAttempt(
+            loadTaskId = loadErrorInfo.loadEventInfo.loadTaskId,
+            cumulativeBytesLoaded = cumulativeBytesLoaded,
+        )
+        val resumableDirectPlay = isResumableProgressiveDirectPlay()
+        val delayMs = siloMediaLoadRetryDelayMs(
             responseCode = invalidResponse?.responseCode,
             retryAfterHeaders = invalidResponse?.retryAfterHeaders().orEmpty(),
             cause = loadErrorInfo.exception,
             errorCount = loadErrorInfo.errorCount,
+            isResumableProgressiveDirectPlay = resumableDirectPlay,
+            bytesLoaded = bytesLoaded,
         )
+        logProgressiveResumeDecision(
+            loadErrorInfo = loadErrorInfo,
+            resumableDirectPlay = resumableDirectPlay,
+            bytesLoaded = bytesLoaded,
+            delayMs = delayMs,
+        )
+        return delayMs
+    }
+
+    override fun onLoadTaskConcluded(loadTaskId: Long) {
+        attemptBytesTracker.onLoadTaskConcluded(loadTaskId)
+        super.onLoadTaskConcluded(loadTaskId)
     }
 
     override fun getMinimumLoadableRetryCount(dataType: Int): Int =
         Int.MAX_VALUE
+
+    private fun logProgressiveResumeDecision(
+        loadErrorInfo: LoadErrorHandlingPolicy.LoadErrorInfo,
+        resumableDirectPlay: Boolean,
+        bytesLoaded: Long,
+        delayMs: Long,
+    ) {
+        if (!resumableDirectPlay) return
+        val transportFailure = loadErrorInfo.exception.findResumableTransportFailure() ?: return
+        val resumeOffset = loadErrorInfo.loadEventInfo.dataSpec.position.coerceAtLeast(0L) +
+            bytesLoaded.coerceAtLeast(0L)
+        val errorDescription = buildString {
+            append(transportFailure.javaClass.simpleName)
+            transportFailure.message?.takeIf(String::isNotBlank)?.let {
+                append(": ")
+                append(it)
+            }
+        }
+        if (delayMs != C.TIME_UNSET) {
+            Log.i(
+                TAG,
+                "progressive direct-play retry error=$errorDescription " +
+                    "bytes_loaded=$bytesLoaded resume_offset=$resumeOffset " +
+                    "attempt=${loadErrorInfo.errorCount} retry_delay_ms=$delayMs",
+            )
+        } else {
+            Log.w(
+                TAG,
+                "progressive direct-play retry exhausted error=$errorDescription " +
+                    "bytes_loaded=$bytesLoaded resume_offset=$resumeOffset " +
+                    "attempt=${loadErrorInfo.errorCount}",
+            )
+        }
+    }
+
+    private companion object {
+        const val TAG = "MediaLoadRetry"
+    }
+}
+
+internal class MediaLoadAttemptBytesTracker {
+    private val cumulativeBytesByLoadTask = ConcurrentHashMap<Long, Long>()
+
+    fun bytesLoadedForAttempt(
+        loadTaskId: Long,
+        cumulativeBytesLoaded: Long,
+    ): Long {
+        val sanitizedCumulativeBytes = cumulativeBytesLoaded.coerceAtLeast(0L)
+        val previousCumulativeBytes = cumulativeBytesByLoadTask.put(
+            loadTaskId,
+            sanitizedCumulativeBytes,
+        ) ?: 0L
+        return (sanitizedCumulativeBytes - previousCumulativeBytes).coerceAtLeast(0L)
+    }
+
+    fun onLoadTaskConcluded(loadTaskId: Long) {
+        cumulativeBytesByLoadTask.remove(loadTaskId)
+    }
 }
 
 internal fun siloMediaLoadRetryDelayMs(
@@ -40,9 +128,20 @@ internal fun siloMediaLoadRetryDelayMs(
     retryAfterHeaders: List<String> = emptyList(),
     cause: Throwable? = null,
     errorCount: Int,
+    isResumableProgressiveDirectPlay: Boolean = false,
+    bytesLoaded: Long = 0L,
     retryWindowMs: Long = MEDIA_LOAD_RETRY_WINDOW_MS,
 ): Long {
-    if (!isRetryableMediaLoadFailure(responseCode, cause)) return C.TIME_UNSET
+    if (
+        !isRetryableMediaLoadFailure(
+            responseCode = responseCode,
+            cause = cause,
+            isResumableProgressiveDirectPlay = isResumableProgressiveDirectPlay,
+            bytesLoaded = bytesLoaded,
+        )
+    ) {
+        return C.TIME_UNSET
+    }
 
     val delayMs = retryAfterHeaders.firstNotNullOfOrNull(::parseRetryAfterDelayMs)
         ?: mediaLoadBackoffDelayMs(errorCount)
@@ -50,7 +149,18 @@ internal fun siloMediaLoadRetryDelayMs(
     return if (elapsedBeforeRetry + delayMs <= retryWindowMs) delayMs else C.TIME_UNSET
 }
 
-private fun isRetryableMediaLoadFailure(responseCode: Int?, cause: Throwable?): Boolean {
+private fun isRetryableMediaLoadFailure(
+    responseCode: Int?,
+    cause: Throwable?,
+    isResumableProgressiveDirectPlay: Boolean,
+    bytesLoaded: Long,
+): Boolean {
+    if (
+        generateSequence(cause) { it.cause }
+            .any { it is EntityChangedException || it is ParserException }
+    ) {
+        return false
+    }
     if (responseCode != null) return responseCode.isRetryableMediaStatus()
     return generateSequence(cause) { it.cause }
         .any { error ->
@@ -58,20 +168,45 @@ private fun isRetryableMediaLoadFailure(responseCode: Int?, cause: Throwable?): 
                 error is ConnectException ||
                 error is SocketException ||
                 error is UnknownHostException ||
-                error.isPrematureHttpEndOfStream()
+                error.isRetryablePrematureEnd(
+                    isResumableProgressiveDirectPlay = isResumableProgressiveDirectPlay,
+                    bytesLoaded = bytesLoaded,
+                )
         }
+}
+
+private fun Throwable.isRetryablePrematureEnd(
+    isResumableProgressiveDirectPlay: Boolean,
+    bytesLoaded: Long,
+): Boolean {
+    val madeProgress = bytesLoaded > 0L
+    return when {
+        this is ProtocolException && isUnexpectedEndOfStream() ->
+            !isResumableProgressiveDirectPlay || madeProgress
+        isResumableTransportFailure() ->
+            isResumableProgressiveDirectPlay && madeProgress
+        else -> false
+    }
 }
 
 /**
  * OkHttp reports a response that closes before its declared Content-Length as
  * a ProtocolException wrapped by Media3's HttpDataSourceException. Progressive
- * extractors can safely reopen their current byte range, so keep this narrowly
- * scoped transport failure retryable without masking unrelated protocol or
- * container errors.
+ * extractors can safely reopen their current byte range after real byte
+ * progress. HTTP/2 stream and connection shutdowns are similarly resumable,
+ * but only for original-file progressive delivery.
  */
-private fun Throwable.isPrematureHttpEndOfStream(): Boolean =
-    this is ProtocolException &&
-        message?.contains("unexpected end of stream", ignoreCase = true) == true
+private fun Throwable.isResumableTransportFailure(): Boolean =
+    this is StreamResetException ||
+        this is ConnectionShutdownException ||
+        this is EOFException ||
+        (this is ProtocolException && isUnexpectedEndOfStream())
+
+private fun ProtocolException.isUnexpectedEndOfStream(): Boolean =
+    message?.contains("unexpected end of stream", ignoreCase = true) == true
+
+private fun Throwable?.findResumableTransportFailure(): Throwable? =
+    generateSequence(this) { it.cause }.firstOrNull(Throwable::isResumableTransportFailure)
 
 private fun Int.isRetryableMediaStatus(): Boolean =
     this == 404 ||

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicy.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicy.kt
@@ -1,12 +1,14 @@
 package org.siloserver.silo.common.player
 
-import android.util.Log
+import android.net.Uri
 import androidx.media3.common.C
 import androidx.media3.common.ParserException
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
+import org.siloserver.silo.common.diagnostics.SiloLog
+import org.siloserver.silo.model.diagnostics.DiagnosticsLogCategory
 import java.io.EOFException
 import java.net.ConnectException
 import java.net.ProtocolException
@@ -18,16 +20,20 @@ import okhttp3.internal.http2.ConnectionShutdownException
 import okhttp3.internal.http2.StreamResetException
 
 /**
- * Keeps transient HLS loads alive and resumes eligible progressive direct play
- * after mid-body transport failures.
+ * Keeps transient media loads alive and resumes eligible progressive direct
+ * play after mid-body transport failures.
  *
- * HLS retains its existing server-restart retries. Original-file progressive
- * loads additionally reopen only after real byte progress, allowing Media3 to
- * continue at its current extraction position without surfacing a player error.
+ * Eligibility is classified per load URI because the source factories are
+ * shared by HLS, progressive, and sidecar subtitle loads. HLS retains its
+ * existing server-restart retries, including zero-progress unexpected-end
+ * failures. Original-file progressive loads additionally reopen stream resets
+ * and EOF-style transport failures only after real byte progress, allowing
+ * Media3 to continue at its current extraction position without surfacing a
+ * player error.
  */
 @UnstableApi
 internal class SiloMediaLoadErrorHandlingPolicy(
-    private val isResumableProgressiveDirectPlay: () -> Boolean = { false },
+    private val isResumableProgressiveDirectPlay: (Uri) -> Boolean = { false },
 ) : DefaultLoadErrorHandlingPolicy() {
     private val attemptBytesTracker = MediaLoadAttemptBytesTracker()
 
@@ -38,7 +44,9 @@ internal class SiloMediaLoadErrorHandlingPolicy(
             loadTaskId = loadErrorInfo.loadEventInfo.loadTaskId,
             cumulativeBytesLoaded = cumulativeBytesLoaded,
         )
-        val resumableDirectPlay = isResumableProgressiveDirectPlay()
+        val resumableDirectPlay = isResumableProgressiveDirectPlay(
+            loadErrorInfo.loadEventInfo.dataSpec.uri,
+        )
         val delayMs = siloMediaLoadRetryDelayMs(
             responseCode = invalidResponse?.responseCode,
             retryAfterHeaders = invalidResponse?.retryAfterHeaders().orEmpty(),
@@ -82,14 +90,16 @@ internal class SiloMediaLoadErrorHandlingPolicy(
             }
         }
         if (delayMs != C.TIME_UNSET) {
-            Log.i(
+            SiloLog.i(
+                DiagnosticsLogCategory.PLAYBACK,
                 TAG,
                 "progressive direct-play retry error=$errorDescription " +
                     "bytes_loaded=$bytesLoaded resume_offset=$resumeOffset " +
                     "attempt=${loadErrorInfo.errorCount} retry_delay_ms=$delayMs",
             )
         } else {
-            Log.w(
+            SiloLog.w(
+                DiagnosticsLogCategory.PLAYBACK,
                 TAG,
                 "progressive direct-play retry exhausted error=$errorDescription " +
                     "bytes_loaded=$bytesLoaded resume_offset=$resumeOffset " +
@@ -155,24 +165,29 @@ private fun isRetryableMediaLoadFailure(
     isResumableProgressiveDirectPlay: Boolean,
     bytesLoaded: Long,
 ): Boolean {
-    if (
-        generateSequence(cause) { it.cause }
-            .any { it is EntityChangedException || it is ParserException }
-    ) {
-        return false
-    }
+    val chain = generateSequence(cause) { it.cause }.toList()
+    if (chain.any { it is EntityChangedException }) return false
     if (responseCode != null) return responseCode.isRetryableMediaStatus()
-    return generateSequence(cause) { it.cause }
-        .any { error ->
+
+    if (
+        chain.any { error ->
             error is SocketTimeoutException ||
                 error is ConnectException ||
                 error is SocketException ||
-                error is UnknownHostException ||
-                error.isRetryablePrematureEnd(
-                    isResumableProgressiveDirectPlay = isResumableProgressiveDirectPlay,
-                    bytesLoaded = bytesLoaded,
-                )
+                error is UnknownHostException
         }
+    ) {
+        return true
+    }
+
+    if (chain.any { it is ParserException }) return false
+
+    return chain.any { error ->
+        error.isRetryablePrematureEnd(
+            isResumableProgressiveDirectPlay = isResumableProgressiveDirectPlay,
+            bytesLoaded = bytesLoaded,
+        )
+    }
 }
 
 private fun Throwable.isRetryablePrematureEnd(
@@ -182,7 +197,7 @@ private fun Throwable.isRetryablePrematureEnd(
     val madeProgress = bytesLoaded > 0L
     return when {
         this is ProtocolException && isUnexpectedEndOfStream() ->
-            !isResumableProgressiveDirectPlay || madeProgress
+            true
         isResumableTransportFailure() ->
             isResumableProgressiveDirectPlay && madeProgress
         else -> false

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
@@ -88,6 +88,7 @@ class SiloPlayerFactory(
     )
 
     @Volatile private var requestHeaderScope: RequestHeaderScope? = null
+    @Volatile private var resumableProgressiveDirectPlay: Boolean = false
     private val runtimeCorrectionState = PlaybackRuntimeCorrectionState()
 
     private val dataSourceFactory = AuthenticatedDataSourceFactory(
@@ -250,7 +251,9 @@ class SiloPlayerFactory(
             .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
             .build()
 
-        val mediaLoadErrorHandlingPolicy = SiloMediaLoadErrorHandlingPolicy()
+        val mediaLoadErrorHandlingPolicy = SiloMediaLoadErrorHandlingPolicy(
+            isResumableProgressiveDirectPlay = { resumableProgressiveDirectPlay },
+        )
         fun defaultMediaSourceFactory(
             mode: DolbyVisionTransformMode,
             expectedDynamicRange: String? = null,
@@ -406,6 +409,7 @@ class SiloPlayerFactory(
         runtimeCorrections: List<String> = emptyList(),
     ): MediaItem {
         this.serverUrl = serverUrl
+        resumableProgressiveDirectPlay = delivery == PlaybackDelivery.ORIGINAL_HTTP
         runtimeCorrectionState.activate(runtimeCorrections)
         subtitleOffsetHolder.setTimelineOffsetSeconds(timelineOffsetSeconds)
         val absoluteUrl = buildAbsoluteUrl(serverUrl, streamUrl)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
@@ -88,7 +88,7 @@ class SiloPlayerFactory(
     )
 
     @Volatile private var requestHeaderScope: RequestHeaderScope? = null
-    @Volatile private var resumableProgressiveDirectPlay: Boolean = false
+    @Volatile private var resumableDirectPlayUri: android.net.Uri? = null
     private val runtimeCorrectionState = PlaybackRuntimeCorrectionState()
 
     private val dataSourceFactory = AuthenticatedDataSourceFactory(
@@ -97,6 +97,7 @@ class SiloPlayerFactory(
         authSession = mediaAuthSession,
         serverUrlProvider = { serverUrl },
         requestHeadersProvider = ::requestHeadersFor,
+        isResumableDirectPlayUri = ::isResumableDirectPlayUri,
     )
 
     private val embeddedSubtitleParserFactory = OffsetSubtitleParserFactory(
@@ -252,7 +253,7 @@ class SiloPlayerFactory(
             .build()
 
         val mediaLoadErrorHandlingPolicy = SiloMediaLoadErrorHandlingPolicy(
-            isResumableProgressiveDirectPlay = { resumableProgressiveDirectPlay },
+            isResumableProgressiveDirectPlay = ::isResumableDirectPlayUri,
         )
         fun defaultMediaSourceFactory(
             mode: DolbyVisionTransformMode,
@@ -409,10 +410,14 @@ class SiloPlayerFactory(
         runtimeCorrections: List<String> = emptyList(),
     ): MediaItem {
         this.serverUrl = serverUrl
-        resumableProgressiveDirectPlay = delivery == PlaybackDelivery.ORIGINAL_HTTP
         runtimeCorrectionState.activate(runtimeCorrections)
         subtitleOffsetHolder.setTimelineOffsetSeconds(timelineOffsetSeconds)
         val absoluteUrl = buildAbsoluteUrl(serverUrl, streamUrl)
+        resumableDirectPlayUri = if (delivery == PlaybackDelivery.ORIGINAL_HTTP) {
+            android.net.Uri.parse(absoluteUrl)
+        } else {
+            null
+        }
         requestHeaderScope = requestHeaders.takeIf { it.isNotEmpty() }?.let {
             RequestHeaderScope(android.net.Uri.parse(absoluteUrl), it)
         }
@@ -481,6 +486,9 @@ class SiloPlayerFactory(
             emptyMap()
         }
     }
+
+    private fun isResumableDirectPlayUri(uri: android.net.Uri): Boolean =
+        uri == resumableDirectPlayUri
 
     private fun buildAbsoluteUrl(serverUrl: String, streamUrl: String): String =
         resolvePlaybackStreamUrl(serverUrl, streamUrl)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactoryTest.kt
@@ -102,9 +102,49 @@ class AuthenticatedDataSourceFactoryTest {
     }
 
     @Test
-    fun `etag is captured and attached as if-range on ranged reopen`() {
+    fun `guard disabled skips if-range and entity-change validation`() {
         val initial = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v1\"")))
-        val resumed = FakeHttpDataSource(responseHeaders = mapOf("etag" to listOf("\"v1\"")))
+        val changed = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v2\"")))
+        val source = refreshingSource(
+            initial,
+            changed,
+            isResumableDirectPlayUri = { false },
+        )
+        val uri = Uri.parse("https://cdn.example/video.mp4")
+
+        source.open(DataSpec(uri))
+        source.close()
+        source.open(DataSpec.Builder().setUri(uri).setPosition(4_096L).build())
+
+        assertFalse(initial.openedDataSpecs.single().httpRequestHeaders.containsKey("If-Range"))
+        assertFalse(changed.openedDataSpecs.single().httpRequestHeaders.containsKey("If-Range"))
+        assertFalse(changed.closed)
+    }
+
+    @Test
+    fun `weak etag is captured but not sent as if-range on ranged reopen`() {
+        val initial = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("""W/"v1"""")))
+        val resumed = FakeHttpDataSource(
+            responseHeaders = mapOf("etag" to listOf("""W/"v1"""")),
+            responseCode = 200,
+        )
+        val source = refreshingSource(initial, resumed)
+        val uri = Uri.parse("https://cdn.example/video.mp4")
+
+        source.open(DataSpec(uri))
+        source.close()
+        source.open(DataSpec.Builder().setUri(uri).setPosition(4_096L).build())
+
+        assertFalse(resumed.openedDataSpecs.single().httpRequestHeaders.containsKey("If-Range"))
+    }
+
+    @Test
+    fun `strong etag is captured and attached as if-range on ranged reopen`() {
+        val initial = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v1\"")))
+        val resumed = FakeHttpDataSource(
+            responseHeaders = mapOf("etag" to listOf("\"v1\"")),
+            responseCode = 206,
+        )
         val source = refreshingSource(initial, resumed)
         val uri = Uri.parse("https://cdn.example/video.mp4")
 
@@ -130,6 +170,57 @@ class AuthenticatedDataSourceFactoryTest {
             source.open(DataSpec.Builder().setUri(uri).setPosition(8_192L).build())
         }
         assertTrue(changed.closed)
+        assertEquals(C.RESULT_END_OF_INPUT, source.read(ByteArray(1), 0, 1))
+    }
+
+    @Test
+    fun `ranged reopen with prior etag rejects 200 without matching etag`() {
+        val initial = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v1\"")))
+        val full = FakeHttpDataSource(responseCode = 200)
+        val source = refreshingSource(initial, full)
+        val uri = Uri.parse("https://cdn.example/video.mp4")
+
+        source.open(DataSpec(uri))
+        source.close()
+
+        assertFailsWith<EntityChangedException> {
+            source.open(DataSpec.Builder().setUri(uri).setPosition(8_192L).build())
+        }
+        assertTrue(full.closed)
+        assertEquals(C.RESULT_END_OF_INPUT, source.read(ByteArray(1), 0, 1))
+    }
+
+    @Test
+    fun `ranged reopen with prior etag accepts 200 with matching etag`() {
+        val initial = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v1\"")))
+        val full = FakeHttpDataSource(
+            responseHeaders = mapOf("ETag" to listOf("\"v1\"")),
+            responseCode = 200,
+        )
+        val source = refreshingSource(initial, full)
+        val uri = Uri.parse("https://cdn.example/video.mp4")
+
+        source.open(DataSpec(uri))
+        source.close()
+        source.open(DataSpec.Builder().setUri(uri).setPosition(8_192L).build())
+
+        assertEquals("\"v1\"", full.openedDataSpecs.single().httpRequestHeaders["If-Range"])
+        assertFalse(full.closed)
+    }
+
+    @Test
+    fun `ranged reopen with prior etag accepts 206 without response etag`() {
+        val initial = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v1\"")))
+        val partial = FakeHttpDataSource(responseCode = 206)
+        val source = refreshingSource(initial, partial)
+        val uri = Uri.parse("https://cdn.example/video.mp4")
+
+        source.open(DataSpec(uri))
+        source.close()
+        source.open(DataSpec.Builder().setUri(uri).setPosition(8_192L).build())
+
+        assertEquals("\"v1\"", partial.openedDataSpecs.single().httpRequestHeaders["If-Range"])
+        assertFalse(partial.closed)
     }
 
     @Test
@@ -205,6 +296,7 @@ class AuthenticatedDataSourceFactoryTest {
 
     private fun refreshingSource(
         vararg dataSources: FakeHttpDataSource,
+        isResumableDirectPlayUri: (Uri) -> Boolean = { true },
     ): RefreshingHttpDataSource {
         val client = OkHttpClient().also {
             closeables += it
@@ -212,6 +304,7 @@ class AuthenticatedDataSourceFactoryTest {
         return RefreshingHttpDataSource(
             factory = FakeHttpDataSourceFactory(ArrayDeque(dataSources.toList())),
             authSession = MediaAuthSession(TokenManagerImpl(), client),
+            isResumableDirectPlayUri = isResumableDirectPlayUri,
         )
     }
 
@@ -227,6 +320,7 @@ class AuthenticatedDataSourceFactoryTest {
 
     private class FakeHttpDataSource(
         private val responseHeaders: Map<String, List<String>> = emptyMap(),
+        private val responseCode: Int = 200,
         private val onOpen: (DataSpec) -> Long = { C.LENGTH_UNSET.toLong() },
     ) : HttpDataSource {
         val openedDataSpecs = mutableListOf<DataSpec>()
@@ -244,7 +338,7 @@ class AuthenticatedDataSourceFactoryTest {
 
         override fun getUri(): Uri? = openedDataSpecs.lastOrNull()?.uri
 
-        override fun getResponseCode(): Int = 200
+        override fun getResponseCode(): Int = responseCode
 
         override fun getResponseHeaders(): Map<String, List<String>> = responseHeaders
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactoryTest.kt
@@ -1,11 +1,37 @@
 package org.siloserver.silo.common.player
 
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.datasource.TransferListener
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.siloserver.silo.network.TokenManagerImpl
 
+@RunWith(RobolectricTestRunner::class)
 class AuthenticatedDataSourceFactoryTest {
+    private val closeables = mutableListOf<OkHttpClient>()
+
+    @AfterTest
+    fun tearDown() {
+        closeables.forEach { client ->
+            client.dispatcher.executorService.shutdown()
+            client.connectionPool.evictAll()
+        }
+    }
+
     @Test
     fun streamRelativeFallbackUsesPlaybackStreamResolver() {
         assertEquals(
@@ -73,5 +99,163 @@ class AuthenticatedDataSourceFactoryTest {
     fun nonSrtPayloadsDoNotUseSubtitleNormalization() {
         assertFalse(shouldNormalizeSubripPath("/video/segment.ts", 0L))
         assertFalse(shouldNormalizeSubripPath("/api/v1/stream/session/subtitles/4.srt", 512L))
+    }
+
+    @Test
+    fun `etag is captured and attached as if-range on ranged reopen`() {
+        val initial = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v1\"")))
+        val resumed = FakeHttpDataSource(responseHeaders = mapOf("etag" to listOf("\"v1\"")))
+        val source = refreshingSource(initial, resumed)
+        val uri = Uri.parse("https://cdn.example/video.mp4")
+
+        source.open(DataSpec(uri))
+        source.close()
+        source.open(DataSpec.Builder().setUri(uri).setPosition(4_096L).build())
+
+        assertFalse(initial.openedDataSpecs.single().httpRequestHeaders.containsKey("If-Range"))
+        assertEquals("\"v1\"", resumed.openedDataSpecs.single().httpRequestHeaders["If-Range"])
+    }
+
+    @Test
+    fun `etag mismatch aborts ranged reopen and closes response`() {
+        val initial = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v1\"")))
+        val changed = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v2\"")))
+        val source = refreshingSource(initial, changed)
+        val uri = Uri.parse("https://cdn.example/video.mp4")
+
+        source.open(DataSpec(uri))
+        source.close()
+
+        assertFailsWith<EntityChangedException> {
+            source.open(DataSpec.Builder().setUri(uri).setPosition(8_192L).build())
+        }
+        assertTrue(changed.closed)
+    }
+
+    @Test
+    fun `changing uri resets the stored entity validator`() {
+        val first = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v1\"")))
+        val second = FakeHttpDataSource(responseHeaders = mapOf("ETag" to listOf("\"v2\"")))
+        val source = refreshingSource(first, second)
+
+        source.open(DataSpec(Uri.parse("https://cdn.example/video-a.mp4")))
+        source.close()
+        source.open(
+            DataSpec.Builder()
+                .setUri(Uri.parse("https://cdn.example/video-b.mp4"))
+                .setPosition(1_024L)
+                .build(),
+        )
+
+        assertFalse(second.openedDataSpecs.single().httpRequestHeaders.containsKey("If-Range"))
+    }
+
+    @Test
+    fun `single flight 401 refresh still retries once with fresh authorization`() {
+        val unauthorized = FakeHttpDataSource { dataSpec ->
+            throw HttpDataSource.InvalidResponseCodeException(
+                401,
+                "Unauthorized",
+                null,
+                emptyMap(),
+                dataSpec,
+                byteArrayOf(),
+            )
+        }
+        val retried = FakeHttpDataSource()
+        val tokens = TokenManagerImpl()
+        runBlocking {
+            tokens.setServerUrl("https://silo.example")
+            tokens.saveTokens("expired-access", "refresh-token", 3_600)
+        }
+        val refreshClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body(
+                        """{"access_token":"fresh-access","refresh_token":"fresh-refresh","expires_in":3600}"""
+                            .toResponseBody(null),
+                    )
+                    .build()
+            }
+            .build()
+            .also {
+                closeables += it
+            }
+        val source = RefreshingHttpDataSource(
+            FakeHttpDataSourceFactory(ArrayDeque(listOf(unauthorized, retried))),
+            MediaAuthSession(tokens, refreshClient),
+        )
+
+        source.open(DataSpec(Uri.parse("https://silo.example/api/v1/stream/session")))
+
+        assertEquals(
+            "Bearer expired-access",
+            unauthorized.openedDataSpecs.single().httpRequestHeaders["Authorization"],
+        )
+        assertEquals(
+            "Bearer fresh-access",
+            retried.openedDataSpecs.single().httpRequestHeaders["Authorization"],
+        )
+        assertTrue(unauthorized.closed)
+    }
+
+    private fun refreshingSource(
+        vararg dataSources: FakeHttpDataSource,
+    ): RefreshingHttpDataSource {
+        val client = OkHttpClient().also {
+            closeables += it
+        }
+        return RefreshingHttpDataSource(
+            factory = FakeHttpDataSourceFactory(ArrayDeque(dataSources.toList())),
+            authSession = MediaAuthSession(TokenManagerImpl(), client),
+        )
+    }
+
+    private class FakeHttpDataSourceFactory(
+        private val dataSources: ArrayDeque<FakeHttpDataSource>,
+    ) : HttpDataSource.Factory {
+        override fun createDataSource(): HttpDataSource = dataSources.removeFirst()
+
+        override fun setDefaultRequestProperties(
+            defaultRequestProperties: Map<String, String>,
+        ): HttpDataSource.Factory = this
+    }
+
+    private class FakeHttpDataSource(
+        private val responseHeaders: Map<String, List<String>> = emptyMap(),
+        private val onOpen: (DataSpec) -> Long = { C.LENGTH_UNSET.toLong() },
+    ) : HttpDataSource {
+        val openedDataSpecs = mutableListOf<DataSpec>()
+        var closed = false
+
+        override fun addTransferListener(transferListener: TransferListener) = Unit
+
+        override fun open(dataSpec: DataSpec): Long {
+            openedDataSpecs += dataSpec
+            return onOpen(dataSpec)
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int =
+            C.RESULT_END_OF_INPUT
+
+        override fun getUri(): Uri? = openedDataSpecs.lastOrNull()?.uri
+
+        override fun getResponseCode(): Int = 200
+
+        override fun getResponseHeaders(): Map<String, List<String>> = responseHeaders
+
+        override fun setRequestProperty(name: String, value: String) = Unit
+
+        override fun clearRequestProperty(name: String) = Unit
+
+        override fun clearAllRequestProperties() = Unit
+
+        override fun close() {
+            closed = true
+        }
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicyTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicyTest.kt
@@ -6,6 +6,7 @@ import java.io.EOFException
 import java.io.IOException
 import java.net.ConnectException
 import java.net.ProtocolException
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -127,7 +128,7 @@ class MediaLoadRetryPolicyTest {
             ),
         )
         assertEquals(
-            C.TIME_UNSET,
+            1_000L,
             siloMediaLoadRetryDelayMs(
                 cause = ProtocolException("unexpected end of stream"),
                 errorCount = 1,
@@ -185,6 +186,22 @@ class MediaLoadRetryPolicyTest {
             C.TIME_UNSET,
             siloMediaLoadRetryDelayMs(
                 cause = EntityChangedException(),
+                errorCount = 1,
+                isResumableProgressiveDirectPlay = true,
+                bytesLoaded = 32_768L,
+            ),
+        )
+    }
+
+    @Test
+    fun `parser failures still retry when wrapping a socket failure`() {
+        assertEquals(
+            1_000L,
+            siloMediaLoadRetryDelayMs(
+                cause = ParserException.createForMalformedContainer(
+                    "parser observed transport failure",
+                    SocketException("connection reset"),
+                ),
                 errorCount = 1,
                 isResumableProgressiveDirectPlay = true,
                 bytesLoaded = 32_768L,

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicyTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicyTest.kt
@@ -1,14 +1,42 @@
 package org.siloserver.silo.common.player
 
 import androidx.media3.common.C
+import androidx.media3.common.ParserException
+import java.io.EOFException
 import java.io.IOException
 import java.net.ConnectException
 import java.net.ProtocolException
 import java.net.SocketTimeoutException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import okhttp3.internal.http2.ErrorCode
+import okhttp3.internal.http2.StreamResetException
 
 class MediaLoadRetryPolicyTest {
+
+    @Test
+    fun `attempt progress is derived from cumulative load task bytes`() {
+        val tracker = MediaLoadAttemptBytesTracker()
+
+        assertEquals(
+            1_024L,
+            tracker.bytesLoadedForAttempt(loadTaskId = 7L, cumulativeBytesLoaded = 1_024L),
+        )
+        assertEquals(
+            0L,
+            tracker.bytesLoadedForAttempt(loadTaskId = 7L, cumulativeBytesLoaded = 1_024L),
+        )
+        assertEquals(
+            2_048L,
+            tracker.bytesLoadedForAttempt(loadTaskId = 7L, cumulativeBytesLoaded = 3_072L),
+        )
+
+        tracker.onLoadTaskConcluded(loadTaskId = 7L)
+        assertEquals(
+            3_072L,
+            tracker.bytesLoadedForAttempt(loadTaskId = 7L, cumulativeBytesLoaded = 3_072L),
+        )
+    }
 
     @Test
     fun `gateway and missing-session statuses retry with exponential backoff`() {
@@ -47,6 +75,8 @@ class MediaLoadRetryPolicyTest {
     @Test
     fun `non transient response codes do not retry`() {
         assertEquals(C.TIME_UNSET, siloMediaLoadRetryDelayMs(responseCode = 401, errorCount = 1))
+        assertEquals(C.TIME_UNSET, siloMediaLoadRetryDelayMs(responseCode = 403, errorCount = 1))
+        assertEquals(C.TIME_UNSET, siloMediaLoadRetryDelayMs(responseCode = 416, errorCount = 1))
         assertEquals(C.TIME_UNSET, siloMediaLoadRetryDelayMs(responseCode = 418, errorCount = 1))
     }
 
@@ -85,6 +115,95 @@ class MediaLoadRetryPolicyTest {
                     ProtocolException("unexpected end of stream"),
                 ),
                 errorCount = 1,
+            ),
+        )
+        assertEquals(
+            1_000L,
+            siloMediaLoadRetryDelayMs(
+                cause = ProtocolException("unexpected end of stream"),
+                errorCount = 1,
+                isResumableProgressiveDirectPlay = true,
+                bytesLoaded = 4_096L,
+            ),
+        )
+        assertEquals(
+            C.TIME_UNSET,
+            siloMediaLoadRetryDelayMs(
+                cause = ProtocolException("unexpected end of stream"),
+                errorCount = 1,
+                isResumableProgressiveDirectPlay = true,
+                bytesLoaded = 0L,
+            ),
+        )
+        assertEquals(
+            2_000L,
+            siloMediaLoadRetryDelayMs(
+                cause = EOFException("response body ended early"),
+                errorCount = 2,
+                isResumableProgressiveDirectPlay = true,
+                bytesLoaded = 8_192L,
+            ),
+        )
+    }
+
+    @Test
+    fun `stream reset retries only for resumable direct play after byte progress`() {
+        val reset = StreamResetException(ErrorCode.INTERNAL_ERROR)
+
+        assertEquals(
+            1_000L,
+            siloMediaLoadRetryDelayMs(
+                cause = reset,
+                errorCount = 1,
+                isResumableProgressiveDirectPlay = true,
+                bytesLoaded = 32_768L,
+            ),
+        )
+        assertEquals(
+            C.TIME_UNSET,
+            siloMediaLoadRetryDelayMs(
+                cause = reset,
+                errorCount = 1,
+                isResumableProgressiveDirectPlay = true,
+                bytesLoaded = 0L,
+            ),
+        )
+        assertEquals(
+            C.TIME_UNSET,
+            siloMediaLoadRetryDelayMs(
+                cause = reset,
+                errorCount = 1,
+                isResumableProgressiveDirectPlay = false,
+                bytesLoaded = 32_768L,
+            ),
+        )
+    }
+
+    @Test
+    fun `entity changes never retry`() {
+        assertEquals(
+            C.TIME_UNSET,
+            siloMediaLoadRetryDelayMs(
+                cause = EntityChangedException(),
+                errorCount = 1,
+                isResumableProgressiveDirectPlay = true,
+                bytesLoaded = 32_768L,
+            ),
+        )
+    }
+
+    @Test
+    fun `parser failures do not become retries through a nested eof`() {
+        assertEquals(
+            C.TIME_UNSET,
+            siloMediaLoadRetryDelayMs(
+                cause = ParserException.createForMalformedContainer(
+                    "truncated container metadata",
+                    EOFException("parser reached end of input"),
+                ),
+                errorCount = 1,
+                isResumableProgressiveDirectPlay = true,
+                bytesLoaded = 32_768L,
             ),
         )
     }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/ProgressiveDirectPlayResumeIntegrationTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/ProgressiveDirectPlayResumeIntegrationTest.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.common.player
 
 import android.content.Context
+import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.OptIn
@@ -81,22 +82,32 @@ class ProgressiveDirectPlayResumeIntegrationTest {
     }
 
     @Test
-    fun `zero progress on ranged reopen escapes instead of retrying again`() {
+    fun `zero progress unexpected end on ranged reopen retries again`() {
         val dispatcher = RangeFixtureDispatcher(fixture, ResumeResponse.NO_PROGRESS)
         val harness = prepareHarness(dispatcher)
 
         awaitResumeRequest(harness.player, dispatcher)
-        val terminal = awaitTerminalLoadError(harness, dispatcher)
+        try {
+            RobolectricUtil.runMainLooperUntil { dispatcher.requests.size >= 3 }
+        } catch (error: TimeoutException) {
+            val retryLogs = ShadowLog.getLogsForTag("MediaLoadRetry")
+                .joinToString(separator = " | ") { it.msg }
+            throw AssertionError(
+                "third retry request not observed: requests=${dispatcher.requests.size}, " +
+                    "loadErrors=${harness.loadErrors.size}, state=${harness.player.playbackState}, " +
+                    "isLoading=${harness.player.isLoading}, playerError=${harness.player.playerError}, " +
+                    "retryLogs=[$retryLogs]",
+                error,
+            )
+        }
 
-        assertEquals(
-            harness.loadErrors[0].cumulativeBytesLoaded,
-            terminal.cumulativeBytesLoaded,
-        )
-        assertTrue(terminal.wasCanceled)
-        assertEquals(2, dispatcher.requests.size)
         assertEquals(
             "bytes=${fixture.size / 2}-",
             dispatcher.requests[1].getHeader("Range"),
+        )
+        assertEquals(
+            "bytes=${fixture.size / 2}-",
+            dispatcher.requests[2].getHeader("Range"),
         )
     }
 
@@ -183,18 +194,23 @@ class ProgressiveDirectPlayResumeIntegrationTest {
         }
         val authSession = MediaAuthSession(TokenManagerImpl(), refreshClient)
         val upstreamFactory = OkHttpDataSource.Factory(mediaClient)
+        val mediaUri = Uri.parse(server.url("/fixture.wav").toString())
         val guardedFactory = DataSource.Factory {
-            RefreshingHttpDataSource(upstreamFactory, authSession)
+            RefreshingHttpDataSource(
+                factory = upstreamFactory,
+                authSession = authSession,
+                isResumableDirectPlayUri = { it == mediaUri },
+            )
         }
         val mediaSourceFactory = ProgressiveMediaSource.Factory(guardedFactory)
             .setLoadErrorHandlingPolicy(
                 SiloMediaLoadErrorHandlingPolicy(
-                    isResumableProgressiveDirectPlay = { true },
+                    isResumableProgressiveDirectPlay = { it == mediaUri },
                 ),
             )
         val context = ApplicationProvider.getApplicationContext<Context>()
         val mediaSource = mediaSourceFactory.createMediaSource(
-            MediaItem.fromUri(server.url("/fixture.wav").toString()),
+            MediaItem.fromUri(mediaUri),
         )
         val loadErrors = CopyOnWriteArrayList<ObservedLoadError>()
         mediaSource.addEventListener(

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/ProgressiveDirectPlayResumeIntegrationTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/ProgressiveDirectPlayResumeIntegrationTest.kt
@@ -1,0 +1,343 @@
+package org.siloserver.silo.common.player
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.LoadEventInfo
+import androidx.media3.exoplayer.source.MediaLoadData
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.MediaSourceEventListener
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.test.utils.FakeClock
+import androidx.media3.test.utils.robolectric.RobolectricUtil
+import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
+import androidx.test.core.app.ApplicationProvider
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeoutException
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import okhttp3.mockwebserver.SocketPolicy
+import okio.Buffer
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLog
+import org.siloserver.silo.network.TokenManagerImpl
+
+@OptIn(UnstableApi::class)
+@RunWith(RobolectricTestRunner::class)
+class ProgressiveDirectPlayResumeIntegrationTest {
+    private val fixture = seekableWavFixture()
+    private val players = mutableListOf<ExoPlayer>()
+    private val clients = mutableListOf<OkHttpClient>()
+    private val servers = mutableListOf<MockWebServer>()
+
+    @AfterTest
+    fun tearDown() {
+        players.forEach(ExoPlayer::release)
+        clients.forEach { client ->
+            client.dispatcher.executorService.shutdown()
+            client.connectionPool.evictAll()
+        }
+        servers.forEach(MockWebServer::shutdown)
+    }
+
+    @Test
+    fun `progressive source resumes exact byte range and ends without player error`() {
+        val dispatcher = RangeFixtureDispatcher(fixture, ResumeResponse.COMPLETE)
+        val harness = prepareHarness(dispatcher)
+
+        awaitResumeRequest(harness.player, dispatcher)
+        TestPlayerRunHelper.play(harness.player).untilState(Player.STATE_ENDED)
+
+        assertNull(harness.player.playerError)
+        assertEquals(2, dispatcher.requests.size)
+        assertEquals(1, harness.loadErrors.size)
+        assertFalse(harness.loadErrors.single().wasCanceled)
+        assertNull(dispatcher.requests[0].getHeader("Range"))
+        assertEquals(
+            "bytes=${fixture.size / 2}-",
+            dispatcher.requests[1].getHeader("Range"),
+        )
+        assertEquals("\"fixture-v1\"", dispatcher.requests[1].getHeader("If-Range"))
+    }
+
+    @Test
+    fun `zero progress on ranged reopen escapes instead of retrying again`() {
+        val dispatcher = RangeFixtureDispatcher(fixture, ResumeResponse.NO_PROGRESS)
+        val harness = prepareHarness(dispatcher)
+
+        awaitResumeRequest(harness.player, dispatcher)
+        val terminal = awaitTerminalLoadError(harness, dispatcher)
+
+        assertEquals(
+            harness.loadErrors[0].cumulativeBytesLoaded,
+            terminal.cumulativeBytesLoaded,
+        )
+        assertTrue(terminal.wasCanceled)
+        assertEquals(2, dispatcher.requests.size)
+        assertEquals(
+            "bytes=${fixture.size / 2}-",
+            dispatcher.requests[1].getHeader("Range"),
+        )
+    }
+
+    @Test
+    fun `changed etag aborts progressive resume`() {
+        val dispatcher = RangeFixtureDispatcher(fixture, ResumeResponse.ENTITY_CHANGED)
+        val harness = prepareHarness(dispatcher)
+
+        awaitResumeRequest(harness.player, dispatcher)
+        val terminal = awaitTerminalLoadError(harness, dispatcher)
+
+        assertTrue(terminal.error.hasCause<EntityChangedException>())
+        assertTrue(terminal.wasCanceled)
+        assertEquals(2, dispatcher.requests.size)
+    }
+
+    @Test
+    fun `range not satisfiable aborts progressive resume`() {
+        val dispatcher = RangeFixtureDispatcher(fixture, ResumeResponse.RANGE_NOT_SATISFIABLE)
+        val harness = prepareHarness(dispatcher)
+
+        awaitResumeRequest(harness.player, dispatcher)
+        val terminal = awaitTerminalLoadError(harness, dispatcher)
+
+        val invalidResponse = terminal.error.findCause<HttpDataSource.InvalidResponseCodeException>()
+        assertEquals(416, invalidResponse?.responseCode)
+        assertTrue(terminal.wasCanceled)
+        assertEquals(2, dispatcher.requests.size)
+    }
+
+    private fun awaitResumeRequest(
+        player: ExoPlayer,
+        dispatcher: RangeFixtureDispatcher,
+    ) {
+        try {
+            RobolectricUtil.runMainLooperUntil { dispatcher.requests.size >= 2 }
+        } catch (error: TimeoutException) {
+            val retryLogs = ShadowLog.getLogsForTag("MediaLoadRetry")
+                .joinToString(separator = " | ") { it.msg }
+            throw AssertionError(
+                "resume request not observed: requests=${dispatcher.requests.size}, " +
+                    "state=${player.playbackState}, isLoading=${player.isLoading}, " +
+                    "playerError=${player.playerError}, retryLogs=[$retryLogs]",
+                error,
+            )
+        }
+    }
+
+    private fun awaitTerminalLoadError(
+        harness: ProgressiveHarness,
+        dispatcher: RangeFixtureDispatcher,
+    ): ObservedLoadError {
+        try {
+            RobolectricUtil.runMainLooperUntil { harness.loadErrors.size >= 2 }
+            RobolectricUtil.runMainLooperUntil {
+                !harness.player.isLoading || dispatcher.requests.size > 2
+            }
+        } catch (error: TimeoutException) {
+            val retryLogs = ShadowLog.getLogsForTag("MediaLoadRetry")
+                .joinToString(separator = " | ") { it.msg }
+            throw AssertionError(
+                "terminal load error not observed: requests=${dispatcher.requests.size}, " +
+                    "loadErrors=${harness.loadErrors.size}, state=${harness.player.playbackState}, " +
+                    "isLoading=${harness.player.isLoading}, playerError=${harness.player.playerError}, " +
+                    "retryLogs=[$retryLogs]",
+                error,
+            )
+        }
+        assertEquals(2, dispatcher.requests.size, "Terminal failures must not issue a third request.")
+        return harness.loadErrors[1]
+    }
+
+    private fun prepareHarness(dispatcher: Dispatcher): ProgressiveHarness {
+        val server = MockWebServer().also {
+            it.dispatcher = dispatcher
+            it.start()
+            servers += it
+        }
+        val mediaClient = OkHttpClient().also {
+            clients += it
+        }
+        val refreshClient = OkHttpClient().also {
+            clients += it
+        }
+        val authSession = MediaAuthSession(TokenManagerImpl(), refreshClient)
+        val upstreamFactory = OkHttpDataSource.Factory(mediaClient)
+        val guardedFactory = DataSource.Factory {
+            RefreshingHttpDataSource(upstreamFactory, authSession)
+        }
+        val mediaSourceFactory = ProgressiveMediaSource.Factory(guardedFactory)
+            .setLoadErrorHandlingPolicy(
+                SiloMediaLoadErrorHandlingPolicy(
+                    isResumableProgressiveDirectPlay = { true },
+                ),
+            )
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val mediaSource = mediaSourceFactory.createMediaSource(
+            MediaItem.fromUri(server.url("/fixture.wav").toString()),
+        )
+        val loadErrors = CopyOnWriteArrayList<ObservedLoadError>()
+        mediaSource.addEventListener(
+            Handler(Looper.getMainLooper()),
+            object : MediaSourceEventListener {
+                override fun onLoadError(
+                    windowIndex: Int,
+                    mediaPeriodId: MediaSource.MediaPeriodId?,
+                    loadEventInfo: LoadEventInfo,
+                    mediaLoadData: MediaLoadData,
+                    error: IOException,
+                    wasCanceled: Boolean,
+                ) {
+                    loadErrors += ObservedLoadError(
+                        error = error,
+                        cumulativeBytesLoaded = loadEventInfo.bytesLoaded,
+                        wasCanceled = wasCanceled,
+                    )
+                }
+            },
+        )
+        val player = ExoPlayer.Builder(context)
+            .setMediaSourceFactory(mediaSourceFactory)
+            .setClock(FakeClock(/* isAutoAdvancing = */ true))
+            .build()
+            .also { player ->
+                players += player
+                player.setMediaSource(mediaSource)
+                player.prepare()
+            }
+        return ProgressiveHarness(player, loadErrors)
+    }
+
+    private data class ProgressiveHarness(
+        val player: ExoPlayer,
+        val loadErrors: CopyOnWriteArrayList<ObservedLoadError>,
+    )
+
+    private data class ObservedLoadError(
+        val error: IOException,
+        val cumulativeBytesLoaded: Long,
+        val wasCanceled: Boolean,
+    )
+
+    private enum class ResumeResponse {
+        COMPLETE,
+        NO_PROGRESS,
+        ENTITY_CHANGED,
+        RANGE_NOT_SATISFIABLE,
+    }
+
+    private class RangeFixtureDispatcher(
+        private val fixture: ByteArray,
+        private val resumeResponse: ResumeResponse,
+    ) : Dispatcher() {
+        val requests = CopyOnWriteArrayList<RecordedRequest>()
+
+        override fun dispatch(request: RecordedRequest): MockResponse {
+            requests += request
+            return if (requests.size == 1) {
+                partialResponse(start = 0, etag = "\"fixture-v1\"")
+                    .setSocketPolicy(SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY)
+            } else {
+                val start = request.getHeader("Range")
+                    ?.let(RANGE_HEADER::matchEntire)
+                    ?.groupValues
+                    ?.get(1)
+                    ?.toInt()
+                    ?: return MockResponse().setResponseCode(400)
+                when (resumeResponse) {
+                    ResumeResponse.COMPLETE ->
+                        partialResponse(start, etag = "\"fixture-v1\"")
+                    ResumeResponse.NO_PROGRESS ->
+                        partialResponse(start, etag = "\"fixture-v1\"", body = byteArrayOf())
+                            .setHeader("Content-Length", fixture.size - start)
+                            .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END)
+                    ResumeResponse.ENTITY_CHANGED ->
+                        partialResponse(start, etag = "\"fixture-v2\"")
+                    ResumeResponse.RANGE_NOT_SATISFIABLE ->
+                        MockResponse()
+                            .setResponseCode(416)
+                            .setHeader("Content-Range", "bytes */${fixture.size}")
+                            .setHeader("ETag", "\"fixture-v1\"")
+                }
+            }
+        }
+
+        private fun partialResponse(
+            start: Int,
+            etag: String,
+            body: ByteArray = fixture.copyOfRange(start, fixture.size),
+        ): MockResponse =
+            MockResponse()
+                .setResponseCode(206)
+                .setHeader("Accept-Ranges", "bytes")
+                .setHeader("Content-Type", "audio/wav")
+                .setHeader("Content-Range", "bytes $start-${fixture.lastIndex}/${fixture.size}")
+                .setHeader("ETag", etag)
+                .setBody(Buffer().write(body))
+
+        private companion object {
+            val RANGE_HEADER = Regex("""bytes=(\d+)-""")
+        }
+    }
+
+    private inline fun <reified T : Throwable> Throwable.hasCause(): Boolean =
+        findCause<T>() != null
+
+    private inline fun <reified T : Throwable> Throwable.findCause(): T? =
+        generateSequence(this as Throwable?) { it.cause }.filterIsInstance<T>().firstOrNull()
+
+    private companion object {
+        fun seekableWavFixture(): ByteArray {
+            val sampleRate = 8_000
+            val pcm = ByteArray(sampleRate / 4) { index ->
+                (128 + (index % 64) - 32).toByte()
+            }
+            return ByteArrayOutputStream(44 + pcm.size).apply {
+                writeAscii("RIFF")
+                writeLittleEndian(36 + pcm.size, 4)
+                writeAscii("WAVE")
+                writeAscii("fmt ")
+                writeLittleEndian(16, 4)
+                writeLittleEndian(1, 2)
+                writeLittleEndian(1, 2)
+                writeLittleEndian(sampleRate, 4)
+                writeLittleEndian(sampleRate, 4)
+                writeLittleEndian(1, 2)
+                writeLittleEndian(8, 2)
+                writeAscii("data")
+                writeLittleEndian(pcm.size, 4)
+                write(pcm)
+            }.toByteArray()
+        }
+
+        fun ByteArrayOutputStream.writeAscii(value: String) {
+            write(value.encodeToByteArray())
+        }
+
+        fun ByteArrayOutputStream.writeLittleEndian(value: Int, byteCount: Int) {
+            repeat(byteCount) { shift ->
+                write(value ushr (shift * 8) and 0xFF)
+            }
+        }
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SiloPlayerFactoryRetryPolicySourceTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SiloPlayerFactoryRetryPolicySourceTest.kt
@@ -11,7 +11,7 @@ class SiloPlayerFactoryRetryPolicySourceTest {
     @Test
     fun mediaSourceFactoryUsesServerRestartRetryPolicy() {
         assertTrue(
-            source.contains("val mediaLoadErrorHandlingPolicy = SiloMediaLoadErrorHandlingPolicy()") &&
+            source.contains("val mediaLoadErrorHandlingPolicy = SiloMediaLoadErrorHandlingPolicy(") &&
                 source.split(".setLoadErrorHandlingPolicy(mediaLoadErrorHandlingPolicy)").size - 1 >= 2,
             "DefaultMediaSourceFactory must keep retrying transient manifest/segment failures during server restarts.",
         )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ uiautomator = "2.3.0"
 firebase-messaging = "25.1.0"
 google-services = "4.5.0"
 junit4 = "4.13.2"
+okhttp = "4.12.0"
 # Google Cast (Chromecast, phone app only) + its MediaRouter dependency.
 play-services-cast-framework = "21.5.0"
 androidx-mediarouter = "1.7.0"
@@ -99,8 +100,11 @@ media3-common-ktx = { module = "androidx.media3:media3-common-ktx", version.ref 
 media3-extractor = { module = "androidx.media3:media3-extractor", version.ref = "media3" }
 media3-container = { module = "androidx.media3:media3-container", version.ref = "media3" }
 media3-ui-compose = { module = "androidx.media3:media3-ui-compose", version.ref = "media3" }
+media3-test-utils = { module = "androidx.media3:media3-test-utils", version.ref = "media3" }
+media3-test-utils-robolectric = { module = "androidx.media3:media3-test-utils-robolectric", version.ref = "media3" }
 ass-media = { module = "io.github.peerless2012:ass-media", version.ref = "ass-media" }
 ass-kt = { module = "io.github.peerless2012:ass-kt", version.ref = "ass-media" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 
 # DataStore
 datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
@@ -20,6 +20,7 @@ const val LAYOUT_AWARE_PASSTHROUGH_FEATURE = "layout_aware_passthrough"
 const val CLIENT_VIDEO_TRANSFORMATIONS_FEATURE = "client_video_transformations_v1"
 const val DEVICE_QUIRKS_V3_FEATURE = "device_quirks_v1"
 const val SEEK_REANCHOR_V3_FEATURE = "seek_reanchor_v1"
+const val DIRECT_STREAM_RESUME_V1_FEATURE = "direct_stream_resume_v1"
 const val SEEK_REANCHOR_V3_OPERATION = "seek_reanchor"
 const val SEEK_FAILURE_RECOVERY_V3_OPERATION = "seek_failure_recovery"
 const val CLIENT_DV7_TO_DV81 = "client_dv7_to_dv81"
@@ -226,6 +227,7 @@ data class PlaybackStartRequestV3(
         CLIENT_VIDEO_TRANSFORMATIONS_FEATURE,
         DEVICE_QUIRKS_V3_FEATURE,
         SEEK_REANCHOR_V3_FEATURE,
+        DIRECT_STREAM_RESUME_V1_FEATURE,
     ),
     @SerialName("file_id") val fileId: Int,
     @SerialName("profile_id") val profileId: String,


### PR DESCRIPTION
Implements #80.

## Problem

A Shield fills Media3's buffer, stops reading, and a proxy with nginx's default `send_timeout 60s` kills the idle HTTP/2 stream. OkHttp surfaces `StreamResetException` → `ERROR_CODE_IO_UNSPECIFIED`, which bypasses even the one-shot transient recovery and lands on a full server replan with a visible hiccup.

## What this does

- **In-loader range resume** (`MediaLoadRetryPolicy`): HTTP/2 stream resets, connection shutdowns, and premature EOF become retryable for progressive `ORIGINAL_HTTP` loads that have made real byte progress — Media3's progressive loader then reopens a ranged `DataSpec` at the exact byte offset through the existing authed stack. No player error, no `setMediaItem`+`prepare`, no replan, no ViewModel involvement.
- **Per-attempt progress tracking**: Media3 reports *cumulative* bytes per load task, so the policy tracks deltas per `loadTaskId` (cleaned up in `onLoadTaskConcluded`) — zero-progress reopens fall out of the retryable class and exhaust instead of looping. Existing 90s cumulative retry window and backoff still bound everything.
- **Entity guard** (`RefreshingHttpDataSource`): captures the response ETag per URI, sends `If-Range` on ranged reopens, and throws a non-retryable `EntityChangedException` when the entity changed — closing the Media3 silent-skip hole where a 200 answer to a ranged request splices bytes from two file revisions. The single-flight 401 refresh is untouched.
- **Scope discipline**: HLS retry behavior unchanged (delivery-gated), ViewModel recovery ladder unchanged, `SiloLoadControl` audit deferred as the issue allows. Phone and TV share all of this via `android-shared`. `direct_stream_resume_v1` added to advertised client features.
- **Diagnostics**: per-retry log (exception, bytesLoaded, resume offset, attempt, delay) and a retry-exhausted marker.

## Coordination

- Server contract (strong ETag/If-Range, stall observability, capability): Silo-Server/silo-server#443 (deployed to dev)
- Apple bounded park/detach + ranged resume: Silo-Server/silo-apple#94

## Verification

```
./gradlew :android-shared:testDebugUnitTest    735 tests, 0 failures (rerun fresh)
./gradlew :androidApp:assembleDebug :androidTvApp:assembleDebug   BUILD SUCCESSFUL
```

New coverage includes a **real Media3 integration test** (`ProgressiveDirectPlayResumeIntegrationTest`: ExoPlayer + MockWebServer + the production data-source chain under Robolectric): kills the first 206 mid-body and asserts the next request carries the exact `Range` and `If-Range` and playback reaches `STATE_ENDED` with no player error; plus zero-progress exhaustion, ETag-mismatch abort, and 416 terminal cases — each asserting no third request is issued. Policy unit tests and entity-guard tests cover the remaining matrix.

Field check: debug build installed on a Galaxy S26 Ultra streaming against the updated dev server — clean `200 → 206` ranged request pattern observed server-side, no errors.

### AI Disclosure
- Tool(s): Claude Code (orchestration/spec/review), OpenAI Codex CLI (implementation)
- Model(s): claude-fable-5, gpt-5.6-sol
- Involvement: fully AI-generated, human-directed
- Adversarial review: Codex's two-axis self-review reported no remaining findings after fixes; Claude's independent review confirmed the cumulative-vs-per-attempt bytes distinction (the subtlest correctness point), verified the shared policy can't regress HLS, and validated the ETag guard against Media3's skip-splice behavior. Tests re-run independently by the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for guarded resumption of interrupted direct playback using ETag validation (`If-Range`) to ensure the media hasn’t changed.
  * Enabled progressive direct-play recovery after mid-body transport failures.
  * Playback now advertises direct-stream resume support during playback setup.

* **Bug Fixes**
  * Improved retry/abort behavior to prevent unsafe retries (e.g., entity changes, invalid/unsatisfiable ranges, and zero-progress scenarios).

* **Tests**
  * Expanded unit and Robolectric integration coverage for ranged reopen/ETag handling and progressive resume retry behavior.

* **Chores**
  * Updated Gradle test dependencies for mocking and Media3 testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->