### PR TITLE
fix(playback): take the media runtime from the v3 plan

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackV3Session.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackV3Session.kt
@@ -134,6 +134,12 @@ internal fun PlaybackPlanV3.toSessionResponse(
         position = timeline.sourceStartSeconds,
         streamUrl = stream.url,
         audioTrackIndex = selectedTracks.audio?.index ?: 0,
+        // The server's runtime for the effective file, or null when it does
+        // not know. Callers must keep null as null rather than substituting
+        // the engine's duration: on an HLS copy remux the engine reports the
+        // window produced so far, so adopting it shows a feature film as a
+        // couple of minutes.
+        durationSeconds = source.durationSeconds,
         subtitleUrls = subtitles,
         playbackPlan = legacyPlan,
     )

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackV3SessionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackV3SessionTest.kt
@@ -3,6 +3,7 @@ package org.siloserver.silo.common.player
 import org.siloserver.silo.model.playback.PlaybackDelivery
 import org.siloserver.silo.model.playback.PlaybackEngineKind
 import org.siloserver.silo.model.playback.PlaybackPlanV3
+import org.siloserver.silo.model.playback.PlaybackSourceDescriptorV3
 import org.siloserver.silo.model.playback.PlaybackStreamProtocol
 import org.siloserver.silo.model.playback.PlaybackStreamV3
 import org.siloserver.silo.model.playback.PlaybackSubtitleArtifactV3
@@ -11,8 +12,10 @@ import org.siloserver.silo.model.playback.PlaybackSubtitleModeV3
 import org.siloserver.silo.model.playback.PlaybackTimelineV3
 import org.siloserver.silo.model.playback.PlaybackTrackIdentityV3
 import org.siloserver.silo.model.playback.SelectedPlaybackTracksV3
+import org.siloserver.silo.network.SiloJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class PlaybackV3SessionTest {
     @Test
@@ -75,12 +78,61 @@ class PlaybackV3SessionTest {
         assertEquals(timeline.seekRestoration, converted.seekRestoration)
     }
 
+    @Test
+    fun sourceRuntimeReachesTheSessionResponse() {
+        val response = plan(
+            mode = PlaybackSubtitleModeV3.OFF,
+            format = "",
+            url = "",
+            source = PlaybackSourceDescriptorV3(mediaFileId = 482, durationSeconds = 5400.0),
+        ).toSessionResponse("session", "profile", 482)
+
+        assertEquals(5400.0, response.durationSeconds)
+    }
+
+    // A server that does not know the runtime must leave the client knowing it
+    // does not know. Substituting 0.0 here is what let the playback engine's
+    // growing-HLS-window duration win and show a feature film as a minute.
+    @Test
+    fun unknownSourceRuntimeStaysUnknown() {
+        val response = plan(
+            mode = PlaybackSubtitleModeV3.OFF,
+            format = "",
+            url = "",
+            source = PlaybackSourceDescriptorV3(mediaFileId = 482),
+        ).toSessionResponse("session", "profile", 482)
+
+        assertNull(response.durationSeconds)
+    }
+
+    // Servers predating the descriptor omit it entirely; decoding must not fail
+    // and the runtime must read as unknown rather than zero.
+    @Test
+    fun planWithoutASourceDescriptorDecodesWithAnUnknownRuntime() {
+        val decoded = SiloJson.decodeFromString<PlaybackPlanV3>(
+            """
+            {
+              "plan_id": "plan",
+              "delivery": "original_http",
+              "engine": "media3_direct",
+              "stream": {"url": "/stream/session", "protocol": "http_progressive"},
+              "decision_reason": "test"
+            }
+            """.trimIndent(),
+        )
+
+        assertNull(decoded.source.durationSeconds)
+        assertNull(decoded.toSessionResponse("session", "profile", 482).durationSeconds)
+    }
+
     private fun plan(
         mode: PlaybackSubtitleModeV3,
         format: String,
         url: String,
         timeline: PlaybackTimelineV3 = PlaybackTimelineV3(),
+        source: PlaybackSourceDescriptorV3 = PlaybackSourceDescriptorV3(),
     ) = PlaybackPlanV3(
+        source = source,
         planId = "plan",
         delivery = PlaybackDelivery.ORIGINAL_HTTP,
         engine = PlaybackEngineKind.MEDIA3_DIRECT,

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
@@ -134,6 +134,30 @@ data class PlaybackPlanV3(
     @SerialName("decision_reason") val decisionReason: String,
     @SerialName("requested_media_file_id") val requestedMediaFileId: Int? = null,
     @SerialName("effective_media_file_id") val effectiveMediaFileId: Int? = null,
+    val source: PlaybackSourceDescriptorV3 = PlaybackSourceDescriptorV3(),
+)
+
+/**
+ * Facts about the media file the plan resolved to, as opposed to the transport
+ * carrying it. Defaulted throughout so a server that predates the descriptor
+ * still decodes.
+ */
+@Serializable
+data class PlaybackSourceDescriptorV3(
+    @SerialName("media_file_id") val mediaFileId: Int? = null,
+    /**
+     * Full runtime of the source, or null when the server does not know it.
+     *
+     * Null must survive as null: `SiloJson` sets `coerceInputValues`, so a
+     * non-nullable `Double` here would silently become 0.0 — the very value
+     * this field exists to stop the player inventing.
+     *
+     * This is the whole file, never `total - sourceStartSeconds`, and it is
+     * never adjusted by `timelineOffsetSeconds`. Do not substitute the
+     * engine's reported duration for it: on an HLS copy remux the engine
+     * reports the window produced so far, not the runtime.
+     */
+    @SerialName("duration_seconds") val durationSeconds: Double? = null,
 )
 
 @Serializable


### PR DESCRIPTION
## Problem

A 90-minute movie played back as `0:37 / 1:01`.

The v3 plan carries a `source` descriptor that this client never decoded, and `PlaybackV3Session.toSessionResponse()` never set `durationSeconds` at all. With no runtime from the server, duration fell through to the catalog value and then to the playback engine's report.

On an HLS copy remux the server intentionally serves FFmpeg's still-growing playlist, so the engine reports only the length produced so far. The grow-only ratchet in `PlayerViewModel` is a correct defense — `maxOf(state.duration, durationSec)` never lets a known runtime shrink — but with a wrong catalog value it had no floor to hold, so the growing window won.

## What this does

Decodes `source.duration_seconds` from the plan and carries it into `PlaybackSessionResponse`, which both `MobileVideoPlaybackStarter` and `TvVideoPlaybackStarter` already consume via `resolved.durationSeconds ?: effectiveVersion?.duration ?: 0.0`. The existing fallback chain is untouched — it simply gains an authoritative first rung.

**Nullability is load-bearing.** `SiloJson` sets `coerceInputValues`, so a non-nullable `Double` here would silently turn an unknown runtime into `0.0` — the exact value the ratchet then has no floor to defend against, which is how the engine's window won in the first place. The field is `Double?` end to end, and the server omits the key rather than sending null.

The descriptor and every field default, so a server predating it still decodes and reports an unknown runtime rather than failing the plan.

## Scope

Client half of Silo-Server/silo-server#482, which adds `source.duration_seconds` to the v3 plan and fixes the underlying scanner rule that let a wrong duration persist.

**Merge the server PR first.** This change is inert without it — the field will simply be absent and behavior is unchanged from today. It is safe to merge in either order, but provides no benefit until the server ships.

## Verification

```
$ ./gradlew :shared:testDebugUnitTest :android-shared:testDebugUnitTest
BUILD SUCCESSFUL
```

`PlaybackV3SessionTest` results:
```
tests="6" skipped="0" failures="0" errors="0"
```

Three tests added, per the repo guidance to cover critical shared-logic behavior:
- the runtime reaches the session response
- an unknown runtime stays `null` rather than becoming `0.0`
- a plan with no `source` object at all still decodes, with the runtime reading as unknown

## Notes

Not addressed here, and worth separate issues:
- `PlaybackSessionLifecycle` writes `duration = 0.0` with `forceOverwrite = true` on stop, and the server clobbers a good stored duration with it.
- `PlayerViewModel` does not refresh duration on replan (`TvPlayerViewModel` does), so a replan that changes the effective file leaves the phone with a stale runtime.
- `timing_origin_seconds` is declared in `PlaybackProtocolV3.kt` and read nowhere in the client; on a re-anchored copy stream every sidecar subtitle cue is offset by the anchor.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-opus-5[1m]
- Involvement: fully AI-generated
- Adversarial review: The design was reviewed by three independent agents before implementation. Two findings changed this client's half specifically. First, the field must be nullable end to end — `coerceInputValues` would otherwise convert an explicit null to `0.0` and reintroduce the bug, which is why the server omits the key rather than sending null. Second, a proposed rule to represent duration as genuinely "unknown" in the UI was withdrawn: review traced it to `TvPlayerViewModel` scrub clamping and `PlayerProgressBar`, where a null/zero runtime kills D-pad scrubbing entirely and shrinks the phone seek bar to a one-second slider — worse than the bug being fixed. This client therefore keeps treating `0` as unknown internally and only gains a trustworthy first source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback sessions now report the resolved media source’s runtime when available.
  * Unknown runtimes remain explicitly unavailable instead of being replaced with an estimated duration.
  * Older playback plans continue to decode safely with an unknown runtime.

* **Tests**
  * Added coverage for known, unknown, and legacy playback duration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->