### PR TITLE
feat(tv): add a manual Up Next control to the player transport

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1838,6 +1838,14 @@ fun TvPlayerScreen(
                             showQuickSubtitlePicker = true
                             viewModel.setControlsVisible(true)
                         },
+                        // Only offered when there is something to advance to;
+                        // the view model owns that predicate so the manual
+                        // control and the automatic trigger cannot disagree.
+                        onUpNext = if (viewModel.canShowNextUpNow()) {
+                            { viewModel.onUserRequestedNextUp() }
+                        } else {
+                            null
+                        },
                         onClose = {
                             when {
                                 roomController != null && roomSnapshot?.isHost == true ->
@@ -2227,6 +2235,8 @@ private fun TvPlayerIdleOverlay(
     focusRequest: TvIdleOverlayFocusRequest,
     onOpenHUD: () -> Unit,
     onOpenQuickSubtitles: () -> Unit,
+    /** Non-null only while a next episode is resolved and not already shown. */
+    onUpNext: (() -> Unit)? = null,
     onClose: () -> Unit,
     // Watch Together transport authority. Solo playback leaves both true.
     // A guest who can't seek gets a no-op scrubber/skip; a guest who can't
@@ -2345,6 +2355,7 @@ private fun TvPlayerIdleOverlay(
                 onPlayPause = onPlayPause,
                 onSkipForward = onSkipForward,
                 onOpenQuickSubtitles = onOpenQuickSubtitles,
+                onUpNext = onUpNext,
                 onOpenHUD = onOpenHUD,
                 onClose = onClose,
                 playPauseFocus = playPauseFocus,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerTransportCluster.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerTransportCluster.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay10
+import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -62,6 +63,12 @@ fun TvPlayerTransportCluster(
     onPlayPause: () -> Unit,
     onSkipForward: () -> Unit,
     onOpenQuickSubtitles: () -> Unit,
+    /**
+     * Non-null only when there is a next episode to show. Mirrors
+     * silo-apple#86: the automatic trigger fires at the credits, and this lets
+     * a viewer who is already done reach it early.
+     */
+    onUpNext: (() -> Unit)? = null,
     onOpenHUD: () -> Unit,
     onClose: () -> Unit,
     playPauseFocus: FocusRequester,
@@ -101,6 +108,15 @@ fun TvPlayerTransportCluster(
 
         // Secondary group — pushed right.
         Row(verticalAlignment = Alignment.CenterVertically) {
+            onUpNext?.let { showUpNext ->
+                TransportIconButton(
+                    icon = Icons.Filled.SkipNext,
+                    description = "Up Next",
+                    onClick = showUpNext,
+                    onMoveUp = onMoveUpToScrubber,
+                )
+                DockGap()
+            }
             TransportIconButton(
                 icon = Icons.Filled.ClosedCaption,
                 description = "Subtitles",

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -2292,6 +2292,40 @@ class TvPlayerViewModel(
         commitApproachingEnd(next, videoEnded)
     }
 
+    /**
+     * Whether an Up Next control has anything to show right now.
+     *
+     * Shared with the automatic path deliberately: a manual button that can
+     * appear when the automatic trigger would find nothing is a button that
+     * does nothing when pressed.
+     */
+    fun canShowNextUpNow(): Boolean {
+        val state = _uiState.value
+        return state.nextEpisode != null && !state.showNextUp
+    }
+
+    /**
+     * Surface Up Next on demand, ahead of the credits trigger.
+     *
+     * Routed through the same commit the automatic timing uses so the overlay,
+     * the countdown gating and the auto-advance accounting behave identically —
+     * the only difference is what asked for it. Mirrors silo-apple#86, which
+     * added the equivalent control to the tvOS transport.
+     *
+     * The countdown is deliberately NOT started here: someone who opened this
+     * themselves is choosing, and a timer that yanks them into the next episode
+     * mid-decision is the opposite of what the press asked for.
+     */
+    fun onUserRequestedNextUp() {
+        val next = _uiState.value.nextEpisode ?: return
+        if (_uiState.value.showNextUp) return
+        nextUpCountdownJob?.cancel()
+        nextUpCountdownJob = null
+        _uiState.update {
+            it.copy(showNextUp = true, nextUpCountdownSeconds = null)
+        }
+    }
+
     private fun commitApproachingEnd(next: NextEpisodeState, videoEnded: Boolean) {
         autoAdvanceHandled = true
         pendingApproachingEndVideoEnded = null


### PR DESCRIPTION
## Problem

Android TV surfaced Up Next automatically at the credits, but there was no way to reach it early. A viewer who is done with an episode had to sit through the outro or leave the player and navigate back in.

Ports Silo-Server/silo-apple#86, which added the equivalent control to the tvOS transport.

## Change

A Skip-Next control in the transport's secondary group, shown **only when a next episode is actually resolved**.

The availability predicate lives on the view model (`canShowNextUpNow`) and is shared with the automatic path, deliberately: a manual button that can appear when the automatic trigger would find nothing is a button that does nothing when pressed. Apple made the same call in #86 for the same reason.

## The one judgement call worth reviewing

**It does not start the auto-advance countdown.** Someone who opened Up Next themselves is choosing what to do next; a timer that pulls them into the following episode mid-decision is the opposite of what the press asked for. The automatic path keeps its countdown and its pass-out gating untouched — the only thing that differs between the two entry points is whether a countdown runs.

If the project would rather the manual path behave identically to the automatic one, that is a one-line change (`startNextUpCountdown()` in `onUserRequestedNextUp`), but I think the asymmetry is right.

## Testing

`:androidTvApp:assembleDebug` and the TV unit suite green on this branch, based on `upstream/main`.

**Not exercised on hardware.** The control is wired and the predicate is shared, but I have not watched an episode to the point of having a resolved next episode and pressed it.

## AI-use disclosure

Written by Claude Opus 5 (Claude Code) working with @RXWatcher, who is tracking Apple/Android parity and directed this port.
