### PR TITLE
fix(tv): stop the request detail screen rendering under the nav

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestDetailScreen.kt
@@ -3,18 +3,29 @@ package org.siloserver.silo.tv.ui.screens.requests
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -22,9 +33,13 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.request.RequestMediaDetail
+import org.siloserver.silo.model.request.requestBackdropUrl
+import org.siloserver.silo.model.request.requestPosterUrl
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvLoadingScreen
+import org.siloserver.silo.tv.ui.theme.RowDimens
 import org.siloserver.silo.tv.ui.theme.SiloBlue
 import org.siloserver.silo.tv.ui.theme.sectionEyebrow
 import org.siloserver.silo.viewmodel.RequestDetailViewModel
@@ -71,6 +86,25 @@ fun TvRequestDetailScreen(
     }
 }
 
+/**
+ * Content starts below the shell's top navigation, which is a `TopStart`
+ * overlay drawn over every screen rather than something that reserves space.
+ * Without this the title rendered *through* the nav row and the eyebrow was
+ * clipped off the top edge entirely.
+ */
+private val ShellNavInset = 96.dp
+
+/** TV-safe horizontal margin; the outer ~5% of a panel is not reliably visible. */
+private val SafeHorizontal = 48.dp
+
+/**
+ * The overview is a full TMDB synopsis — often several hundred words, which on
+ * a 10-foot display filled the screen and pushed the Request action off the
+ * bottom. Clamped to a readable teaser; the point of this screen is deciding
+ * whether to request, not reading the whole plot.
+ */
+private const val OverviewMaxLines = 4
+
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun RequestDetailContent(
@@ -80,93 +114,159 @@ private fun RequestDetailContent(
     error: String?,
     onRequest: () -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 28.dp, vertical = 20.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Text(
-            text = "REQUEST",
-            style = sectionEyebrow,
-            color = SiloBlue.copy(alpha = 0.92f),
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Backdrop, scrimmed hard enough that body copy stays legible over the
+        // busiest frame. Absent artwork simply leaves the background colour.
+        requestBackdropUrl(detail.backdropPath)?.let { url ->
+            ThumbhashImage(
+                url = url,
+                thumbhash = null,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.horizontalGradient(
+                        0f to MaterialTheme.colorScheme.background,
+                        0.55f to MaterialTheme.colorScheme.background.copy(alpha = 0.94f),
+                        1f to Color.Transparent,
+                    ),
+                ),
         )
-        Text(
-            text = detail.title,
-            style = MaterialTheme.typography.displaySmall,
-            color = MaterialTheme.colorScheme.onBackground,
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        0f to MaterialTheme.colorScheme.background.copy(alpha = 0.86f),
+                        0.4f to Color.Transparent,
+                        1f to MaterialTheme.colorScheme.background.copy(alpha = 0.92f),
+                    ),
+                ),
         )
 
-        val meta = buildList {
-            detail.year?.takeIf { it > 0 }?.let { add(it.toString()) }
-            detail.runtime?.takeIf { it > 0 }?.let { add("${it} min") }
-            detail.contentRating.takeIf { it.isNotBlank() }?.let { add(it) }
-            detail.voteAverage?.takeIf { it > 0 }?.let { add("★ ${"%.1f".format(it)}") }
-        }.joinToString("  ·  ")
-        if (meta.isNotBlank()) {
-            Text(meta, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
-
-        if (detail.genres.isNotEmpty()) {
-            Text(
-                text = detail.genres.joinToString(" · "),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-
-        if (detail.tagline.isNotBlank()) {
-            Text(
-                text = detail.tagline,
-                style = MaterialTheme.typography.titleMedium.copy(fontStyle = FontStyle.Italic),
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.86f),
-            )
-        }
-
-        if (detail.overview.isNotBlank()) {
-            Text(
-                text = detail.overview,
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.widthIn(max = 1100.dp),
-            )
-        }
-
-        val request = detail.request
-        when {
-            request.requestable -> {
-                TvRequestActionPill(
-                    label = if (isSubmitting) "Requesting…" else "Request",
-                    icon = Icons.Filled.Add,
-                    onClick = onRequest,
-                    enabled = !isSubmitting,
-                    modifier = Modifier.padding(top = 8.dp),
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(
+                    PaddingValues(
+                        start = SafeHorizontal,
+                        end = SafeHorizontal,
+                        top = ShellNavInset,
+                        bottom = 48.dp,
+                    ),
+                ),
+            horizontalArrangement = Arrangement.spacedBy(32.dp),
+        ) {
+            requestPosterUrl(detail.posterPath)?.let { url ->
+                ThumbhashImage(
+                    url = url,
+                    thumbhash = null,
+                    contentDescription = detail.title,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(RowDimens.PosterWidth, RowDimens.PosterHeight)
+                        .clip(RoundedCornerShape(10.dp)),
                 )
             }
-            !request.status.isNullOrBlank() -> {
+
+            Column(
+                // Held to the scrimmed side so the backdrop stays visible on the
+                // right rather than sitting behind the text.
+                modifier = Modifier.widthIn(max = 900.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
                 Text(
-                    text = "Request status: ${request.status}",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(top = 8.dp),
+                    text = "REQUEST",
+                    style = sectionEyebrow,
+                    color = SiloBlue.copy(alpha = 0.92f),
                 )
-            }
-            request.reason.isNotBlank() -> {
                 Text(
-                    text = request.reason,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 8.dp),
+                    text = detail.title,
+                    style = MaterialTheme.typography.displaySmall,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
                 )
-            }
-        }
 
-        notice?.let {
-            Text(it, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
-        }
-        error?.let {
-            Text(it, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.error)
+                val meta = buildList {
+                    detail.year?.takeIf { it > 0 }?.let { add(it.toString()) }
+                    detail.runtime?.takeIf { it > 0 }?.let { add("${it} min") }
+                    detail.contentRating.takeIf { it.isNotBlank() }?.let { add(it) }
+                    detail.voteAverage?.takeIf { it > 0 }?.let { add("★ ${"%.1f".format(it)}") }
+                    detail.genres.take(3).takeIf { it.isNotEmpty() }?.let { add(it.joinToString(" · ")) }
+                }.joinToString("  ·  ")
+                if (meta.isNotBlank()) {
+                    Text(
+                        text = meta,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+
+                if (detail.tagline.isNotBlank()) {
+                    Text(
+                        text = detail.tagline,
+                        style = MaterialTheme.typography.titleMedium.copy(fontStyle = FontStyle.Italic),
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.86f),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+
+                if (detail.overview.isNotBlank()) {
+                    Text(
+                        text = detail.overview,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.92f),
+                        maxLines = OverviewMaxLines,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+
+                val request = detail.request
+                when {
+                    request.requestable -> {
+                        TvRequestActionPill(
+                            label = if (isSubmitting) "Requesting…" else "Request",
+                            icon = Icons.Filled.Add,
+                            onClick = onRequest,
+                            enabled = !isSubmitting,
+                            modifier = Modifier.padding(top = 12.dp),
+                        )
+                    }
+                    !request.status.isNullOrBlank() -> {
+                        Text(
+                            text = "Request status: ${request.status}",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(top = 12.dp),
+                        )
+                    }
+                    request.reason.isNotBlank() -> {
+                        Text(
+                            text = request.reason,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 12.dp),
+                        )
+                    }
+                }
+
+                notice?.let {
+                    Text(it, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
+                }
+                error?.let {
+                    Text(it, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.error)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

The TV request detail screen drew its content from the top of the window, but the shell's top navigation is a `TopStart` overlay that reserves no space. So the title rendered **through** the nav row — "Movies" sitting on top of the title text — and the `REQUEST` eyebrow above it was clipped off the top edge of the screen entirely. The content was also outside the overscan-safe area.

Separately, the overview was the full TMDB synopsis with no bound. On a 10-foot display that filled the screen and pushed the **Request** action — the only reason to be on this screen — off the bottom.

## Change

- Content starts below the nav and inside a TV-safe horizontal margin.
- Overview clamped to four lines. The job here is deciding whether to request something, not reading the plot.
- Title, metadata and tagline are bounded too, so a long title cannot push the action off-screen again.
- Adds the backdrop the screen always had the artwork for (`backdrop_path` was in the model, unused), behind a horizontal and a vertical scrim so body copy stays legible over a busy frame, with the poster alongside the text.

## Testing

`:androidTvApp:assembleDebug` and the TV unit suite green on this branch based on `upstream/main`. Checked on an NVIDIA Shield: the title clears the nav, the eyebrow is visible, and the Request action sits on screen for a long synopsis.

Before/after is easiest to see on a series with a long overview — the earlier build had the title overlapping the nav tabs.

## AI-use disclosure

Written by Claude Opus 5 (Claude Code) working with @RXWatcher, who reported the overlap from a device screenshot, directed the change, and confirmed the result on hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated TV request details with a layered backdrop and gradient overlays.
  * Improved poster and content layout for TV screens.
  * Added safer navigation spacing to prevent title clipping.
  * Included genres in request metadata and limited long overviews with ellipsis.

* **Bug Fixes**
  * Improved request detail readability, spacing, and scrolling behavior.
  * Refined request status and error message presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->