### PR TITLE
fix(catalog): stop dropping mixed libraries on the floor

### DIFF
--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/navigation/MediaMode.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/navigation/MediaMode.kt
@@ -34,6 +34,12 @@ private val videoLibraryTypes = setOf(
     "shows",
     "tv",
     "video",
+    // A server library holding movies AND series in one folder. Omitting it
+    // here did not degrade the library — it erased it: the type mapped to no
+    // MediaMode, so the library never reached navigation, search or browse on
+    // either platform, with nothing to indicate anything was missing.
+    // silo-apple hit the same thing and fixed it in #93.
+    "mixed",
 )
 
 private val audioLibraryTypes = setOf(

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/navigation/MediaModeTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/navigation/MediaModeTest.kt
@@ -3,6 +3,7 @@ package org.siloserver.silo.model.navigation
 import org.siloserver.silo.model.personal.UserLibrary
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class MediaModeTest {
     @Test
@@ -177,4 +178,36 @@ class MediaModeTest {
 
     private fun userLibrary(id: Int, type: String): UserLibrary =
         UserLibrary(id = id, name = "Library $id", type = type)
+}
+
+/**
+ * A server library of type "mixed" holds movies and series in one folder.
+ * Leaving it out of the video types did not degrade it — it erased it: the type
+ * mapped to no [MediaMode], so the library never reached navigation, search or
+ * browse on either platform and nothing indicated anything was missing.
+ * silo-apple hit the same thing (#93).
+ */
+class MixedLibraryModeTest {
+
+    @Test
+    fun `a mixed library is a video library on both platforms`() {
+        assertEquals(MediaMode.Video, mobileMediaModeForLibraryType("mixed"))
+        assertEquals(MediaMode.Video, tvMediaModeForLibraryType("mixed"))
+    }
+
+    @Test
+    fun `casing and padding from the server do not hide it`() {
+        assertEquals(MediaMode.Video, mobileMediaModeForLibraryType(" Mixed "))
+        assertEquals(MediaMode.Video, tvMediaModeForLibraryType("MIXED"))
+    }
+
+    /**
+     * Types the client genuinely has no home for must still map to nothing, or
+     * this fix turns "unknown" into "video" and puts photos in the film grid.
+     */
+    @Test
+    fun `still refuses types with no home`() {
+        assertNull(mobileMediaModeForLibraryType("photo"))
+        assertNull(mobileMediaModeForLibraryType("podcast"))
+    }
 }


### PR DESCRIPTION
## Problem

A server library of type `mixed` — movies and series in one folder — mapped to no `MediaMode`, so it never reached navigation, search or browse on **either** platform.

Not degraded: erased. Nothing indicated a library was missing, and there was no way for a user to reach its contents at all.

silo-apple hit the same thing and fixed the decode half in Silo-Server/silo-apple#93, where it was described as "silently dropped at decode". Android's version is the same failure one layer along, in `videoLibraryTypes`.

## Change

Admit `mixed` as a video library type. That is the whole fix for visibility, because the rest of the path already does the right thing with it: `tvCatalogMediaTypeFor` returns null for an unrecognised type, which scopes browse by `libraryId` alone rather than forcing a `mediaType` — exactly what a merged library needs. That fallback exists because music libraries were once wrongly forced to `"movie"`; mixed libraries inherit the correct behaviour from it for free.

## Deliberately not ported

Apple also added a **Type facet** (Movies / Series, single-select) so the merged grid narrows by filtering rather than navigation, and listed the library under both cascade dropdowns on tvOS.

That is a UX decision worth making on purpose rather than mirroring blind — and it is worth nothing while the library is invisible. Visibility first; the facet is a separate, smaller change if the project wants the same shape as Apple.

## Testing

Four tests covering both platforms' mappings, server-side casing and padding (`" Mixed "`, `"MIXED"`), and — importantly — that types the client genuinely has no home for still map to nothing. Without that last one this fix would turn "unrecognised" into "video" and put a photo library in the film grid.

Full unit suites and both `assembleDebug` targets green, based on `upstream/main`.

**Not exercised against a real mixed library.** I do not have one configured; the mapping and its fallbacks are unit-tested, but nobody has browsed one end to end.

## AI-use disclosure

Written by Claude Opus 5 (Claude Code) working with @RXWatcher, who is tracking Apple/Android parity and directed this port.
