### PR TITLE
fix(push): fetch notification metadata before FCM tears down the service

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/push/PushNotificationPresenter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/push/PushNotificationPresenter.kt
@@ -27,6 +27,9 @@ class PushNotificationPresenter(
         fallbackTitle: String? = null,
         fallbackBody: String? = null,
     ) {
+        // Fetch before the permission check: on a direct-lookup miss the fallback
+        // refreshes the inbox, which keeps the in-app badge current even for a
+        // profile that has denied POST_NOTIFICATIONS.
         val row = fetch(deliveryId)
         if (!canPostNotifications()) return
         ensureChannel()
@@ -66,16 +69,24 @@ class PushNotificationPresenter(
     // sync refreshes the inbox for a background_wake push without posting a
     // visible notification.
     suspend fun sync() {
-        runCatching { notificationsRepository.refresh() }
+        withinPushBudget { notificationsRepository.refresh() }
     }
 
+    /**
+     * Budgeted because the shared client allows a 60s request timeout — far
+     * past the window FCM gives us — and a null row here only costs generic
+     * notification text, whereas overrunning the window costs the whole
+     * notification.
+     */
     private suspend fun fetch(deliveryId: String): NotificationRow? =
-        when (val direct = notificationsRepository.get(deliveryId)) {
-            is ApiResult.Success -> direct.data
-            else -> runCatching {
-                notificationsRepository.refresh()
-                notificationsRepository.rows.value.firstOrNull { it.id == deliveryId }
-            }.getOrNull()
+        withinPushBudget {
+            when (val direct = notificationsRepository.get(deliveryId)) {
+                is ApiResult.Success -> direct.data
+                else -> {
+                    notificationsRepository.refresh()
+                    notificationsRepository.rows.value.firstOrNull { it.id == deliveryId }
+                }
+            }
         }
 
     private fun notificationContentFor(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/push/SiloFirebaseMessagingService.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/push/SiloFirebaseMessagingService.kt
@@ -2,11 +2,9 @@ package org.siloserver.silo.android.push
 
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.java.KoinJavaComponent.get
 
 class PushMessageHandler(
@@ -49,31 +47,77 @@ class PushMessageHandler(
     }
 }
 
+/**
+ * Budget for one network call made inside an FCM callback.
+ *
+ * FCM dispatches every message onto a single-threaded intent executor
+ * (`FcmExecutors.newIntentHandleExecutor`) and may kill the process ~20s after
+ * handing one over, so a burst of deliveries queues head-to-tail on one
+ * thread — each callback has to give the thread back promptly or it eats the
+ * next delivery's window. Deliberately below the shared client's 10s connect
+ * timeout ([org.siloserver.silo.network.createSiloClient]): a server we
+ * haven't even connected to by then won't produce anything useful inside the
+ * window either, and giving up early costs only generic notification text.
+ */
+internal const val PUSH_WORK_BUDGET_MS = 8_000L
+
+/**
+ * Runs [block] inside [PUSH_WORK_BUDGET_MS], yielding null if it times out or
+ * fails. Cancellation is rethrown ahead of the broad catch — the convention the
+ * shared repositories already follow — so a swallowed failure can never be
+ * mistaken for a completed one.
+ */
+internal suspend fun <T> withinPushBudget(block: suspend () -> T): T? =
+    withTimeoutOrNull(PUSH_WORK_BUDGET_MS) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+/**
+ * Both callbacks block their calling thread on purpose.
+ *
+ * FCM's `EnhancedIntentService` completes the wakeful intent (releasing the
+ * wake lock) and calls `stopSelf()` the instant these callbacks return, so any
+ * work handed off to a service-scoped coroutine gets cancelled by `onDestroy`
+ * mid-flight. For [onMessageReceived] that cancellation is invisible —
+ * `safeApiCall` catches `CancellationException` like any other exception — so
+ * the delivery-row fetch silently lost its race against `stopSelf` on every
+ * slow connection and the notification degraded to generic fallback text. For
+ * [onNewToken] it silently dropped token re-registration.
+ *
+ * Both callbacks run on the SDK's intent-handling executor (never the main
+ * thread), so running inline is safe; [PUSH_WORK_BUDGET_MS] keeps each one
+ * inside the window FCM allows.
+ */
 class SiloFirebaseMessagingService : FirebaseMessagingService() {
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onMessageReceived(message: RemoteMessage) {
         val handler = runCatching { get<PushMessageHandler>(PushMessageHandler::class.java) }.getOrNull()
             ?: return
-        serviceScope.launch {
-            handler.handle(
-                data = message.data,
-                fallbackTitle = message.notification?.title,
-                fallbackBody = message.notification?.body,
-            )
+        // Budgeted inside the presenter rather than here, so a stalled server
+        // still ends in a posted notification rather than none at all. The catch
+        // is a boundary net: nothing may escape into the Firebase SDK.
+        runBlocking {
+            runCatching {
+                handler.handle(
+                    data = message.data,
+                    fallbackTitle = message.notification?.title,
+                    fallbackBody = message.notification?.body,
+                )
+            }
         }
     }
 
     override fun onNewToken(token: String) {
         val registrar = runCatching { get<AndroidPushRegistrar>(AndroidPushRegistrar::class.java) }.getOrNull()
             ?: return
-        serviceScope.launch {
-            runCatching { registrar.registerToken(token) }
+        runBlocking {
+            withinPushBudget { registrar.registerToken(token) }
         }
-    }
-
-    override fun onDestroy() {
-        serviceScope.cancel()
-        super.onDestroy()
     }
 }


### PR DESCRIPTION
## Problem

Push notifications intermittently showed generic text ("Silo notification" / "Open Silo to view it.") instead of the real title, e.g. "Severance — S2E4 The Hidden Hallway".

Android registers in `private_push` mode, so the relay sends a content-free data payload carrying only `silo_delivery_id`. Every word of user-visible text comes from the `GET /api/v1/notifications/{id}` lookup the client makes on receipt — if that lookup doesn't complete, the notification degrades to the hardcoded fallback in `PushNotificationPresenter`.

## Root cause

`onMessageReceived` only *launched* the lookup on a service-scoped coroutine and returned immediately:

```kotlin
serviceScope.launch { handler.handle(...) }   // returns instantly
...
override fun onDestroy() { serviceScope.cancel() }
```

FCM's `EnhancedIntentService` completes the wakeful intent (releasing the wake lock) and calls `stopSelf()` the instant the callback returns — verified against `firebase-messaging-25.1.0` bytecode. `onDestroy` then cancelled the scope with the HTTP request still in flight.

The cancellation was invisible: `safeApiCall` catches `Exception`, and JVM `CancellationException` is one, so an aborted call came back as an ordinary `NetworkError`. Everything after the fetch is non-suspending, so the notification still posted — just with the generic strings. Whether the request beat `stopSelf` depended on connection warmth, cold-start, and whether the device was dozing, which is why it looked random.

`onNewToken` had the identical bug, silently dropping FCM token re-registration.

## Fix

Run both callbacks inline. They execute on FCM's own intent-handling executor, never the main thread, so blocking there is the documented contract rather than a hazard.

- **`PUSH_WORK_BUDGET_MS` (8s)** bounds each network call. That executor is single-threaded (`FcmExecutors.newIntentHandleExecutor`), so deliveries in a burst queue head-to-tail and each callback must give the thread back promptly. Set deliberately *under* the shared client's 10s connect timeout: a server we haven't connected to by then won't produce anything useful inside FCM's window either, and giving up early costs only generic text — while overrunning the window costs the whole notification.
- **`withinPushBudget`** rethrows `CancellationException` ahead of its broad catch, matching the convention already used across the shared repositories and addressing review feedback on #71 that was never applied.

## Verification

- `:androidApp:compileDebugKotlin` and the full `:androidApp:testDebugUnitTest` suite pass.
- Confirmed the FCM lifecycle claims by decompiling `firebase-messaging-25.1.0`: `EnhancedIntentService` calls `WakeLockHolder.completeWakefulIntent` then `stopSelfResult` on task completion; `handleIntentOnMainThread` is hardcoded `false`; the intent executor is `newSingleThreadExecutor`.
- Confirmed by direct test that `withTimeoutOrNull` still returns `null` when its block swallows the cancellation, and that post-deadline suspend calls fail fast — so the budget is genuinely enforced through `safeApiCall`'s broad catch.

Not folded in: `safeApiCall` swallowing `CancellationException` breaks structured concurrency for ~179 call sites app-wide and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push notification handling so inbox updates and badge counts remain current even when notification permission is denied.
  * Improved reliability when refreshing notification data after a direct notification lookup misses.
  * Added safeguards to prevent push notification and token-processing tasks from exceeding their available processing time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->