### PR TITLE
fix(settings): realign device settings with the server contract

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStore.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStore.kt
@@ -69,6 +69,11 @@ class AndroidPlayerSettingsStore(
             }
         val migrationSentinel: String =
             if (keyPrefix.isEmpty()) MIGRATION_SENTINEL_LEGACY else "migration_v2_$keyPrefix"
+
+        // Separate from [migrationSentinel] on purpose: existing installs have
+        // already recorded that one, so a rename migration folded into it would
+        // never run for exactly the users who need it.
+        val nextUpRenameSentinel: String = "migration_nextup_key_v1_$keyPrefix"
     }
 
     // Re-derive scope on every (profile or server) change.
@@ -95,6 +100,13 @@ class AndroidPlayerSettingsStore(
         }
 
     private suspend fun ensureMigrated(scope: Scope, store: DataStore<Preferences>) {
+        // Must run before the sentinel check below, and before anything else
+        // touches the store: every read path (profileScopedFlow) and every
+        // write path (withScope, and therefore refreshFromServer) funnels
+        // through here, so this is the one place that is guaranteed to happen
+        // first.
+        migrateNextUpPromptKey(scope, store)
+
         val token = scope.profileId + "/" + scope.migrationSentinel
         if (synchronized(migrationDone) { token in migrationDone }) return
         val sentinelKey = booleanPreferencesKey(scope.migrationSentinel)
@@ -105,13 +117,82 @@ class AndroidPlayerSettingsStore(
         }
         store.edit { prefs ->
             for (key in PlaybackSettingsKeys.DeviceSettings) {
-                val legacy = legacyCache.getString(scope.serverUrl, key, MISSING_SENTINEL)
+                var legacy = legacyCache.getString(scope.serverUrl, key, MISSING_SENTINEL)
+                if (legacy == MISSING_SENTINEL && key == PlaybackSettingsKeys.NextUpPromptSeconds) {
+                    // The cache predates the key rename, so an old install
+                    // stored this entry under the "player." spelling.
+                    legacy = legacyCache.getString(
+                        scope.serverUrl,
+                        LEGACY_NEXT_UP_PROMPT_SECONDS,
+                        MISSING_SENTINEL,
+                    )
+                }
                 if (legacy == MISSING_SENTINEL) continue
                 writeRawString(prefs, scope, key, legacy)
             }
             prefs[sentinelKey] = true
         }
         synchronized(migrationDone) { migrationDone.add(token) }
+    }
+
+    /**
+     * Move a value stored under the pre-rename `player.next_up_prompt_seconds`
+     * DataStore slot into the canonical `playback.` slot, once per scope.
+     *
+     * Copying locally is not enough on its own, and neither would a read-time
+     * fallback be. [applyEffectiveLocally] writes the server's effective value
+     * into the canonical slot on every [refreshFromServer], and the server
+     * registry defaults this key to 30. Before the rename that could not clobber
+     * anything — the "player." spelling was unregistered, so the server returned
+     * an empty effective value and writeRawString's Int branch skipped it — but
+     * the canonical key IS registered, so a refresh now returns "30" whenever
+     * the server holds no device row, and that would overwrite the migrated
+     * value. refreshFromServer runs within seconds of upgrade (settings screen,
+     * player load, TV detail, ServerDrivenConfigRefresher).
+     *
+     * So the migrated value is also enqueued for the server, which makes the
+     * server's effective value the user's own rather than the registry default.
+     * The users this matters for are exactly those whose value never reached the
+     * server: an install talking to a pre-alias server, or one whose flush
+     * failed silently.
+     *
+     * Suppressing the write instead — skipping keys the server reports without a
+     * device override — was rejected: the subtitle-appearance block in
+     * [applyEffectiveLocally] deliberately propagates a server-side reset, and a
+     * blanket guard would break that for every key.
+     *
+     * The legacy slot is removed once copied, so a stale value cannot resurface
+     * if the canonical slot is later cleared.
+     */
+    private suspend fun migrateNextUpPromptKey(scope: Scope, store: DataStore<Preferences>) {
+        val token = scope.profileId + "/" + scope.nextUpRenameSentinel
+        if (synchronized(migrationDone) { token in migrationDone }) return
+
+        val sentinelKey = booleanPreferencesKey(scope.nextUpRenameSentinel)
+        var migratedValue: Int? = null
+        if (store.data.first()[sentinelKey] != true) {
+            val canonicalKey =
+                intPreferencesKey(scope.keyPrefix + PlaybackSettingsKeys.NextUpPromptSeconds)
+            val legacyKey = intPreferencesKey(scope.keyPrefix + LEGACY_NEXT_UP_PROMPT_SECONDS)
+            store.edit { prefs ->
+                val legacyValue = prefs[legacyKey]
+                if (legacyValue != null && prefs[canonicalKey] == null) {
+                    prefs[canonicalKey] = legacyValue
+                    migratedValue = legacyValue
+                }
+                prefs.remove(legacyKey)
+                prefs[sentinelKey] = true
+            }
+        }
+        synchronized(migrationDone) { migrationDone.add(token) }
+
+        migratedValue?.let {
+            serverSettingsFlusher.enqueue(
+                scope.profileId,
+                PlaybackSettingsKeys.NextUpPromptSeconds,
+                it.toString(),
+            )
+        }
     }
 
     private fun <T> profileScopedFlow(default: T, read: (Preferences, Scope) -> T): Flow<T> =
@@ -188,18 +269,12 @@ class AndroidPlayerSettingsStore(
     override val subtitleSyncMsFlow: Flow<Int> =
         profileScopedFlow(0) { p, s -> p.intFor(s, PlaybackSettingsKeys.SubtitleSyncMs, 0) }
 
-    // The canonical key was renamed from `player.next_up_prompt_seconds` to
-    // `playback.next_up_prompt_seconds`; fall back to the old DataStore slot so
-    // installs that stored a value under the previous name keep it until the
-    // next write or server refresh migrates it forward.
+    // Reads the canonical `playback.next_up_prompt_seconds` slot only.
+    // migrateNextUpPromptKey has already copied any pre-rename value forward
+    // by the time this flow emits, so a read-time fallback would be dead code
+    // that could only resurface a stale value after a reset.
     override val nextUpPromptSecondsFlow: Flow<Int> =
-        profileScopedFlow(30) { p, s ->
-            p.intFor(
-                s,
-                PlaybackSettingsKeys.NextUpPromptSeconds,
-                p.intFor(s, LEGACY_NEXT_UP_PROMPT_SECONDS, 30),
-            )
-        }
+        profileScopedFlow(30) { p, s -> p.intFor(s, PlaybackSettingsKeys.NextUpPromptSeconds, 30) }
 
     override val sleepTimerDefaultMinutesFlow: Flow<Int> =
         profileScopedFlow(30) { p, s -> p.intFor(s, PlaybackSettingsKeys.SleepTimerDefaultMinutes, 30) }
@@ -554,9 +629,10 @@ class AndroidPlayerSettingsStore(
         const val DEFAULT_PASSOUT_THRESHOLD = 3
         val VALID_VIDEO_GRAVITY = setOf("fit", "fill", "stretch")
 
-        // DataStore slot written before the key was renamed to
-        // PlaybackSettingsKeys.NextUpPromptSeconds ("playback." namespace).
-        // Read-only fallback; nothing writes it any more.
+        // DataStore slot and server-settings-cache entry written before the key
+        // was renamed to PlaybackSettingsKeys.NextUpPromptSeconds ("playback."
+        // namespace). Consumed only by migrateNextUpPromptKey, which copies the
+        // value forward and then removes the slot.
         const val LEGACY_NEXT_UP_PROMPT_SECONDS = "player.next_up_prompt_seconds"
 
         // Type dispatch for `writeRawString`, which only ever sees keys from

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStore.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStore.kt
@@ -115,6 +115,7 @@ class AndroidPlayerSettingsStore(
             synchronized(migrationDone) { migrationDone.add(token) }
             return
         }
+        val imported = mutableMapOf<String, String>()
         store.edit { prefs ->
             for (key in PlaybackSettingsKeys.DeviceSettings) {
                 var legacy = legacyCache.getString(scope.serverUrl, key, MISSING_SENTINEL)
@@ -129,10 +130,36 @@ class AndroidPlayerSettingsStore(
                 }
                 if (legacy == MISSING_SENTINEL) continue
                 writeRawString(prefs, scope, key, legacy)
+                imported[key] = legacy
             }
             prefs[sentinelKey] = true
         }
         synchronized(migrationDone) { migrationDone.add(token) }
+
+        // Recovering a value into the local slot is only half the job: every one
+        // of these keys is server-registered, so the next refreshFromServer
+        // would write the registry default straight back over it. Pushing them
+        // makes the server's effective value the user's own, which is the whole
+        // point of importing them. refreshFromServer flushes before it reads, so
+        // these land ahead of the GET in the same call.
+        imported.forEach { (key, value) ->
+            serverSettingsFlusher.enqueue(scope.profileId, key, clampForServer(key, value))
+        }
+    }
+
+    /**
+     * Clamp a legacy value to the range the server accepts, so an out-of-band
+     * value imported from an old cache is stored rather than 400'd and dropped.
+     */
+    private fun clampForServer(key: String, raw: String): String = when (key) {
+        PlaybackSettingsKeys.NextUpPromptSeconds ->
+            raw.toIntOrNull()
+                ?.coerceIn(NEXT_UP_PROMPT_MIN_SECONDS, NEXT_UP_PROMPT_MAX_SECONDS)
+                ?.toString()
+                ?: raw
+        PlaybackSettingsKeys.PlaybackSpeed ->
+            raw.toDoubleOrNull()?.coerceIn(MIN_PLAYBACK_SPEED, MAX_PLAYBACK_SPEED)?.toString() ?: raw
+        else -> raw
     }
 
     /**
@@ -156,10 +183,24 @@ class AndroidPlayerSettingsStore(
      * server: an install talking to a pre-alias server, or one whose flush
      * failed silently.
      *
+     * The enqueue alone is not enough, because it is debounced: [refreshFromServer]
+     * flushes pending writes before it reads, which is what actually orders the
+     * PUT ahead of the GET. Without that flush this copy is overwritten by the
+     * registry default within the same call.
+     *
      * Suppressing the write instead — skipping keys the server reports without a
-     * device override — was rejected: the subtitle-appearance block in
-     * [applyEffectiveLocally] deliberately propagates a server-side reset, and a
-     * blanket guard would break that for every key.
+     * device override — is not viable, though not for the reason previously
+     * given here. The subtitle-appearance block in [applyEffectiveLocally] sits
+     * outside the key loop and reads `hasDeviceOverride` itself, so gating the
+     * loop would not affect it. The real objection is [resetAllDeviceSettings]:
+     * it deletes every device row and then refreshes precisely to pull the
+     * defaults back down, and a `hasDeviceOverride` gate would make reset a
+     * no-op.
+     *
+     * The value is clamped to the server's accepted range before being sent. An
+     * out-of-range legacy value would otherwise be rejected with a 400 that the
+     * flusher logs and drops, leaving the local slot holding a value the server
+     * will never agree with.
      *
      * The legacy slot is removed once copied, so a stale value cannot resurface
      * if the canonical slot is later cleared.
@@ -190,7 +231,7 @@ class AndroidPlayerSettingsStore(
             serverSettingsFlusher.enqueue(
                 scope.profileId,
                 PlaybackSettingsKeys.NextUpPromptSeconds,
-                it.toString(),
+                it.coerceIn(NEXT_UP_PROMPT_MIN_SECONDS, NEXT_UP_PROMPT_MAX_SECONDS).toString(),
             )
         }
     }
@@ -375,7 +416,7 @@ class AndroidPlayerSettingsStore(
     override suspend fun setPlaybackSpeed(value: Double) {
         // Matches the server's validateFloatRange("player.playback_speed", 0.25, 3.0);
         // anything outside that range is rejected with HTTP 400.
-        val clamped = value.coerceIn(0.25, 3.0)
+        val clamped = value.coerceIn(MIN_PLAYBACK_SPEED, MAX_PLAYBACK_SPEED)
         withScope { scope, store ->
             store.edit { it[stringPreferencesKey(scope.keyPrefix + PlaybackSettingsKeys.PlaybackSpeed)] = clamped.toString() }
             serverSettingsFlusher.enqueue(scope.profileId, PlaybackSettingsKeys.PlaybackSpeed, clamped.toString())
@@ -389,7 +430,10 @@ class AndroidPlayerSettingsStore(
         writeInt(PlaybackSettingsKeys.SubtitleSyncMs, value.coerceIn(-10000, 10000))
 
     override suspend fun setNextUpPromptSeconds(value: Int) =
-        writeInt(PlaybackSettingsKeys.NextUpPromptSeconds, value.coerceIn(0, 120))
+        writeInt(
+            PlaybackSettingsKeys.NextUpPromptSeconds,
+            value.coerceIn(NEXT_UP_PROMPT_MIN_SECONDS, NEXT_UP_PROMPT_MAX_SECONDS),
+        )
 
     override suspend fun setResumeRewindSeconds(value: Int) =
         writeIntLocal(PlaybackSettingsKeys.ResumeRewindSeconds, value.coerceIn(0, 30))
@@ -433,6 +477,21 @@ class AndroidPlayerSettingsStore(
     override suspend fun refreshFromServer() {
         val repo = settingsRepository ?: return
         withScope { scope, store ->
+            // Push everything still queued before asking the server what the
+            // effective values are.
+            //
+            // Without this, a write made moments ago is still sitting behind the
+            // flusher's 750 ms debounce when the GET goes out, so the server
+            // answers with the registry default and applyEffectiveLocally writes
+            // that default straight over the local value — a silent reset of a
+            // setting the user just changed. The migration in ensureMigrated is
+            // the worst case: withScope runs it and then falls into this block,
+            // so on a LAN server the GET returns and clobbers the migrated value
+            // hundreds of milliseconds before its own PUT would have been sent.
+            //
+            // If the flush fails the GET almost always fails with it, and the
+            // early return below leaves the local value untouched.
+            serverSettingsFlusher.flushNow()
             val result = repo.getEffectiveSettings(PlaybackSettingsKeys.DeviceSettings)
             if (result !is ApiResult.Success) return@withScope
             applyEffectiveLocally(scope, store, result.data)
@@ -476,6 +535,14 @@ class AndroidPlayerSettingsStore(
     }
 
     override suspend fun resetDeviceSetting(key: String) {
+        // The only path that can reach the server with a caller-supplied key.
+        // A key outside DeviceSettings is either device-local or unregistered:
+        // the DELETE would 400, the flusher would log and drop it, and the
+        // round trip would look like it succeeded while the setting was
+        // untouched. Refusing here keeps that failure visible in one place.
+        require(key in PlaybackSettingsKeys.DeviceSettings) {
+            "resetDeviceSetting($key) is not a server-synced device setting"
+        }
         withScope { scope, _ ->
             serverSettingsFlusher.enqueueDelete(scope.profileId, key)
             serverSettingsFlusher.flushNow()
@@ -627,6 +694,16 @@ class AndroidPlayerSettingsStore(
         // the previous hardcoded AutoPlayGuard threshold of 3).
         const val DEFAULT_RESUME_REWIND_SECONDS = 7
         const val DEFAULT_PASSOUT_THRESHOLD = 3
+
+        // The server's accepted range for playback.next_up_prompt_seconds.
+        // Anything outside it is rejected with a 400 that the flusher logs and
+        // drops, so every path that sends this key clamps first.
+        const val NEXT_UP_PROMPT_MIN_SECONDS = 0
+        const val NEXT_UP_PROMPT_MAX_SECONDS = 120
+
+        // The contract's declared range for player.playback_speed.
+        const val MIN_PLAYBACK_SPEED = 0.25
+        const val MAX_PLAYBACK_SPEED = 3.0
         val VALID_VIDEO_GRAVITY = setOf("fit", "fill", "stretch")
 
         // DataStore slot and server-settings-cache entry written before the key

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStore.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStore.kt
@@ -140,8 +140,10 @@ class AndroidPlayerSettingsStore(
     override val hdrEnabledFlow: Flow<Boolean> =
         profileScopedFlow(true) { p, s -> p.boolFor(s, PlaybackSettingsKeys.HdrEnabled, true) }
 
+    // Default OFF, mirroring the server registry default for
+    // `player.dv_profile7_hdr10_fallback` and Apple's client default.
     override val dvProfile7HDR10FallbackFlow: Flow<Boolean> =
-        profileScopedFlow(true) { p, s -> p.boolFor(s, PlaybackSettingsKeys.DvProfile7HDR10Fallback, true) }
+        profileScopedFlow(false) { p, s -> p.boolFor(s, PlaybackSettingsKeys.DvProfile7HDR10Fallback, false) }
 
     override val dolbyVisionEnabledFlow: Flow<Boolean> =
         profileScopedFlow(true) { p, s -> p.boolFor(s, PlaybackSettingsKeys.DolbyVisionEnabled, true) }
@@ -186,8 +188,18 @@ class AndroidPlayerSettingsStore(
     override val subtitleSyncMsFlow: Flow<Int> =
         profileScopedFlow(0) { p, s -> p.intFor(s, PlaybackSettingsKeys.SubtitleSyncMs, 0) }
 
+    // The canonical key was renamed from `player.next_up_prompt_seconds` to
+    // `playback.next_up_prompt_seconds`; fall back to the old DataStore slot so
+    // installs that stored a value under the previous name keep it until the
+    // next write or server refresh migrates it forward.
     override val nextUpPromptSecondsFlow: Flow<Int> =
-        profileScopedFlow(30) { p, s -> p.intFor(s, PlaybackSettingsKeys.NextUpPromptSeconds, 30) }
+        profileScopedFlow(30) { p, s ->
+            p.intFor(
+                s,
+                PlaybackSettingsKeys.NextUpPromptSeconds,
+                p.intFor(s, LEGACY_NEXT_UP_PROMPT_SECONDS, 30),
+            )
+        }
 
     override val sleepTimerDefaultMinutesFlow: Flow<Int> =
         profileScopedFlow(30) { p, s -> p.intFor(s, PlaybackSettingsKeys.SleepTimerDefaultMinutes, 30) }
@@ -271,7 +283,7 @@ class AndroidPlayerSettingsStore(
         writeBool(PlaybackSettingsKeys.DolbyVisionEnabled, value)
 
     override suspend fun setMatchContentFrameRate(value: Boolean) =
-        writeBool(PlaybackSettingsKeys.MatchContentFrameRate, value)
+        writeBoolLocal(PlaybackSettingsKeys.MatchContentFrameRate, value)
 
     override suspend fun setPictureInPictureEnabled(value: Boolean) =
         writeBoolLocal(PlaybackSettingsKeys.PictureInPictureEnabled, value)
@@ -286,7 +298,9 @@ class AndroidPlayerSettingsStore(
         writeStringLocal(PlaybackSettingsKeys.DefaultDownloadQuality, DownloadQuality.fromWire(value).wire)
 
     override suspend fun setPlaybackSpeed(value: Double) {
-        val clamped = value.coerceIn(0.25, 4.0)
+        // Matches the server's validateFloatRange("player.playback_speed", 0.25, 3.0);
+        // anything outside that range is rejected with HTTP 400.
+        val clamped = value.coerceIn(0.25, 3.0)
         withScope { scope, store ->
             store.edit { it[stringPreferencesKey(scope.keyPrefix + PlaybackSettingsKeys.PlaybackSpeed)] = clamped.toString() }
             serverSettingsFlusher.enqueue(scope.profileId, PlaybackSettingsKeys.PlaybackSpeed, clamped.toString())
@@ -309,7 +323,7 @@ class AndroidPlayerSettingsStore(
         writeIntLocal(PlaybackSettingsKeys.PassOutThreshold, value.coerceIn(0, 10))
 
     override suspend fun setSleepTimerDefaultMinutes(value: Int) =
-        writeInt(PlaybackSettingsKeys.SleepTimerDefaultMinutes, value.coerceIn(0, 240))
+        writeIntLocal(PlaybackSettingsKeys.SleepTimerDefaultMinutes, value.coerceIn(0, 240))
 
     override suspend fun setPreferredQuality(value: String) =
         writeString(PlaybackSettingsKeys.PreferredQuality, value)
@@ -540,6 +554,16 @@ class AndroidPlayerSettingsStore(
         const val DEFAULT_PASSOUT_THRESHOLD = 3
         val VALID_VIDEO_GRAVITY = setOf("fit", "fill", "stretch")
 
+        // DataStore slot written before the key was renamed to
+        // PlaybackSettingsKeys.NextUpPromptSeconds ("playback." namespace).
+        // Read-only fallback; nothing writes it any more.
+        const val LEGACY_NEXT_UP_PROMPT_SECONDS = "player.next_up_prompt_seconds"
+
+        // Type dispatch for `writeRawString`, which only ever sees keys from
+        // PlaybackSettingsKeys.DeviceSettings (legacy-cache import and the
+        // effective-settings apply both iterate that list). Device-local keys
+        // are written through the typed `*Local` helpers instead and must not
+        // be listed here.
         val BOOLEAN_KEYS: Set<String> = setOf(
             PlaybackSettingsKeys.AutoSkipIntro,
             PlaybackSettingsKeys.AutoSkipCredits,
@@ -547,16 +571,12 @@ class AndroidPlayerSettingsStore(
             PlaybackSettingsKeys.HdrEnabled,
             PlaybackSettingsKeys.DvProfile7HDR10Fallback,
             PlaybackSettingsKeys.DolbyVisionEnabled,
-            PlaybackSettingsKeys.MatchContentFrameRate,
-            PlaybackSettingsKeys.SubtitleTextOutline,
         )
 
         val INT_KEYS: Set<String> = setOf(
             PlaybackSettingsKeys.AudioSyncMs,
             PlaybackSettingsKeys.SubtitleSyncMs,
             PlaybackSettingsKeys.NextUpPromptSeconds,
-            PlaybackSettingsKeys.SleepTimerDefaultMinutes,
-            PlaybackSettingsKeys.SubtitleBackgroundOpacity,
         )
 
         val DOUBLE_KEYS: Set<String> = setOf(

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStoreTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStoreTest.kt
@@ -3,6 +3,8 @@ package org.siloserver.silo.common.settings
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import org.siloserver.silo.model.settings.EffectiveSetting
 import org.siloserver.silo.model.settings.EffectiveSettingsResponse
 import org.siloserver.silo.model.settings.EffectiveSubtitleAppearance
@@ -50,8 +52,11 @@ class AndroidPlayerSettingsStoreTest {
         server: String? = serverUrl,
         repository: SettingsRepository? = null,
         deviceId: String? = null,
+        dataStore: DataStore<Preferences>? = null,
     ): AndroidPlayerSettingsStore {
-        // In-process DataStore factory backed by a temp directory.
+        // In-process DataStore factory backed by a temp directory. Tests that
+        // need to seed the file up front pass the instance in — DataStore
+        // rejects two live instances over the same file.
         return AndroidPlayerSettingsStore(
             context = mockContextStub(),
             legacyCache = legacy,
@@ -62,11 +67,13 @@ class AndroidPlayerSettingsStoreTest {
             profileChangeSignal = flowOf(Unit),
             settingsRepository = repository,
             getDeviceId = { deviceId },
-            dataStoreFactory = { id ->
-                val file = File(tempFolder.root, "ds_$id.preferences_pb")
-                PreferenceDataStoreFactory.create(produceFile = { file })
-            },
+            dataStoreFactory = { id -> dataStore ?: newDataStore(id) },
         )
+    }
+
+    private fun newDataStore(id: String): DataStore<Preferences> {
+        val file = File(tempFolder.root, "ds_$id.preferences_pb")
+        return PreferenceDataStoreFactory.create(produceFile = { file })
     }
 
     @Test
@@ -105,10 +112,52 @@ class AndroidPlayerSettingsStoreTest {
     @Test
     fun `setPlaybackSpeed clamps out-of-range values`() = runTest {
         val store = newStore()
+        // Upper bound mirrors the server's validateFloatRange("player.playback_speed", 0.25, 3.0).
         store.setPlaybackSpeed(10.0)
-        assertEquals(4.0, store.playbackSpeedFlow.first(), 0.0)
+        assertEquals(3.0, store.playbackSpeedFlow.first(), 0.0)
         store.setPlaybackSpeed(0.01)
         assertEquals(0.25, store.playbackSpeedFlow.first(), 0.0)
+    }
+
+    @Test
+    fun `match frame rate and sleep timer stay local`() = runTest {
+        val store = newStore()
+        assertEquals(false, store.matchContentFrameRateFlow.first())
+        assertEquals(30, store.sleepTimerDefaultMinutesFlow.first())
+
+        store.setMatchContentFrameRate(true)
+        store.setSleepTimerDefaultMinutes(45)
+
+        assertEquals(true, store.matchContentFrameRateFlow.first())
+        assertEquals(45, store.sleepTimerDefaultMinutesFlow.first())
+        assertFalse(
+            fakeFlusher.calls.any {
+                it.key == PlaybackSettingsKeys.MatchContentFrameRate ||
+                    it.key == PlaybackSettingsKeys.SleepTimerDefaultMinutes
+            },
+            "Neither key is registered server-side; flushing them would only earn an HTTP 400.",
+        )
+    }
+
+    @Test
+    fun `nextUpPromptSeconds falls back to the pre-rename local key`() = runTest {
+        // Simulate an install that stored the value under the old
+        // "player.next_up_prompt_seconds" DataStore slot. `deviceId` is null in
+        // these tests, so the scope prefix is empty.
+        val dataStore = newDataStore(activeProfileId)
+        dataStore.edit { it[intPreferencesKey("player.next_up_prompt_seconds")] = 15 }
+
+        val store = newStore(dataStore = dataStore)
+        assertEquals(15, store.nextUpPromptSecondsFlow.first())
+
+        // A write lands on the canonical key and takes precedence from then on.
+        store.setNextUpPromptSeconds(20)
+        assertEquals(20, store.nextUpPromptSecondsFlow.first())
+        assertTrue(
+            fakeFlusher.calls.any {
+                it.key == PlaybackSettingsKeys.NextUpPromptSeconds && it.value == "20"
+            },
+        )
     }
 
     @Test
@@ -117,6 +166,8 @@ class AndroidPlayerSettingsStoreTest {
         assertEquals(false, store.autoSkipIntroFlow.first())
         assertEquals(true, store.autoPlayNextFlow.first())
         assertEquals(true, store.hdrEnabledFlow.first())
+        // Server registry default for player.dv_profile7_hdr10_fallback is false.
+        assertEquals(false, store.dvProfile7HDR10FallbackFlow.first())
         assertEquals(true, store.pictureInPictureEnabledFlow.first())
         assertEquals(1.0, store.playbackSpeedFlow.first(), 0.0)
         assertEquals(0, store.audioSyncMsFlow.first())

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStoreTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStoreTest.kt
@@ -136,7 +136,11 @@ class AndroidPlayerSettingsStoreTest {
                 it.key == PlaybackSettingsKeys.MatchContentFrameRate ||
                     it.key == PlaybackSettingsKeys.SleepTimerDefaultMinutes
             },
-            "Neither key is registered server-side; flushing them would only earn an HTTP 400.",
+            "Neither key is in the server's settingsRegistry today, so a write would earn an " +
+                "HTTP 400 that the flusher logs and drops. Both ARE registered as remote " +
+                "profile_device settings in contracts/settings/v1/manifest.json, so this " +
+                "assertion inverts when the server implements the manifest — it is pinning " +
+                "current behaviour, not the end state.",
         )
     }
 
@@ -206,6 +210,125 @@ class AndroidPlayerSettingsStoreTest {
 
         val fresh = newStore(dataStore = dataStore)
         assertEquals(20, fresh.nextUpPromptSecondsFlow.first())
+    }
+
+    @Test
+    fun `refreshFromServer pushes the migrated value before it reads`() = runTest {
+        // The regression this guards: withScope runs the migration and then
+        // falls straight into the refresh. The migration's push is debounced, so
+        // unless the refresh flushes first, the GET answers with the registry
+        // default (30) and applyEffectiveLocally writes it over the 15 that was
+        // just recovered — losing the value for exactly the users the migration
+        // exists to protect.
+        val dataStore = newDataStore(activeProfileId)
+        dataStore.edit { it[intPreferencesKey("player.next_up_prompt_seconds")] = 15 }
+
+        val api = FakeSettingsApi(
+            effective = mapOf(PlaybackSettingsKeys.NextUpPromptSeconds to "30"),
+        )
+        fakeFlusher.sink = api
+
+        val store = newStore(dataStore = dataStore, repository = SettingsRepository(api))
+        store.refreshFromServer()
+
+        assertEquals(
+            15,
+            store.nextUpPromptSecondsFlow.first(),
+            "The refresh must flush the migrated value before reading, or it reads the default over it.",
+        )
+        assertTrue(fakeFlusher.flushNowCount > 0, "refreshFromServer must flush before it reads.")
+    }
+
+    @Test
+    fun `legacy cache imports are pushed so the next refresh cannot overwrite them`() = runTest {
+        // Importing into the local slot is only half the job: every DeviceSettings
+        // key is server-registered, so the next refresh writes the registry
+        // default back over anything that was not also pushed.
+        fakeLegacyCache.putString(serverUrl, PlaybackSettingsKeys.AutoSkipIntro, "true")
+        fakeLegacyCache.putString(serverUrl, PlaybackSettingsKeys.PreferredQuality, "1080p")
+
+        val api = FakeSettingsApi(
+            effective = mapOf(
+                PlaybackSettingsKeys.AutoSkipIntro to "false",
+                PlaybackSettingsKeys.PreferredQuality to "auto",
+            ),
+        )
+        fakeFlusher.sink = api
+
+        val store = newStore(repository = SettingsRepository(api))
+        store.refreshFromServer()
+
+        assertEquals(true, store.autoSkipIntroFlow.first())
+        assertEquals("1080p", store.preferredQualityFlow.first())
+        assertTrue(
+            fakeFlusher.calls.any {
+                it.key == PlaybackSettingsKeys.AutoSkipIntro && it.value == "true"
+            },
+            "An imported legacy value must be enqueued, not just written locally.",
+        )
+    }
+
+    @Test
+    fun `migrated value is clamped to the range the server accepts`() = runTest {
+        // An out-of-range legacy value would be rejected with a 400 that the
+        // flusher logs and drops, leaving the local slot holding something the
+        // server will never agree with.
+        val dataStore = newDataStore(activeProfileId)
+        dataStore.edit { it[intPreferencesKey("player.next_up_prompt_seconds")] = 300 }
+
+        val store = newStore(dataStore = dataStore)
+        store.nextUpPromptSecondsFlow.first()
+
+        assertTrue(
+            fakeFlusher.calls.any {
+                it.key == PlaybackSettingsKeys.NextUpPromptSeconds && it.value == "120"
+            },
+            "300 is outside 0..120 and must be clamped before being sent.",
+        )
+    }
+
+    @Test
+    fun `migration works on the scoped key path that actually ships`() = runTest {
+        // Every other migration test runs with a null deviceId, which makes
+        // keyPrefix empty. In production getDeviceId always resolves, so the
+        // scoped prefix is the only path that ever runs.
+        val deviceId = "device-abc"
+        val prefix = "scope_" + sha256Hex("$serverUrl|$activeProfileId|$deviceId").take(24) + "."
+
+        val dataStore = newDataStore(activeProfileId)
+        dataStore.edit { it[intPreferencesKey(prefix + "player.next_up_prompt_seconds")] = 15 }
+
+        val store = newStore(dataStore = dataStore, deviceId = deviceId)
+        assertEquals(15, store.nextUpPromptSecondsFlow.first())
+
+        val prefs = dataStore.data.first()
+        assertEquals(
+            15,
+            prefs[intPreferencesKey(prefix + PlaybackSettingsKeys.NextUpPromptSeconds)],
+            "The value must land in the scoped canonical slot.",
+        )
+        assertNull(
+            prefs[intPreferencesKey(prefix + "player.next_up_prompt_seconds")],
+            "The scoped legacy slot must be cleared.",
+        )
+        assertTrue(
+            fakeFlusher.calls.any {
+                it.key == PlaybackSettingsKeys.NextUpPromptSeconds && it.value == "15"
+            },
+        )
+    }
+
+    @Test
+    fun `resetDeviceSetting refuses a key that is not server-synced`() = runTest {
+        val store = newStore(repository = SettingsRepository(FakeSettingsApi()))
+        var threw = false
+        try {
+            store.resetDeviceSetting(PlaybackSettingsKeys.PictureInPictureEnabled)
+        } catch (_: IllegalArgumentException) {
+            threw = true
+        }
+        assertTrue(threw, "A device-local key must not reach DELETE /settings/device/{key}.")
+        assertTrue(fakeFlusher.calls.isEmpty(), "Nothing should have been queued for the server.")
     }
 
     @Test
@@ -474,20 +597,57 @@ class AndroidPlayerSettingsStoreTest {
     }
 }
 
+/**
+ * Mirrors AndroidPlayerSettingsStore's scope hashing so a test can address the
+ * scoped DataStore slots the shipping configuration actually uses.
+ */
+private fun sha256Hex(s: String): String =
+    java.security.MessageDigest.getInstance("SHA-256")
+        .digest(s.toByteArray(Charsets.UTF_8))
+        .joinToString(separator = "") { "%02x".format(it) }
+
 private class FakeServerSettingsFlusher : ServerSettingsFlusher {
     data class Call(val profileId: String, val key: String, val value: String?, val isDelete: Boolean)
     val calls = mutableListOf<Call>()
     var flushNowCount: Int = 0
+
+    /**
+     * When set, [flushNow] applies queued ops to this API stub, the way a real
+     * flush makes a value visible to the next `GET /settings/effective`.
+     *
+     * Tests that leave it null keep the old record-only behaviour. Tests that
+     * set it can observe ordering: whether a value was pushed *before* the
+     * refresh read, or after, when the read has already overwritten it.
+     */
+    var sink: FakeSettingsApi? = null
+    private val pending = mutableListOf<Call>()
+
     override fun enqueue(profileId: String, key: String, value: String) {
-        calls.add(Call(profileId, key, value, isDelete = false))
+        val call = Call(profileId, key, value, isDelete = false)
+        calls.add(call)
+        pending.add(call)
     }
 
     override fun enqueueDelete(profileId: String, key: String) {
-        calls.add(Call(profileId, key, value = null, isDelete = true))
+        val call = Call(profileId, key, value = null, isDelete = true)
+        calls.add(call)
+        pending.add(call)
     }
 
     override suspend fun flushNow() {
         flushNowCount++
+        sink?.let { api ->
+            for (call in pending) {
+                if (call.isDelete) {
+                    api.effective = api.effective - call.key
+                    api.hasDeviceOverride = api.hasDeviceOverride - call.key
+                } else {
+                    api.effective = api.effective + (call.key to call.value!!)
+                    api.hasDeviceOverride = api.hasDeviceOverride + call.key
+                }
+            }
+        }
+        pending.clear()
     }
 }
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStoreTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStoreTest.kt
@@ -26,6 +26,7 @@ import org.junit.rules.TemporaryFolder
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -140,8 +141,8 @@ class AndroidPlayerSettingsStoreTest {
     }
 
     @Test
-    fun `nextUpPromptSeconds falls back to the pre-rename local key`() = runTest {
-        // Simulate an install that stored the value under the old
+    fun `pre-rename nextUpPromptSeconds migrates forward and is pushed to the server`() = runTest {
+        // An install that stored the value under the old
         // "player.next_up_prompt_seconds" DataStore slot. `deviceId` is null in
         // these tests, so the scope prefix is empty.
         val dataStore = newDataStore(activeProfileId)
@@ -150,14 +151,61 @@ class AndroidPlayerSettingsStoreTest {
         val store = newStore(dataStore = dataStore)
         assertEquals(15, store.nextUpPromptSecondsFlow.first())
 
-        // A write lands on the canonical key and takes precedence from then on.
-        store.setNextUpPromptSeconds(20)
-        assertEquals(20, store.nextUpPromptSecondsFlow.first())
+        val prefs = dataStore.data.first()
+        assertEquals(
+            15,
+            prefs[intPreferencesKey(PlaybackSettingsKeys.NextUpPromptSeconds)],
+            "The value must be copied into the canonical slot, not merely read through a fallback.",
+        )
+        assertNull(
+            prefs[intPreferencesKey("player.next_up_prompt_seconds")],
+            "The legacy slot must be cleared so a stale value cannot resurface after a reset.",
+        )
+
+        // The push is what actually protects the value. applyEffectiveLocally
+        // writes the server's effective value for every registered DeviceSettings
+        // key on refresh, and the canonical key defaults to 30 server-side, so
+        // without this the first refresh after upgrade would overwrite 15 with 30.
         assertTrue(
             fakeFlusher.calls.any {
-                it.key == PlaybackSettingsKeys.NextUpPromptSeconds && it.value == "20"
+                it.key == PlaybackSettingsKeys.NextUpPromptSeconds && it.value == "15"
             },
+            "The migrated value must be enqueued so the server stops reporting the default.",
         )
+    }
+
+    @Test
+    fun `nextUpPromptSeconds migration does not clobber an existing canonical value`() = runTest {
+        val dataStore = newDataStore(activeProfileId)
+        dataStore.edit {
+            it[intPreferencesKey("player.next_up_prompt_seconds")] = 15
+            it[intPreferencesKey(PlaybackSettingsKeys.NextUpPromptSeconds)] = 45
+        }
+
+        val store = newStore(dataStore = dataStore)
+        assertEquals(45, store.nextUpPromptSecondsFlow.first())
+        assertNull(dataStore.data.first()[intPreferencesKey("player.next_up_prompt_seconds")])
+        assertTrue(
+            fakeFlusher.calls.none { it.key == PlaybackSettingsKeys.NextUpPromptSeconds },
+            "Nothing was migrated, so nothing should be pushed to the server.",
+        )
+    }
+
+    @Test
+    fun `nextUpPromptSeconds migration runs once and leaves later values alone`() = runTest {
+        val dataStore = newDataStore(activeProfileId)
+        dataStore.edit { it[intPreferencesKey("player.next_up_prompt_seconds")] = 15 }
+
+        val store = newStore(dataStore = dataStore)
+        assertEquals(15, store.nextUpPromptSecondsFlow.first())
+
+        // A later write wins, and re-reading must not re-run the migration and
+        // resurrect the pre-rename value.
+        store.setNextUpPromptSeconds(20)
+        assertEquals(20, store.nextUpPromptSecondsFlow.first())
+
+        val fresh = newStore(dataStore = dataStore)
+        assertEquals(20, fresh.nextUpPromptSecondsFlow.first())
     }
 
     @Test

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
@@ -53,7 +53,7 @@ data class SettingsUiState(
     val autoSkipCredits: Boolean = false,
     val pictureInPictureEnabled: Boolean = true,
     val dolbyVisionEnabled: Boolean = true,
-    val dvProfile7HDR10Fallback: Boolean = true,
+    val dvProfile7HDR10Fallback: Boolean = false,
     val subtitleMatchesDevice: Boolean = false,
     val showAudiobooks: Boolean = false,
     val subtitleAppearance: org.siloserver.silo.model.settings.SubtitleAppearance =

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
@@ -84,7 +84,7 @@ class TvSettingsViewModel(
         val dolbyVisionEnabled: Boolean = true,
         val showAudiobooksTab: Boolean = false,
         val subtitleMatchesDevice: Boolean = false,
-        val dvProfile7HDR10Fallback: Boolean = true,
+        val dvProfile7HDR10Fallback: Boolean = false,
         val autoSkipCredits: Boolean = false,
         // Seconds to skip back on resume (0 = off); consecutive auto-advances
         // before the "Still watching?" prompt (0 = off).

--- a/docs/superpowers/plans/2026-06-17-playback-behavior-migration.md
+++ b/docs/superpowers/plans/2026-06-17-playback-behavior-migration.md
@@ -33,7 +33,7 @@ These correct real bugs Codex found in the original tasks — they affect **mobi
 - **R2 — F3 hello race (Tasks 8, 11).** The base plan's separate `scope.launch { client.sendHello(sessionId) }` can run before `connect()` assigns `session`, so hello is a no-op and the server never marks the connection realtime-ready. **Fix:** add a `PlaybackRealtimeEvent.Opened` emitted from inside the opened-socket block, and have the controller `sendHello` when it observes `Opened` (not in a parallel launch). Applies to the mobile controller and the TV one.
 - **R3 — F3 seek payload aliases (Task 9).** The web issuer sends the seek position as `position`, `position_seconds`, **or** `seconds`. `decidePlaybackAction` must accept all three (try in that order) — don't pin tests to a single spelling.
 - **R4 — server-contract checks (do before/during DI + settings tasks).**
-  - `PlaybackSettingsKeys.NextUpPromptSeconds` is `player.next_up_prompt_seconds` but the server registry uses `playback.next_up_prompt_seconds` — reconcile.
+  - `PlaybackSettingsKeys.NextUpPromptSeconds` is `player.next_up_prompt_seconds` but the server registry uses `playback.next_up_prompt_seconds` — reconcile. *(Resolved 2026-07-25: Android now uses the canonical `playback.next_up_prompt_seconds`.)*
   - The new `player.resume_rewind_seconds` and `player.passout_threshold_episodes` keys are **not** registered server-side. Either register them server-side or keep them device-local (don't add to the server-synced `DeviceSettings` list until registered).
   - Realtime endpoint/hello/ack/result contract must be preserved; the server requires `hello` before `HasRealtimeConnection`.
 

--- a/docs/superpowers/plans/2026-06-17-playback-behavior-migration.md
+++ b/docs/superpowers/plans/2026-06-17-playback-behavior-migration.md
@@ -33,7 +33,7 @@ These correct real bugs Codex found in the original tasks — they affect **mobi
 - **R2 — F3 hello race (Tasks 8, 11).** The base plan's separate `scope.launch { client.sendHello(sessionId) }` can run before `connect()` assigns `session`, so hello is a no-op and the server never marks the connection realtime-ready. **Fix:** add a `PlaybackRealtimeEvent.Opened` emitted from inside the opened-socket block, and have the controller `sendHello` when it observes `Opened` (not in a parallel launch). Applies to the mobile controller and the TV one.
 - **R3 — F3 seek payload aliases (Task 9).** The web issuer sends the seek position as `position`, `position_seconds`, **or** `seconds`. `decidePlaybackAction` must accept all three (try in that order) — don't pin tests to a single spelling.
 - **R4 — server-contract checks (do before/during DI + settings tasks).**
-  - `PlaybackSettingsKeys.NextUpPromptSeconds` is `player.next_up_prompt_seconds` but the server registry uses `playback.next_up_prompt_seconds` — reconcile. *(Resolved 2026-07-25: Android now uses the canonical `playback.next_up_prompt_seconds`.)*
+  - `PlaybackSettingsKeys.NextUpPromptSeconds` is `player.next_up_prompt_seconds` but the server registry uses `playback.next_up_prompt_seconds` — reconcile.
   - The new `player.resume_rewind_seconds` and `player.passout_threshold_episodes` keys are **not** registered server-side. Either register them server-side or keep them device-local (don't add to the server-synced `DeviceSettings` list until registered).
   - Realtime endpoint/hello/ack/result contract must be preserved; the server requires `hello` before `HasRealtimeConnection`.
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/PlaybackSettingsKeys.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/PlaybackSettingsKeys.kt
@@ -13,11 +13,32 @@ object PlaybackSettingsKeys {
     const val SubtitleSyncMs = "player.subtitle_sync_ms"
     const val VideoGravity = "player.video_gravity"
     const val OrientationMode = "player.orientation_mode"
-    const val NextUpPromptSeconds = "player.next_up_prompt_seconds"
+    const val NextUpPromptSeconds = "playback.next_up_prompt_seconds"
     const val DvProfile7HDR10Fallback = "player.dv_profile7_hdr10_fallback"
     const val DolbyVisionEnabled = "player.dolby_vision_enabled"
+
+    /**
+     * Local-only per-profile setting: switch the display refresh rate to match
+     * the content frame rate. Not server-registered → excluded from
+     * [DeviceSettings] (Apple keeps the equivalent toggle local too).
+     */
     const val MatchContentFrameRate = "player.match_frame_rate"
+
+    /**
+     * Local-only per-profile setting: default duration preselected in the
+     * player's sleep timer. Not server-registered → excluded from
+     * [DeviceSettings].
+     */
     const val SleepTimerDefaultMinutes = "player.sleep_timer_default_minutes"
+
+    /*
+     * Legacy per-field subtitle appearance names. The server registers subtitle
+     * appearance as a single JSON blob under [SubtitleAppearance]
+     * (`subtitle_appearance`), which is Android's source of truth — nothing
+     * reads or writes these individual fields. They are not server-registered,
+     * so they stay out of [DeviceSettings]; unifying or deleting them is
+     * follow-up work (see issue #376).
+     */
     const val SubtitleFontSize = "subtitle.font_size"
     const val SubtitleFontFamily = "subtitle.font_family"
     const val SubtitleTextColor = "subtitle.text_color"
@@ -88,6 +109,16 @@ object PlaybackSettingsKeys {
      */
     const val PictureInPictureEnabled = "player.picture_in_picture_enabled"
 
+    /**
+     * Keys that participate in the server's device-scope settings cascade:
+     * pulled by `GET /settings/effective`, pushed by
+     * `PUT /settings/device/{key}`, cleared by `DELETE /settings/device/{key}`.
+     *
+     * Every entry MUST be registered server-side; the server rejects writes and
+     * resets for unregistered keys with HTTP 400. Keys Silo stores only on the
+     * device stay out of this list and are written through the store's
+     * `*Local` helpers.
+     */
     val DeviceSettings = listOf(
         PreferredQuality,
         AudioLanguage,
@@ -104,16 +135,5 @@ object PlaybackSettingsKeys {
         NextUpPromptSeconds,
         DvProfile7HDR10Fallback,
         DolbyVisionEnabled,
-        MatchContentFrameRate,
-        SleepTimerDefaultMinutes,
-        SubtitleFontSize,
-        SubtitleFontFamily,
-        SubtitleTextColor,
-        SubtitleBackgroundColor,
-        SubtitleBackgroundStyle,
-        SubtitleBackgroundOpacity,
-        SubtitleTextOutline,
-        SubtitleTextOutlineColor,
-        SubtitlePosition,
     )
 }


### PR DESCRIPTION
Android's copy of the settings contract had drifted from the server registry in `internal/api/handlers/settings.go`. Verified findings from Silo-Server/silo-server#376.

## What changed

**`PlaybackSettingsKeys.kt`**
- `NextUpPromptSeconds`: `player.next_up_prompt_seconds` → `playback.next_up_prompt_seconds`, matching the server and Apple
- Eleven keys removed from the server-sync list (`DeviceSettings`): `player.match_frame_rate`, `player.sleep_timer_default_minutes`, and nine `subtitle.*` fields. The server registers none of them, so `keyUsesDeviceScope` returns false and both the set and delete handlers 400 before validation — **every write and every reset for these was being rejected**

**`AndroidPlayerSettingsStore.kt`**
- Playback speed clamp `4.0` → `3.0`, matching `validateFloatRange("player.playback_speed", 0.25, 3.0)`
- `player.dv_profile7_hdr10_fallback` default `true` → `false`, matching the server and Apple
- `setMatchContentFrameRate` and `setSleepTimerDefaultMinutes` move to the `*Local` helpers — identical preference keys, identical clamps, read flows untouched, so **local behavior is preserved exactly**; they simply stop syncing
- New `migrateNextUpPromptKey` (see below)

**Tests** — the speed clamp assertion was **updated, not weakened**: it now asserts both bounds (`10.0 → 3.0`, `0.01 → 0.25`). Three new migration cases.

## The migration bug, found in review

The first commit shipped a **read-only** fallback to the old DataStore slot and claimed a later write or refresh would migrate it forward. Neither does, and a refresh actively destroys it.

`applyEffectiveLocally` writes the server's effective value into the canonical slot for every registered key. Before the rename that could not clobber anything — the `player.` spelling was unregistered, so the server returned an empty value and the Int branch skipped the write. The canonical key **is** registered, with a registry default of `30`, so the first refresh after upgrade writes 30 and it shadows the legacy slot permanently. `refreshFromServer` runs on settings-screen open, player load, TV detail, and `ServerDrivenConfigRefresher` — within seconds of upgrading. Affected users are exactly those whose value never reached the server: a pre-alias server, or a flush that failed silently.

`migrateNextUpPromptKey` copies the legacy slot forward once per scope, removes it, and **enqueues the migrated value** so the server stops reporting the registry default. Copying locally is not enough on its own — the refresh would still overwrite it. It runs at the top of `ensureMigrated`, which every read path and every write path funnels through, and carries its own sentinel because existing installs have already recorded the `ensureMigrated` one; folding it in there would skip precisely the users who need it.

Suppressing the refresh write instead (skipping keys the server reports without a device override) was considered and **rejected**: the subtitle-appearance block deliberately propagates a server-side reset, and a blanket guard would break that for every key.

## Second review pass — the migration's push was still losing the race

The migration commit above enqueued the recovered value for the server, and its own KDoc said that push is what protects it. It does not, on its own: `enqueue` is debounced 750 ms, and `withScope` runs `ensureMigrated` and then falls straight into `refreshFromServer`. On a LAN server the GET returns in ~30 ms with the registry default of 30, `applyEffectiveLocally` writes it over the value just recovered, and the sentinel is already committed so the migration never runs again. **Deterministic, not a rare race** — and it loses the value for exactly the users the migration exists to protect.

`refreshFromServer` now flushes pending writes before it reads, which is what `setSubtitleDeviceOverrideEnabled` already did ten lines away. This also closes the general case: any local write that had not yet flushed was reset by the next refresh. When the flush fails the GET almost always fails with it, and the existing early return leaves local values untouched.

The legacy-SharedPreferences import had the same hole and no push at all — it wrote recovered values into local slots that the next refresh would overwrite with registry defaults. It now enqueues what it imports, clamped to the server's accepted range so an out-of-band legacy value is stored rather than 400'd and silently dropped.

**The KDoc's stated reason for not fixing the root cause was wrong.** It claimed a `hasDeviceOverride` gate on the apply loop would break the subtitle-appearance reset. That block sits *outside* the loop and reads `hasDeviceOverride` itself, so gating the loop would not touch it. The real objection is `resetAllDeviceSettings`, which deletes every device row and refreshes precisely to pull the defaults back down — a gate would make reset a no-op. Corrected in place so the next reader isn't misled.

`resetDeviceSetting(key)` — listed below as a follow-up — is fixed here too, since it is the only path that can reach the server with a caller-supplied key.

**Test coverage.** Every existing migration test ran with `deviceId = null`, which makes `keyPrefix` empty. In production `getDeviceId` always resolves, so the scoped prefix is the only path that ships and it had zero coverage. Added. The two new ordering tests were confirmed to fail without the fix, with the exact symptom: `expected:<15> but was:<30>`.

## Correcting the issue's framing

Current server `main` already aliases the old Android spelling via `canonicalDeviceSettingKey`, with legacy-fallback reads and dual delete. So this was **not** active data loss against a current server — the rename drops Android's dependence on a deprecated compatibility shim so that shim can eventually be retired. #376's "never reaches the server" was only true against pre-alias servers.

## Verification

```
$ ./gradlew :android-shared:testDebugUnitTest --tests '*AndroidPlayerSettingsStoreTest*' --rerun-tasks
BUILD SUCCESSFUL

tests=31 failures=0 errors=0 skipped=0
```

Negative control — with the `flushNow()` removed from `refreshFromServer`, two tests fail
and nothing else does:

```
AndroidPlayerSettingsStoreTest > refreshFromServer pushes the migrated value before it reads FAILED
    java.lang.AssertionError: The refresh must flush the migrated value before reading,
    or it reads the default over it. expected:<15> but was:<30>
AndroidPlayerSettingsStoreTest > legacy cache imports are pushed so the next refresh cannot
    overwrite them FAILED
```

## Out of scope, worth follow-ups

- **A fifth drift of the same family:** the server registers `player.orientation_mode` as `{landscapeLocked, rotateFreely}`, but `orientationModeFlow` defaults to `"auto"` and `setOrientationMode` writes unvalidated — any value outside those two 400s
- ~~`resetDeviceSetting(key)` forwards an arbitrary key to `enqueueDelete` with no membership check.~~ **Fixed in the review commit** — it now requires membership in `DeviceSettings`.
- `match_frame_rate` and `sleep_timer_default_minutes` are registered in the contract manifest (Silo-Server/silo-server#479), so they return to the sync list at that cutover. Temporary churn, but they are rejected today
- The nine `subtitle.*` names had zero readers and zero writers; all Android subtitle styling already goes through the `subtitle_appearance` blob, which the server does register. Unifying them is follow-up work

Part of Silo-Server/silo-server#376. Server-side contract: Silo-Server/silo-server#479.

### AI Disclosure

- **Tool(s):** Claude Code
- **Model(s):** `claude-opus-5[1m]`
- **Involvement:** AI-assisted, under maintainer direction
- **Adversarial review:** Reviewed by a parallel multi-agent pass plus an independent adversarial pass using Codex. Both independently flagged that the migration's push could not win against the refresh it was meant to survive. The parallel pass additionally found the legacy-cache import writing without enqueuing, the unclamped value, and that every migration test ran on the unscoped key path that never ships. Each fix's test was checked to fail without the fix. One reviewer proposal was investigated and **rejected**: gating `applyEffectiveLocally`'s loop on `hasDeviceOverride` — correct that the KDoc's stated objection was bogus, wrong that the gate is safe, because it would silently break `resetAllDeviceSettings`.

Test results were re-run independently rather than taken from the implementing agent's report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved playback settings migration so legacy values are preserved, validated, and synchronized correctly.
  * Prevented recent setting changes from being overwritten during server refreshes.
  * Clarified which playback options remain profile-local and are not synchronized.
  * Invalid device-setting reset requests are now rejected.

* **Bug Fixes**
  * HDR10 fallback now defaults to off on Android and Android TV.
  * Playback speed and next-up prompt timing now enforce server-supported limits.
  * Match frame rate and sleep timer changes no longer trigger unnecessary server updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->