### PR TITLE
feat(android): production-ready Watch Together (PR 108 slice F)

### DIFF
--- a/.superpowers/sdd/2026-07-27-pr108-slice-f-watch-together/task-1-report.md
+++ b/.superpowers/sdd/2026-07-27-pr108-slice-f-watch-together/task-1-report.md
@@ -153,3 +153,56 @@ Total: 64 tests, 0 failures, 0 errors.
   Slice F Task 2.
 - Existing Kotlin/Gradle deprecation and coroutine opt-in warnings remain.
 - No push, PR, or merge was performed.
+
+## Review correction: coherent websocket auth scope
+
+The websocket handshake now captures `snapshotCurrentScope()` exactly once at
+connect start. It validates the access token against that exact snapshot,
+derives `profile_id` and `profile_token` from the same snapshot, and passes the
+snapshot through the connector boundary. The production Ktor connector applies
+`authScope(scope)` to the websocket request, so URL rebasing, bearer lookup, and
+profile headers remain pinned even if the globally-active server, profile, or
+temporary identity changes before the engine builds the handshake. A missing
+snapshot or missing exact-scope access token terminates before the connector
+opens.
+
+### Correction TDD evidence
+
+RED command:
+
+```text
+./gradlew :android-shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.common.network.WatchTogetherRealtimeWebSocketTest.handshake remains entirely on captured auth scope when active identity switches'
+```
+
+Before the correction, the deterministic fixture switched the active identity
+from server A to server B immediately before engine/auth-plugin processing.
+The test failed because the request did not reach captured server A:
+
+```text
+1 test completed, 1 failed
+BUILD FAILED in 2s
+```
+
+After the correction, that real-WebSocket test proves the request reaches only
+server A and carries A's room/profile query fields, bearer, and profile headers;
+server B receives no request. A common seam test additionally proves that an
+unavailable exact-scope access token fails closed before connector invocation.
+
+Fresh focused GREEN used the same command listed above with all six test
+classes and `--rerun-tasks`. Observed:
+
+```text
+RoomFrameDecoderTest: 10 tests, 0 failures/errors
+WatchTogetherRealtimeClientTest: 8 tests, 0 failures/errors
+HttpOriginPolicyTest: 13 tests, 0 failures/errors
+SiloAuthPluginPinTest: 20 tests, 0 failures/errors
+WatchTogetherRepositoryTest: 11 tests, 0 failures/errors
+WatchTogetherRealtimeWebSocketTest: 4 tests, 0 failures/errors
+BUILD SUCCESSFUL in 17s
+70 actionable tasks: 70 executed
+```
+
+Total after correction: 66 tests, 0 failures, 0 errors. Existing off-origin and
+cleartext-consent gates, including the real pre-engine rejection test, remain
+covered and green. No push, PR, or merge was performed.

--- a/.superpowers/sdd/2026-07-27-pr108-slice-f-watch-together/task-1-report.md
+++ b/.superpowers/sdd/2026-07-27-pr108-slice-f-watch-together/task-1-report.md
@@ -206,3 +206,55 @@ BUILD SUCCESSFUL in 17s
 Total after correction: 66 tests, 0 failures, 0 errors. Existing off-origin and
 cleartext-consent gates, including the real pre-engine rejection test, remain
 covered and green. No push, PR, or merge was performed.
+
+## Review correction 2: token loss before engine
+
+The exact-scope validation at connect start is not the final token read: the
+auth plugin reads the scoped token again while building the request so it can
+honor rotation. A credential scope can disappear between those reads. The
+Watch Together connector now marks its pinned request with the internal,
+opt-in `requireSiloAuth()` attribute. When that marked request's exact scoped
+token is null or blank, `SiloAuthPlugin` removes Silo headers and throws before
+the engine runs. Unmarked public requests and `skipSiloAuth()` paths retain
+their existing behavior.
+
+### Correction 2 TDD evidence
+
+The deterministic real-WebSocket fixture returns `ACCESS_A` for connect
+validation and null for the plugin's second exact-scope read.
+
+RED:
+
+```text
+./gradlew :android-shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.common.network.WatchTogetherRealtimeWebSocketTest.handshake fails before engine when captured scope token disappears after validation'
+
+1 test completed, 1 failed
+BUILD FAILED in 2s
+```
+
+The failure was the expected zero-request assertion: before the correction,
+the plugin omitted `Authorization` but still sent the query-bearing handshake
+to `MockWebServer`.
+
+Fresh focused GREEN:
+
+```text
+./gradlew \
+  :shared:testDebugUnitTest \
+    --tests 'org.siloserver.silo.network.SiloAuthPluginPinTest' \
+    --tests 'org.siloserver.silo.network.WatchTogetherRealtimeClientTest' \
+  :android-shared:testDebugUnitTest \
+    --tests 'org.siloserver.silo.common.network.WatchTogetherRealtimeWebSocketTest' \
+  --rerun-tasks
+
+SiloAuthPluginPinTest: 20 tests, 0 failures/errors
+WatchTogetherRealtimeClientTest: 8 tests, 0 failures/errors
+WatchTogetherRealtimeWebSocketTest: 5 tests, 0 failures/errors
+BUILD SUCCESSFUL in 15s
+70 actionable tasks: 70 executed
+```
+
+The new regression verifies two scoped token reads, typed transport
+termination, and zero engine/server requests. Total in this focused correction
+run: 33 tests, 0 failures, 0 errors. No push, PR, or merge was performed.

--- a/.superpowers/sdd/2026-07-27-pr108-slice-f-watch-together/task-1-report.md
+++ b/.superpowers/sdd/2026-07-27-pr108-slice-f-watch-together/task-1-report.md
@@ -1,0 +1,155 @@
+# Slice F Task 1 report
+
+## Status
+
+Implemented realtime transport semantics and credential boundaries only:
+
+- explicit decoded `room_closed` remains the terminal
+  `RoomRealtimeEvent.Closed` protocol event;
+- writable handshakes publish `RoomRealtimeEvent.Opened`;
+- physical EOF, handshake failure, and socket I/O failure publish typed
+  `RoomRealtimeEvent.TransportTerminated`;
+- connection-owner cancellation is rethrown without publishing either close
+  event;
+- all client and repository send methods return actual Boolean delivery;
+- socket session assignment and cleanup are guarded by a mutex and connection
+  identity, so an old finalizer cannot clear its replacement;
+- the websocket URL encodes room id as one path segment, removes the access
+  JWT, and retains only the server-required room/profile query fields;
+- `ws://` and `wss://` canonicalize to their corresponding HTTP origins for
+  same-origin and cleartext-consent checks.
+
+No repository reconnect/lease redesign, `RoomSession`, controller, or UI work
+was implemented.
+
+## Design
+
+### Testable physical socket boundary
+
+`DefaultWatchTogetherRealtimeClient` uses a small common socket connector seam.
+The production connector is a real Ktor `webSocketSession`; common tests use
+controlled connections to deterministically exercise EOF, receive/open
+failure, cancellation, send failure, concurrent replacement, and cleanup.
+
+The active physical connection is assigned before `Opened`. Both assignment
+and send lookup use one mutex. Finalization clears the mutable send target only
+when it is still the exact connection being finalized.
+
+### Protocol versus transport termination
+
+`decodeRoomFrame` alone creates `Closed`, and only from a `room_closed` frame.
+The socket loop creates `TransportTerminated` for normal EOF and failures.
+Cancellation is handled before the general failure branch and rethrown, so an
+owner-driven cancellation remains silent.
+
+### Credential boundary
+
+The access token is still required to attempt the room socket but is no longer
+placed in the request target. The existing same-origin Silo auth plugin adds
+`Authorization`, `X-Profile-Id`, and `X-Profile-Token` headers. The server
+currently still requires `room_token`, `profile_id`, and `profile_token` query
+parameters; the client KDoc records that residual request-target exposure.
+
+Cleartext consent canonicalizes `ws://host[:port]` to
+`http://host[:port]` and `wss://` to `https://`. It passes the canonical HTTP
+origin to the consent store, allowing an existing exact-origin approval to
+authorize the corresponding websocket. Unapproved cleartext fails in the auth
+plugin before the OkHttp engine observes any header or query credential.
+
+## Tests
+
+Common:
+
+- `RoomFrameDecoderTest`
+- `WatchTogetherRealtimeClientTest`
+- `HttpOriginPolicyTest`
+- `SiloAuthPluginPinTest`
+- `WatchTogetherRepositoryTest`
+
+Android/JVM real transport:
+
+- `WatchTogetherRealtimeWebSocketTest`
+
+The real test uses the production Ktor/OkHttp client against
+`MockWebServer`. It verifies the encoded handshake path, JWT absence from the
+query, retained room/profile query contract, auth/profile headers,
+open-before-early-snapshot ordering, outbound attach/ping ordering, normal
+physical EOF, owner cancellation, and pre-engine cleartext rejection.
+
+## TDD evidence
+
+### RED
+
+Command:
+
+```text
+./gradlew :shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.network.WatchTogetherRealtimeClientTest' \
+  --tests 'org.siloserver.silo.network.HttpOriginPolicyTest' \
+  --tests 'org.siloserver.silo.network.SiloAuthPluginPinTest'
+```
+
+Observed compile RED:
+
+```text
+Unresolved reference 'Opened'
+Unresolved reference 'TransportTerminated'
+Unit send results were incompatible with Boolean delivery assertions
+WatchTogetherSocketConnector / WatchTogetherSocketConnection were unresolved
+No socket-seam constructor existed
+BUILD FAILED in 1s
+```
+
+This established the missing physical/protocol distinction, writable epoch,
+Boolean send contract, and testable connection-ownership boundary before
+production changes.
+
+The first real-websocket run then passed every app assertion except
+MockWebServer shutdown in the cancellation test. Its server listener observed
+the client close but did not answer the close handshake, leaving the dispatcher
+queue alive. Adding the correct server-side close response fixed the fixture;
+no production behavior changed for that failure.
+
+### GREEN
+
+Fresh focused command:
+
+```text
+./gradlew \
+  :shared:testDebugUnitTest \
+    --tests 'org.siloserver.silo.network.RoomFrameDecoderTest' \
+    --tests 'org.siloserver.silo.network.WatchTogetherRealtimeClientTest' \
+    --tests 'org.siloserver.silo.network.HttpOriginPolicyTest' \
+    --tests 'org.siloserver.silo.network.SiloAuthPluginPinTest' \
+    --tests 'org.siloserver.silo.repository.WatchTogetherRepositoryTest' \
+  :android-shared:testDebugUnitTest \
+    --tests 'org.siloserver.silo.common.network.WatchTogetherRealtimeWebSocketTest' \
+  --rerun-tasks
+```
+
+Observed:
+
+```text
+RoomFrameDecoderTest: 10 tests, 0 failures/errors
+WatchTogetherRealtimeClientTest: 7 tests, 0 failures/errors
+HttpOriginPolicyTest: 13 tests, 0 failures/errors
+SiloAuthPluginPinTest: 20 tests, 0 failures/errors
+WatchTogetherRepositoryTest: 11 tests, 0 failures/errors
+WatchTogetherRealtimeWebSocketTest: 3 tests, 0 failures/errors
+BUILD SUCCESSFUL in 16s
+70 actionable tasks: 70 executed
+```
+
+Total: 64 tests, 0 failures, 0 errors.
+
+## Concerns
+
+- Room/profile credentials remain in the query because the server contract
+  still requires them. The access JWT is removed, and the residual exposure is
+  documented.
+- `WatchTogetherRepository` only receives the new open/termination event and
+  Boolean send surface in this task. Attempt counting, stable-window reset,
+  immutable leases, and reconnect ownership are intentionally deferred to
+  Slice F Task 2.
+- Existing Kotlin/Gradle deprecation and coroutine opt-in warnings remain.
+- No push, PR, or merge was performed.

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlayWhenReadyReconciliation.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlayWhenReadyReconciliation.kt
@@ -1,0 +1,92 @@
+package org.siloserver.silo.common.player
+
+import androidx.media3.common.Player
+
+/**
+ * Only deliberate user/MediaSession changes may become room transport intent.
+ *
+ * Audio-focus loss, noisy-route changes, end-of-item, and playback suppression
+ * are local player conditions. Broadcasting them would pause the room for
+ * everyone, while forcibly undoing them could resume playback against the
+ * platform's safety decision.
+ */
+fun shouldReconcileExternalPlayWhenReady(reason: Int): Boolean =
+    reason == Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST ||
+        reason == Player.PLAY_WHEN_READY_CHANGE_REASON_REMOTE
+
+/**
+ * Suppresses the callback produced by our own room/ViewModel synchronization.
+ * Media3 reports a programmatic `playWhenReady` assignment as USER_REQUEST, so
+ * the reason alone cannot distinguish it from a notification/headset command.
+ */
+class PlayWhenReadyReconciliationGate(
+    private val nowMs: () -> Long = { android.os.SystemClock.elapsedRealtime() },
+) {
+    private data class PendingChange(val value: Boolean, val createdAtMs: Long)
+
+    data class CallbackDecision(
+        val shouldReconcile: Boolean,
+        val followUpProgrammaticValue: Boolean? = null,
+    )
+
+    private var inFlight: PendingChange? = null
+    private var queuedLatest: Boolean? = null
+
+    val hasPendingChanges: Boolean
+        get() {
+            discardExpired()
+            return inFlight != null || queuedLatest != null
+        }
+
+    /**
+     * Register a programmatic target. Returns true only when the caller should
+     * issue it now. While one command awaits its callback, later targets are
+     * coalesced and issued by [onPlayWhenReadyChanged] after that callback.
+     */
+    fun requestProgrammaticChange(value: Boolean): Boolean {
+        discardExpired()
+        if (inFlight == null) {
+            inFlight = PendingChange(value, nowMs())
+            return true
+        }
+        queuedLatest = value
+        return false
+    }
+
+    fun onPlayWhenReadyChanged(value: Boolean, reason: Int): CallbackDecision {
+        discardExpired()
+        if (inFlight?.value == value) {
+            inFlight = null
+            val followUp = queuedLatest
+            queuedLatest = null
+            if (followUp != null && followUp != value) {
+                inFlight = PendingChange(followUp, nowMs())
+                return CallbackDecision(
+                    shouldReconcile = false,
+                    followUpProgrammaticValue = followUp,
+                )
+            }
+            return CallbackDecision(shouldReconcile = false)
+        }
+        return CallbackDecision(
+            shouldReconcile = shouldReconcileExternalPlayWhenReady(reason),
+        )
+    }
+
+    fun reset() {
+        inFlight = null
+        queuedLatest = null
+    }
+
+    private fun discardExpired() {
+        val cutoff = nowMs() - PENDING_CHANGE_MAX_AGE_MS
+        if (inFlight?.createdAtMs?.let { it < cutoff } == true) {
+            inFlight = null
+            queuedLatest = null
+        }
+    }
+
+    private companion object {
+        const val PENDING_CHANGE_MAX_AGE_MS = 2_000L
+    }
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionLifecycle.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionLifecycle.kt
@@ -263,6 +263,7 @@ class PlaybackSessionLifecycle(
         manageProgress: Boolean = true,
         stopSessionOnStop: Boolean = true,
         renewMissingSessionWithLegacyStart: Boolean = true,
+        deferPublication: Boolean = false,
         expectedOwnershipEpoch: Long,
     ): Boolean = try {
         currentCoroutineContext().ensureActive()
@@ -272,7 +273,7 @@ class PlaybackSessionLifecycle(
             manageProgress = manageProgress,
             stopSessionOnStop = stopSessionOnStop,
             renewMissingSessionWithLegacyStart = renewMissingSessionWithLegacyStart,
-            deferPublication = false,
+            deferPublication = deferPublication,
             isCurrent = { stopEpoch == expectedOwnershipEpoch },
         )
         if (!adopted) {

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/network/WatchTogetherRealtimeWebSocketTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/network/WatchTogetherRealtimeWebSocketTest.kt
@@ -2,6 +2,7 @@ package org.siloserver.silo.common.network
 
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collect
@@ -15,11 +16,13 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.siloserver.silo.network.AuthScopeSnapshot
 import org.siloserver.silo.network.CleartextOriginConsent
 import org.siloserver.silo.network.CleartextOriginNotApprovedException
 import org.siloserver.silo.network.DefaultWatchTogetherRealtimeClient
 import org.siloserver.silo.network.RoomRealtimeEvent
 import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.network.TokenManagerImpl
 import org.siloserver.silo.network.canonicalHttpOrigin
 import org.siloserver.silo.network.createSiloClient
@@ -32,6 +35,59 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class WatchTogetherRealtimeWebSocketTest {
+
+    @Test
+    fun `handshake remains entirely on captured auth scope when active identity switches`() = runBlocking {
+        val serverA = MockWebServer()
+        val serverB = MockWebServer()
+        val socketListener = object : WebSocketListener() {
+            override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                webSocket.close(code, reason)
+            }
+        }
+        serverA.enqueue(MockResponse().withWebSocketUpgrade(socketListener))
+        serverB.enqueue(MockResponse().withWebSocketUpgrade(socketListener))
+        serverA.start()
+        serverB.start()
+
+        val tokens = SwitchingScopeTokenManager(
+            serverAUrl = serverA.url("/").toString(),
+            serverBUrl = serverB.url("/").toString(),
+        )
+        val approvedOrigins = setOf(
+            canonicalHttpOrigin(serverA.url("/").toString()),
+            canonicalHttpOrigin(serverB.url("/").toString()),
+        )
+        val httpClient = createSiloClient(
+            tokenManager = tokens,
+            cleartextOriginConsent = object : CleartextOriginConsent {
+                override suspend fun isApproved(origin: String): Boolean = origin in approvedOrigins
+            },
+        )
+        var collection: Job? = null
+        try {
+            val realtime = DefaultWatchTogetherRealtimeClient(httpClient, tokens)
+            val events = Channel<RoomRealtimeEvent>(Channel.UNLIMITED)
+            collection = launch {
+                realtime.connect("room-a", "ROOM_A").collect(events::send)
+            }
+
+            assertIs<RoomRealtimeEvent.Opened>(withTimeout(5_000) { events.receive() })
+            val requestA = assertNotNull(serverA.takeRequest(1, TimeUnit.SECONDS))
+            assertEquals(0, serverB.requestCount)
+            assertEquals("ROOM_A", requestA.requestUrl?.queryParameter("room_token"))
+            assertEquals("profile-a", requestA.requestUrl?.queryParameter("profile_id"))
+            assertEquals("PROFILE_A", requestA.requestUrl?.queryParameter("profile_token"))
+            assertEquals("Bearer ACCESS_A", requestA.getHeader("Authorization"))
+            assertEquals("profile-a", requestA.getHeader("X-Profile-Id"))
+            assertEquals("PROFILE_A", requestA.getHeader("X-Profile-Token"))
+        } finally {
+            collection?.cancelAndJoin()
+            httpClient.close()
+            serverA.shutdown()
+            serverB.shutdown()
+        }
+    }
 
     @Test
     fun `real handshake protects credentials orders open before snapshot and delivers outbound frames`() = runBlocking {
@@ -176,13 +232,25 @@ class WatchTogetherRealtimeWebSocketTest {
         }
     }
 
-    private suspend fun configuredTokens(server: MockWebServer): TokenManagerImpl =
-        TokenManagerImpl().apply {
-            setServerUrl(server.url("/").toString())
+    private suspend fun configuredTokens(server: MockWebServer): TokenManager {
+        val serverUrl = server.url("/").toString()
+        val delegate = TokenManagerImpl().apply {
+            setServerUrl(serverUrl)
             saveTokens("ACCESS_SECRET", "refresh", 3_600)
             setProfileId("profile-1")
             setProfileToken("PROFILE_SECRET")
         }
+        return SnapshotTokenManager(
+            delegate = delegate,
+            scope = AuthScopeSnapshot(
+                serverId = "server-1",
+                profileId = "profile-1",
+                serverUrl = serverUrl,
+                profileToken = "PROFILE_SECRET",
+            ),
+            accessToken = "ACCESS_SECRET",
+        )
+    }
 
     private fun approvedConsent(server: MockWebServer): CleartextOriginConsent {
         val approvedOrigin = canonicalHttpOrigin(server.url("/").toString())
@@ -190,5 +258,61 @@ class WatchTogetherRealtimeWebSocketTest {
             override suspend fun isApproved(origin: String): Boolean =
                 origin == approvedOrigin
         }
+    }
+
+    /**
+     * Returns scope A once, then makes generic active-scope reads report B.
+     *
+     * The old client switches on [getProfileToken], immediately before the
+     * engine/auth plugin runs. The corrected client switches after its first
+     * exact-scope access-token validation. Either path deterministically puts
+     * the active identity on B before the handshake is built.
+     */
+    private class SwitchingScopeTokenManager(
+        serverAUrl: String,
+        private val serverBUrl: String,
+        private val delegate: TokenManager = TokenManagerImpl(),
+    ) : TokenManager by delegate {
+        private val scopeA = AuthScopeSnapshot(
+            serverId = "server-a",
+            profileId = "profile-a",
+            serverUrl = serverAUrl,
+            profileToken = "PROFILE_A",
+            identityGeneration = 1,
+            credentialEpoch = 1,
+        )
+        private var activeB = false
+
+        override suspend fun snapshotCurrentScope(): AuthScopeSnapshot = scopeA
+
+        override suspend fun getAccessToken(): String = if (activeB) "ACCESS_B" else "ACCESS_A"
+
+        override suspend fun getProfileId(): String = if (activeB) "profile-b" else "profile-a"
+
+        override suspend fun getProfileToken(): String {
+            val token = if (activeB) "PROFILE_B" else "PROFILE_A"
+            activeB = true
+            return token
+        }
+
+        override suspend fun getServerUrl(): String = if (activeB) serverBUrl else scopeA.serverUrl
+
+        override suspend fun getCurrentServerId(): String = if (activeB) "server-b" else "server-a"
+
+        override suspend fun getAccessTokenForScope(scope: AuthScopeSnapshot): String? {
+            activeB = true
+            return if (scope == scopeA) "ACCESS_A" else null
+        }
+    }
+
+    private class SnapshotTokenManager(
+        private val delegate: TokenManager,
+        private val scope: AuthScopeSnapshot,
+        private val accessToken: String,
+    ) : TokenManager by delegate {
+        override suspend fun snapshotCurrentScope(): AuthScopeSnapshot = scope
+
+        override suspend fun getAccessTokenForScope(scope: AuthScopeSnapshot): String? =
+            accessToken.takeIf { scope == this.scope }
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/network/WatchTogetherRealtimeWebSocketTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/network/WatchTogetherRealtimeWebSocketTest.kt
@@ -37,6 +37,31 @@ import kotlin.test.assertTrue
 class WatchTogetherRealtimeWebSocketTest {
 
     @Test
+    fun `handshake fails before engine when captured scope token disappears after validation`() = runBlocking {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setResponseCode(401))
+        server.start()
+        val tokens = VanishingScopeTokenManager(server.url("/").toString())
+        val httpClient = createSiloClient(
+            tokenManager = tokens,
+            cleartextOriginConsent = approvedConsent(server),
+        )
+        try {
+            val events = mutableListOf<RoomRealtimeEvent>()
+            DefaultWatchTogetherRealtimeClient(httpClient, tokens)
+                .connect("room-a", "ROOM_A")
+                .collect(events::add)
+
+            assertIs<RoomRealtimeEvent.TransportTerminated>(events.single())
+            assertEquals(0, server.requestCount)
+            assertEquals(2, tokens.scopedAccessReads)
+        } finally {
+            httpClient.close()
+            server.shutdown()
+        }
+    }
+
+    @Test
     fun `handshake remains entirely on captured auth scope when active identity switches`() = runBlocking {
         val serverA = MockWebServer()
         val serverB = MockWebServer()
@@ -314,5 +339,28 @@ class WatchTogetherRealtimeWebSocketTest {
 
         override suspend fun getAccessTokenForScope(scope: AuthScopeSnapshot): String? =
             accessToken.takeIf { scope == this.scope }
+    }
+
+    private class VanishingScopeTokenManager(
+        serverUrl: String,
+        private val delegate: TokenManager = TokenManagerImpl(),
+    ) : TokenManager by delegate {
+        private val scope = AuthScopeSnapshot(
+            serverId = "server-a",
+            profileId = "profile-a",
+            serverUrl = serverUrl,
+            profileToken = "PROFILE_A",
+            identityGeneration = 1,
+            credentialEpoch = 1,
+        )
+        var scopedAccessReads = 0
+            private set
+
+        override suspend fun snapshotCurrentScope(): AuthScopeSnapshot = scope
+
+        override suspend fun getAccessTokenForScope(scope: AuthScopeSnapshot): String? {
+            scopedAccessReads += 1
+            return "ACCESS_A".takeIf { scope == this.scope && scopedAccessReads == 1 }
+        }
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/network/WatchTogetherRealtimeWebSocketTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/network/WatchTogetherRealtimeWebSocketTest.kt
@@ -1,0 +1,194 @@
+package org.siloserver.silo.common.network
+
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.siloserver.silo.network.CleartextOriginConsent
+import org.siloserver.silo.network.CleartextOriginNotApprovedException
+import org.siloserver.silo.network.DefaultWatchTogetherRealtimeClient
+import org.siloserver.silo.network.RoomRealtimeEvent
+import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.TokenManagerImpl
+import org.siloserver.silo.network.canonicalHttpOrigin
+import org.siloserver.silo.network.createSiloClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WatchTogetherRealtimeWebSocketTest {
+
+    @Test
+    fun `real handshake protects credentials orders open before snapshot and delivers outbound frames`() = runBlocking {
+        val server = MockWebServer()
+        val outbound = Channel<String>(Channel.UNLIMITED)
+        val serverSocket = CompletableDeferred<WebSocket>()
+        server.enqueue(
+            MockResponse().withWebSocketUpgrade(
+                object : WebSocketListener() {
+                    override fun onOpen(webSocket: WebSocket, response: Response) {
+                        serverSocket.complete(webSocket)
+                        webSocket.send(
+                            """{"type":"snapshot","room":{"room_id":"room/segment ?#","code":"ABCD1234"}}""",
+                        )
+                    }
+
+                    override fun onMessage(webSocket: WebSocket, text: String) {
+                        outbound.trySend(text)
+                    }
+                },
+            ),
+        )
+        server.start()
+        val tokens = configuredTokens(server)
+        val httpClient = createSiloClient(
+            tokenManager = tokens,
+            cleartextOriginConsent = approvedConsent(server),
+        )
+        try {
+            val realtime = DefaultWatchTogetherRealtimeClient(httpClient, tokens)
+            val events = Channel<RoomRealtimeEvent>(Channel.UNLIMITED)
+            val collection = launch {
+                realtime.connect("room/segment ?#", "ROOM_SECRET").collect(events::send)
+            }
+
+            assertIs<RoomRealtimeEvent.Opened>(withTimeout(5_000) { events.receive() })
+            val snapshot = assertIs<RoomRealtimeEvent.SnapshotEvent>(
+                withTimeout(5_000) { events.receive() },
+            )
+            assertEquals("room/segment ?#", snapshot.room.roomId)
+
+            assertTrue(realtime.attachSession("playback-1"))
+            assertTrue(realtime.ping("2026-07-27T10:00:00Z"))
+            assertEquals(
+                listOf("attach_session", "ping"),
+                listOf(
+                    withTimeout(5_000) { outbound.receive() },
+                    withTimeout(5_000) { outbound.receive() },
+                ).map { SiloJson.parseToJsonElement(it).jsonObject.getValue("type").jsonPrimitive.content },
+            )
+
+            val request = assertNotNull(server.takeRequest(5, TimeUnit.SECONDS))
+            assertEquals(
+                "/api/v1/watch-together/rooms/room%2Fsegment%20%3F%23/ws",
+                request.requestUrl?.encodedPath,
+            )
+            assertNull(request.requestUrl?.queryParameter("token"))
+            assertEquals("ROOM_SECRET", request.requestUrl?.queryParameter("room_token"))
+            assertEquals("profile-1", request.requestUrl?.queryParameter("profile_id"))
+            assertEquals("PROFILE_SECRET", request.requestUrl?.queryParameter("profile_token"))
+            assertEquals("Bearer ACCESS_SECRET", request.getHeader("Authorization"))
+            assertEquals("profile-1", request.getHeader("X-Profile-Id"))
+            assertEquals("PROFILE_SECRET", request.getHeader("X-Profile-Token"))
+
+            assertTrue(serverSocket.await().close(1000, "physical EOF"))
+            val terminated = assertIs<RoomRealtimeEvent.TransportTerminated>(
+                withTimeout(5_000) { events.receive() },
+            )
+            assertNull(terminated.cause)
+            assertTrue(collection.join().let { collection.isCompleted })
+        } finally {
+            httpClient.close()
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun `real socket cancellation is silent`() = runBlocking {
+        val server = MockWebServer()
+        val serverClosed = CompletableDeferred<Unit>()
+        server.enqueue(
+            MockResponse().withWebSocketUpgrade(
+                object : WebSocketListener() {
+                    override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                        webSocket.close(code, reason)
+                    }
+
+                    override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                        serverClosed.complete(Unit)
+                    }
+                },
+            ),
+        )
+        server.start()
+        val tokens = configuredTokens(server)
+        val httpClient = createSiloClient(
+            tokenManager = tokens,
+            cleartextOriginConsent = approvedConsent(server),
+        )
+        try {
+            val realtime = DefaultWatchTogetherRealtimeClient(httpClient, tokens)
+            val events = Channel<RoomRealtimeEvent>(Channel.UNLIMITED)
+            val collection = launch {
+                realtime.connect("room-1", "ROOM_SECRET").collect(events::send)
+            }
+            assertIs<RoomRealtimeEvent.Opened>(withTimeout(5_000) { events.receive() })
+
+            collection.cancelAndJoin()
+            withTimeout(5_000) { serverClosed.await() }
+
+            assertNull(events.tryReceive().getOrNull())
+            assertFalse(realtime.ping("after-cancel"))
+        } finally {
+            httpClient.close()
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun `unapproved ws origin fails before credentials reach OkHttp`() = runBlocking {
+        val server = MockWebServer()
+        server.start()
+        val tokens = configuredTokens(server)
+        val httpClient = createSiloClient(
+            tokenManager = tokens,
+            cleartextOriginConsent = object : CleartextOriginConsent {
+                override suspend fun isApproved(origin: String): Boolean = false
+            },
+        )
+        try {
+            val events = mutableListOf<RoomRealtimeEvent>()
+            DefaultWatchTogetherRealtimeClient(httpClient, tokens)
+                .connect("room-1", "ROOM_SECRET")
+                .collect(events::add)
+
+            val terminated = assertIs<RoomRealtimeEvent.TransportTerminated>(events.single())
+            assertIs<CleartextOriginNotApprovedException>(terminated.cause)
+            assertEquals(0, server.requestCount)
+        } finally {
+            httpClient.close()
+            server.shutdown()
+        }
+    }
+
+    private suspend fun configuredTokens(server: MockWebServer): TokenManagerImpl =
+        TokenManagerImpl().apply {
+            setServerUrl(server.url("/").toString())
+            saveTokens("ACCESS_SECRET", "refresh", 3_600)
+            setProfileId("profile-1")
+            setProfileToken("PROFILE_SECRET")
+        }
+
+    private fun approvedConsent(server: MockWebServer): CleartextOriginConsent {
+        val approvedOrigin = canonicalHttpOrigin(server.url("/").toString())
+        return object : CleartextOriginConsent {
+            override suspend fun isApproved(origin: String): Boolean =
+                origin == approvedOrigin
+        }
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlayWhenReadyReconciliationTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlayWhenReadyReconciliationTest.kt
@@ -1,0 +1,119 @@
+package org.siloserver.silo.common.player
+
+import androidx.media3.common.Player
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PlayWhenReadyReconciliationTest {
+    @Test
+    fun `deliberate user and media session changes are reconciled`() {
+        assertTrue(shouldReconcileExternalPlayWhenReady(Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST))
+        assertTrue(shouldReconcileExternalPlayWhenReady(Player.PLAY_WHEN_READY_CHANGE_REASON_REMOTE))
+    }
+
+    @Test
+    fun `local safety and lifecycle changes never become room intent`() {
+        assertFalse(shouldReconcileExternalPlayWhenReady(Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS))
+        assertFalse(shouldReconcileExternalPlayWhenReady(Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_BECOMING_NOISY))
+        assertFalse(shouldReconcileExternalPlayWhenReady(Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM))
+        assertFalse(shouldReconcileExternalPlayWhenReady(Player.PLAY_WHEN_READY_CHANGE_REASON_SUPPRESSED_TOO_LONG))
+    }
+
+    @Test
+    fun `programmatic room synchronization is consumed instead of rebroadcast`() {
+        val gate = PlayWhenReadyReconciliationGate()
+        assertTrue(gate.requestProgrammaticChange(false))
+
+        assertFalse(
+            gate.onPlayWhenReadyChanged(
+                false,
+                Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST,
+            ).shouldReconcile,
+        )
+        assertTrue(
+            gate.onPlayWhenReadyChanged(
+                true,
+                Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST,
+            ).shouldReconcile,
+        )
+    }
+
+    @Test
+    fun `unrelated safety callback does not consume a pending programmatic value`() {
+        val gate = PlayWhenReadyReconciliationGate()
+        gate.requestProgrammaticChange(false)
+
+        assertFalse(
+            gate.onPlayWhenReadyChanged(
+                true,
+                Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS,
+            ).shouldReconcile,
+        )
+        assertFalse(
+            gate.onPlayWhenReadyChanged(
+                false,
+                Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST,
+            ).shouldReconcile,
+        )
+    }
+
+    @Test
+    fun `rapid programmatic pause resume preserves ordered callback provenance`() {
+        val gate = PlayWhenReadyReconciliationGate()
+        assertTrue(gate.requestProgrammaticChange(false))
+        assertFalse(gate.requestProgrammaticChange(true))
+
+        val pause = gate.onPlayWhenReadyChanged(false, Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
+        assertFalse(pause.shouldReconcile)
+        assertEquals(true, pause.followUpProgrammaticValue)
+        val play = gate.onPlayWhenReadyChanged(true, Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
+        assertFalse(play.shouldReconcile)
+        assertNull(play.followUpProgrammaticValue)
+        assertFalse(gate.hasPendingChanges)
+    }
+
+    @Test
+    fun `alternating queued targets coalesce before a second command is issued`() {
+        val gate = PlayWhenReadyReconciliationGate()
+        assertTrue(gate.requestProgrammaticChange(false))
+        assertFalse(gate.requestProgrammaticChange(true))
+        assertFalse(gate.requestProgrammaticChange(false))
+
+        val pause = gate.onPlayWhenReadyChanged(false, Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
+        assertFalse(pause.shouldReconcile)
+        assertNull(pause.followUpProgrammaticValue)
+        assertFalse(gate.hasPendingChanges)
+    }
+
+    @Test
+    fun `dropped callback expires instead of swallowing a later user command`() {
+        var nowMs = 0L
+        val gate = PlayWhenReadyReconciliationGate(nowMs = { nowMs })
+        gate.requestProgrammaticChange(false)
+        nowMs = 2_001L
+
+        assertTrue(
+            gate.onPlayWhenReadyChanged(
+                false,
+                Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST,
+            ).shouldReconcile,
+        )
+    }
+
+    @Test
+    fun `reset clears provenance on controller or room replacement`() {
+        val gate = PlayWhenReadyReconciliationGate()
+        gate.requestProgrammaticChange(false)
+        gate.reset()
+
+        assertTrue(
+            gate.onPlayWhenReadyChanged(
+                false,
+                Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST,
+            ).shouldReconcile,
+        )
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionLifecycleTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionLifecycleTest.kt
@@ -295,6 +295,28 @@ class PlaybackSessionLifecycleTest {
     }
 
     @Test
+    fun `epoch adoption can defer publication for the first session`() = runTest {
+        val sessionMgr = FakeSessionManager()
+        val lifecycle = newLifecycle(sessionMgr, scope = backgroundScope)
+        val ownershipEpoch = lifecycle.acquireOwnershipEpoch()
+
+        assertTrue(
+            lifecycle.adoptActiveSessionIfCurrent(
+                params = defaultStartParams(),
+                session = makeSession("sess-first"),
+                deferPublication = true,
+                expectedOwnershipEpoch = ownershipEpoch,
+            ),
+        )
+
+        assertTrue(lifecycle.confirmActiveSessionPublication("sess-first"))
+        assertEquals(
+            "sess-first",
+            (lifecycle.state.value as SessionState.Active).session.sessionId,
+        )
+    }
+
+    @Test
     fun `ownership acquisition waits for queued stop before accepting a new start`() = runTest {
         val oldStopEntered = CompletableDeferred<Unit>()
         val releaseOldStop = CompletableDeferred<Unit>()

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -468,6 +468,7 @@ val androidModule = module {
         )
     }
     viewModel { org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherEntryViewModel(get()) }
+    viewModel { org.siloserver.silo.android.ui.screens.watchtogether.SuggestToRoomViewModel(get()) }
     viewModel { params ->
         org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherLobbyViewModel(
             roomId = params.get(),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -472,6 +472,7 @@ val androidModule = module {
         org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherLobbyViewModel(
             roomId = params.get(),
             repository = get(),
+            roomSession = get(),
         )
     }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
@@ -37,6 +37,7 @@ import org.siloserver.silo.android.ui.components.DetailLoadingSkeleton
 import org.siloserver.silo.android.ui.components.ErrorView
 import org.siloserver.silo.android.ui.screens.cast.SiloCastTargetPickerSheet
 import org.siloserver.silo.android.ui.screens.downloads.openDownloadTargetInExternalApp
+import org.siloserver.silo.android.ui.screens.watchtogether.SuggestToRoomViewModel
 import org.siloserver.silo.android.ui.util.playbackResumePosition
 import org.siloserver.silo.cast.SiloCastLaunchRequest
 import org.siloserver.silo.cast.SiloCastPlaybackRequest
@@ -55,6 +56,7 @@ import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.playback.selectPlaybackVersion
 import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 import org.siloserver.silo.metadata.DescriptionTranslationPhase
 import org.siloserver.silo.model.feature.MetadataAiFeatureStore
 import org.siloserver.silo.model.metadata.MetadataAiOnView
@@ -89,7 +91,18 @@ fun ItemDetailScreen(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsState()
+    val suggestViewModel: SuggestToRoomViewModel = koinViewModel()
+    val suggestRoom by suggestViewModel.room.collectAsState()
+    val suggestState by suggestViewModel.uiState.collectAsState()
     val context = LocalContext.current
+    LaunchedEffect(suggestState.notice, suggestState.error) {
+        val message = suggestState.notice ?: suggestState.error
+        if (message != null) {
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            suggestViewModel.consumeNotice()
+            suggestViewModel.clearError()
+        }
+    }
 
     // Refresh on return (e.g. backing out of the player): the ViewModel loads
     // once in init, so without this the Play button keeps the resume label
@@ -635,6 +648,19 @@ fun ItemDetailScreen(
                                         ?: playbackResumePosition(detail.userData),
                                 )
                             },
+                            onSuggestToRoom = if (suggestRoom != null && nextEpisode != null) {
+                                {
+                                    suggestViewModel.suggest(
+                                        contentId = nextEpisode.contentId,
+                                        contentType = "episode",
+                                        title = nextEpisode.title ?: detail.title,
+                                        subtitle = detail.title,
+                                        posterUrl = nextEpisode.stillUrl ?: detail.posterUrl,
+                                    )
+                                }
+                            } else {
+                                null
+                            },
                             onWatchTogether = if (CLIENT_WATCH_TOGETHER_SURFACE_ENABLED) {
                                 { onWatchTogether(nextEpisode?.contentId ?: detail.contentId, null) }
                             } else {
@@ -819,6 +845,17 @@ fun ItemDetailScreen(
                                     subtitleTrackIndex = explicitSubtitleIndex,
                                     resumePositionSeconds = playbackResumePosition(detail.userData),
                                 )
+                            },
+                            onSuggestToRoom = suggestRoom?.let {
+                                {
+                                    suggestViewModel.suggest(
+                                        contentId = detail.contentId,
+                                        contentType = detail.type,
+                                        title = detail.title,
+                                        subtitle = detail.seriesTitle?.takeIf { value -> value.isNotBlank() },
+                                        posterUrl = detail.posterUrl,
+                                    )
+                                }
                             },
                             onWatchTogether = if (CLIENT_WATCH_TOGETHER_SURFACE_ENABLED) {
                                 { onWatchTogether(detail.contentId, explicitFileId) }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.DownloadDone
@@ -95,6 +96,7 @@ fun MovieDetailContent(
     onDownloadTapped: (() -> Unit)? = null,
     onPlayOnDevice: (() -> Unit)? = null,
     onWatchTogether: (() -> Unit)? = null,
+    onSuggestToRoom: (() -> Unit)? = null,
     translation: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -110,7 +112,8 @@ fun MovieDetailContent(
     val subtitleTracks = selectedVersion?.subtitleTracks.orEmpty()
     val hasTrackSelectors = detail.versions.isNotEmpty()
     val hasOverflow = onPlayOnDevice != null ||
-        onSeriesClick != null || onSeasonClick != null || onWatchTogether != null
+        onSeriesClick != null || onSeasonClick != null || onWatchTogether != null ||
+        onSuggestToRoom != null
 
     val eyebrow = if (detail.type == "episode") {
         HeroMetadata.episodeEyebrow(detail)
@@ -180,6 +183,18 @@ fun MovieDetailContent(
                                     onClick = {
                                         dismiss()
                                         onSeriesClick()
+                                    },
+                                )
+                            }
+                            if (onSuggestToRoom != null) {
+                                DropdownMenuItem(
+                                    text = { Text("Suggest to Watch Together") },
+                                    leadingIcon = {
+                                        Icon(Icons.Filled.Add, contentDescription = null)
+                                    },
+                                    onClick = {
+                                        dismiss()
+                                        onSuggestToRoom()
                                     },
                                 )
                             }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
@@ -75,6 +75,7 @@ fun SeriesDetailContent(
     playOnDeviceLabel: String = "Play on device",
     onPlayOnDevice: (() -> Unit)? = null,
     onWatchTogether: (() -> Unit)? = null,
+    onSuggestToRoom: (() -> Unit)? = null,
     translation: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -121,7 +122,10 @@ fun SeriesDetailContent(
                     onToggleWatched = onToggleWatched,
                     userRating = userRating,
                     onRateClick = { showRatingSheet = true },
-                    overflow = if (onWatchTogether != null || onPlayOnDevice != null) {
+                    overflow = if (
+                        onWatchTogether != null || onPlayOnDevice != null ||
+                        onSuggestToRoom != null
+                    ) {
                         { dismiss ->
                             if (onPlayOnDevice != null) {
                                 DropdownMenuItem(
@@ -132,6 +136,18 @@ fun SeriesDetailContent(
                                     onClick = {
                                         dismiss()
                                         onPlayOnDevice()
+                                    },
+                                )
+                            }
+                            if (onSuggestToRoom != null) {
+                                DropdownMenuItem(
+                                    text = { Text("Suggest to Watch Together") },
+                                    leadingIcon = {
+                                        Icon(Icons.Outlined.Groups, contentDescription = null)
+                                    },
+                                    onClick = {
+                                        dismiss()
+                                        onSuggestToRoom()
                                     },
                                 )
                             }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -241,7 +241,11 @@ fun PlayerScreen(
     }
     DisposableEffect(roomController) {
         roomController?.start()
-        onDispose { /* repo teardown happens on explicit leave (onBack) */ }
+        onDispose {
+            // Cancel only this replaceable controller's collectors. The
+            // application RoomSession persists until explicit leave.
+            roomController?.dispose()
+        }
     }
     val roomSnapshot by produceRoomSnapshotState(roomController)
     val roomClosedReason by produceRoomClosedState(roomController)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -45,6 +45,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.media3.common.Player
+import org.siloserver.silo.common.player.PlayWhenReadyReconciliationGate
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
@@ -312,6 +313,9 @@ fun PlayerScreen(
     // resolves when the service binds. We hold the controller in a compose
     // state so downstream effects can re-run once it's ready.
     var mediaController by remember { mutableStateOf<MediaController?>(null) }
+    val playWhenReadyReconciliationGate = remember(mediaController, roomId) {
+        PlayWhenReadyReconciliationGate()
+    }
     // service. The video PlayerView binds its SurfaceView directly to this (NOT the
     // MediaController) so the engine receives proper surface-lifecycle callbacks
     // (surfaceCreated/Changed/Destroyed) and recovers across seek/recreate/rotation
@@ -404,13 +408,29 @@ fun PlayerScreen(
         if (castState.isConnected && !wasCasting) {
             wasCasting = true
             viewModel.remotePause()
-            mediaController?.pause()
+            mediaController?.let { controller ->
+                if (controller.playWhenReady) {
+                    if (playWhenReadyReconciliationGate.requestProgrammaticChange(false)) {
+                        controller.pause()
+                    }
+                } else {
+                    controller.pause()
+                }
+            }
         } else if (!castState.isConnected && wasCasting) {
             wasCasting = false
             val resumeAt = castManager.getLastPosition()
             if (resumeAt > 0.0) viewModel.remoteSeek(resumeAt)
             viewModel.remoteUnpause()
-            mediaController?.play()
+            mediaController?.let { controller ->
+                if (!controller.playWhenReady) {
+                    if (playWhenReadyReconciliationGate.requestProgrammaticChange(true)) {
+                        controller.play()
+                    }
+                } else {
+                    controller.play()
+                }
+            }
         }
     }
 
@@ -657,9 +677,16 @@ fun PlayerScreen(
         backend.refresh(mediaSpec)
     }
 
-    // Sync play/pause from ViewModel to player
-    LaunchedEffect(mediaController, uiState.isPaused) {
-        mediaController?.playWhenReady = !uiState.isPaused
+    // Sync play/pause from ViewModel to player without reclassifying this
+    // programmatic write as a MediaSession/user room command.
+    LaunchedEffect(mediaController, uiState.isPaused, playWhenReadyReconciliationGate) {
+        val controller = mediaController ?: return@LaunchedEffect
+        val desired = !uiState.isPaused
+        if (controller.playWhenReady != desired) {
+            if (playWhenReadyReconciliationGate.requestProgrammaticChange(desired)) {
+                controller.playWhenReady = desired
+            }
+        }
     }
 
     // Preflight listener: evaluates the resolved Tracks and triggers the
@@ -685,12 +712,31 @@ fun PlayerScreen(
     }
 
     // Player event listener to feed state back to ViewModel + track video size for PiP
-    DisposableEffect(mediaController) {
+    DisposableEffect(mediaController, playWhenReadyReconciliationGate) {
         val controller = mediaController
         if (controller == null) {
             onDispose { }
         } else {
             val listener = object : Player.Listener {
+                override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+                    val provenance = playWhenReadyReconciliationGate
+                        .onPlayWhenReadyChanged(playWhenReady, reason)
+                    provenance.followUpProgrammaticValue?.let { controller.playWhenReady = it }
+                    if (!provenance.shouldReconcile) return
+                    roomController
+                        ?.onExternalPlayWhenReadyChanged(playWhenReady)
+                        ?.let { authoritative ->
+                            if (controller.playWhenReady != authoritative) {
+                                if (
+                                    playWhenReadyReconciliationGate
+                                        .requestProgrammaticChange(authoritative)
+                                ) {
+                                    controller.playWhenReady = authoritative
+                                }
+                            }
+                        }
+                }
+
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
                     viewModel.onPlayingChanged(isPlaying)
                     val live = viewModel.uiState.value

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -212,15 +212,17 @@ fun PlayerScreen(
     var wasCasting by remember { mutableStateOf(false) }
 
     // Watch Together binding. Built once per roomId; null for solo playback.
-    // The controller owns the room WS connection + RoomSyncEngine for the
-    // lifetime of this screen and tears them down on explicit leave.
+    // The process RoomSession owns the WS; this controller owns only the
+    // screen's RoomSyncEngine and requests durable teardown on explicit leave.
     val watchTogetherRepository: org.siloserver.silo.repository.WatchTogetherRepository = koinInject()
+    val roomSession: org.siloserver.silo.watchtogether.RoomSession = koinInject()
     val roomScope = rememberCoroutineScope()
     val roomController = remember(roomId) {
         roomId?.takeIf { it.isNotBlank() }?.let { id ->
             RoomSyncController(
                 roomId = id,
                 repository = watchTogetherRepository,
+                roomSession = roomSession,
                 viewModel = viewModel,
                 scope = roomScope,
             )
@@ -266,6 +268,7 @@ fun PlayerScreen(
     LaunchedEffect(Unit) {
         viewModel.remoteStopRequests.collect {
             exitRequested = true
+            roomController?.leave(closeRoom = false)
             viewModel.onExit()
             // Nothing behind the player (launcher/deep-link/notification open) →
             // popBackStack can't land anywhere and leaves a blank NavHost, then
@@ -278,6 +281,7 @@ fun PlayerScreen(
     LaunchedEffect(roomClosedReason) {
         if (roomClosedReason != null && roomController != null) {
             exitRequested = true
+            roomController.leave(closeRoom = false)
             viewModel.onExit()
             // Nothing behind the player (launcher/deep-link/notification open) →
             // popBackStack can't land anywhere and leaves a blank NavHost, then

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/RoomSyncController.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/RoomSyncController.kt
@@ -11,6 +11,7 @@ import org.siloserver.silo.repository.PongSample
 import org.siloserver.silo.repository.ScheduledTransportCommand
 import org.siloserver.silo.repository.WatchTogetherRepository
 import org.siloserver.silo.watchtogether.RoomTransportIntent
+import org.siloserver.silo.watchtogether.RoomSession
 import org.siloserver.silo.watchtogether.roomTransportAuthorized
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -28,8 +29,8 @@ import java.time.Instant
  *
  * The controller OWNS a [RoomSyncEngine] (the shared engine is a pure class that
  * lives in the binding, not the repo). It:
- *  - launches the repo WS reconnect loop ([WatchTogetherRepository.connect] is
- *    suspend) and attaches the player's playback session id once it resolves;
+ *  - adopts the application-scoped room session and attaches the player's
+ *    playback session id once it resolves;
  *  - drives a ping loop so pongs flow, stamps `clientReceivedMs` on each pong and
  *    feeds [RoomSyncEngine.recordPongSample] to keep the clock offset fresh;
  *  - feeds each [ScheduledTransportCommand] into [RoomSyncEngine.decide] and
@@ -55,6 +56,7 @@ import java.time.Instant
 class RoomSyncController(
     private val roomId: String,
     private val repository: WatchTogetherRepository,
+    private val roomSession: RoomSession,
     private val viewModel: PlayerViewModel,
     private val scope: CoroutineScope,
     private val engine: RoomSyncEngine = RoomSyncEngine(),
@@ -96,10 +98,9 @@ class RoomSyncController(
     @Volatile private var serverHadOurSession: Boolean = false
 
     fun start() {
-        // Reconnect-with-backoff loop. Suspends until the scope is cancelled or
-        // the server closes the room. The lobby's connect() ran in its own
-        // (now-dead) scope, so the player owns the live connection.
-        scope.launch { repository.connect(roomId) }
+        // Lobby and player adopt the same application-scoped connection; route
+        // disposal does not tear down or duplicate the socket.
+        roomSession.adopt(roomId)
 
         // Attach the player's own playback session id, and RE-attach on WS
         // reconnect. We combine the local session id with each server snapshot.
@@ -299,11 +300,8 @@ class RoomSyncController(
 
     /** Leave the room. Host close tears the room down for everyone; both reset local state. */
     fun leave(closeRoom: Boolean) {
-        scope.launch {
-            if (closeRoom) repository.closeRoom()
-            engine.reset()
-            repository.reset()
-        }
+        engine.reset()
+        roomSession.depart(closeRoom)
     }
 
     /** Wall-clock RFC3339 string for the ping `client_sent_at`. */

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/RoomSyncController.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/RoomSyncController.kt
@@ -12,11 +12,17 @@ import org.siloserver.silo.repository.ScheduledTransportCommand
 import org.siloserver.silo.repository.WatchTogetherRepository
 import org.siloserver.silo.watchtogether.RoomTransportIntent
 import org.siloserver.silo.watchtogether.RoomSession
+import org.siloserver.silo.watchtogether.RoomCommandDispatcher
+import org.siloserver.silo.watchtogether.RoomControllerLifetime
+import org.siloserver.silo.watchtogether.RoomPendingExecutions
 import org.siloserver.silo.watchtogether.roomTransportAuthorized
+import org.siloserver.silo.watchtogether.scheduledCommandStillCurrent
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.isActive
@@ -80,100 +86,76 @@ class RoomSyncController(
 
     // Monotonic-domain state-report cadence bookkeeping.
     @Volatile private var lastReportMs = 0L
-    @Volatile private var pendingExecuteAtMs: Long? = null
-
-    // Session id we have already SENT attach_session for (in-flight/sent latch),
-    // distinct from the server's echoed confirmation. We send attach_session AT
-    // MOST ONCE per session-id resolution; this latch suppresses re-sends on the
-    // many intervening snapshots (member-count / host-connected / transport-state)
-    // the server emits before it echoes our attached_session_id back. Reset to
-    // null when the session id clears OR on a genuine server-side detach (see
-    // [serverHadOurSession]) so a reconnect re-attaches exactly once.
-    @Volatile private var sentAttachForSessionId: String? = null
-
-    // Tracks whether the LAST snapshot had the server associated with our session.
-    // A true -> false transition is a genuine server-side detach (mid-session
-    // reconnect drops the association); that — not the pre-echo window — is what
-    // re-arms the latch to re-send attach_session once.
-    @Volatile private var serverHadOurSession: Boolean = false
+    private val lifetime = RoomControllerLifetime(scope)
+    private val controllerScope = lifetime.scope
+    private val deliveryLatch = repository.roomDeliveryLatch
+    private val commandDispatcher = RoomCommandDispatcher(controllerScope)
+    private val pendingExecutions = RoomPendingExecutions()
 
     fun start() {
-        // Lobby and player adopt the same application-scoped connection; route
-        // disposal does not tear down or duplicate the socket.
-        roomSession.adopt(roomId)
-
-        // Attach the player's own playback session id, and RE-attach on WS
-        // reconnect. We combine the local session id with each server snapshot.
-        //
-        // The server takes SEVERAL snapshots (member-count, host-connected,
-        // transport-state changes) to echo back our attached_session_id. So
-        // "the server doesn't yet have our session" is true for every snapshot
-        // in that pre-echo window — sending on each would spam attach frames.
-        // We therefore use a SENT latch ([sentAttachForSessionId]) that is
-        // distinct from the echo-confirmed check:
-        //  - send attach_session AT MOST ONCE per session-id resolution, the
-        //    moment our session id first resolves (set the latch immediately so
-        //    intervening pre-echo snapshots don't re-send);
-        //  - re-arm the latch (and thus re-send once) ONLY on a genuine
-        //    server-side detach: a snapshot transition where the server HAD our
-        //    session and now doesn't ([serverHadOurSession] true -> false). A
-        //    mid-session reconnect produces exactly that transition, so we
-        //    re-attach once without ever firing during the initial pre-echo
-        //    window (where serverHadOurSession was never true).
-        scope.launch {
+        // Install every inbound/outbound collector before adopting the socket.
+        // UNDISTPATCHED closes the initial-snapshot race when adopt opens
+        // synchronously on this same UI turn.
+        controllerScope.launch(start = CoroutineStart.UNDISPATCHED) {
             combine(
                 viewModel.uiState.map { it.sessionId }.distinctUntilChanged(),
-                repository.roomSnapshot,
-            ) { sessionId, snapshot -> sessionId to snapshot }
-                .collect { (sessionId, snapshot) ->
-                    if (sessionId == null) {
-                        sentAttachForSessionId = null
-                        serverHadOurSession = false
-                        return@collect
-                    }
-                    val serverHasOurSession = snapshot?.attachedSessionId == sessionId
-                    // Genuine server-side detach: previously associated, now not.
-                    // Re-arm the latch so we re-attach this session exactly once.
-                    if (serverHadOurSession && !serverHasOurSession) {
-                        sentAttachForSessionId = null
-                    }
-                    serverHadOurSession = serverHasOurSession
-
-                    // Send at most once per resolution while the server hasn't
-                    // confirmed our association. Setting the latch BEFORE the
-                    // (suspending) send is what suppresses pre-echo re-sends.
-                    if (!serverHasOurSession && sentAttachForSessionId != sessionId) {
-                        sentAttachForSessionId = sessionId
-                        repository.attachSession(sessionId)
+                repository.connectionState,
+            ) { sessionId, connection -> deliveryLatch.keyOrNull(connection, sessionId) }
+                .distinctUntilChanged()
+                .collectLatest { key ->
+                    key ?: return@collectLatest
+                    while (isActive && deliveryLatch.needsAttach(key)) {
+                        val delivered = repository.attachSession(key.playbackSessionId)
+                        deliveryLatch.recordAttach(key, delivered)
+                        if (!delivered) {
+                            delay(500)
+                        }
                     }
                 }
         }
 
         // Clock-sync: drive pings (once on start + every PING_INTERVAL_MS) and
         // fold pongs into the engine's offset estimate.
-        scope.launch {
-            while (isActive) {
-                repository.ping(clientSentAt = nowWallClockRfc3339())
-                delay(PING_INTERVAL_MS)
+        controllerScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            combine(
+                viewModel.uiState.map { it.sessionId }.distinctUntilChanged(),
+                repository.connectionState,
+            ) { sessionId, connection ->
+                deliveryLatch.keyOrNull(connection, sessionId) to connection.writable
             }
+                .distinctUntilChanged()
+                .collectLatest { (key, writable) ->
+                    if (!writable || key == null) return@collectLatest
+                    while (!deliveryLatch.isAttached(key)) delay(10)
+                    while (isActive) {
+                        repository.ping(clientSentAt = nowWallClockRfc3339())
+                        delay(PING_INTERVAL_MS)
+                    }
+                }
         }
-        scope.launch {
+        controllerScope.launch(start = CoroutineStart.UNDISPATCHED) {
             repository.pongs.collect { pong -> recordPong(pong) }
         }
 
         // Apply engine decisions for each scheduled transport command.
-        scope.launch {
+        controllerScope.launch(start = CoroutineStart.UNDISPATCHED) {
             repository.transportCommands.collect { scheduled -> handleCommand(scheduled) }
         }
 
         // Drift reporting loop (suppressed around a pending execute).
-        scope.launch {
+        controllerScope.launch {
             while (isActive) {
                 val state = viewModel.uiState.value
                 val sessionId = state.sessionId
                 val now = monotonicMs()
                 if (sessionId != null &&
-                    shouldEmitStateReport(now, lastReportMs, REPORT_CADENCE_MS, pendingExecuteAtMs, SUPPRESS_WINDOW_MS)
+                    shouldEmitStateReport(
+                        now,
+                        lastReportMs,
+                        REPORT_CADENCE_MS,
+                        pendingExecutions.nearestTo(now),
+                        SUPPRESS_WINDOW_MS,
+                    )
                 ) {
                     lastReportMs = now
                     repository.stateReport(
@@ -187,21 +169,49 @@ class RoomSyncController(
         }
 
         // ready / buffering during the waiting barrier.
-        scope.launch {
-            var lastBuffering: Boolean? = null
-            viewModel.uiState.collect { state ->
-                val waiting = repository.roomSnapshot.value?.playbackState == RoomPlaybackState.Waiting
-                val sessionId = state.sessionId
-                if (waiting && sessionId != null && state.isBuffering != lastBuffering) {
-                    lastBuffering = state.isBuffering
-                    if (state.isBuffering) {
-                        repository.buffering(sessionId, state.position, state.isPaused)
-                    } else {
-                        repository.ready(sessionId, state.position, state.isPaused)
+        controllerScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            combine(
+                viewModel.uiState
+                    .map { it.sessionId to it.isBuffering }
+                    .distinctUntilChanged(),
+                repository.roomSnapshot
+                    .map { it?.playbackState }
+                    .distinctUntilChanged(),
+                repository.connectionState,
+            ) { readiness, playbackState, connection -> Triple(readiness, playbackState, connection) }
+                .collectLatest { (readiness, playbackState, connection) ->
+                    val (sessionId, buffering) = readiness
+                    val key = deliveryLatch.keyOrNull(connection, sessionId)
+                    if (playbackState != RoomPlaybackState.Waiting || key == null) {
+                        return@collectLatest
+                    }
+                    while (!deliveryLatch.isAttached(key)) delay(10)
+                    while (isActive && deliveryLatch.needsReadiness(key, buffering)) {
+                        val currentState = viewModel.uiState.value
+                        val delivered = if (buffering) {
+                            repository.buffering(
+                                key.playbackSessionId,
+                                currentState.position,
+                                currentState.isPaused,
+                            )
+                        } else {
+                            repository.ready(
+                                key.playbackSessionId,
+                                currentState.position,
+                                currentState.isPaused,
+                            )
+                        }
+                        deliveryLatch.recordReadiness(key, buffering, delivered)
+                        if (!delivered) {
+                            delay(500)
+                        }
                     }
                 }
-            }
         }
+
+        // Lobby and player adopt the same application-scoped connection; route
+        // disposal does not tear down or duplicate the socket.
+        roomSession.adopt(roomId)
     }
 
     /**
@@ -221,7 +231,12 @@ class RoomSyncController(
         )
     }
 
-    private suspend fun handleCommand(scheduled: ScheduledTransportCommand) {
+    private fun handleCommand(scheduled: ScheduledTransportCommand) {
+        if (!scheduled.connection.writable ||
+            scheduled.connection != repository.connectionState.value
+        ) {
+            return
+        }
         val command = scheduled.command
         val state = viewModel.uiState.value
         val snapshot = repository.roomSnapshot.value
@@ -239,33 +254,58 @@ class RoomSyncController(
             attachedSessionId = snapshot?.attachedSessionId ?: state.sessionId,
         ) ?: return // duplicate / revision / session gate → ignore
 
-        applyDecision(decision, state.sessionId)
+        commandDispatcher.dispatch {
+            applyDecision(
+                decision = decision,
+                sessionId = state.sessionId,
+                command = command,
+                acceptedConnection = scheduled.connection,
+            )
+        }
     }
 
-    private suspend fun applyDecision(decision: SyncDecision, sessionId: String?) {
+    private suspend fun applyDecision(
+        decision: SyncDecision,
+        sessionId: String?,
+        command: org.siloserver.silo.model.watchtogether.TransportCommand,
+        acceptedConnection: org.siloserver.silo.repository.WatchTogetherConnectionState,
+    ) {
         val delayMs = decision.localExecuteDelayMs.coerceAtLeast(0L)
         // Record the pending execute against the MONOTONIC clock for the
         // state-report suppression gate, then wait the engine-computed delay.
-        pendingExecuteAtMs = monotonicMs() + delayMs
-        if (delayMs > 0) delay(delayMs)
+        val pendingToken = pendingExecutions.record(monotonicMs() + delayMs)
+        try {
+            if (delayMs > 0) delay(delayMs)
+            if (
+                !scheduledCommandStillCurrent(
+                    command = command,
+                    acceptedPlaybackSessionId = sessionId,
+                    acceptedRoomId = roomId,
+                    acceptedConnection = acceptedConnection,
+                    currentPlaybackSessionId = viewModel.uiState.value.sessionId,
+                    currentRoom = repository.roomSnapshot.value,
+                    currentConnection = repository.connectionState.value,
+                )
+            ) {
+                return
+            }
 
-        // Use the deadband-free immediate-seek path: room corrective seeks can be
-        // as small as the engine's 0.35s DRIFT_THRESHOLD_MS, well under the 2.0s
-        // position-mirror deadband in PlayerScreen, so onSeek() alone would never
-        // reach the MediaController.
-        decision.seekToMs?.let { ms -> viewModel.seekImmediate(ms / 1000.0) }
-        // onPlayPause() is a TOGGLE — only flip when the desired state differs
-        // from current intent.
-        if (viewModel.uiState.value.isPaused == decision.setPlaying) {
-            viewModel.onPlayPause()
+            // Use the deadband-free immediate-seek path: room corrective seeks can be
+            // as small as the engine's 0.35s DRIFT_THRESHOLD_MS, well under the 2.0s
+            // position-mirror deadband in PlayerScreen, so onSeek() alone would never
+            // reach the MediaController.
+            decision.seekToMs?.let { ms -> viewModel.seekImmediate(ms / 1000.0) }
+            // onPlayPause() is a TOGGLE — only flip when the desired state differs
+            // from current intent.
+            if (viewModel.uiState.value.isPaused == decision.setPlaying) {
+                viewModel.onPlayPause()
+            }
+        } finally {
+            pendingExecutions.finish(pendingToken)
         }
-        pendingExecuteAtMs = null
 
-        // Auto-emit ready on the waiting barrier (command.playback_state == waiting).
-        if (decision.shouldEmitReady && sessionId != null) {
-            val s = viewModel.uiState.value
-            repository.ready(sessionId, s.position, s.isPaused)
-        }
+        // The epoch/session-keyed readiness collector owns ready delivery and
+        // retries. Do not advance an untracked one-shot latch here.
     }
 
     // ---- User-initiated transport: route through the room instead of local apply ----
@@ -276,12 +316,13 @@ class RoomSyncController(
         // isPaused is current intent; tapping toggles it. The request carries the
         // target action and the new paused state.
         val willPause = !state.isPaused
-        scope.launch {
-            repository.transportRequest(
+        controllerScope.launch {
+            val delivered = repository.transportRequest(
                 action = if (willPause) TransportAction.Pause.wire else TransportAction.Play.wire,
                 positionSeconds = state.position,
                 isPaused = willPause,
             )
+            if (!delivered) repository.reportDeliveryFailure("room_transport_unavailable")
         }
     }
 
@@ -289,12 +330,13 @@ class RoomSyncController(
         // Seek is host-only (the server rejects guest seeks regardless of policy).
         if (!roomTransportAuthorized(repository.roomSnapshot.value, RoomTransportIntent.Seek)) return
         val state = viewModel.uiState.value
-        scope.launch {
-            repository.transportRequest(
+        controllerScope.launch {
+            val delivered = repository.transportRequest(
                 action = TransportAction.Seek.wire,
                 positionSeconds = positionSeconds,
                 isPaused = state.isPaused,
             )
+            if (!delivered) repository.reportDeliveryFailure("room_transport_unavailable")
         }
     }
 
@@ -302,6 +344,12 @@ class RoomSyncController(
     fun leave(closeRoom: Boolean) {
         engine.reset()
         roomSession.depart(closeRoom)
+    }
+
+    /** Cancel this screen binding without ending the process-owned room lease. */
+    fun dispose() {
+        engine.reset()
+        lifetime.dispose()
     }
 
     /** Wall-clock RFC3339 string for the ping `client_sent_at`. */

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/RoomSyncController.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/RoomSyncController.kt
@@ -15,6 +15,7 @@ import org.siloserver.silo.watchtogether.RoomSession
 import org.siloserver.silo.watchtogether.RoomCommandDispatcher
 import org.siloserver.silo.watchtogether.RoomControllerLifetime
 import org.siloserver.silo.watchtogether.RoomPendingExecutions
+import org.siloserver.silo.watchtogether.externalPlayPauseDecision
 import org.siloserver.silo.watchtogether.roomTransportAuthorized
 import org.siloserver.silo.watchtogether.scheduledCommandStillCurrent
 import kotlinx.coroutines.CoroutineStart
@@ -311,13 +312,17 @@ class RoomSyncController(
     // ---- User-initiated transport: route through the room instead of local apply ----
 
     fun onUserPlayPause() {
-        if (!roomTransportAuthorized(repository.roomSnapshot.value, RoomTransportIntent.PlayPause)) return
+        val authorization = repository.currentTransportAuthorization() ?: return
+        val snapshot = authorization.snapshot
+        if (!roomTransportAuthorized(snapshot, RoomTransportIntent.PlayPause)) return
         val state = viewModel.uiState.value
         // isPaused is current intent; tapping toggles it. The request carries the
         // target action and the new paused state.
         val willPause = !state.isPaused
         controllerScope.launch {
-            val delivered = repository.transportRequest(
+            val delivered = repository.transportRequestForAuthorization(
+                authorization = authorization,
+                intent = RoomTransportIntent.PlayPause,
                 action = if (willPause) TransportAction.Pause.wire else TransportAction.Play.wire,
                 positionSeconds = state.position,
                 isPaused = willPause,
@@ -328,16 +333,56 @@ class RoomSyncController(
 
     fun onUserSeek(positionSeconds: Double) {
         // Seek is host-only (the server rejects guest seeks regardless of policy).
-        if (!roomTransportAuthorized(repository.roomSnapshot.value, RoomTransportIntent.Seek)) return
+        val authorization = repository.currentTransportAuthorization() ?: return
+        val snapshot = authorization.snapshot
+        if (!roomTransportAuthorized(snapshot, RoomTransportIntent.Seek)) return
         val state = viewModel.uiState.value
         controllerScope.launch {
-            val delivered = repository.transportRequest(
+            val delivered = repository.transportRequestForAuthorization(
+                authorization = authorization,
+                intent = RoomTransportIntent.Seek,
                 action = TransportAction.Seek.wire,
                 positionSeconds = positionSeconds,
                 isPaused = state.isPaused,
             )
             if (!delivered) repository.reportDeliveryFailure("room_transport_unavailable")
         }
+    }
+
+    /**
+     * Reconcile a direct MediaSession play/pause change with room authority.
+     *
+     * Returns the authoritative `playWhenReady` value when the caller must
+     * immediately undo a local-only change. Authorized attempts are also sent
+     * through the room and take effect later via the scheduled room command.
+     */
+    fun onExternalPlayWhenReadyChanged(localPlayWhenReady: Boolean): Boolean? {
+        val authorization = repository.currentTransportAuthorization()
+        val snapshot = authorization?.snapshot
+        val decision = externalPlayPauseDecision(
+            snapshot = snapshot,
+            localPlayWhenReady = localPlayWhenReady,
+        ) ?: return null
+        if (authorization == null) return decision.restorePlayWhenReady
+        val requestIsPaused = decision.requestIsPaused
+        if (requestIsPaused != null) {
+            val state = viewModel.uiState.value
+            controllerScope.launch {
+                val delivered = repository.transportRequestForAuthorization(
+                    authorization = authorization,
+                    intent = RoomTransportIntent.PlayPause,
+                    action = if (requestIsPaused) {
+                        TransportAction.Pause.wire
+                    } else {
+                        TransportAction.Play.wire
+                    },
+                    positionSeconds = state.position,
+                    isPaused = requestIsPaused,
+                )
+                if (!delivered) repository.reportDeliveryFailure("room_transport_unavailable")
+            }
+        }
+        return decision.restorePlayWhenReady
     }
 
     /** Leave the room. Host close tears the room down for everyone; both reset local state. */

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/SuggestToRoomViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/SuggestToRoomViewModel.kt
@@ -1,0 +1,61 @@
+package org.siloserver.silo.android.ui.screens.watchtogether
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.siloserver.silo.model.watchtogether.AddSuggestionRequest
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.errorMessage
+import org.siloserver.silo.repository.WatchTogetherRepository
+
+class SuggestToRoomViewModel(
+    private val repository: WatchTogetherRepository,
+) : ViewModel() {
+    data class UiState(
+        val isBusy: Boolean = false,
+        val notice: String? = null,
+        val error: String? = null,
+    )
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+    val room: StateFlow<RoomSnapshot?> = repository.roomSnapshot
+
+    fun suggest(
+        contentId: String,
+        contentType: String,
+        title: String,
+        subtitle: String?,
+        posterUrl: String?,
+    ) {
+        if (_uiState.value.isBusy) return
+        _uiState.update { it.copy(isBusy = true, error = null, notice = null) }
+        viewModelScope.launch {
+            val result = repository.addSuggestion(
+                AddSuggestionRequest(
+                    contentId = contentId,
+                    contentType = contentType,
+                    title = title,
+                    subtitle = subtitle,
+                    posterUrl = posterUrl,
+                ),
+            )
+            when (result) {
+                is ApiResult.Success ->
+                    _uiState.update { it.copy(isBusy = false, notice = "Suggested to the room") }
+                is ApiResult.Error, is ApiResult.NetworkError ->
+                    _uiState.update {
+                        it.copy(isBusy = false, error = result.errorMessage("Could not suggest that"))
+                    }
+            }
+        }
+    }
+
+    fun consumeNotice() = _uiState.update { it.copy(notice = null) }
+    fun clearError() = _uiState.update { it.copy(error = null) }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntrySheet.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntrySheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -23,11 +24,14 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
+import org.siloserver.silo.watchtogether.canDismissRoomEntry
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
@@ -48,6 +52,7 @@ fun WatchTogetherEntrySheet(
     val state by viewModel.uiState.collectAsState()
     var code by remember { mutableStateOf("") }
     var showJoin by remember { mutableStateOf(false) }
+    val latestBusy by rememberUpdatedState(state.busy)
 
     LaunchedEffect(state.destination) {
         val dest = state.destination ?: return@LaunchedEffect
@@ -57,8 +62,15 @@ fun WatchTogetherEntrySheet(
     }
 
     ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        onDismissRequest = {
+            if (canDismissRoomEntry(state.busy)) onDismiss()
+        },
+        sheetState = rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+            confirmValueChange = { target ->
+                target != SheetValue.Hidden || canDismissRoomEntry(latestBusy)
+            },
+        ),
         containerColor = MaterialTheme.colorScheme.surface,
     ) {
         Text(
@@ -83,6 +95,14 @@ fun WatchTogetherEntrySheet(
                     enabled = !state.busy,
                     modifier = Modifier.fillMaxWidth(),
                 ) { Text(if (state.busy) "Creating…" else "Host a room") }
+
+                OutlinedButton(
+                    onClick = {
+                        viewModel.host(contentId, fileId, RoomSelectionMode.Vote)
+                    },
+                    enabled = !state.busy,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Host a vote room") }
 
                 OutlinedButton(
                     onClick = { viewModel.clearError(); showJoin = true },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.android.ui.navigation.Route
 import org.siloserver.silo.model.watchtogether.CreateRoomRequest
 import org.siloserver.silo.model.watchtogether.JoinRoomRequest
+import org.siloserver.silo.model.watchtogether.MemberRole
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.model.watchtogether.SetSelectionRequest
 import org.siloserver.silo.network.ApiResult
@@ -24,7 +26,9 @@ import kotlinx.coroutines.launch
  * Kept top-level + pure so it is unit-testable without Compose or the repo.
  */
 fun watchTogetherDestination(room: RoomSnapshot): String =
-    if (!room.selectedContentId.isNullOrBlank()) {
+    if (!room.selectedContentId.isNullOrBlank() &&
+        !(room.selfRole == MemberRole.Host && room.memberCount <= 1)
+    ) {
         Route.Player(
             contentId = room.selectedContentId!!,
             fileId = room.selectedFileId,
@@ -59,12 +63,24 @@ class WatchTogetherEntryViewModel(
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
     /** Host flow: create a room with this title pre-selected as the room selection. */
-    fun host(contentId: String, fileId: Int?) {
+    fun host(
+        contentId: String,
+        fileId: Int?,
+        selectionMode: RoomSelectionMode = RoomSelectionMode.HostPick,
+    ) {
         if (_uiState.value.busy) return
         _uiState.update { it.copy(busy = true, error = null) }
         viewModelScope.launch {
-            when (val created = repository.createRoom(CreateRoomRequest())) {
+            when (
+                val created = repository.createRoom(
+                    CreateRoomRequest(selectionMode = selectionMode.wire),
+                )
+            ) {
                 is ApiResult.Success -> {
+                    if (selectionMode == RoomSelectionMode.Vote) {
+                        finish(created.data.room)
+                        return@launch
+                    }
                     // Set this title as the room selection so everyone lands on it.
                     when (
                         val sel = repository.setSelection(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.HowToVote
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -37,6 +38,8 @@ import androidx.compose.ui.unit.dp
 import org.siloserver.silo.model.watchtogether.MemberRole
 import org.siloserver.silo.model.watchtogether.RoomSelectionMode
 import org.siloserver.silo.model.watchtogether.Suggestion
+import org.siloserver.silo.watchtogether.isVoteRoom
+import org.siloserver.silo.watchtogether.roomVoteWinner
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -64,7 +67,7 @@ fun WatchTogetherLobbyScreen(
     val context = LocalContext.current
 
     // Auto-navigate into the synced player when the room starts playing.
-    LaunchedEffect(room?.phase, room?.selectedContentId) {
+    LaunchedEffect(room?.phase, room?.selectedContentId, room?.memberCount, room?.selfRole) {
         val snapshot = room ?: return@LaunchedEffect
         lobbyPlayerDestinationOrNull(snapshot)?.let { onNavigateToPlayer(it) }
     }
@@ -131,12 +134,27 @@ fun WatchTogetherLobbyScreen(
                 }
 
                 HorizontalDivider()
+                val isVoteRoom = room.isVoteRoom()
+                val winner = roomVoteWinner(suggestions)
+                if (isVoteRoom && canManage) {
+                    Button(
+                        onClick = { winner?.let { viewModel.promote(it.id) } },
+                        enabled = winner != null,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            winner?.let { "Start winner: ${it.title}" }
+                                ?: "Start winner — no votes yet",
+                        )
+                    }
+                }
                 Text("Suggestions", style = MaterialTheme.typography.titleSmall)
                 LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     items(suggestions, key = { it.id }) { s ->
                         SuggestionRow(
                             suggestion = s,
                             canManage = canManage,
+                            isWinning = isVoteRoom && winner?.id == s.id,
                             onVote = { if (s.votedByMe) viewModel.unvote(s.id) else viewModel.vote(s.id) },
                             onPromote = { viewModel.promote(s.id) },
                             onRemove = { viewModel.removeSuggestion(s.id) },
@@ -158,6 +176,7 @@ private fun selectionModeLabel(mode: RoomSelectionMode): String = when (mode) {
 private fun SuggestionRow(
     suggestion: Suggestion,
     canManage: Boolean,
+    isWinning: Boolean,
     onVote: () -> Unit,
     onPromote: () -> Unit,
     onRemove: () -> Unit,
@@ -166,6 +185,9 @@ private fun SuggestionRow(
         Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
             Column(Modifier.weight(1f)) {
                 Text(suggestion.title, style = MaterialTheme.typography.bodyLarge)
+                if (isWinning) {
+                    Text("WINNING", style = MaterialTheme.typography.labelSmall)
+                }
                 if (suggestion.subtitle.isNotBlank()) {
                     Text(suggestion.subtitle, style = MaterialTheme.typography.bodySmall)
                 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyViewModel.kt
@@ -72,7 +72,7 @@ class WatchTogetherLobbyViewModel(
 
     /** Guest/host leave: tear down the WS + clear room state. */
     fun leave() {
-        repository.reset()
+        viewModelScope.launch { repository.reset() }
     }
 
     override fun onCleared() {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.android.ui.navigation.Route
 import org.siloserver.silo.model.watchtogether.PromoteSuggestionRequest
+import org.siloserver.silo.model.watchtogether.MemberRole
 import org.siloserver.silo.model.watchtogether.RoomPhase
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.model.watchtogether.Suggestion
@@ -22,7 +23,10 @@ import kotlinx.coroutines.launch
  * shared model uses lenient enums, see WatchTogetherModels.kt.
  */
 fun lobbyPlayerDestinationOrNull(room: RoomSnapshot): String? =
-    if (room.phase == RoomPhase.Playing && !room.selectedContentId.isNullOrBlank()) {
+    if (room.phase == RoomPhase.Playing &&
+        !room.selectedContentId.isNullOrBlank() &&
+        !(room.selfRole == MemberRole.Host && room.memberCount <= 1)
+    ) {
         Route.Player(
             contentId = room.selectedContentId!!,
             fileId = room.selectedFileId,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyViewModel.kt
@@ -8,6 +8,7 @@ import org.siloserver.silo.model.watchtogether.RoomPhase
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.model.watchtogether.Suggestion
 import org.siloserver.silo.repository.WatchTogetherRepository
+import org.siloserver.silo.watchtogether.RoomSession
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -38,18 +39,17 @@ fun lobbyPlayerDestinationOrNull(room: RoomSnapshot): String? =
  *
  * The repository owns the room JWT and reads the active roomId from its own
  * snapshot, so the room-scoped ops take only request/id params (not a roomId).
- * [connect] is suspend and runs the reconnect-with-backoff loop until the
- * scope is cancelled, so it is launched in [viewModelScope].
+ * The application-scoped [RoomSession] owns reconnect and survives navigation
+ * from this lobby into the synced player.
  */
 class WatchTogetherLobbyViewModel(
     private val roomId: String,
     private val repository: WatchTogetherRepository,
+    private val roomSession: RoomSession,
 ) : ViewModel() {
 
     init {
-        // The repo owns reconnect/backoff; we just bind on enter. connect()
-        // suspends for the lifetime of the socket, so launch it (don't call bare).
-        viewModelScope.launch { repository.connect(roomId) }
+        roomSession.adopt(roomId)
     }
 
     val room: StateFlow<RoomSnapshot?> = repository.roomSnapshot
@@ -72,7 +72,7 @@ class WatchTogetherLobbyViewModel(
 
     /** Guest/host leave: tear down the WS + clear room state. */
     fun leave() {
-        viewModelScope.launch { repository.reset() }
+        roomSession.depart()
     }
 
     override fun onCleared() {

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/LobbyAutoNavigateTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/LobbyAutoNavigateTest.kt
@@ -5,6 +5,7 @@ import org.siloserver.silo.model.watchtogether.RoomPhase
 import org.siloserver.silo.model.watchtogether.RoomPlaybackState
 import org.siloserver.silo.model.watchtogether.RoomSelectionMode
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.MemberRole
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -40,5 +41,17 @@ class LobbyAutoNavigateTest {
 
     @Test fun playing_without_selection_does_not_navigate() {
         assertNull(lobbyPlayerDestinationOrNull(room(null, phase = RoomPhase.Playing)))
+    }
+
+    @Test fun host_alone_stays_in_lobby_until_a_guest_arrives() {
+        val host = room("c9", RoomPhase.Playing).copy(
+            selfRole = MemberRole.Host,
+            memberCount = 1,
+        )
+        assertNull(lobbyPlayerDestinationOrNull(host))
+        assertEquals(
+            Route.Player(contentId = "c9", fileId = 3, roomId = "r1").route,
+            lobbyPlayerDestinationOrNull(host.copy(memberCount = 2)),
+        )
     }
 }

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/SuggestToRoomSurfaceSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/SuggestToRoomSurfaceSourceTest.kt
@@ -1,0 +1,40 @@
+package org.siloserver.silo.android.ui.screens.watchtogether
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SuggestToRoomSurfaceSourceTest {
+    private val entrySheet = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntrySheet.kt",
+    ).readText()
+    private val itemDetail = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt",
+    ).readText()
+    private val movieDetail = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt",
+    ).readText()
+    private val seriesDetail = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt",
+    ).readText()
+
+    @Test
+    fun activeRoomExposesSuggestionActionForMoviesAndSeries() {
+        assertTrue(itemDetail.contains("SuggestToRoomViewModel"))
+        assertTrue(itemDetail.contains("suggestViewModel.suggest("))
+        assertTrue(movieDetail.contains("Suggest to Watch Together"))
+        assertTrue(seriesDetail.contains("Suggest to Watch Together"))
+    }
+
+    @Test
+    fun seriesSuggestionUsesItsPlayableEpisodeIdentity() {
+        assertTrue(itemDetail.contains("contentType = \"episode\""))
+        assertTrue(itemDetail.contains("nextEpisode.stillUrl ?: detail.posterUrl"))
+    }
+
+    @Test
+    fun inFlightRoomMutationCannotBeDismissed() {
+        assertTrue(entrySheet.contains("canDismissRoomEntry(state.busy)"))
+        assertTrue(entrySheet.contains("confirmValueChange"))
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryDestinationTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryDestinationTest.kt
@@ -5,6 +5,7 @@ import org.siloserver.silo.model.watchtogether.RoomPhase
 import org.siloserver.silo.model.watchtogether.RoomPlaybackState
 import org.siloserver.silo.model.watchtogether.RoomSelectionMode
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.MemberRole
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.runner.RunWith
@@ -49,5 +50,16 @@ class WatchTogetherEntryDestinationTest {
     fun selection_set_but_no_fileId_still_routes_to_player() {
         val dest = watchTogetherDestination(snapshot(selectedContentId = "c2", selectedFileId = null))
         assertEquals(Route.Player(contentId = "c2", fileId = null, roomId = "room-1").route, dest)
+    }
+
+    @Test
+    fun host_alone_with_selection_stays_in_lobby_to_share_invite() {
+        val dest = watchTogetherDestination(
+            snapshot(selectedContentId = "c1").copy(
+                selfRole = MemberRole.Host,
+                memberCount = 1,
+            ),
+        )
+        assertEquals(Route.WatchTogetherLobby(roomId = "room-1").route, dest)
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -428,6 +428,7 @@ val androidTvModule = module {
         org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherLobbyViewModel(
             roomId = params.get(),
             repository = get(),
+            roomSession = get(),
         )
     }
     viewModel { params ->

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -422,6 +422,9 @@ val androidTvModule = module {
     viewModel {
         org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherViewModel(get())
     }
+    viewModel {
+        org.siloserver.silo.tv.ui.screens.watchtogether.TvSuggestToRoomViewModel(get())
+    }
     // Watch Together lobby — keyed per roomId (koinViewModel key="wt-lobby-$roomId");
     // roomId is read from the positional parameter.
     viewModel { params ->

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -46,6 +46,7 @@ import org.siloserver.silo.tv.ui.screens.settings.diagnostics.TvDiagnosticsPromp
 import org.siloserver.silo.tv.ui.screens.settings.diagnostics.TvDiagnosticsReportScreen
 import org.siloserver.silo.tv.ui.screens.settings.diagnostics.TvDiagnosticsSettingsScreen
 import org.siloserver.silo.tv.ui.screens.settings.diagnostics.TvDiagnosticsViewModel
+import org.siloserver.silo.model.watchtogether.MemberRole
 import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherLobbyScreen
 import org.siloserver.silo.common.overlays.ProvideCardOverlays
 import org.siloserver.silo.common.diagnostics.DiagnosticsLifecycleLogger
@@ -685,7 +686,9 @@ fun TvAppNavigation(
                 // host-with-selection straight to the synced player (carrying
                 // roomId), otherwise into the lobby to wait/vote/pick.
                 onWatchTogether = { snapshot ->
-                    val target = if (!snapshot.selectedContentId.isNullOrBlank()) {
+                    val hostAlone =
+                        snapshot.selfRole == MemberRole.Host && snapshot.memberCount <= 1
+                    val target = if (!snapshot.selectedContentId.isNullOrBlank() && !hostAlone) {
                         TvRoute.Player(
                             contentId = snapshot.selectedContentId!!,
                             fileId = snapshot.selectedFileId,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/QrCodePanel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/QrCodePanel.kt
@@ -3,13 +3,12 @@ package org.siloserver.silo.tv.ui.screens.auth
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -39,7 +38,7 @@ fun QrCodePanel(
         val writer = QRCodeWriter()
         val hints = mapOf(
             EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M,
-            EncodeHintType.MARGIN to 0,  // We add our own padding via the surrounding Box.
+            EncodeHintType.MARGIN to 4,
         )
         // 256 is the requested matrix dimension; ZXing rounds to module count.
         writer.encode(content, BarcodeFormat.QR_CODE, 256, 256, hints)
@@ -48,11 +47,10 @@ fun QrCodePanel(
     Box(
         modifier = modifier
             .size(size)
-            .clip(RoundedCornerShape(16.dp))
             .background(background),
         contentAlignment = Alignment.Center,
     ) {
-        Canvas(modifier = Modifier.size(size)) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
             val moduleCount = matrix.width
             val modulePx = this.size.minDimension / moduleCount
             for (y in 0 until moduleCount) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -34,6 +35,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
@@ -96,8 +98,10 @@ import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.catalog.VersionChapter
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.ebook.MediaRelatedItem
+import org.siloserver.silo.model.feature.CLIENT_WATCH_TOGETHER_SURFACE_ENABLED
 import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
 import org.siloserver.silo.tv.ui.components.TvDialogOption
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvHeroActionPill
@@ -110,6 +114,10 @@ import org.siloserver.silo.tv.ui.components.TvSquareToggleButton
 import org.siloserver.silo.tv.ui.components.TvPillVariant
 import org.siloserver.silo.tv.ui.components.TvRowStyle
 import org.siloserver.silo.tv.ui.screens.audiobook.formatAudiobookTime
+import org.siloserver.silo.tv.ui.screens.watchtogether.TvJoinCodeDialog
+import org.siloserver.silo.tv.ui.screens.watchtogether.TvSuggestToRoomViewModel
+import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherEntryDialog
+import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherViewModel
 import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.TvControlCorner
 import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
@@ -118,7 +126,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.compose.koinInject
-import androidx.compose.runtime.LaunchedEffect
 import org.siloserver.silo.metadata.DescriptionTranslationPhase
 import org.siloserver.silo.model.feature.MetadataAiFeatureStore
 import org.siloserver.silo.model.metadata.MetadataAiOnView
@@ -190,6 +197,7 @@ fun TvItemDetailScreen(
             onItemDetailReplace = onItemDetailReplace,
             onSeriesClick = onSeriesClick,
             onSeasonClick = onSeasonClick,
+            onWatchTogether = onWatchTogether,
             onOpenPerson = onOpenPerson,
         )
     }
@@ -206,6 +214,7 @@ private fun TvDetailContent(
     onItemDetailReplace: (contentId: String) -> Unit,
     onSeriesClick: (seriesId: String) -> Unit,
     onSeasonClick: (seriesId: String, seasonNumber: Int) -> Unit,
+    onWatchTogether: (RoomSnapshot) -> Unit,
     onOpenPerson: (personId: Long) -> Unit,
 ) {
     val playFocus = remember { FocusRequester() }
@@ -448,6 +457,7 @@ private fun TvDetailContent(
                                     onPlay = onPlay,
                                     onSeriesClick = onSeriesClick,
                                     onSeasonClick = onSeasonClick,
+                                    onWatchTogether = onWatchTogether,
                                 )
                             },
                         )
@@ -728,8 +738,23 @@ private fun HeroActionRow(
     onPlay: (contentId: String, fileId: Int?, audioTrackIndex: Int?, subtitleTrackIndex: Int?, itemType: String?, resumePositionSeconds: Double?) -> Unit,
     onSeriesClick: (seriesId: String) -> Unit,
     onSeasonClick: (seriesId: String, seasonNumber: Int) -> Unit,
+    onWatchTogether: (RoomSnapshot) -> Unit,
 ) {
+    val suggestViewModel: TvSuggestToRoomViewModel = koinViewModel()
+    val activeRoom by suggestViewModel.room.collectAsState()
+    val suggestState by suggestViewModel.uiState.collectAsState()
+    val suggestContext = LocalContext.current
+    LaunchedEffect(suggestState.notice, suggestState.error) {
+        val message = suggestState.notice ?: suggestState.error
+        if (message != null) {
+            Toast.makeText(suggestContext, message, Toast.LENGTH_SHORT).show()
+            suggestViewModel.consumeNotice()
+            suggestViewModel.clearError()
+        }
+    }
     var moreOpen by remember(detail.contentId) { mutableStateOf(false) }
+    var watchTogetherOpen by remember(detail.contentId) { mutableStateOf(false) }
+    var joinCodeOpen by remember(detail.contentId) { mutableStateOf(false) }
     var playLaunchPending by remember(detail.contentId) { mutableStateOf(false) }
     LaunchedEffect(playLaunchPending) {
         if (playLaunchPending) {
@@ -766,7 +791,11 @@ private fun HeroActionRow(
     // `TVSeasonDetailView.moreMenu`). Movies do not show an overflow button.
     val hasSeriesNavigation = detail.type in setOf("episode", "season") && detail.seriesId != null
     val hasOverflowNavigation = hasSeriesNavigation
-    val hasOverflowMenu = hasOverflowNavigation
+    val hasWatchTogether =
+        CLIENT_WATCH_TOGETHER_SURFACE_ENABLED && !isAudiobookItemType(detail.type)
+    val hasSuggestionTarget = detail.type in setOf("movie", "episode") || nextUp != null
+    val canSuggestToRoom = activeRoom != null && hasSuggestionTarget
+    val hasOverflowMenu = hasOverflowNavigation || hasWatchTogether || canSuggestToRoom
 
     // Version set + selection state driving the selector row / Play file id.
     // Series/season use the next-up episode's versions + the next-up selection;
@@ -958,6 +987,38 @@ private fun HeroActionRow(
 
     if (moreOpen && hasOverflowMenu) {
         val options = buildList {
+            if (canSuggestToRoom) {
+                add(
+                    TvDialogOption(
+                        key = "suggest-to-room",
+                        title = "Suggest to Watch Together",
+                        subtitle = "Add to the room you are in",
+                        onClick = {
+                            moreOpen = false
+                            suggestViewModel.suggest(
+                                contentId = playContentId,
+                                contentType = playType,
+                                title = nextUp?.title ?: detail.title,
+                                subtitle = if (nextUp != null) detail.title else detail.seriesTitle,
+                                posterUrl = nextUp?.stillUrl ?: detail.posterUrl,
+                            )
+                        },
+                    ),
+                )
+            }
+            if (hasWatchTogether) {
+                add(
+                    TvDialogOption(
+                        key = "watch-together",
+                        title = "Watch Together",
+                        subtitle = "Host a room or join by code",
+                        onClick = {
+                            moreOpen = false
+                            watchTogetherOpen = true
+                        },
+                    ),
+                )
+            }
             if (hasOverflowNavigation) {
                 detail.seriesId?.let { seriesId ->
                     // "Go to Season" is episode-only — a season page is already at
@@ -996,6 +1057,52 @@ private fun HeroActionRow(
             options = options,
             onDismiss = { moreOpen = false },
         )
+    }
+
+    if (watchTogetherOpen && hasWatchTogether) {
+        val watchTogetherViewModel: TvWatchTogetherViewModel = koinViewModel()
+        val watchTogetherState by watchTogetherViewModel.uiState.collectAsState()
+
+        LaunchedEffect(watchTogetherState.result) {
+            val room = watchTogetherState.result ?: return@LaunchedEffect
+            watchTogetherViewModel.consumeResult()
+            watchTogetherOpen = false
+            joinCodeOpen = false
+            onWatchTogether(room)
+        }
+
+        if (joinCodeOpen) {
+            TvJoinCodeDialog(
+                isBusy = watchTogetherState.isBusy,
+                error = watchTogetherState.error,
+                onJoin = watchTogetherViewModel::joinRoom,
+                onDismiss = {
+                    watchTogetherViewModel.clearError()
+                    joinCodeOpen = false
+                },
+            )
+        } else {
+            TvWatchTogetherEntryDialog(
+                isBusy = watchTogetherState.isBusy,
+                error = watchTogetherState.error,
+                onHost = { watchTogetherViewModel.createRoom(playContentId, playFileId) },
+                onHostVote = {
+                    watchTogetherViewModel.createRoom(
+                        playContentId,
+                        playFileId,
+                        RoomSelectionMode.Vote,
+                    )
+                },
+                onJoin = {
+                    watchTogetherViewModel.clearError()
+                    joinCodeOpen = true
+                },
+                onDismiss = {
+                    watchTogetherViewModel.clearError()
+                    watchTogetherOpen = false
+                },
+            )
+        }
     }
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -64,6 +64,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -75,6 +77,7 @@ import androidx.media3.common.C
 import androidx.media3.common.Format
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
+import org.siloserver.silo.common.player.PlayWhenReadyReconciliationGate
 import androidx.media3.common.Tracks
 import androidx.media3.common.VideoSize
 import androidx.media3.session.MediaController
@@ -124,6 +127,7 @@ import org.siloserver.silo.tv.cast.TvSiloCastPlayerAdapter
 import org.siloserver.silo.tv.cast.TvSiloCastReceiver
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvLoadingScreen
+import org.siloserver.silo.tv.ui.components.rememberTvDialogInitialFocus
 import com.google.common.util.concurrent.MoreExecutors
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
@@ -398,6 +402,9 @@ fun TvPlayerScreen(
     // Connect a MediaController to the SiloPlaybackService. Async —
     // downstream effects gate on a non-null controller.
     var mediaController by remember { mutableStateOf<MediaController?>(null) }
+    val playWhenReadyReconciliationGate = remember(mediaController, roomId) {
+        PlayWhenReadyReconciliationGate()
+    }
     val videoBackend = remember(
         sessionPlayer,
         mediaController,
@@ -1171,12 +1178,47 @@ fun TvPlayerScreen(
         }
     }
 
+    val latestLifecycleRoomSnapshot by rememberUpdatedState(roomSnapshot)
+
     // Lifecycle pausing — send pause to the service when we're backgrounded.
-    DisposableEffect(lifecycleOwner, mediaController, isInPictureInPictureMode) {
+    DisposableEffect(
+        lifecycleOwner,
+        mediaController,
+        isInPictureInPictureMode,
+        playWhenReadyReconciliationGate,
+    ) {
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
-                Lifecycle.Event.ON_PAUSE -> if (!isInPictureInPictureMode) mediaController?.pause()
-                Lifecycle.Event.ON_STOP -> if (!isInPictureInPictureMode) mediaController?.pause()
+                Lifecycle.Event.ON_PAUSE,
+                Lifecycle.Event.ON_STOP -> if (!isInPictureInPictureMode) {
+                    mediaController?.let { controller ->
+                        if (controller.playWhenReady) {
+                            if (
+                                playWhenReadyReconciliationGate
+                                    .requestProgrammaticChange(false)
+                            ) {
+                                controller.pause()
+                            }
+                        }
+                    }
+                }
+                Lifecycle.Event.ON_RESUME -> if (roomController != null) {
+                    val desired = latestLifecycleRoomSnapshot?.isPaused?.not()
+                    mediaController?.let { controller ->
+                        if (
+                            desired != null &&
+                            (controller.playWhenReady != desired ||
+                                playWhenReadyReconciliationGate.hasPendingChanges)
+                        ) {
+                            if (
+                                playWhenReadyReconciliationGate
+                                    .requestProgrammaticChange(desired)
+                            ) {
+                                controller.playWhenReady = desired
+                            }
+                        }
+                    }
+                }
                 else -> Unit
             }
         }
@@ -1206,12 +1248,35 @@ fun TvPlayerScreen(
     // Player listener → ViewModel. Pushes play/pause state, refreshes the
     // track menu state on track changes, and drives HDMI display-mode
     // switching on video size changes.
-    DisposableEffect(mediaController, state.effectiveFrameRate) {
+    DisposableEffect(
+        mediaController,
+        state.effectiveFrameRate,
+        playWhenReadyReconciliationGate,
+    ) {
         val controller = mediaController
         if (controller == null) {
             onDispose { }
         } else {
             val listener = object : Player.Listener {
+                override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+                    val provenance = playWhenReadyReconciliationGate
+                        .onPlayWhenReadyChanged(playWhenReady, reason)
+                    provenance.followUpProgrammaticValue?.let { controller.playWhenReady = it }
+                    if (!provenance.shouldReconcile) return
+                    roomController
+                        ?.onExternalPlayWhenReadyChanged(playWhenReady)
+                        ?.let { authoritative ->
+                            if (controller.playWhenReady != authoritative) {
+                                if (
+                                    playWhenReadyReconciliationGate
+                                        .requestProgrammaticChange(authoritative)
+                                ) {
+                                    controller.playWhenReady = authoritative
+                                }
+                            }
+                        }
+                }
+
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
                     viewModel.onPlayingChanged(isPlaying)
                     val live = viewModel.uiState.value
@@ -1538,8 +1603,14 @@ fun TvPlayerScreen(
     // Mirror user-intent pause state into the player. Kept separate from the
     // onPlayingChanged listener so a transient buffering stall can't flip the
     // pause icon or cancel the auto-hide timer.
-    LaunchedEffect(mediaController, state.isPaused) {
-        mediaController?.playWhenReady = !state.isPaused
+    LaunchedEffect(mediaController, state.isPaused, playWhenReadyReconciliationGate) {
+        val controller = mediaController ?: return@LaunchedEffect
+        val desired = !state.isPaused
+        if (controller.playWhenReady != desired) {
+            if (playWhenReadyReconciliationGate.requestProgrammaticChange(desired)) {
+                controller.playWhenReady = desired
+            }
+        }
     }
 
     LaunchedEffect(mediaController) {
@@ -2770,40 +2841,56 @@ private fun TvRoomCloseConfirmDialog(
     onClose: () -> Unit,
     onCancel: () -> Unit,
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.72f)),
-        contentAlignment = Alignment.Center,
+    val closeActionFocus = remember { FocusRequester() }
+
+    Popup(
+        alignment = Alignment.Center,
+        onDismissRequest = onCancel,
+        properties = PopupProperties(
+            focusable = true,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+            clippingEnabled = false,
+        ),
     ) {
-        Column(
+        Box(
             modifier = Modifier
-                .clip(RoundedCornerShape(24.dp))
-                .background(Color.Black.copy(alpha = 0.92f))
-                .padding(40.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.72f)),
+            contentAlignment = Alignment.Center,
         ) {
-            androidx.tv.material3.Text(
-                text = "Close this room?",
-                color = Color.White,
-                style = androidx.tv.material3.MaterialTheme.typography.titleLarge,
-            )
-            androidx.tv.material3.Text(
-                text = "Closing ends Watch Together for everyone in the room.",
-                color = Color.White.copy(alpha = 0.80f),
-                style = androidx.tv.material3.MaterialTheme.typography.bodyMedium,
-            )
-            TvDialogActionRow(
-                title = "Close room for everyone",
-                onClick = onClose,
-                modifier = Modifier.width(360.dp),
-            )
-            TvDialogActionRow(
-                title = "Keep watching",
-                onClick = onCancel,
-                modifier = Modifier.width(360.dp),
-            )
+            Column(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(Color.Black.copy(alpha = 0.92f))
+                    .padding(40.dp)
+                    .then(rememberTvDialogInitialFocus(closeActionFocus)),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                androidx.tv.material3.Text(
+                    text = "Close this room?",
+                    color = Color.White,
+                    style = androidx.tv.material3.MaterialTheme.typography.titleLarge,
+                )
+                androidx.tv.material3.Text(
+                    text = "Closing ends Watch Together for everyone in the room.",
+                    color = Color.White.copy(alpha = 0.80f),
+                    style = androidx.tv.material3.MaterialTheme.typography.bodyMedium,
+                )
+                TvDialogActionRow(
+                    title = "Close room for everyone",
+                    onClick = onClose,
+                    modifier = Modifier
+                        .width(360.dp)
+                        .focusRequester(closeActionFocus),
+                )
+                TvDialogActionRow(
+                    title = "Keep watching",
+                    onClick = onCancel,
+                    modifier = Modifier.width(360.dp),
+                )
+            }
         }
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -116,6 +116,7 @@ import org.siloserver.silo.model.settings.SubtitlePositionPreset
 import org.siloserver.silo.model.settings.legacyPosition
 import org.siloserver.silo.model.watchtogether.RoomPlaybackState
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.watchtogether.shouldNavigateToLocalNext
 import org.siloserver.silo.player.DolbyVisionDetection
 import org.siloserver.silo.player.formatSubtitleTrackDisplayLabel
 import org.siloserver.silo.tv.R
@@ -351,15 +352,17 @@ fun TvPlayerScreen(
     var pictureInPictureSourceRect by remember { mutableStateOf<Rect?>(null) }
 
     // Watch Together binding. Built once per roomId; null for solo playback.
-    // The controller owns the room WS connection + RoomSyncEngine for the
-    // lifetime of this screen and tears them down on explicit leave.
+    // The process RoomSession owns the WS; this controller owns only the
+    // screen's RoomSyncEngine and requests durable teardown on explicit leave.
     val watchTogetherRepository: org.siloserver.silo.repository.WatchTogetherRepository = koinInject()
+    val roomSession: org.siloserver.silo.watchtogether.RoomSession = koinInject()
     val roomScope = rememberCoroutineScope()
     val roomController = remember(roomId) {
         roomId?.takeIf { it.isNotBlank() }?.let { id ->
             TvRoomSyncController(
                 roomId = id,
                 repository = watchTogetherRepository,
+                roomSession = roomSession,
                 viewModel = viewModel,
                 scope = roomScope,
             )
@@ -507,6 +510,10 @@ fun TvPlayerScreen(
     val stopPlaybackAndExit = {
         if (!exitRequested) {
             exitRequested = true
+            // Every terminal player exit must release the process-owned room
+            // session. Explicit host-close paths enqueue close first, then this
+            // idempotent local departure follows behind it.
+            roomController?.leave(closeRoom = false)
             mediaController?.let { controller ->
                 viewModel.onPositionChanged(
                     controller.currentPosition,
@@ -529,6 +536,9 @@ fun TvPlayerScreen(
     // Back doesn't walk back through a chain of auto-played episodes.
     LaunchedEffect(Unit) {
         viewModel.playNextRequests.collect { req ->
+            if (!shouldNavigateToLocalNext(roomController != null)) {
+                return@collect
+            }
             exitRequested = true
             mediaController?.let { c -> c.pause(); c.stop(); c.clearMediaItems() }
             // AWAIT the old session stop before navigating: the lifecycle is a

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -371,8 +371,9 @@ fun TvPlayerScreen(
     DisposableEffect(roomController) {
         roomController?.start()
         // Repo teardown happens on explicit leave (Leave affordance) or
-        // room_closed; the connect scope dies with roomScope on dispose.
-        onDispose { }
+        // room_closed; only this replaceable controller's child jobs are
+        // canceled on disposal.
+        onDispose { roomController?.dispose() }
     }
     val roomSnapshot by (roomController?.room ?: kotlinx.coroutines.flow.MutableStateFlow(null))
         .collectAsState()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvRoomSyncController.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvRoomSyncController.kt
@@ -12,12 +12,18 @@ import org.siloserver.silo.repository.PongSample
 import org.siloserver.silo.repository.ScheduledTransportCommand
 import org.siloserver.silo.repository.WatchTogetherRepository
 import org.siloserver.silo.watchtogether.RoomSession
+import org.siloserver.silo.watchtogether.RoomCommandDispatcher
+import org.siloserver.silo.watchtogether.RoomControllerLifetime
+import org.siloserver.silo.watchtogether.RoomPendingExecutions
+import org.siloserver.silo.watchtogether.scheduledCommandStillCurrent
+import kotlinx.coroutines.CoroutineStart
 import org.siloserver.silo.watchtogether.RoomTransportIntent
 import org.siloserver.silo.watchtogether.roomTransportAuthorized
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.isActive
@@ -140,78 +146,61 @@ class TvRoomSyncController(
 
     // Monotonic-domain state-report cadence bookkeeping.
     @Volatile private var lastReportMs = 0L
-    @Volatile private var pendingExecuteAtMs: Long? = null
-
-    // Session id we have already SENT attach_session for. We send attach_session
-    // AT MOST ONCE per session-id resolution; this latch suppresses re-sends on
-    // the many intervening pre-echo snapshots. Re-armed on a genuine server-side
-    // detach (see [serverHadOurSession]) so a reconnect re-attaches exactly once.
-    @Volatile private var sentAttachForSessionId: String? = null
-
-    // Tracks whether the LAST snapshot had the server associated with our
-    // session. A true -> false transition is a genuine server-side detach
-    // (mid-session reconnect drops the association); that — not the pre-echo
-    // window — re-arms the latch to re-send attach_session once.
-    @Volatile private var serverHadOurSession: Boolean = false
+    private val lifetime = RoomControllerLifetime(scope)
+    private val controllerScope = lifetime.scope
+    private val deliveryLatch = repository.roomDeliveryLatch
+    private val commandDispatcher = RoomCommandDispatcher(controllerScope)
+    private val pendingExecutions = RoomPendingExecutions()
 
     fun start() {
-        // Lobby and player adopt the same application-scoped connection; route
-        // disposal does not tear down or duplicate the socket.
-        roomSession.adopt(roomId)
-
-        // Attach the player's own playback session id, and RE-attach on WS
-        // reconnect. We combine the local session id with each server snapshot
-        // and use a SENT latch distinct from the echo-confirmed check:
-        //  - send attach_session AT MOST ONCE per session-id resolution, the
-        //    moment the id first resolves (set the latch immediately so
-        //    intervening pre-echo snapshots don't re-send);
-        //  - re-arm the latch (and re-send once) ONLY on a genuine server-side
-        //    detach: a snapshot transition where the server HAD our session and
-        //    now doesn't ([serverHadOurSession] true -> false). A mid-session
-        //    reconnect produces exactly that transition.
-        scope.launch {
+        controllerScope.launch(start = CoroutineStart.UNDISPATCHED) {
             combine(
                 viewModel.uiState.map { it.sessionId }.distinctUntilChanged(),
-                repository.roomSnapshot,
-            ) { sessionId, snapshot -> sessionId to snapshot }
-                .collect { (sessionId, snapshot) ->
-                    if (sessionId == null) {
-                        sentAttachForSessionId = null
-                        serverHadOurSession = false
-                        return@collect
-                    }
-                    val serverHasOurSession = snapshot?.attachedSessionId == sessionId
-                    if (serverHadOurSession && !serverHasOurSession) {
-                        sentAttachForSessionId = null
-                    }
-                    serverHadOurSession = serverHasOurSession
-
-                    if (!serverHasOurSession && sentAttachForSessionId != sessionId) {
-                        sentAttachForSessionId = sessionId
-                        repository.attachSession(sessionId)
+                repository.connectionState,
+            ) { sessionId, connection -> deliveryLatch.keyOrNull(connection, sessionId) }
+                .distinctUntilChanged()
+                .collectLatest { key ->
+                    key ?: return@collectLatest
+                    while (isActive && deliveryLatch.needsAttach(key)) {
+                        val delivered = repository.attachSession(key.playbackSessionId)
+                        deliveryLatch.recordAttach(key, delivered)
+                        if (!delivered) {
+                            delay(500)
+                        }
                     }
                 }
         }
 
         // Clock-sync: drive pings (once on start + every PING_INTERVAL_MS) and
         // fold pongs into the engine's offset estimate.
-        scope.launch {
-            while (isActive) {
-                repository.ping(clientSentAt = nowWallClockRfc3339())
-                delay(PING_INTERVAL_MS)
+        controllerScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            combine(
+                viewModel.uiState.map { it.sessionId }.distinctUntilChanged(),
+                repository.connectionState,
+            ) { sessionId, connection ->
+                deliveryLatch.keyOrNull(connection, sessionId) to connection.writable
             }
+                .distinctUntilChanged()
+                .collectLatest { (key, writable) ->
+                    if (!writable || key == null) return@collectLatest
+                    while (!deliveryLatch.isAttached(key)) delay(10)
+                    while (isActive) {
+                        repository.ping(clientSentAt = nowWallClockRfc3339())
+                        delay(PING_INTERVAL_MS)
+                    }
+                }
         }
-        scope.launch {
+        controllerScope.launch(start = CoroutineStart.UNDISPATCHED) {
             repository.pongs.collect { pong -> recordPong(pong) }
         }
 
         // Apply engine decisions for each scheduled transport command.
-        scope.launch {
+        controllerScope.launch(start = CoroutineStart.UNDISPATCHED) {
             repository.transportCommands.collect { scheduled -> handleCommand(scheduled) }
         }
 
         // Drift reporting loop (suppressed around a pending execute).
-        scope.launch {
+        controllerScope.launch {
             while (isActive) {
                 val state = viewModel.uiState.value
                 val sessionId = state.sessionId
@@ -221,7 +210,7 @@ class TvRoomSyncController(
                         now,
                         lastReportMs,
                         REPORT_CADENCE_MS,
-                        pendingExecuteAtMs,
+                        pendingExecutions.nearestTo(now),
                         SUPPRESS_WINDOW_MS,
                     )
                 ) {
@@ -237,21 +226,47 @@ class TvRoomSyncController(
         }
 
         // ready / buffering during the waiting barrier.
-        scope.launch {
-            var lastBuffering: Boolean? = null
-            viewModel.uiState.collect { state ->
-                val waiting = repository.roomSnapshot.value?.playbackState == RoomPlaybackState.Waiting
-                val sessionId = state.sessionId
-                if (waiting && sessionId != null && state.isBuffering != lastBuffering) {
-                    lastBuffering = state.isBuffering
-                    if (state.isBuffering) {
-                        repository.buffering(sessionId, state.position, state.isPaused)
-                    } else {
-                        repository.ready(sessionId, state.position, state.isPaused)
+        controllerScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            combine(
+                viewModel.uiState
+                    .map { it.sessionId to it.isBuffering }
+                    .distinctUntilChanged(),
+                repository.roomSnapshot
+                    .map { it?.playbackState }
+                    .distinctUntilChanged(),
+                repository.connectionState,
+            ) { readiness, playbackState, connection -> Triple(readiness, playbackState, connection) }
+                .collectLatest { (readiness, playbackState, connection) ->
+                    val (sessionId, buffering) = readiness
+                    val key = deliveryLatch.keyOrNull(connection, sessionId)
+                    if (playbackState != RoomPlaybackState.Waiting || key == null) {
+                        return@collectLatest
+                    }
+                    while (!deliveryLatch.isAttached(key)) delay(10)
+                    while (isActive && deliveryLatch.needsReadiness(key, buffering)) {
+                        val currentState = viewModel.uiState.value
+                        val delivered = if (buffering) {
+                            repository.buffering(
+                                key.playbackSessionId,
+                                currentState.position,
+                                currentState.isPaused,
+                            )
+                        } else {
+                            repository.ready(
+                                key.playbackSessionId,
+                                currentState.position,
+                                currentState.isPaused,
+                            )
+                        }
+                        deliveryLatch.recordReadiness(key, buffering, delivered)
+                        if (!delivered) {
+                            delay(500)
+                        }
                     }
                 }
-            }
         }
+
+        roomSession.adopt(roomId)
     }
 
     /**
@@ -271,7 +286,12 @@ class TvRoomSyncController(
         )
     }
 
-    private suspend fun handleCommand(scheduled: ScheduledTransportCommand) {
+    private fun handleCommand(scheduled: ScheduledTransportCommand) {
+        if (!scheduled.connection.writable ||
+            scheduled.connection != repository.connectionState.value
+        ) {
+            return
+        }
         val command = scheduled.command
         val state = viewModel.uiState.value
         val snapshot = repository.roomSnapshot.value
@@ -289,32 +309,57 @@ class TvRoomSyncController(
             attachedSessionId = snapshot?.attachedSessionId ?: state.sessionId,
         ) ?: return // duplicate / revision / session gate → ignore
 
-        applyDecision(decision, state.sessionId)
+        commandDispatcher.dispatch {
+            applyDecision(
+                decision = decision,
+                sessionId = state.sessionId,
+                command = command,
+                acceptedConnection = scheduled.connection,
+            )
+        }
     }
 
-    private suspend fun applyDecision(decision: SyncDecision, sessionId: String?) {
+    private suspend fun applyDecision(
+        decision: SyncDecision,
+        sessionId: String?,
+        command: org.siloserver.silo.model.watchtogether.TransportCommand,
+        acceptedConnection: org.siloserver.silo.repository.WatchTogetherConnectionState,
+    ) {
         val delayMs = decision.localExecuteDelayMs.coerceAtLeast(0L)
         // Record the pending execute against the MONOTONIC clock for the
         // state-report suppression gate, then wait the engine-computed delay.
-        pendingExecuteAtMs = monotonicMs() + delayMs
-        if (delayMs > 0) delay(delayMs)
+        val pendingToken = pendingExecutions.record(monotonicMs() + delayMs)
+        try {
+            if (delayMs > 0) delay(delayMs)
+            if (
+                !scheduledCommandStillCurrent(
+                    command = command,
+                    acceptedPlaybackSessionId = sessionId,
+                    acceptedRoomId = roomId,
+                    acceptedConnection = acceptedConnection,
+                    currentPlaybackSessionId = viewModel.uiState.value.sessionId,
+                    currentRoom = repository.roomSnapshot.value,
+                    currentConnection = repository.connectionState.value,
+                )
+            ) {
+                return
+            }
 
-        // Use the deadband-free immediate-seek path: room corrective seeks can
-        // be as small as the engine's 0.35s DRIFT_THRESHOLD_MS, and a normal
-        // seekRequest would be fine on TV (no position-mirror deadband), but we
-        // route through seekImmediate to match mobile's contract exactly and
-        // guarantee the MediaController moves regardless of any future deadband.
-        decision.seekToMs?.let { ms -> viewModel.seekImmediate(ms / 1000.0) }
-        // Idempotent pause: set the desired state directly (NOT a toggle) so a
-        // duplicate command can't flip us the wrong way.
-        viewModel.setPaused(!decision.setPlaying)
-        pendingExecuteAtMs = null
-
-        // Auto-emit ready on the waiting barrier (command.playback_state == waiting).
-        if (decision.shouldEmitReady && sessionId != null) {
-            val s = viewModel.uiState.value
-            repository.ready(sessionId, s.position, s.isPaused)
+            // Use the deadband-free immediate-seek path: room corrective seeks can
+            // be as small as the engine's 0.35s DRIFT_THRESHOLD_MS, and a normal
+            // seekRequest would be fine on TV (no position-mirror deadband), but we
+            // route through seekImmediate to match mobile's contract exactly and
+            // guarantee the MediaController moves regardless of any future deadband.
+            decision.seekToMs?.let { ms -> viewModel.seekImmediate(ms / 1000.0) }
+            // Idempotent pause: set the desired state directly (NOT a toggle) so a
+            // duplicate command can't flip us the wrong way.
+            viewModel.setPaused(!decision.setPlaying)
+        } finally {
+            pendingExecutions.finish(pendingToken)
         }
+
+        // The epoch/session-keyed readiness collector owns ready delivery and
+        // retries. Do not advance an untracked one-shot latch here.
     }
 
     // ---- User-initiated transport: route through the room instead of local apply ----
@@ -330,12 +375,13 @@ class TvRoomSyncController(
         }
         val state = viewModel.uiState.value
         val willPause = !state.isPaused
-        scope.launch {
-            repository.transportRequest(
+        controllerScope.launch {
+            val delivered = repository.transportRequest(
                 action = if (willPause) TransportAction.Pause.wire else TransportAction.Play.wire,
                 positionSeconds = state.position,
                 isPaused = willPause,
             )
+            if (!delivered) repository.reportDeliveryFailure("room_transport_unavailable")
         }
     }
 
@@ -345,12 +391,13 @@ class TvRoomSyncController(
             return
         }
         val state = viewModel.uiState.value
-        scope.launch {
-            repository.transportRequest(
+        controllerScope.launch {
+            val delivered = repository.transportRequest(
                 action = TransportAction.Seek.wire,
                 positionSeconds = positionSeconds,
                 isPaused = state.isPaused,
             )
+            if (!delivered) repository.reportDeliveryFailure("room_transport_unavailable")
         }
     }
 
@@ -358,6 +405,12 @@ class TvRoomSyncController(
     fun leave(closeRoom: Boolean) {
         engine.reset()
         roomSession.depart(closeRoom)
+    }
+
+    /** Cancel this screen binding without ending the process-owned room lease. */
+    fun dispose() {
+        engine.reset()
+        lifetime.dispose()
     }
 
     /** Wall-clock RFC3339 string for the ping `client_sent_at`. */

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvRoomSyncController.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvRoomSyncController.kt
@@ -11,6 +11,7 @@ import org.siloserver.silo.model.watchtogether.TransportAction
 import org.siloserver.silo.repository.PongSample
 import org.siloserver.silo.repository.ScheduledTransportCommand
 import org.siloserver.silo.repository.WatchTogetherRepository
+import org.siloserver.silo.watchtogether.RoomSession
 import org.siloserver.silo.watchtogether.RoomTransportIntent
 import org.siloserver.silo.watchtogether.roomTransportAuthorized
 import kotlinx.coroutines.CoroutineScope
@@ -115,6 +116,7 @@ fun tvShouldEmitStateReport(
 class TvRoomSyncController(
     private val roomId: String,
     private val repository: WatchTogetherRepository,
+    private val roomSession: RoomSession,
     private val viewModel: TvPlayerViewModel,
     private val scope: CoroutineScope,
     private val engine: RoomSyncEngine = RoomSyncEngine(),
@@ -153,10 +155,9 @@ class TvRoomSyncController(
     @Volatile private var serverHadOurSession: Boolean = false
 
     fun start() {
-        // Reconnect-with-backoff loop. The lobby's connect() ran in its own
-        // (now-dead) scope (the lobby route was popped on hand-off), so the
-        // player owns the live connection and re-runs connect(roomId).
-        scope.launch { repository.connect(roomId) }
+        // Lobby and player adopt the same application-scoped connection; route
+        // disposal does not tear down or duplicate the socket.
+        roomSession.adopt(roomId)
 
         // Attach the player's own playback session id, and RE-attach on WS
         // reconnect. We combine the local session id with each server snapshot
@@ -355,11 +356,8 @@ class TvRoomSyncController(
 
     /** Leave the room. Host close tears the room down for everyone; both reset local state. */
     fun leave(closeRoom: Boolean) {
-        scope.launch {
-            if (closeRoom) repository.closeRoom()
-            engine.reset()
-            repository.reset()
-        }
+        engine.reset()
+        roomSession.depart(closeRoom)
     }
 
     /** Wall-clock RFC3339 string for the ping `client_sent_at`. */

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvRoomSyncController.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvRoomSyncController.kt
@@ -15,6 +15,7 @@ import org.siloserver.silo.watchtogether.RoomSession
 import org.siloserver.silo.watchtogether.RoomCommandDispatcher
 import org.siloserver.silo.watchtogether.RoomControllerLifetime
 import org.siloserver.silo.watchtogether.RoomPendingExecutions
+import org.siloserver.silo.watchtogether.externalPlayPauseDecision
 import org.siloserver.silo.watchtogether.scheduledCommandStillCurrent
 import kotlinx.coroutines.CoroutineStart
 import org.siloserver.silo.watchtogether.RoomTransportIntent
@@ -370,13 +371,17 @@ class TvRoomSyncController(
      * the defensive backstop.
      */
     fun onUserPlayPause() {
-        if (tvRoomTransportGate(repository.roomSnapshot.value, TvTransportIntent.PlayPause) != TransportGate.Send) {
+        val authorization = repository.currentTransportAuthorization() ?: return
+        val snapshot = authorization.snapshot
+        if (tvRoomTransportGate(snapshot, TvTransportIntent.PlayPause) != TransportGate.Send) {
             return
         }
         val state = viewModel.uiState.value
         val willPause = !state.isPaused
         controllerScope.launch {
-            val delivered = repository.transportRequest(
+            val delivered = repository.transportRequestForAuthorization(
+                authorization = authorization,
+                intent = RoomTransportIntent.PlayPause,
                 action = if (willPause) TransportAction.Pause.wire else TransportAction.Play.wire,
                 positionSeconds = state.position,
                 isPaused = willPause,
@@ -387,18 +392,48 @@ class TvRoomSyncController(
 
     /** Route a local seek through the room. Guests never seek (gated). */
     fun onUserSeek(positionSeconds: Double) {
-        if (tvRoomTransportGate(repository.roomSnapshot.value, TvTransportIntent.Seek) != TransportGate.Send) {
+        val authorization = repository.currentTransportAuthorization() ?: return
+        val snapshot = authorization.snapshot
+        if (tvRoomTransportGate(snapshot, TvTransportIntent.Seek) != TransportGate.Send) {
             return
         }
         val state = viewModel.uiState.value
         controllerScope.launch {
-            val delivered = repository.transportRequest(
+            val delivered = repository.transportRequestForAuthorization(
+                authorization = authorization,
+                intent = RoomTransportIntent.Seek,
                 action = TransportAction.Seek.wire,
                 positionSeconds = positionSeconds,
                 isPaused = state.isPaused,
             )
             if (!delivered) repository.reportDeliveryFailure("room_transport_unavailable")
         }
+    }
+
+    /** Reconcile a deliberate external MediaSession play/pause through room authority. */
+    fun onExternalPlayWhenReadyChanged(localPlayWhenReady: Boolean): Boolean? {
+        val authorization = repository.currentTransportAuthorization()
+        val snapshot = authorization?.snapshot
+        val decision = externalPlayPauseDecision(snapshot, localPlayWhenReady) ?: return null
+        if (authorization == null) return decision.restorePlayWhenReady
+        decision.requestIsPaused?.let { requestIsPaused ->
+            val state = viewModel.uiState.value
+            controllerScope.launch {
+                val delivered = repository.transportRequestForAuthorization(
+                    authorization = authorization,
+                    intent = RoomTransportIntent.PlayPause,
+                    action = if (requestIsPaused) {
+                        TransportAction.Pause.wire
+                    } else {
+                        TransportAction.Play.wire
+                    },
+                    positionSeconds = state.position,
+                    isPaused = requestIsPaused,
+                )
+                if (!delivered) repository.reportDeliveryFailure("room_transport_unavailable")
+            }
+        }
+        return decision.restorePlayWhenReady
     }
 
     /** Leave the room. Host close tears the room down for everyone; both reset local state. */

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -133,6 +133,7 @@ class TvVideoPlaybackStarter(
                     subtitleTrackIndex = request.subtitleTrackIndex,
                     qualityPreference = playbackQualityIntent,
                     startPosition = startRequestPosition,
+                    deferPublication = true,
                 )
             ) {
                 is ApiResult.Success -> r.data
@@ -195,6 +196,7 @@ class TvVideoPlaybackStarter(
                 ),
                 session = resolved,
                 renewMissingSessionWithLegacyStart = false,
+                deferPublication = true,
                 expectedOwnershipEpoch = ownershipEpoch,
             )
             if (!adopted) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvJoinCodeDialog.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvJoinCodeDialog.kt
@@ -43,6 +43,7 @@ import org.siloserver.silo.tv.ui.screens.player.TvDialogActionRow
 import org.siloserver.silo.tv.ui.theme.DarkBackground
 import org.siloserver.silo.tv.ui.theme.FocusedContainer
 import org.siloserver.silo.tv.ui.theme.FocusedContent
+import org.siloserver.silo.watchtogether.canDismissRoomEntry
 
 /**
  * Pure 8-char D-pad join-code accumulator. Appends only A–Z / 0–9 (uppercasing
@@ -85,11 +86,13 @@ fun TvJoinCodeDialog(
 
     Popup(
         alignment = Alignment.Center,
-        onDismissRequest = onDismiss,
+        onDismissRequest = {
+            if (canDismissRoomEntry(isBusy)) onDismiss()
+        },
         properties = PopupProperties(
             focusable = true,
-            dismissOnBackPress = true,
-            dismissOnClickOutside = true,
+            dismissOnBackPress = canDismissRoomEntry(isBusy),
+            dismissOnClickOutside = canDismissRoomEntry(isBusy),
             clippingEnabled = false,
         ),
     ) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvSuggestToRoomViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvSuggestToRoomViewModel.kt
@@ -1,0 +1,61 @@
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.siloserver.silo.model.watchtogether.AddSuggestionRequest
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.errorMessage
+import org.siloserver.silo.repository.WatchTogetherRepository
+
+class TvSuggestToRoomViewModel(
+    private val repository: WatchTogetherRepository,
+) : ViewModel() {
+    data class UiState(
+        val isBusy: Boolean = false,
+        val notice: String? = null,
+        val error: String? = null,
+    )
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+    val room: StateFlow<RoomSnapshot?> = repository.roomSnapshot
+
+    fun suggest(
+        contentId: String,
+        contentType: String,
+        title: String,
+        subtitle: String?,
+        posterUrl: String?,
+    ) {
+        if (_uiState.value.isBusy) return
+        _uiState.update { it.copy(isBusy = true, error = null, notice = null) }
+        viewModelScope.launch {
+            val result = repository.addSuggestion(
+                AddSuggestionRequest(
+                    contentId = contentId,
+                    contentType = contentType,
+                    title = title,
+                    subtitle = subtitle,
+                    posterUrl = posterUrl,
+                ),
+            )
+            when (result) {
+                is ApiResult.Success ->
+                    _uiState.update { it.copy(isBusy = false, notice = "Suggested to the room") }
+                is ApiResult.Error, is ApiResult.NetworkError ->
+                    _uiState.update {
+                        it.copy(isBusy = false, error = result.errorMessage("Could not suggest that"))
+                    }
+            }
+        }
+    }
+
+    fun consumeNotice() = _uiState.update { it.copy(notice = null) }
+    fun clearError() = _uiState.update { it.copy(error = null) }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherEntryDialog.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherEntryDialog.kt
@@ -26,6 +26,7 @@ import androidx.tv.material3.Text
 import org.siloserver.silo.tv.ui.components.rememberTvDialogInitialFocus
 import org.siloserver.silo.tv.ui.screens.player.TvDialogActionRow
 import org.siloserver.silo.tv.ui.theme.DarkBackground
+import org.siloserver.silo.watchtogether.canDismissRoomEntry
 
 /**
  * D-pad Watch Together entry dialog. Panel + row idiom mirrors
@@ -38,6 +39,7 @@ fun TvWatchTogetherEntryDialog(
     isBusy: Boolean,
     error: String?,
     onHost: () -> Unit,
+    onHostVote: () -> Unit,
     onJoin: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -45,11 +47,13 @@ fun TvWatchTogetherEntryDialog(
 
     Popup(
         alignment = Alignment.Center,
-        onDismissRequest = onDismiss,
+        onDismissRequest = {
+            if (canDismissRoomEntry(isBusy)) onDismiss()
+        },
         properties = PopupProperties(
             focusable = true,
-            dismissOnBackPress = true,
-            dismissOnClickOutside = true,
+            dismissOnBackPress = canDismissRoomEntry(isBusy),
+            dismissOnClickOutside = canDismissRoomEntry(isBusy),
             clippingEnabled = false,
         ),
     ) {
@@ -85,6 +89,12 @@ fun TvWatchTogetherEntryDialog(
                     enabled = !isBusy,
                     onClick = onHost,
                     modifier = Modifier.focusRequester(hostFocus),
+                )
+
+                TvDialogActionRow(
+                    title = if (isBusy) "Working…" else "Host a vote room",
+                    enabled = !isBusy,
+                    onClick = onHostVote,
                 )
 
                 TvDialogActionRow(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyScreen.kt
@@ -17,13 +17,14 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -53,10 +54,14 @@ import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.model.watchtogether.Suggestion
 import org.siloserver.silo.tv.ui.navigation.TvRoute
 import org.siloserver.silo.tv.ui.screens.auth.QrCodePanel
+import org.siloserver.silo.tv.ui.screens.player.TvDialogActionRow
 import org.siloserver.silo.tv.ui.screens.player.TvDialogCyclerRow
 import org.siloserver.silo.tv.ui.theme.DarkBackground
 import org.siloserver.silo.tv.ui.theme.FocusedContainer
 import org.siloserver.silo.tv.ui.theme.FocusedContent
+import org.siloserver.silo.tv.ui.theme.SiloBlue
+import org.siloserver.silo.watchtogether.isVoteRoom
+import org.siloserver.silo.watchtogether.roomVoteWinner
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -66,8 +71,11 @@ import org.koin.core.parameter.parametersOf
  * the phone lobby's `lobbyPlayerDestinationOrNull` semantics (enum compare +
  * isNullOrBlank, NOT a wire-string compare).
  */
-fun shouldEnterSyncedPlayer(s: RoomSnapshot?): Boolean =
-    s != null && s.phase == RoomPhase.Playing && !s.selectedContentId.isNullOrBlank()
+fun shouldEnterSyncedPlayer(s: RoomSnapshot?): Boolean {
+    if (s == null || s.phase != RoomPhase.Playing || s.selectedContentId.isNullOrBlank()) return false
+    if (s.selfRole == MemberRole.Host && s.memberCount <= 1) return false
+    return true
+}
 
 /**
  * Watch Together lobby (TV). Shows member count / role / selection mode, the
@@ -106,9 +114,16 @@ fun TvWatchTogetherLobbyScreen(
     val snapshot = room
     val isHostLabel = snapshot?.selfRole == MemberRole.Host
     val canManage = snapshot?.selfCanManageRoom == true
+    val isVoteRoom = snapshot.isVoteRoom()
 
     // Auto-hand-off into the synced player once the room is playing + selected.
-    LaunchedEffect(room?.phase, room?.selectedContentId, room?.selectedFileId) {
+    LaunchedEffect(
+        room?.phase,
+        room?.selectedContentId,
+        room?.selectedFileId,
+        room?.memberCount,
+        room?.selfRole,
+    ) {
         val snapshot = room ?: return@LaunchedEffect
         if (shouldEnterSyncedPlayer(snapshot)) {
             onNavigateToPlayer(
@@ -146,10 +161,14 @@ fun TvWatchTogetherLobbyScreen(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background),
     ) {
-        Column(
+        Row(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 56.dp, vertical = 40.dp),
+                .padding(start = 56.dp, end = 56.dp, top = 40.dp, bottom = 48.dp),
+            horizontalArrangement = Arrangement.spacedBy(48.dp),
+        ) {
+        Column(
+            modifier = Modifier.weight(0.42f),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             // --- Header --------------------------------------------------------
@@ -231,6 +250,19 @@ fun TvWatchTogetherLobbyScreen(
                             )
                         }
                     }
+                }
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(0.58f)
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = 48.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            if (snapshot != null) {
+                if (canManage) {
                     // Selection mode is fixed at room creation — shown read-only.
                     TvDialogCyclerRow(
                         title = "Selection mode",
@@ -251,6 +283,16 @@ fun TvWatchTogetherLobbyScreen(
                     CloseRoomButton(onClick = viewModel::closeRoom)
                 }
 
+                val winner = roomVoteWinner(suggestions)
+                if (isVoteRoom && canManage) {
+                    TvDialogActionRow(
+                        title = winner?.let { "Start winner: ${it.title}" }
+                            ?: "Start winner — no votes yet",
+                        enabled = winner != null,
+                        onClick = { winner?.let { viewModel.promote(it.id) } },
+                    )
+                }
+
                 Text(
                     text = "SUGGESTIONS",
                     style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 2.sp),
@@ -263,24 +305,28 @@ fun TvWatchTogetherLobbyScreen(
                         color = Color.White.copy(alpha = 0.5f),
                     )
                 } else {
-                    LazyColumn(
+                    Column(
                         verticalArrangement = Arrangement.spacedBy(10.dp),
                         modifier = Modifier.fillMaxWidth(),
                     ) {
-                        items(suggestions, key = { it.id }) { s ->
-                            SuggestionRow(
-                                suggestion = s,
-                                canManage = canManage,
-                                onVote = {
-                                    if (s.votedByMe) viewModel.unvote(s.id) else viewModel.vote(s.id)
-                                },
-                                onPromote = { viewModel.promote(s.id) },
-                                onRemove = { viewModel.removeSuggestion(s.id) },
-                            )
+                        suggestions.forEach { s ->
+                            key(s.id) {
+                                SuggestionRow(
+                                    suggestion = s,
+                                    canManage = canManage,
+                                    isWinning = isVoteRoom && winner?.id == s.id,
+                                    onVote = {
+                                        if (s.votedByMe) viewModel.unvote(s.id) else viewModel.vote(s.id)
+                                    },
+                                    onPromote = { viewModel.promote(s.id) },
+                                    onRemove = { viewModel.removeSuggestion(s.id) },
+                                )
+                            }
                         }
                     }
                 }
             }
+        }
         }
     }
 }
@@ -314,6 +360,7 @@ private fun nextPolicy(policy: GuestControlPolicy): GuestControlPolicy = when (p
 private fun SuggestionRow(
     suggestion: Suggestion,
     canManage: Boolean,
+    isWinning: Boolean,
     onVote: () -> Unit,
     onPromote: () -> Unit,
     onRemove: () -> Unit,
@@ -413,6 +460,17 @@ private fun SuggestionRow(
                 style = MaterialTheme.typography.titleMedium,
                 color = if (isFocused) FocusedContent else Color.White,
             )
+            if (isWinning) {
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = "WINNING",
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 1.sp,
+                    ),
+                    color = if (isFocused) FocusedContent else SiloBlue,
+                )
+            }
             if (canManage) {
                 Spacer(Modifier.width(8.dp))
                 RowAction(text = "Pick", onClick = onPromote)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyViewModel.kt
@@ -7,6 +7,7 @@ import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.model.watchtogether.Suggestion
 import org.siloserver.silo.model.watchtogether.UpdatePolicyRequest
 import org.siloserver.silo.repository.WatchTogetherRepository
+import org.siloserver.silo.watchtogether.RoomSession
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -20,19 +21,17 @@ import kotlinx.coroutines.launch
  *
  * The repository owns the room JWT and reads the active roomId from its own
  * snapshot, so the room-scoped ops take only request/id params (not a roomId).
- * [WatchTogetherRepository.connect] is suspend and runs the reconnect-with-backoff
- * loop until the scope is cancelled, so it is launched in [viewModelScope] (NOT
- * called bare in init).
+ * The application-scoped [RoomSession] owns reconnect and survives navigation
+ * from this lobby into the synced player.
  */
 class TvWatchTogetherLobbyViewModel(
     private val roomId: String,
     private val repository: WatchTogetherRepository,
+    private val roomSession: RoomSession,
 ) : ViewModel() {
 
     init {
-        // The repo owns reconnect/backoff; we just bind on enter. connect()
-        // suspends for the lifetime of the socket, so launch it.
-        viewModelScope.launch { repository.connect(roomId) }
+        roomSession.adopt(roomId)
     }
 
     val room: StateFlow<RoomSnapshot?> = repository.roomSnapshot
@@ -71,7 +70,7 @@ class TvWatchTogetherLobbyViewModel(
      * network call against viewModelScope cancellation during screen dispose.
      */
     fun leave() {
-        viewModelScope.launch { repository.reset() }
+        roomSession.depart()
     }
 
     override fun onCleared() {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyViewModel.kt
@@ -71,7 +71,7 @@ class TvWatchTogetherLobbyViewModel(
      * network call against viewModelScope cancellation during screen dispose.
      */
     fun leave() {
-        repository.reset()
+        viewModelScope.launch { repository.reset() }
     }
 
     override fun onCleared() {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.model.watchtogether.CreateRoomRequest
 import org.siloserver.silo.model.watchtogether.JoinRoomRequest
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.model.watchtogether.SetSelectionRequest
 import org.siloserver.silo.network.ApiResult
@@ -46,12 +47,24 @@ class TvWatchTogetherViewModel(
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
     /** Host flow: create a room with this title pre-selected as the room selection. */
-    fun createRoom(contentId: String, fileId: Int?) {
+    fun createRoom(
+        contentId: String,
+        fileId: Int?,
+        selectionMode: RoomSelectionMode = RoomSelectionMode.HostPick,
+    ) {
         if (_uiState.value.isBusy) return
         _uiState.update { it.copy(isBusy = true, error = null) }
         viewModelScope.launch {
-            when (val created = repository.createRoom(CreateRoomRequest())) {
+            when (
+                val created = repository.createRoom(
+                    CreateRoomRequest(selectionMode = selectionMode.wire),
+                )
+            ) {
                 is ApiResult.Success -> {
+                    if (selectionMode == RoomSelectionMode.Vote) {
+                        finish(created.data.room)
+                        return@launch
+                    }
                     // createRoom does NOT auto-select; set this title as the room
                     // selection so the host lands on the synced player. The repo
                     // already stored the snapshot synchronously, so setSelection

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/pip/TvPictureInPictureSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/pip/TvPictureInPictureSourceTest.kt
@@ -31,7 +31,11 @@ class TvPictureInPictureSourceTest {
         assertTrue(player.contains("isPlaying = state.isPlaying && !state.isPaused"))
         assertTrue(player.contains("!isInPictureInPictureMode"))
         assertTrue(player.contains("if (!isInPictureInPictureMode && state.showControls"))
-        assertTrue(player.contains("Lifecycle.Event.ON_PAUSE -> if (!isInPictureInPictureMode)"))
+        val lifecyclePauseBranch = player
+            .substringAfter("Lifecycle.Event.ON_PAUSE,")
+            .substringBefore("Lifecycle.Event.ON_RESUME")
+        assertTrue(lifecyclePauseBranch.contains("Lifecycle.Event.ON_STOP"))
+        assertTrue(lifecyclePauseBranch.contains("if (!isInPictureInPictureMode)"))
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackFreshLoadOwnershipTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackFreshLoadOwnershipTest.kt
@@ -28,6 +28,22 @@ import org.siloserver.silo.playback.encodeSubtitleIdentityPreference
 
 class TvPlaybackFreshLoadOwnershipTest {
     @Test
+    fun `fresh TV starter defers manager and lifecycle publication until UI is ready`() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt",
+        ).readText()
+        val managerStart = source
+            .substringAfter("playbackSessionManager.startVideoSessionV3(")
+            .substringBefore("\n                )")
+        val lifecycleAdoption = source
+            .substringAfter("sessionLifecycle.adoptActiveSessionIfCurrent(")
+            .substringBefore("\n            )")
+
+        assertTrue(managerStart.contains("deferPublication = true"))
+        assertTrue(lifecycleAdoption.contains("deferPublication = true"))
+    }
+
+    @Test
     fun `post publication failure restores exact predecessor while stale B cannot overwrite C`() {
         data class State(val sessionId: String)
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/LobbyNavigationDecisionTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/LobbyNavigationDecisionTest.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.tv.ui.screens.watchtogether
 
+import org.siloserver.silo.model.watchtogether.MemberRole
 import org.siloserver.silo.model.watchtogether.RoomPhase
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import kotlin.test.Test
@@ -53,5 +54,27 @@ class LobbyNavigationDecisionTest {
     @Test
     fun nullSnapshotDoesNotEnter() {
         assertFalse(shouldEnterSyncedPlayer(null))
+    }
+
+    @Test
+    fun hostAloneHoldsOnTheInviteCodeUntilSomeoneJoins() {
+        val alone = fixture(RoomPhase.Playing, "m1").copy(
+            selfRole = MemberRole.Host,
+            memberCount = 1,
+        )
+        assertFalse(shouldEnterSyncedPlayer(alone))
+        assertTrue(shouldEnterSyncedPlayer(alone.copy(memberCount = 2)))
+    }
+
+    @Test
+    fun guestEntersAnAlreadyPlayingRoomImmediately() {
+        assertTrue(
+            shouldEnterSyncedPlayer(
+                fixture(RoomPhase.Playing, "m1").copy(
+                    selfRole = MemberRole.Guest,
+                    memberCount = 1,
+                ),
+            ),
+        )
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherSurfaceSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherSurfaceSourceTest.kt
@@ -20,6 +20,9 @@ class TvWatchTogetherSurfaceSourceTest {
     private val qrPanel = File(
         "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/QrCodePanel.kt",
     ).readText()
+    private val playerScreen = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt",
+    ).readText()
 
     @Test
     fun detailOverflowOpensTheEntryDialog() {
@@ -70,5 +73,17 @@ class TvWatchTogetherSurfaceSourceTest {
     fun qrQuietZoneIsModuleAware() {
         assertTrue(qrPanel.contains("EncodeHintType.MARGIN to 4"))
         assertTrue(!qrPanel.contains("quietZone: Dp"))
+    }
+
+    @Test
+    fun roomCloseConfirmationTakesDpadFocusFromThePlayer() {
+        val dialog = playerScreen.substringAfter("private fun TvRoomCloseConfirmDialog(")
+        assertTrue(dialog.contains("rememberTvDialogInitialFocus(closeActionFocus)"))
+        assertTrue(dialog.contains(".focusRequester(closeActionFocus)"))
+        assertTrue(!dialog.contains("closeActionFocus.requestFocus()"))
+        assertTrue(dialog.contains("Popup("))
+        assertTrue(dialog.contains("PopupProperties("))
+        assertTrue(dialog.contains("focusable = true"))
+        assertTrue(dialog.contains("onDismissRequest = onCancel"))
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherSurfaceSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherSurfaceSourceTest.kt
@@ -1,0 +1,74 @@
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class TvWatchTogetherSurfaceSourceTest {
+    private val itemDetailScreen = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
+    ).readText()
+    private val appNavigation = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt",
+    ).readText()
+    private val entryDialog = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherEntryDialog.kt",
+    ).readText()
+    private val joinDialog = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvJoinCodeDialog.kt",
+    ).readText()
+    private val qrPanel = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/QrCodePanel.kt",
+    ).readText()
+
+    @Test
+    fun detailOverflowOpensTheEntryDialog() {
+        assertTrue(itemDetailScreen.contains("CLIENT_WATCH_TOGETHER_SURFACE_ENABLED"))
+        assertTrue(itemDetailScreen.contains("key = \"watch-together\""))
+        assertTrue(itemDetailScreen.contains("watchTogetherOpen = true"))
+        assertTrue(itemDetailScreen.contains("TvWatchTogetherEntryDialog("))
+        assertTrue(itemDetailScreen.contains("TvJoinCodeDialog("))
+    }
+
+    @Test
+    fun aResolvedRoomReachesTheNavigationCallback() {
+        assertTrue(itemDetailScreen.contains("onWatchTogether(room)"))
+        assertTrue(itemDetailScreen.contains("watchTogetherViewModel.consumeResult()"))
+        assertTrue(appNavigation.contains("TvRoute.WatchTogetherLobby(roomId = snapshot.roomId).route"))
+    }
+
+    @Test
+    fun audiobooksDoNotOfferARoom() {
+        assertTrue(
+            itemDetailScreen.contains(
+                "CLIENT_WATCH_TOGETHER_SURFACE_ENABLED && !isAudiobookItemType(detail.type)",
+            ),
+        )
+    }
+
+    @Test
+    fun activeRoomExposesSuggestionActionFromDetail() {
+        assertTrue(itemDetailScreen.contains("TvSuggestToRoomViewModel"))
+        assertTrue(itemDetailScreen.contains("key = \"suggest-to-room\""))
+        assertTrue(itemDetailScreen.contains("Suggest to Watch Together"))
+        assertTrue(itemDetailScreen.contains("suggestViewModel.suggest("))
+    }
+
+    @Test
+    fun seriesSuggestionUsesItsPlayableEpisodeIdentity() {
+        assertTrue(itemDetailScreen.contains("contentType = playType"))
+        assertTrue(itemDetailScreen.contains("posterUrl = nextUp?.stillUrl ?: detail.posterUrl"))
+    }
+
+    @Test
+    fun inFlightRoomMutationCannotBeDismissed() {
+        assertTrue(entryDialog.contains("canDismissRoomEntry(isBusy)"))
+        assertTrue(joinDialog.contains("canDismissRoomEntry(isBusy)"))
+    }
+
+    @Test
+    fun qrQuietZoneIsModuleAware() {
+        assertTrue(qrPanel.contains("EncodeHintType.MARGIN to 4"))
+        assertTrue(!qrPanel.contains("quietZone: Dp"))
+    }
+}

--- a/docs/superpowers/plans/2026-07-27-pr108-slice-f-watch-together.md
+++ b/docs/superpowers/plans/2026-07-27-pr108-slice-f-watch-together.md
@@ -81,6 +81,10 @@ OkHttp/MockWebServer, Koin, Android Compose, Gradle, ADB/emulator tooling.
 - Snapshot plus 30 seconds of stable connection resets the failure window.
 - Cancellation/obsolete generation cannot clear or fold into a replacement.
 - Room A's late REST/socket completion cannot use or mutate room B.
+- Blank room tokens and mismatched room responses fail closed instead of
+  retaining an earlier room token.
+- Every room-scoped REST completion revalidates its captured lease before
+  publishing state.
 - Missing room fails fast.
 - Attach/readiness/user transport sends report actual delivery.
 
@@ -110,10 +114,18 @@ OkHttp/MockWebServer, Koin, Android Compose, Gradle, ADB/emulator tooling.
 - Concurrent enters serialize deterministically.
 - Leave cancels and joins before reset.
 - Server/profile/logout/credential-generation change ends the lease.
+- `IdentityTransitionBarrier` WILL_CHANGE hides room state and cancels the
+  lease before the new identity is published; old WS/REST completions cannot
+  repopulate state after profile/server/sign-out/temporary-scope transitions.
+- A terminal room close tombstones that room-binding generation. Recreation
+  cannot reconnect it; only a fresh successful create/join response can mint a
+  new live binding.
 
 **Implementation:**
 - Port the intent of `864de27e`/`79b4278d`, replacing cancel-only behavior with
   cancel-and-join and immutable generation ownership.
+- Bind the session to `TokenManager.snapshotCurrentScope()` and the existing
+  `IdentityTransitionBarrier`, rather than relying on screen logout callbacks.
 - Register one session per app process with an application coroutine scope.
 
 - [ ] Establish RED.
@@ -133,6 +145,9 @@ OkHttp/MockWebServer, Koin, Android Compose, Gradle, ADB/emulator tooling.
 - Failed ready/buffering does not advance the local latch and retries.
 - Failed user transport is surfaced/deferred rather than silently dropped.
 - Player leave calls `RoomSession.leave`; screen disposal does not.
+- `leave`/`closeAndLeave` is owned by the application session, completes close
+  at most once, joins the socket, and resets even if the initiating screen or
+  ViewModel scope is canceled immediately after navigation.
 - Attach/readiness state is keyed by connection epoch plus playback session id,
   including equal initial snapshots and unchanged buffering after reconnect.
 - A command accepted for playback session A is revalidated after its

--- a/docs/superpowers/plans/2026-07-27-pr108-slice-f-watch-together.md
+++ b/docs/superpowers/plans/2026-07-27-pr108-slice-f-watch-together.md
@@ -1,0 +1,221 @@
+# PR 108 Slice F: Watch Together Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development or superpowers:executing-plans.
+> Every behavioral change follows test-driven development.
+
+**Goal:** Forward-port PR 108's complete Watch Together feature onto Slice E,
+correct its production transport/session/security defects, and validate a real
+host/guest flow on two concurrent Android emulators.
+
+**Architecture:** `RoomSession` is the application-scoped owner of one
+immutable room/auth lease and one reconnect job. The repository folds room
+state only for the current generation. The realtime client distinguishes
+protocol closure from transport termination, exposes a writable connection
+epoch, and keeps credentials on same-origin approved transports. Phone and TV
+controllers subscribe before attach and re-attach on every epoch.
+
+**Tech stack:** Kotlin Multiplatform, coroutines/Flow, Ktor WebSockets,
+OkHttp/MockWebServer, Koin, Android Compose, Gradle, ADB/emulator tooling.
+
+## Constraints
+
+- Base is draft Slice E PR #116 (`split/108-e-subtitles`).
+- Preserve closed PR #108 as archival reference; do not merge any PR.
+- Do not import TV request UX, catalog/mixed-library polish, or unrelated
+  home/startup work; those belong to Slice G.
+- Preserve the A-E auth-origin, Room, playback, subtitle, and lifecycle
+  contracts.
+- Fully removing room/profile credentials from query parameters is blocked on
+  server protocol support; remove the redundant access JWT now and document
+  the residual contract.
+- Do not use a physical device for destructive validation. Use at least two
+  concurrent emulators with separate app data/identities.
+
+---
+
+### Task 1: Correct realtime transport semantics and credential boundaries
+
+**Files:**
+- Modify `shared/.../network/WatchTogetherRealtimeEvent.kt`
+- Modify `shared/.../network/WatchTogetherRealtimeClient.kt`
+- Modify `shared/.../network/CleartextOriginConsent.kt`
+- Modify focused common tests
+- Add Android/JVM real-websocket tests under `android-shared/src/androidUnitTest`
+
+**Red tests:**
+- Normal socket EOF and I/O failure are transient transport termination, not a
+  decoded `room_closed`.
+- Cancellation never emits a terminal close.
+- The handshake URL omits the access JWT while same-origin Authorization and
+  profile headers are present.
+- `ws://` requires the exact `http://` origin's cleartext approval before the
+  engine sees any credential.
+- Early server snapshot and outbound attach/ping ordering survive a real
+  MockWebServer upgrade.
+
+**Implementation:**
+- Split explicit protocol room closure from physical connection termination.
+- Re-throw cancellation and surface typed transport termination.
+- Protect mutable session ownership by connection identity.
+- Encode the room id as a path segment.
+- Rely on the pinned/same-origin auth plugin for the access bearer; retain only
+  server-required query fields.
+
+- [ ] Establish RED.
+- [ ] Implement minimum production changes.
+- [ ] Run forced focused tests green and commit.
+
+### Task 2: Make repository reconnect and room leases production-safe
+
+**Files:**
+- Modify `shared/.../repository/WatchTogetherRepository.kt`
+- Modify `shared/.../network/api/WatchTogetherApi.kt` only where scoped room
+  binding requires it
+- Modify `shared/.../repository/WatchTogetherRepositoryTest.kt`
+- Add a deterministic per-attempt transport harness
+
+**Red tests:**
+- EOF/I/O reconnect; decoded room close never reconnects.
+- Every unstable failed attempt counts even after one healthy frame.
+- Snapshot plus 30 seconds of stable connection resets the failure window.
+- Cancellation/obsolete generation cannot clear or fold into a replacement.
+- Room A's late REST/socket completion cannot use or mutate room B.
+- Missing room fails fast.
+- Attach/readiness/user transport sends report actual delivery.
+
+**Implementation:**
+- Capture immutable room id/token/auth scope in a generation lease.
+- Gate fold, close, send, and final cleanup on the current generation.
+- Expose connection state/epoch.
+- Keep capped 500/1000/2000/5000 ms backoff with the 30-second stability rule.
+- Make voted-id state concurrency-safe and retain the PR 108 fail-fast room
+  behavior.
+
+- [ ] Establish RED.
+- [ ] Implement minimum production changes.
+- [ ] Run forced focused tests green and commit.
+
+### Task 3: Add the application-scoped RoomSession owner
+
+**Files:**
+- Create `shared/.../watchtogether/RoomSession.kt`
+- Modify shared Koin registration
+- Add `RoomSessionTest.kt`
+
+**Red tests:**
+- Same-room enter is idempotent.
+- A-to-B replacement cancels and joins blocked A before B starts.
+- Late A frames/finalizers cannot clear B.
+- Concurrent enters serialize deterministically.
+- Leave cancels and joins before reset.
+- Server/profile/logout/credential-generation change ends the lease.
+
+**Implementation:**
+- Port the intent of `864de27e`/`79b4278d`, replacing cancel-only behavior with
+  cancel-and-join and immutable generation ownership.
+- Register one session per app process with an application coroutine scope.
+
+- [ ] Establish RED.
+- [ ] Implement minimum production changes.
+- [ ] Run forced focused tests green and commit.
+
+### Task 4: Port phone/TV controllers with reconnect-safe delivery
+
+**Files:**
+- Modify mobile `RoomSyncController`, `PlayerScreen`, and lifecycle tests
+- Modify TV `TvRoomSyncController`, `TvPlayerScreen`, and lifecycle tests
+- Add shared/two-client transport-broker tests
+
+**Red tests:**
+- Collectors are active before initial attach/ping.
+- Every connection epoch re-attaches exactly once.
+- Failed ready/buffering does not advance the local latch and retries.
+- Failed user transport is surfaced/deferred rather than silently dropped.
+- Player leave calls `RoomSession.leave`; screen disposal does not.
+- Attach/readiness state is keyed by connection epoch plus playback session id,
+  including equal initial snapshots and unchanged buffering after reconnect.
+- A command accepted for playback session A is revalidated after its
+  `execute_at` delay; publishing replacement session B prevents the stale
+  command from seeking/pausing B or sending `ready(A)`.
+- Two participants receive the same revision/command and independently apply
+  host play/pause/seek, guest policy, drift correction, buffering, and ready.
+- Host terminal close reaches both and stops reconnect.
+
+**Implementation:**
+- Port `323510a2`, `c6ba32ef`, and the controller portions of `79b4278d`.
+- Keep RoomSyncEngine scheduling/session/revision/dedupe behavior from the
+  current base.
+- Use the connection epoch as the attach/ping/reconciliation trigger.
+
+- [ ] Establish RED.
+- [ ] Implement minimum production changes.
+- [ ] Run phone/TV controller and two-client tests green and commit.
+
+### Task 5: Port the complete reachable lobby, voting, and suggestion surface
+
+**Files:**
+- Modify phone entry/lobby/detail/navigation/ViewModels
+- Modify TV entry/lobby/detail/navigation/ViewModels/QR layout
+- Add/restore destination, policy, navigation, source-surface, voting, and
+  focus tests
+
+**Behavior:**
+- Phone and TV can host or join.
+- Vote rooms open empty, accept suggestions, votes, promotion, and host
+  override.
+- Invite code remains visible and TV controls remain reachable/focusable.
+- Members can browse and suggest while the application-scoped room remains
+  connected.
+- Lobby-to-player and back do not create a second socket.
+
+**Sources:** `9fe27a27`, `e171e011`, `acfac18a`, `fca6d7c6`, `bc58049b`,
+`ea5756ec`, `8f36f7d2`, `530f9488`, `f91aa62e`, `923a1a7f`.
+
+- [ ] Restore/author RED tests for missing behavior.
+- [ ] Forward-port the net UI behavior against the current stack.
+- [ ] Run focused phone/TV suites green and commit.
+
+### Task 6: Validate two real emulator participants
+
+**Environment:**
+- Use two concurrent dedicated AVDs, preferring `Silo_Phone` and `Silo_TV`.
+- Use distinct app data and user/profile identities.
+- Start an appropriate local/configured Silo test backend without modifying
+  production data.
+
+**Flow:**
+- [ ] Record AVD/API/app/backend versions and startup commands.
+- [ ] Host, join, verify handshake and attach-session ordering.
+- [ ] Exercise host and guest transport policy.
+- [ ] Exercise suggestions, vote/unvote, promote, and host override.
+- [ ] Exercise drift/seek/buffer/ready propagation.
+- [ ] Interrupt/restore one emulator's network and verify reconnect/re-attach.
+- [ ] Background/foreground both clients.
+- [ ] Replace one room with another.
+- [ ] Close/depart as host and verify terminal guest closure.
+- [ ] Capture redacted ADB/backend logs and classify any limitation or defect.
+- [ ] Commit the reproducible evidence document.
+
+### Task 7: Audit, review, verify, and publish
+
+- [ ] Audit net diff and remove Slice G/unrelated paths.
+- [ ] Run all focused Watch Together, auth/origin, Room, and player suites.
+- [ ] Run `./scripts/check-build-supply-chain.sh`.
+- [ ] Run fresh `testDebugUnitTest` and phone/TV release assemblies.
+- [ ] Obtain independent lifecycle/concurrency/security review.
+- [ ] Fix every Critical/Important finding test-first and repeat full gates.
+- [ ] Update source-to-local mapping and emulator evidence.
+- [ ] Push `split/108-f-watch-together`.
+- [ ] Create a draft PR based on `split/108-e-subtitles`; do not merge.
+
+## Initial source mapping
+
+| Area | PR 108 sources |
+| --- | --- |
+| Feature entry | `9fe27a27` |
+| Send/open and room action fixes | `323510a2`, `c6ba32ef`, `e171e011` |
+| Lobby/invite/TV focus | `acfac18a`, `fca6d7c6`, `bc58049b` |
+| Voting and empty vote rooms | `ea5756ec`, `8f36f7d2`, `923a1a7f` |
+| Browsing suggestions | `530f9488`, `f91aa62e` |
+| App-scoped ownership intent | `864de27e`, `79b4278d` |

--- a/docs/superpowers/specs/2026-07-27-pr108-slice-f-watch-together-design.md
+++ b/docs/superpowers/specs/2026-07-27-pr108-slice-f-watch-together-design.md
@@ -1,0 +1,173 @@
+# PR 108 Slice F: Watch Together Forward-Port Design
+
+**Date:** 2026-07-27  
+**Status:** Approved by the existing Watch Together design plus the user's
+explicit instruction to continue Slice F and validate with multiple emulators  
+**Base:** `split/108-e-subtitles` / draft PR #116  
+**Source:** Closed archival PR #108 and the approved
+`2026-06-12-watch-together-design.md`
+
+## Goal
+
+Forward-port the complete, user-reachable Watch Together vertical slice onto
+the reviewed A-E stack, while correcting connection ownership, room
+replacement races, credential exposure, and the gap between fake-flow tests
+and real two-participant behavior.
+
+Success means phone and TV can create, join, vote, promote, enter playback,
+exchange transport state, recover from transient disconnects, and terminate
+cleanly when the room closes. One application-scoped owner must hold exactly
+one room connection across lobby, browsing, and player screens.
+
+## Considered approaches
+
+1. **Forward-port the PR 108 net behavior behind corrected ownership
+   boundaries (selected).** Preserve the already-designed UI/protocol surface,
+   reconcile each source commit against the current A-E stack, and replace the
+   fragile lifecycle pieces before publication. This keeps traceability while
+   making review about the resulting behavior rather than old conflict
+   resolutions.
+2. **Cherry-pick the original Watch Together commits.** This preserves commit
+   history but replays obsolete screen-owned connection logic and conflicts
+   with the current player/subtitle/auth stack. It would require corrective
+   commits whose review surface is harder to understand.
+3. **Rewrite only a minimal host/join/player path.** This reduces immediate
+   code volume but drops the voting, suggestion, lobby, and TV behavior the
+   approved feature requires. It would not be a coherent replacement for the
+   PR 108 slice.
+
+## Ownership and concurrency
+
+`RoomSession` is the application-scoped authority for room membership and the
+single reconnect job. Lobby and player components observe it and send through
+the repository; they never start their own socket loops and never call
+`repository.reset()` directly.
+
+`enter(roomId)` is serialized. Re-entering the active room is idempotent.
+Replacing a room cancels and joins the previous connection before publishing
+the replacement owner. `leave()` cancels and joins before clearing repository
+state. A monotonically increasing connection generation prevents an obsolete
+connection's cancellation/finally path from clearing the current client,
+snapshot, token, or close reason.
+
+Create/join responses bind the room id, room token, and captured
+`AuthScopeSnapshot` together. Room-scoped REST and websocket work captures that
+immutable lease, so a late operation from room A cannot use room B's token or
+mutate room B's state. Server/profile/logout or credential-generation changes
+terminate the lease rather than silently continuing under a replacement
+identity.
+
+## Realtime transport and reconnect
+
+The event model distinguishes:
+
+- an explicit server `room_closed` frame, which is terminal and never
+  reconnects;
+- a transport EOF/exception, which is transient and participates in capped
+  exponential backoff;
+- cancellation by the current owner, which is silent and cannot mutate a
+  replacement connection.
+
+Each physical socket attempt publishes an "open" readiness epoch. One-shot
+frames such as `attach_session` and the initial ping are sent only after that
+attempt is writable, and are re-sent after every successful reconnect.
+Ordinary outbound calls return whether the frame reached the current attempt;
+they do not silently succeed before a handshake. Attach/readiness/latest-state
+messages are retained or coalesced until sent; user transport requests surface
+failure instead of disappearing.
+
+The reconnect cap counts every failed or unexpectedly ended attempt, including
+an attempt that emitted frames before dropping. A connection resets the
+failure window only after receiving an authoritative snapshot and remaining
+open for at least 30 seconds; a single frame cannot keep a flapping connection
+alive forever. Backoff uses the protocol's 500 ms, 1 s, 2 s, and 5 s steps. A
+terminal close, identity change, or explicit leave stops the loop immediately.
+
+Discrete commands and pong samples are not delivered through a replay-zero
+flow before subscribers exist. Player controllers subscribe to commands,
+pongs, close state, and the connection-epoch `StateFlow` before attaching.
+Every new epoch triggers attach plus the initial ping, so no command can be
+valid for that local playback session before its collector is ready.
+Reconnection reconciles from the authoritative snapshot and never replays an
+already-applied command.
+
+## Credentials
+
+The Silo auth plugin already attaches same-origin `Authorization`,
+`X-Profile-Id`, and `X-Profile-Token` headers to websocket handshakes. Slice F
+removes the redundant access JWT from the websocket URL and verifies the
+header/query boundary with a real handshake test.
+
+The current server contract still reads `room_token`, `profile_id`, and
+`profile_token` from the query. Changing those requires coordinated server
+work outside this Android slice, so the residual exposure is documented rather
+than hidden. All websocket URLs remain same-origin and pass the existing
+cleartext-consent/origin policy before credentials leave the client. The
+cleartext policy must treat `ws://` as `http://` and `wss://` as `https://`;
+tests prove that an unapproved cleartext websocket is blocked before the
+engine observes any header or query credential.
+
+## UI and player integration
+
+Port the PR 108 phone/TV entry, lobby, suggestion/voting, host override, and
+browsing-to-suggest behavior as one vertical feature. Screen ViewModels call
+`RoomSession.enter` to adopt an already-created/joined room, but screen
+destruction does not leave it. Explicit leave, host close, or a terminal server
+close ends the session.
+
+Phone and TV room controllers attach the current playback session after
+connection readiness and again after reconnect. They keep the existing
+`RoomSyncEngine` authority checks, command de-duplication, selection/session
+gates, execution scheduling, drift thresholds, ready/buffering barrier, and
+state-report suppression window.
+
+## Automated verification
+
+Test-first coverage includes:
+
+- repository transport EOF versus explicit room-close behavior, reconnect cap,
+  stable-window reset, cancellation, generation ownership, identity changes,
+  and room-token scoping;
+- `RoomSession` same-room idempotence, A-to-B replacement with a blocked old
+  connection, leave during connect, and concurrent enter calls;
+- real Ktor/OkHttp websocket handshakes against `MockWebServer`, verifying
+  access JWT absence from the URL, Authorization/header presence, early
+  server-frame delivery, outbound frame ordering, cleartext consent,
+  disconnect, and reconnect;
+- a two-participant transport harness exercising host and guest snapshots,
+  attach ordering, commands, votes, promotion/override, buffering/ready, drift
+  correction, terminal close, and replacement;
+- phone/TV lifecycle/controller and source-surface tests.
+
+## Required two-emulator validation
+
+Run at least two Android emulator instances concurrently on this Mac with
+separate app data and participant identities. Prefer the dedicated
+`Silo_Phone` and `Silo_TV` AVDs; do not reset or repurpose unrelated physical
+devices.
+
+Against a local or configured test backend:
+
+1. host a room and join from the second emulator;
+2. verify websocket handshake and attach-session ordering;
+3. exercise host play/pause/seek and permitted/blocked guest controls;
+4. add/vote/unvote, promote, and use host override;
+5. observe drift correction, seek, buffering, and ready propagation;
+6. interrupt and restore networking to prove transient reconnect/re-attach;
+7. background/foreground each participant without creating duplicate owners;
+8. replace one held room with another;
+9. close or depart as host and verify the guest receives terminal room close.
+
+Capture ADB logcat, emulator/device metadata, backend logs, timestamps, room
+ids, and the exact commands in a reproducible evidence document. Redact
+credentials and classify every unmet step as an app defect, backend defect, or
+environment limitation.
+
+## Traceability and scope
+
+The source commits are `9fe27a27`, `323510a2`, `c6ba32ef`, `e171e011`,
+`acfac18a`, `fca6d7c6`, `bc58049b`, `ea5756ec`, `8f36f7d2`, `530f9488`,
+`864de27e`, `79b4278d`, `f91aa62e`, and `923a1a7f`.
+
+Slice F excludes TV request UX, catalog/mixed-library polish, and unrelated
+home/startup work. Those remain Slice G.

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
@@ -25,7 +25,11 @@ import org.siloserver.silo.repository.SectionRepository
 import org.siloserver.silo.repository.SettingsRepository
 import org.siloserver.silo.repository.WatchTogetherRepository
 import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.watchtogether.RoomSession
 import org.koin.dsl.module
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
 /**
  * Koin module providing all repository and domain use case instances.
@@ -105,6 +109,16 @@ val repositoryModule = module {
                     tokenManager = tokenManager,
                 )
             },
+        )
+    }
+    // Eager so the identity-transition privacy gate is installed before any
+    // profile/server/token mutation can occur. This process-lifetime scope,
+    // rather than a screen scope, owns connection replacement and teardown.
+    single(createdAtStart = true) {
+        RoomSession(
+            repository = get<WatchTogetherRepository>(),
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+            identityTransitions = get(),
         )
     }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
@@ -89,8 +89,10 @@ val repositoryModule = module {
     }
 
     // One room's snapshot/suggestions state + WS lifecycle. The realtime factory
-    // builds the per-room socket client from the shared HttpClient + TokenManager
-    // (query-param auth). Lazy so a socket is only minted when connect() runs.
+    // builds the per-room socket client from the shared HttpClient + TokenManager.
+    // Access auth is supplied by the same-origin Silo auth plugin; the room/profile
+    // query fields are a residual server contract. Lazy so a socket is only minted
+    // when connect() runs.
     single {
         WatchTogetherRepository(
             api = get(),

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
@@ -24,6 +24,7 @@ import org.siloserver.silo.repository.RequestsRepository
 import org.siloserver.silo.repository.SectionRepository
 import org.siloserver.silo.repository.SettingsRepository
 import org.siloserver.silo.repository.WatchTogetherRepository
+import org.siloserver.silo.network.TokenManager
 import org.koin.dsl.module
 
 /**
@@ -94,12 +95,14 @@ val repositoryModule = module {
     // query fields are a residual server contract. Lazy so a socket is only minted
     // when connect() runs.
     single {
+        val tokenManager: TokenManager = get()
         WatchTogetherRepository(
             api = get(),
+            authScopeProvider = { tokenManager.snapshotCurrentScope() },
             realtimeFactory = {
                 org.siloserver.silo.network.DefaultWatchTogetherRealtimeClient(
                     client = get(),
-                    tokenManager = get(),
+                    tokenManager = tokenManager,
                 )
             },
         )

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/catalog/CatalogModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/catalog/CatalogModels.kt
@@ -294,7 +294,9 @@ data class VideoTrack(
     val resolution: String? = null,
     val width: Int? = null,
     val height: Int? = null,
-    @SerialName("frame_rate") val frameRate: Double? = null,
+    @SerialName("frame_rate")
+    @Serializable(with = NullableFrameRateSerializer::class)
+    val frameRate: Double? = null,
     val bitrate: Int? = null,
     val hdr: Boolean = false,
     @SerialName("hdr_format") val hdrFormat: String? = null,

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/catalog/FrameRateSerializer.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/catalog/FrameRateSerializer.kt
@@ -1,0 +1,50 @@
+package org.siloserver.silo.model.catalog
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.nullable
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.doubleOrNull
+
+@OptIn(ExperimentalSerializationApi::class)
+internal object NullableFrameRateSerializer : KSerializer<Double?> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("FrameRate", PrimitiveKind.DOUBLE).nullable
+
+    override fun deserialize(decoder: Decoder): Double? {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("Frame rate requires JSON decoding")
+        val element = jsonDecoder.decodeJsonElement()
+        if (element is JsonNull) return null
+
+        val primitive = element as? JsonPrimitive
+            ?: throw SerializationException("Frame rate must be a number or rational string")
+        primitive.doubleOrNull?.let { return it }
+
+        val parts = primitive.content.split('/')
+        if (parts.size == 2) {
+            val numerator = parts[0].toDoubleOrNull()
+            val denominator = parts[1].toDoubleOrNull()
+            if (numerator != null && denominator != null && denominator != 0.0) {
+                return numerator / denominator
+            }
+        }
+        throw SerializationException("Invalid frame rate: ${primitive.content}")
+    }
+
+    override fun serialize(encoder: Encoder, value: Double?) {
+        if (value == null) {
+            encoder.encodeNull()
+        } else {
+            encoder.encodeDouble(value)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/feature/ClientSurfacePolicy.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/feature/ClientSurfacePolicy.kt
@@ -5,4 +5,4 @@ package org.siloserver.silo.model.feature
  * appear in normal user navigation yet. Routes, repositories, and deep-link
  * plumbing can remain compiled while menus/actions stay hidden.
  */
-const val CLIENT_WATCH_TOGETHER_SURFACE_ENABLED: Boolean = false
+const val CLIENT_WATCH_TOGETHER_SURFACE_ENABLED: Boolean = true

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthInterceptorImpl.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthInterceptorImpl.kt
@@ -60,6 +60,7 @@ val SiloAuthPlugin = createClientPlugin("SiloAuthPlugin", ::SiloAuthConfig) {
 
     onRequest { request, _ ->
         val skipAuth = request.attributes.getOrNull(SkipSiloAuthAttributeKey) == true
+        val requireAuth = request.attributes.getOrNull(RequireSiloAuthAttributeKey) == true
         val diagnosticsScope = request.attributes.getOrNull(DiagnosticsRequestScopeKey)
         val pinned = request.attributes.getOrNull(AuthScopeAttributeKey)
         val activeServerIdBefore = if (pinned == null) tokenManager.getCurrentServerId() else null
@@ -109,7 +110,12 @@ val SiloAuthPlugin = createClientPlugin("SiloAuthPlugin", ::SiloAuthConfig) {
             // Replace (never append) the scoped headers; clear the profile token
             // header when the snapshot has none.
             request.headers.remove(HttpHeaders.Authorization)
-            tokenManager.getAccessTokenForScope(pinned)?.let { token ->
+            val scopedAccessToken = tokenManager.getAccessTokenForScope(pinned)
+            if (requireAuth && scopedAccessToken.isNullOrBlank()) {
+                request.removeSiloCredentialHeaders()
+                throw IllegalStateException("required_silo_auth_unavailable")
+            }
+            scopedAccessToken?.let { token ->
                 request.header(HttpHeaders.Authorization, "Bearer $token")
             }
             request.headers.remove("X-Profile-Id")

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthScopeSnapshot.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthScopeSnapshot.kt
@@ -49,7 +49,13 @@ data class AuthScopeSnapshot(
      * recorded.
      */
     val credentialEpoch: Long = 0L,
-)
+) {
+    override fun toString(): String =
+        "AuthScopeSnapshot(" +
+            "serverId=<redacted>, profileId=<redacted>, serverUrl=<redacted>, " +
+            "profileToken=<redacted>, credentialGenerationId=<redacted>, " +
+            "identityGeneration=<redacted>, credentialEpoch=<redacted>)"
+}
 
 /** Attribute carrying the [AuthScopeSnapshot] that [SiloAuthPlugin] honors. */
 val AuthScopeAttributeKey: AttributeKey<AuthScopeSnapshot> = AttributeKey("SiloAuthScope")

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthScopeSnapshot.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthScopeSnapshot.kt
@@ -63,9 +63,22 @@ val AuthScopeAttributeKey: AttributeKey<AuthScopeSnapshot> = AttributeKey("SiloA
  */
 val SkipSiloAuthAttributeKey: AttributeKey<Boolean> = AttributeKey("SiloSkipAuth")
 
+/**
+ * Marks a same-origin request as unsafe to send without a Silo bearer.
+ *
+ * This is intentionally opt-in: public endpoints and [skipSiloAuth] requests
+ * retain their existing behavior.
+ */
+internal val RequireSiloAuthAttributeKey: AttributeKey<Boolean> = AttributeKey("SiloRequireAuth")
+
 /** Pin this request to [snapshot]'s scope; [SiloAuthPlugin] uses it verbatim. */
 fun HttpRequestBuilder.authScope(snapshot: AuthScopeSnapshot) {
     attributes.put(AuthScopeAttributeKey, snapshot)
+}
+
+/** Abort before the engine if the request's exact auth scope has no access token. */
+internal fun HttpRequestBuilder.requireSiloAuth() {
+    attributes.put(RequireSiloAuthAttributeKey, true)
 }
 
 /** Opt this request out of Silo auth/profile headers and auth-refresh handling. */

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/CleartextOriginConsent.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/CleartextOriginConsent.kt
@@ -17,8 +17,9 @@ suspend fun CleartextOriginConsent.requiresApproval(url: String): Boolean {
     val origin = httpOrigin(url)
     return when {
         origin?.scheme == "https" -> false
-        origin?.scheme == "http" -> !isApproved(url)
-        url.trim().startsWith("http:", ignoreCase = true) -> true
+        origin?.scheme == "http" -> !isApproved(checkNotNull(canonicalHttpOrigin(url)))
+        url.trim().startsWith("http:", ignoreCase = true) ||
+            url.trim().startsWith("ws:", ignoreCase = true) -> true
         else -> false
     }
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/HttpOriginPolicy.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/HttpOriginPolicy.kt
@@ -9,10 +9,11 @@ data class HttpOrigin(
 )
 
 fun httpOrigin(raw: String): HttpOrigin? = runCatching {
-    val scheme = raw.httpSchemeOrNull() ?: return null
-    val authorityHost = raw.authorityHostOrNull(scheme) ?: return null
+    val normalized = raw.normalizedHttpOriginUrl()
+    val scheme = normalized.httpSchemeOrNull() ?: return null
+    val authorityHost = normalized.authorityHostOrNull(scheme) ?: return null
 
-    val url = Url(raw)
+    val url = Url(normalized)
     if (url.user != null || url.password != null) return null
     if (url.protocol.name.lowercase() != scheme) return null
 
@@ -26,6 +27,12 @@ fun httpOrigin(raw: String): HttpOrigin? = runCatching {
         port = url.port,
     )
 }.getOrNull()
+
+private fun String.normalizedHttpOriginUrl(): String = when {
+    startsWith("wss://", ignoreCase = true) -> "https://${drop(6)}"
+    startsWith("ws://", ignoreCase = true) -> "http://${drop(5)}"
+    else -> this
+}
 
 fun isSameHttpOrigin(serverUrl: String, requestUrl: String): Boolean {
     val serverOrigin = httpOrigin(serverUrl) ?: return false

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/IdentityTransitionBarrier.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/IdentityTransitionBarrier.kt
@@ -32,8 +32,8 @@ interface IdentityTransitionBarrier {
     val transitions: SharedFlow<IdentityTransition>
     val generation: StateFlow<Long>
 
-    /** Installs the synchronous privacy gate invoked before any identity mutation. */
-    fun installGate(listener: (IdentityTransition) -> Unit)
+    /** Installs the inline privacy gate, which must complete before identity mutation. */
+    fun installGate(listener: suspend (IdentityTransition) -> Unit)
 
     suspend fun <T> changing(kind: IdentityTransitionKind, block: suspend () -> T): T
 }
@@ -48,7 +48,7 @@ class DefaultIdentityTransitionBarrier : IdentityTransitionBarrier {
     private val _generation = MutableStateFlow(0L)
 
     @Volatile
-    private var gate: ((IdentityTransition) -> Unit)? = null
+    private var gates: List<suspend (IdentityTransition) -> Unit> = emptyList()
 
     @Volatile
     private var testObserver: ((IdentityTransition) -> Unit)? = null
@@ -56,8 +56,11 @@ class DefaultIdentityTransitionBarrier : IdentityTransitionBarrier {
     override val transitions: SharedFlow<IdentityTransition> = _transitions.asSharedFlow()
     override val generation: StateFlow<Long> = _generation.asStateFlow()
 
-    override fun installGate(listener: (IdentityTransition) -> Unit) {
-        gate = listener
+    override fun installGate(listener: suspend (IdentityTransition) -> Unit) {
+        // Gates are installed during sequential application startup. Publish an
+        // immutable snapshot so mutations can iterate safely without holding a
+        // lock across suspending privacy cleanup.
+        gates = gates + listener
     }
 
     override suspend fun <T> changing(kind: IdentityTransitionKind, block: suspend () -> T): T =
@@ -69,7 +72,7 @@ class DefaultIdentityTransitionBarrier : IdentityTransitionBarrier {
                 generation = nextGeneration,
             )
             // This callback is the privacy boundary. It runs inline before new identity is visible.
-            gate?.invoke(willChange)
+            gates.forEach { gate -> gate(willChange) }
             _generation.value = nextGeneration
             publish(willChange)
             try {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/PlaybackRealtimeClient.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/PlaybackRealtimeClient.kt
@@ -52,7 +52,8 @@ fun decodePlaybackFrame(json: Json, raw: String): PlaybackRealtimeEvent? {
 /**
  * Per-session control socket. One [connect] = one connection to
  * `/api/v1/playback/sessions/{session_id}/control/ws`, authenticated by query
- * string (token + profile, matching [DefaultWatchTogetherRealtimeClient]). The
+ * string (token + profile; unlike [DefaultWatchTogetherRealtimeClient], which
+ * keeps the access bearer in the same-origin Authorization header). The
  * returned flow emits [PlaybackRealtimeEvent.Opened] once the socket is live,
  * then decoded frames, and ends with [PlaybackRealtimeEvent.Closed]; reconnect
  * with backoff is the controller's job. [sendHello]/[sendAck]/[sendResult]

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
@@ -78,6 +78,7 @@ private class KtorWatchTogetherSocketConnector(
             client.webSocketSession {
                 url(request.url)
                 authScope(request.authScope)
+                requireSiloAuth()
             },
         )
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
@@ -12,6 +12,7 @@ import org.siloserver.silo.model.watchtogether.WsTransportRequest
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.client.request.url
 import io.ktor.http.encodeURLParameter
 import io.ktor.http.encodeURLPathPart
 import io.ktor.websocket.Frame
@@ -60,15 +61,25 @@ internal interface WatchTogetherSocketConnection {
     suspend fun close()
 }
 
+internal data class WatchTogetherSocketRequest(
+    val url: String,
+    val authScope: AuthScopeSnapshot,
+)
+
 internal fun interface WatchTogetherSocketConnector {
-    suspend fun open(url: String): WatchTogetherSocketConnection
+    suspend fun open(request: WatchTogetherSocketRequest): WatchTogetherSocketConnection
 }
 
 private class KtorWatchTogetherSocketConnector(
     private val client: HttpClient,
 ) : WatchTogetherSocketConnector {
-    override suspend fun open(url: String): WatchTogetherSocketConnection =
-        KtorWatchTogetherSocketConnection(client.webSocketSession(urlString = url))
+    override suspend fun open(request: WatchTogetherSocketRequest): WatchTogetherSocketConnection =
+        KtorWatchTogetherSocketConnection(
+            client.webSocketSession {
+                url(request.url)
+                authScope(request.authScope)
+            },
+        )
 }
 
 private class KtorWatchTogetherSocketConnection(
@@ -114,13 +125,13 @@ class DefaultWatchTogetherRealtimeClient private constructor(
     private var session: WatchTogetherSocketConnection? = null
 
     override fun connect(roomId: String, roomToken: String): Flow<RoomRealtimeEvent> = callbackFlow {
-        val token = tokenManager.getAccessToken()
-        val profileId = tokenManager.getProfileId()
-        val profileToken = tokenManager.getProfileToken()
-        if (token.isNullOrBlank() || profileId.isNullOrBlank()) {
+        val scope = tokenManager.snapshotCurrentScope()
+        val profileId = scope?.profileId
+        val scopedAccessToken = scope?.let { tokenManager.getAccessTokenForScope(it) }
+        if (scope == null || scopedAccessToken.isNullOrBlank() || profileId.isNullOrBlank()) {
             trySend(
                 RoomRealtimeEvent.TransportTerminated(
-                    IllegalStateException("missing_auth"),
+                    IllegalStateException("missing_auth_scope"),
                 ),
             )
             close()
@@ -132,14 +143,19 @@ class DefaultWatchTogetherRealtimeClient private constructor(
             append(roomId.encodeURLPathPart())
             append("/ws?room_token=").append(roomToken.encodeURLParameter())
             append("&profile_id=").append(profileId.encodeURLParameter())
-            if (!profileToken.isNullOrBlank()) {
-                append("&profile_token=").append(profileToken.encodeURLParameter())
+            if (!scope.profileToken.isNullOrBlank()) {
+                append("&profile_token=").append(scope.profileToken.encodeURLParameter())
             }
         }
 
         var connection: WatchTogetherSocketConnection? = null
         try {
-            connection = socketConnector.open(url)
+            connection = socketConnector.open(
+                WatchTogetherSocketRequest(
+                    url = url,
+                    authScope = scope,
+                ),
+            )
             sessionMutex.withLock {
                 session = connection
             }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
@@ -11,13 +11,18 @@ import org.siloserver.silo.model.watchtogether.WsStateReport
 import org.siloserver.silo.model.watchtogether.WsTransportRequest
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
-import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.http.encodeURLParameter
+import io.ktor.http.encodeURLPathPart
 import io.ktor.websocket.Frame
+import io.ktor.websocket.close
 import io.ktor.websocket.readText
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -26,87 +31,151 @@ import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Per-room websocket. One [connect] = one connection to
- * `/api/v1/watch-together/rooms/{id}/ws`, authenticated by query string only:
- * `?token=<authJWT>&room_token=<roomJWT>&profile_id=<id>&profile_token=<token>`
- * (a separate socket from `/events/ws`). Every server frame is mapped through
- * the pure [decodeRoomFrame] into the returned [Flow]; the flow completes
- * (emitting [RoomRealtimeEvent.Closed]) when the socket ends — reconnect with
- * capped backoff is the repository's job.
+ * `/api/v1/watch-together/rooms/{id}/ws`. The same-origin Silo auth plugin
+ * supplies the access bearer and profile headers. The server still requires
+ * `room_token`, `profile_id`, and (when present) `profile_token` in the query;
+ * these residual URL credentials remain exposed to infrastructure that logs
+ * request targets until the server protocol can be changed.
  *
- * [send*] methods write client frames on an open session; the repository holds
- * the session and the ping loop. Auth values are read from [TokenManager] at
- * connect time. Behind an interface so the repository's tests use a fake flow
- * — the only logic worth unit-testing is the pure [decodeRoomFrame].
+ * [RoomRealtimeEvent.Closed] is reserved for an explicit decoded
+ * `room_closed` frame. Physical EOF and socket failures surface as
+ * [RoomRealtimeEvent.TransportTerminated], while owner cancellation is silent.
  */
 interface WatchTogetherRealtimeClient {
-    /** Open the room socket. The returned flow ends with [RoomRealtimeEvent.Closed]. */
+    /** Open one physical room socket and publish [RoomRealtimeEvent.Opened] once writable. */
     fun connect(roomId: String, roomToken: String): Flow<RoomRealtimeEvent>
 
-    /** Client→server sends. No-op when no session is open (repository gates on connection). */
-    suspend fun attachSession(sessionId: String)
-    suspend fun transportRequest(action: String, positionSeconds: Double?, isPaused: Boolean)
-    suspend fun stateReport(sessionId: String, positionSeconds: Double, isPaused: Boolean)
-    suspend fun ready(sessionId: String, positionSeconds: Double, isPaused: Boolean)
-    suspend fun buffering(sessionId: String, positionSeconds: Double, isPaused: Boolean)
-    suspend fun ping(clientSentAt: String)
+    /** Client→server sends report whether a frame reached the current writable socket. */
+    suspend fun attachSession(sessionId: String): Boolean
+    suspend fun transportRequest(action: String, positionSeconds: Double?, isPaused: Boolean): Boolean
+    suspend fun stateReport(sessionId: String, positionSeconds: Double, isPaused: Boolean): Boolean
+    suspend fun ready(sessionId: String, positionSeconds: Double, isPaused: Boolean): Boolean
+    suspend fun buffering(sessionId: String, positionSeconds: Double, isPaused: Boolean): Boolean
+    suspend fun ping(clientSentAt: String): Boolean
 }
 
-class DefaultWatchTogetherRealtimeClient(
+internal interface WatchTogetherSocketConnection {
+    suspend fun receiveText(): String?
+    suspend fun sendText(text: String)
+    suspend fun close()
+}
+
+internal fun interface WatchTogetherSocketConnector {
+    suspend fun open(url: String): WatchTogetherSocketConnection
+}
+
+private class KtorWatchTogetherSocketConnector(
     private val client: HttpClient,
+) : WatchTogetherSocketConnector {
+    override suspend fun open(url: String): WatchTogetherSocketConnection =
+        KtorWatchTogetherSocketConnection(client.webSocketSession(urlString = url))
+}
+
+private class KtorWatchTogetherSocketConnection(
+    private val session: DefaultClientWebSocketSession,
+) : WatchTogetherSocketConnection {
+    override suspend fun receiveText(): String? {
+        while (true) {
+            val result = session.incoming.receiveCatching()
+            result.exceptionOrNull()?.let { throw it }
+            val frame = result.getOrNull() ?: return null
+            if (frame is Frame.Text) return frame.readText()
+        }
+    }
+
+    override suspend fun sendText(text: String) {
+        session.send(Frame.Text(text))
+    }
+
+    override suspend fun close() {
+        session.close()
+    }
+}
+
+class DefaultWatchTogetherRealtimeClient private constructor(
     private val tokenManager: TokenManager,
-    private val json: Json = SiloJson,
+    private val json: Json,
+    private val socketConnector: WatchTogetherSocketConnector,
 ) : WatchTogetherRealtimeClient {
 
-    // The live session for the current connect(); send* methods write to it.
-    // Single-connection-at-a-time (the repository owns one room).
-    private var session: DefaultClientWebSocketSession? = null
+    constructor(
+        client: HttpClient,
+        tokenManager: TokenManager,
+        json: Json = SiloJson,
+    ) : this(tokenManager, json, KtorWatchTogetherSocketConnector(client))
+
+    internal constructor(
+        tokenManager: TokenManager,
+        socketConnector: WatchTogetherSocketConnector,
+        json: Json = SiloJson,
+    ) : this(tokenManager, json, socketConnector)
+
+    private val sessionMutex = Mutex()
+    private var session: WatchTogetherSocketConnection? = null
 
     override fun connect(roomId: String, roomToken: String): Flow<RoomRealtimeEvent> = callbackFlow {
         val token = tokenManager.getAccessToken()
         val profileId = tokenManager.getProfileId()
         val profileToken = tokenManager.getProfileToken()
         if (token.isNullOrBlank() || profileId.isNullOrBlank()) {
-            trySend(RoomRealtimeEvent.Closed("missing_auth"))
+            trySend(
+                RoomRealtimeEvent.TransportTerminated(
+                    IllegalStateException("missing_auth"),
+                ),
+            )
             close()
             return@callbackFlow
         }
 
         val url = buildString {
             append("/api/v1/watch-together/rooms/")
-            append(roomId.encodeURLParameter())
-            append("/ws?token=").append(token.encodeURLParameter())
-            append("&room_token=").append(roomToken.encodeURLParameter())
+            append(roomId.encodeURLPathPart())
+            append("/ws?room_token=").append(roomToken.encodeURLParameter())
             append("&profile_id=").append(profileId.encodeURLParameter())
             if (!profileToken.isNullOrBlank()) {
                 append("&profile_token=").append(profileToken.encodeURLParameter())
             }
         }
 
+        var connection: WatchTogetherSocketConnection? = null
         try {
-            client.webSocket(urlString = url) {
-                session = this
-                try {
-                    for (frame in incoming) {
-                        if (frame !is Frame.Text) continue
-                        decodeRoomFrame(json, frame.readText())?.let { trySend(it) }
-                    }
-                } finally {
-                    session = null
-                }
+            connection = socketConnector.open(url)
+            sessionMutex.withLock {
+                session = connection
             }
-            trySend(RoomRealtimeEvent.Closed())
-        } catch (e: Throwable) {
-            session = null
-            trySend(RoomRealtimeEvent.Closed(e.message))
+            trySend(RoomRealtimeEvent.Opened)
+            while (true) {
+                val raw = connection.receiveText() ?: break
+                decodeRoomFrame(json, raw)?.let { trySend(it) }
+            }
+            trySend(RoomRealtimeEvent.TransportTerminated())
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (failure: Throwable) {
+            trySend(RoomRealtimeEvent.TransportTerminated(failure))
         } finally {
+            connection?.let { completed ->
+                sessionMutex.withLock {
+                    if (session === completed) session = null
+                }
+                runCatching { completed.close() }
+            }
             close()
         }
 
-        awaitClose { /* socket closes when the collector is cancelled */ }
+        awaitClose { }
     }
 
-    private suspend fun sendText(text: String) {
-        session?.send(Frame.Text(text))
+    private suspend fun sendText(text: String): Boolean {
+        val writable = sessionMutex.withLock { session } ?: return false
+        return try {
+            writable.sendText(text)
+            true
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (_: Throwable) {
+            false
+        }
     }
 
     override suspend fun attachSession(sessionId: String) =

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
@@ -59,6 +59,20 @@ interface WatchTogetherRealtimeClient {
     suspend fun ready(sessionId: String, positionSeconds: Double, isPaused: Boolean): Boolean
     suspend fun buffering(sessionId: String, positionSeconds: Double, isPaused: Boolean): Boolean
     suspend fun ping(clientSentAt: String): Boolean
+
+    /** Opaque identity of the currently writable physical socket, if any. */
+    suspend fun currentConnectionId(): Long? = null
+
+    /**
+     * Send only on the physical socket identified by [connectionId].
+     * A replacement socket must never receive an old room's delayed command.
+     */
+    suspend fun transportRequestOnConnection(
+        connectionId: Long,
+        action: String,
+        positionSeconds: Double?,
+        isPaused: Boolean,
+    ): Boolean = false
 }
 
 internal interface WatchTogetherSocketConnection {
@@ -70,7 +84,10 @@ internal interface WatchTogetherSocketConnection {
 internal data class WatchTogetherSocketRequest(
     val url: String,
     val authScope: AuthScopeSnapshot,
-)
+) {
+    override fun toString(): String =
+        "WatchTogetherSocketRequest(url=<redacted>, authScope=$authScope)"
+}
 
 internal fun interface WatchTogetherSocketConnector {
     suspend fun open(request: WatchTogetherSocketRequest): WatchTogetherSocketConnection
@@ -130,6 +147,8 @@ class DefaultWatchTogetherRealtimeClient private constructor(
 
     private val sessionMutex = Mutex()
     private var session: WatchTogetherSocketConnection? = null
+    private var sessionId = 0L
+    private var activeSessionId: Long? = null
 
     override fun connect(
         roomId: String,
@@ -169,6 +188,7 @@ class DefaultWatchTogetherRealtimeClient private constructor(
             )
             sessionMutex.withLock {
                 session = connection
+                activeSessionId = ++sessionId
             }
             trySend(RoomRealtimeEvent.Opened)
             while (true) {
@@ -187,7 +207,10 @@ class DefaultWatchTogetherRealtimeClient private constructor(
                 // physical socket before cancelAndJoin is allowed to return.
                 withContext(NonCancellable) {
                     sessionMutex.withLock {
-                        if (session === completed) session = null
+                        if (session === completed) {
+                            session = null
+                            activeSessionId = null
+                        }
                     }
                     runCatching { completed.close() }
                 }
@@ -220,6 +243,32 @@ class DefaultWatchTogetherRealtimeClient private constructor(
                 WsTransportRequest(action = action, positionSeconds = positionSeconds, isPaused = isPaused),
             ),
         )
+
+    override suspend fun currentConnectionId(): Long? =
+        sessionMutex.withLock { activeSessionId }
+
+    override suspend fun transportRequestOnConnection(
+        connectionId: Long,
+        action: String,
+        positionSeconds: Double?,
+        isPaused: Boolean,
+    ): Boolean {
+        val writable = sessionMutex.withLock {
+            session.takeIf { activeSessionId == connectionId }
+        } ?: return false
+        val payload = json.encodeToString(
+            WsTransportRequest.serializer(),
+            WsTransportRequest(action = action, positionSeconds = positionSeconds, isPaused = isPaused),
+        )
+        return try {
+            writable.sendText(payload)
+            true
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (_: Throwable) {
+            false
+        }
+    }
 
     override suspend fun stateReport(sessionId: String, positionSeconds: Double, isPaused: Boolean) =
         sendText(

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
@@ -44,7 +44,11 @@ import kotlinx.serialization.json.JsonPrimitive
  */
 interface WatchTogetherRealtimeClient {
     /** Open one physical room socket and publish [RoomRealtimeEvent.Opened] once writable. */
-    fun connect(roomId: String, roomToken: String): Flow<RoomRealtimeEvent>
+    fun connect(
+        roomId: String,
+        roomToken: String,
+        authScope: AuthScopeSnapshot? = null,
+    ): Flow<RoomRealtimeEvent>
 
     /** Client→server sends report whether a frame reached the current writable socket. */
     suspend fun attachSession(sessionId: String): Boolean
@@ -125,8 +129,12 @@ class DefaultWatchTogetherRealtimeClient private constructor(
     private val sessionMutex = Mutex()
     private var session: WatchTogetherSocketConnection? = null
 
-    override fun connect(roomId: String, roomToken: String): Flow<RoomRealtimeEvent> = callbackFlow {
-        val scope = tokenManager.snapshotCurrentScope()
+    override fun connect(
+        roomId: String,
+        roomToken: String,
+        authScope: AuthScopeSnapshot?,
+    ): Flow<RoomRealtimeEvent> = callbackFlow {
+        val scope = authScope ?: tokenManager.snapshotCurrentScope()
         val profileId = scope?.profileId
         val scopedAccessToken = scope?.let { tokenManager.getAccessTokenForScope(it) }
         if (scope == null || scopedAccessToken.isNullOrBlank() || profileId.isNullOrBlank()) {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt
@@ -19,9 +19,11 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.builtins.ListSerializer
@@ -180,10 +182,15 @@ class DefaultWatchTogetherRealtimeClient private constructor(
             trySend(RoomRealtimeEvent.TransportTerminated(failure))
         } finally {
             connection?.let { completed ->
-                sessionMutex.withLock {
-                    if (session === completed) session = null
+                // Cancellation is the privacy boundary for an identity/room
+                // replacement. Explicitly finish clearing and closing the
+                // physical socket before cancelAndJoin is allowed to return.
+                withContext(NonCancellable) {
+                    sessionMutex.withLock {
+                        if (session === completed) session = null
+                    }
+                    runCatching { completed.close() }
                 }
-                runCatching { completed.close() }
             }
             close()
         }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeEvent.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeEvent.kt
@@ -16,11 +16,12 @@ object WatchTogetherRealtime {
 
 /**
  * A decoded room realtime event. The repository folds these into its
- * StateFlows / feeds them to the RoomSyncEngine. [Closed]
- * is emitted by the client when the socket itself ends (distinct from a server
- * [Closed]-with-reason `room_closed`, surfaced as the same event).
+ * StateFlows / feeds them to the RoomSyncEngine.
  */
 sealed class RoomRealtimeEvent {
+    /** A physical connection completed its handshake and is writable. */
+    data object Opened : RoomRealtimeEvent()
+
     data class SnapshotEvent(val room: RoomSnapshot) : RoomRealtimeEvent()
     data class TransportCommandEvent(val command: TransportCommand) : RoomRealtimeEvent()
     data class SuggestionsEvent(val suggestions: List<Suggestion>) : RoomRealtimeEvent()
@@ -30,8 +31,11 @@ sealed class RoomRealtimeEvent {
         val serverSentAt: String,
     ) : RoomRealtimeEvent()
 
-    /** Server `room_closed{reason}`. The repository stops reconnecting on this. */
+    /** Explicit server `room_closed{reason}`. Terminal at the protocol layer. */
     data class Closed(val reason: String? = null) : RoomRealtimeEvent()
+
+    /** Physical EOF, handshake failure, or socket I/O failure. Transient. */
+    data class TransportTerminated(val cause: Throwable? = null) : RoomRealtimeEvent()
 
     /** Server `error{code,message}`. */
     data class Error(val code: String, val message: String) : RoomRealtimeEvent()

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/WatchTogetherApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/WatchTogetherApi.kt
@@ -22,6 +22,7 @@ import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import io.ktor.http.encodeURLPathPart
 
 /**
  * Watch Together REST surface (`/api/v1/watch-together`). Create/join return a
@@ -130,7 +131,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
 
     override suspend fun getRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot): ApiResult<RoomResponse> =
         safeApiCall {
-            client.get("$BASE/rooms/$roomId") {
+            client.get("$BASE/rooms/${roomId.encodeURLPathPart()}") {
                 pin(scope)
                 parameter("room_token", roomToken)
             }
@@ -142,7 +143,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         request: SetSelectionRequest,
         scope: AuthScopeSnapshot,
     ): ApiResult<RoomResponse> = safeApiCall {
-        client.put("$BASE/rooms/$roomId/selection") {
+        client.put("$BASE/rooms/${roomId.encodeURLPathPart()}/selection") {
             pin(scope)
             parameter("room_token", roomToken)
             contentType(ContentType.Application.Json)
@@ -156,7 +157,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         request: UpdatePolicyRequest,
         scope: AuthScopeSnapshot,
     ): ApiResult<RoomResponse> = safeApiCall {
-        client.patch("$BASE/rooms/$roomId/policy") {
+        client.patch("$BASE/rooms/${roomId.encodeURLPathPart()}/policy") {
             pin(scope)
             parameter("room_token", roomToken)
             contentType(ContentType.Application.Json)
@@ -170,7 +171,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         scope: AuthScopeSnapshot,
     ): ApiResult<Unit> =
         safeApiCall {
-            client.delete("$BASE/rooms/$roomId") {
+            client.delete("$BASE/rooms/${roomId.encodeURLPathPart()}") {
                 pin(scope)
                 parameter("room_token", roomToken)
             }
@@ -181,7 +182,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomToken: String,
         scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
-        client.get("$BASE/rooms/$roomId/suggestions") {
+        client.get("$BASE/rooms/${roomId.encodeURLPathPart()}/suggestions") {
             pin(scope)
             parameter("room_token", roomToken)
         }
@@ -193,7 +194,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         request: AddSuggestionRequest,
         scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
-        client.post("$BASE/rooms/$roomId/suggestions") {
+        client.post("$BASE/rooms/${roomId.encodeURLPathPart()}/suggestions") {
             pin(scope)
             parameter("room_token", roomToken)
             contentType(ContentType.Application.Json)
@@ -207,7 +208,9 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         suggestionId: String,
         scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
-        client.delete("$BASE/rooms/$roomId/suggestions/$suggestionId") {
+        client.delete(
+            "$BASE/rooms/${roomId.encodeURLPathPart()}/suggestions/${suggestionId.encodeURLPathPart()}",
+        ) {
             pin(scope)
             parameter("room_token", roomToken)
         }
@@ -219,7 +222,9 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         suggestionId: String,
         scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
-        client.post("$BASE/rooms/$roomId/suggestions/$suggestionId/vote") {
+        client.post(
+            "$BASE/rooms/${roomId.encodeURLPathPart()}/suggestions/${suggestionId.encodeURLPathPart()}/vote",
+        ) {
             pin(scope)
             parameter("room_token", roomToken)
         }
@@ -231,7 +236,9 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         suggestionId: String,
         scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
-        client.delete("$BASE/rooms/$roomId/suggestions/$suggestionId/vote") {
+        client.delete(
+            "$BASE/rooms/${roomId.encodeURLPathPart()}/suggestions/${suggestionId.encodeURLPathPart()}/vote",
+        ) {
             pin(scope)
             parameter("room_token", roomToken)
         }
@@ -243,7 +250,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         request: PromoteSuggestionRequest,
         scope: AuthScopeSnapshot,
     ): ApiResult<RoomResponse> = safeApiCall {
-        client.post("$BASE/rooms/$roomId/suggestions/promote") {
+        client.post("$BASE/rooms/${roomId.encodeURLPathPart()}/suggestions/promote") {
             pin(scope)
             parameter("room_token", roomToken)
             contentType(ContentType.Application.Json)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/WatchTogetherApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/WatchTogetherApi.kt
@@ -9,6 +9,9 @@ import org.siloserver.silo.model.watchtogether.SetSelectionRequest
 import org.siloserver.silo.model.watchtogether.SuggestionsResponse
 import org.siloserver.silo.model.watchtogether.UpdatePolicyRequest
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.authScope
+import org.siloserver.silo.network.requireSiloAuth
 import io.ktor.client.HttpClient
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
@@ -34,19 +37,20 @@ import io.ktor.http.contentType
 interface WatchTogetherApi {
 
     /** POST /rooms — caller becomes host; 201 with room + room_access_token. */
-    suspend fun createRoom(request: CreateRoomRequest): ApiResult<RoomResponse>
+    suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot? = null): ApiResult<RoomResponse>
 
     /** POST /join — resolves a code or join token; 200 with room + room_access_token. */
-    suspend fun joinRoom(request: JoinRoomRequest): ApiResult<RoomResponse>
+    suspend fun joinRoom(request: JoinRoomRequest, scope: AuthScopeSnapshot? = null): ApiResult<RoomResponse>
 
     /** GET /rooms/{id}?room_token= — current room snapshot. */
-    suspend fun getRoom(roomId: String, roomToken: String): ApiResult<RoomResponse>
+    suspend fun getRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot? = null): ApiResult<RoomResponse>
 
     /** PUT /rooms/{id}/selection?room_token= (host-only). */
     suspend fun setSelection(
         roomId: String,
         roomToken: String,
         request: SetSelectionRequest,
+        scope: AuthScopeSnapshot? = null,
     ): ApiResult<RoomResponse>
 
     /** PATCH /rooms/{id}/policy?room_token= (host-only). */
@@ -54,19 +58,21 @@ interface WatchTogetherApi {
         roomId: String,
         roomToken: String,
         request: UpdatePolicyRequest,
+        scope: AuthScopeSnapshot? = null,
     ): ApiResult<RoomResponse>
 
     /** DELETE /rooms/{id}?room_token= (host-only) — 204 → Unit. */
-    suspend fun closeRoom(roomId: String, roomToken: String): ApiResult<Unit>
+    suspend fun closeRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot? = null): ApiResult<Unit>
 
     /** GET /rooms/{id}/suggestions?room_token=. */
-    suspend fun listSuggestions(roomId: String, roomToken: String): ApiResult<SuggestionsResponse>
+    suspend fun listSuggestions(roomId: String, roomToken: String, scope: AuthScopeSnapshot? = null): ApiResult<SuggestionsResponse>
 
     /** POST /rooms/{id}/suggestions?room_token=. */
     suspend fun addSuggestion(
         roomId: String,
         roomToken: String,
         request: AddSuggestionRequest,
+        scope: AuthScopeSnapshot? = null,
     ): ApiResult<SuggestionsResponse>
 
     /** DELETE /rooms/{id}/suggestions/{sid}?room_token= (host or suggester). */
@@ -74,6 +80,7 @@ interface WatchTogetherApi {
         roomId: String,
         roomToken: String,
         suggestionId: String,
+        scope: AuthScopeSnapshot? = null,
     ): ApiResult<SuggestionsResponse>
 
     /** POST /rooms/{id}/suggestions/{sid}/vote?room_token= — 409 on dup. */
@@ -81,6 +88,7 @@ interface WatchTogetherApi {
         roomId: String,
         roomToken: String,
         suggestionId: String,
+        scope: AuthScopeSnapshot? = null,
     ): ApiResult<SuggestionsResponse>
 
     /** DELETE /rooms/{id}/suggestions/{sid}/vote?room_token= — 409 if not voted. */
@@ -88,6 +96,7 @@ interface WatchTogetherApi {
         roomId: String,
         roomToken: String,
         suggestionId: String,
+        scope: AuthScopeSnapshot? = null,
     ): ApiResult<SuggestionsResponse>
 
     /** POST /rooms/{id}/suggestions/promote?room_token= (host-only) → room. */
@@ -95,38 +104,46 @@ interface WatchTogetherApi {
         roomId: String,
         roomToken: String,
         request: PromoteSuggestionRequest,
+        scope: AuthScopeSnapshot? = null,
     ): ApiResult<RoomResponse>
 }
 
 class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi {
 
-    override suspend fun createRoom(request: CreateRoomRequest): ApiResult<RoomResponse> =
+    override suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot?): ApiResult<RoomResponse> =
         safeApiCall {
             client.post("$BASE/rooms") {
+                pin(scope)
                 contentType(ContentType.Application.Json)
                 setBody(request)
             }
         }
 
-    override suspend fun joinRoom(request: JoinRoomRequest): ApiResult<RoomResponse> =
+    override suspend fun joinRoom(request: JoinRoomRequest, scope: AuthScopeSnapshot?): ApiResult<RoomResponse> =
         safeApiCall {
             client.post("$BASE/join") {
+                pin(scope)
                 contentType(ContentType.Application.Json)
                 setBody(request)
             }
         }
 
-    override suspend fun getRoom(roomId: String, roomToken: String): ApiResult<RoomResponse> =
+    override suspend fun getRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot?): ApiResult<RoomResponse> =
         safeApiCall {
-            client.get("$BASE/rooms/$roomId") { parameter("room_token", roomToken) }
+            client.get("$BASE/rooms/$roomId") {
+                pin(scope)
+                parameter("room_token", roomToken)
+            }
         }
 
     override suspend fun setSelection(
         roomId: String,
         roomToken: String,
         request: SetSelectionRequest,
+        scope: AuthScopeSnapshot?,
     ): ApiResult<RoomResponse> = safeApiCall {
         client.put("$BASE/rooms/$roomId/selection") {
+            pin(scope)
             parameter("room_token", roomToken)
             contentType(ContentType.Application.Json)
             setBody(request)
@@ -137,32 +154,47 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         request: UpdatePolicyRequest,
+        scope: AuthScopeSnapshot?,
     ): ApiResult<RoomResponse> = safeApiCall {
         client.patch("$BASE/rooms/$roomId/policy") {
+            pin(scope)
             parameter("room_token", roomToken)
             contentType(ContentType.Application.Json)
             setBody(request)
         }
     }
 
-    override suspend fun closeRoom(roomId: String, roomToken: String): ApiResult<Unit> =
+    override suspend fun closeRoom(
+        roomId: String,
+        roomToken: String,
+        scope: AuthScopeSnapshot?,
+    ): ApiResult<Unit> =
         safeApiCall {
-            client.delete("$BASE/rooms/$roomId") { parameter("room_token", roomToken) }
+            client.delete("$BASE/rooms/$roomId") {
+                pin(scope)
+                parameter("room_token", roomToken)
+            }
         }
 
     override suspend fun listSuggestions(
         roomId: String,
         roomToken: String,
+        scope: AuthScopeSnapshot?,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
-        client.get("$BASE/rooms/$roomId/suggestions") { parameter("room_token", roomToken) }
+        client.get("$BASE/rooms/$roomId/suggestions") {
+            pin(scope)
+            parameter("room_token", roomToken)
+        }
     }
 
     override suspend fun addSuggestion(
         roomId: String,
         roomToken: String,
         request: AddSuggestionRequest,
+        scope: AuthScopeSnapshot?,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
         client.post("$BASE/rooms/$roomId/suggestions") {
+            pin(scope)
             parameter("room_token", roomToken)
             contentType(ContentType.Application.Json)
             setBody(request)
@@ -173,8 +205,10 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         suggestionId: String,
+        scope: AuthScopeSnapshot?,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
         client.delete("$BASE/rooms/$roomId/suggestions/$suggestionId") {
+            pin(scope)
             parameter("room_token", roomToken)
         }
     }
@@ -183,8 +217,10 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         suggestionId: String,
+        scope: AuthScopeSnapshot?,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
         client.post("$BASE/rooms/$roomId/suggestions/$suggestionId/vote") {
+            pin(scope)
             parameter("room_token", roomToken)
         }
     }
@@ -193,8 +229,10 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         suggestionId: String,
+        scope: AuthScopeSnapshot?,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
         client.delete("$BASE/rooms/$roomId/suggestions/$suggestionId/vote") {
+            pin(scope)
             parameter("room_token", roomToken)
         }
     }
@@ -203,8 +241,10 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         request: PromoteSuggestionRequest,
+        scope: AuthScopeSnapshot?,
     ): ApiResult<RoomResponse> = safeApiCall {
         client.post("$BASE/rooms/$roomId/suggestions/promote") {
+            pin(scope)
             parameter("room_token", roomToken)
             contentType(ContentType.Application.Json)
             setBody(request)
@@ -213,5 +253,12 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
 
     private companion object {
         const val BASE = "/api/v1/watch-together"
+    }
+
+    private fun io.ktor.client.request.HttpRequestBuilder.pin(scope: AuthScopeSnapshot?) {
+        if (scope != null) {
+            authScope(scope)
+            requireSiloAuth()
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/WatchTogetherApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/WatchTogetherApi.kt
@@ -37,20 +37,20 @@ import io.ktor.http.contentType
 interface WatchTogetherApi {
 
     /** POST /rooms — caller becomes host; 201 with room + room_access_token. */
-    suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot? = null): ApiResult<RoomResponse>
+    suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot): ApiResult<RoomResponse>
 
     /** POST /join — resolves a code or join token; 200 with room + room_access_token. */
-    suspend fun joinRoom(request: JoinRoomRequest, scope: AuthScopeSnapshot? = null): ApiResult<RoomResponse>
+    suspend fun joinRoom(request: JoinRoomRequest, scope: AuthScopeSnapshot): ApiResult<RoomResponse>
 
     /** GET /rooms/{id}?room_token= — current room snapshot. */
-    suspend fun getRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot? = null): ApiResult<RoomResponse>
+    suspend fun getRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot): ApiResult<RoomResponse>
 
     /** PUT /rooms/{id}/selection?room_token= (host-only). */
     suspend fun setSelection(
         roomId: String,
         roomToken: String,
         request: SetSelectionRequest,
-        scope: AuthScopeSnapshot? = null,
+        scope: AuthScopeSnapshot,
     ): ApiResult<RoomResponse>
 
     /** PATCH /rooms/{id}/policy?room_token= (host-only). */
@@ -58,21 +58,21 @@ interface WatchTogetherApi {
         roomId: String,
         roomToken: String,
         request: UpdatePolicyRequest,
-        scope: AuthScopeSnapshot? = null,
+        scope: AuthScopeSnapshot,
     ): ApiResult<RoomResponse>
 
     /** DELETE /rooms/{id}?room_token= (host-only) — 204 → Unit. */
-    suspend fun closeRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot? = null): ApiResult<Unit>
+    suspend fun closeRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot): ApiResult<Unit>
 
     /** GET /rooms/{id}/suggestions?room_token=. */
-    suspend fun listSuggestions(roomId: String, roomToken: String, scope: AuthScopeSnapshot? = null): ApiResult<SuggestionsResponse>
+    suspend fun listSuggestions(roomId: String, roomToken: String, scope: AuthScopeSnapshot): ApiResult<SuggestionsResponse>
 
     /** POST /rooms/{id}/suggestions?room_token=. */
     suspend fun addSuggestion(
         roomId: String,
         roomToken: String,
         request: AddSuggestionRequest,
-        scope: AuthScopeSnapshot? = null,
+        scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse>
 
     /** DELETE /rooms/{id}/suggestions/{sid}?room_token= (host or suggester). */
@@ -80,7 +80,7 @@ interface WatchTogetherApi {
         roomId: String,
         roomToken: String,
         suggestionId: String,
-        scope: AuthScopeSnapshot? = null,
+        scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse>
 
     /** POST /rooms/{id}/suggestions/{sid}/vote?room_token= — 409 on dup. */
@@ -88,7 +88,7 @@ interface WatchTogetherApi {
         roomId: String,
         roomToken: String,
         suggestionId: String,
-        scope: AuthScopeSnapshot? = null,
+        scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse>
 
     /** DELETE /rooms/{id}/suggestions/{sid}/vote?room_token= — 409 if not voted. */
@@ -96,7 +96,7 @@ interface WatchTogetherApi {
         roomId: String,
         roomToken: String,
         suggestionId: String,
-        scope: AuthScopeSnapshot? = null,
+        scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse>
 
     /** POST /rooms/{id}/suggestions/promote?room_token= (host-only) → room. */
@@ -104,13 +104,13 @@ interface WatchTogetherApi {
         roomId: String,
         roomToken: String,
         request: PromoteSuggestionRequest,
-        scope: AuthScopeSnapshot? = null,
+        scope: AuthScopeSnapshot,
     ): ApiResult<RoomResponse>
 }
 
 class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi {
 
-    override suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot?): ApiResult<RoomResponse> =
+    override suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot): ApiResult<RoomResponse> =
         safeApiCall {
             client.post("$BASE/rooms") {
                 pin(scope)
@@ -119,7 +119,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
             }
         }
 
-    override suspend fun joinRoom(request: JoinRoomRequest, scope: AuthScopeSnapshot?): ApiResult<RoomResponse> =
+    override suspend fun joinRoom(request: JoinRoomRequest, scope: AuthScopeSnapshot): ApiResult<RoomResponse> =
         safeApiCall {
             client.post("$BASE/join") {
                 pin(scope)
@@ -128,7 +128,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
             }
         }
 
-    override suspend fun getRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot?): ApiResult<RoomResponse> =
+    override suspend fun getRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot): ApiResult<RoomResponse> =
         safeApiCall {
             client.get("$BASE/rooms/$roomId") {
                 pin(scope)
@@ -140,7 +140,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         request: SetSelectionRequest,
-        scope: AuthScopeSnapshot?,
+        scope: AuthScopeSnapshot,
     ): ApiResult<RoomResponse> = safeApiCall {
         client.put("$BASE/rooms/$roomId/selection") {
             pin(scope)
@@ -154,7 +154,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         request: UpdatePolicyRequest,
-        scope: AuthScopeSnapshot?,
+        scope: AuthScopeSnapshot,
     ): ApiResult<RoomResponse> = safeApiCall {
         client.patch("$BASE/rooms/$roomId/policy") {
             pin(scope)
@@ -167,7 +167,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
     override suspend fun closeRoom(
         roomId: String,
         roomToken: String,
-        scope: AuthScopeSnapshot?,
+        scope: AuthScopeSnapshot,
     ): ApiResult<Unit> =
         safeApiCall {
             client.delete("$BASE/rooms/$roomId") {
@@ -179,7 +179,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
     override suspend fun listSuggestions(
         roomId: String,
         roomToken: String,
-        scope: AuthScopeSnapshot?,
+        scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
         client.get("$BASE/rooms/$roomId/suggestions") {
             pin(scope)
@@ -191,7 +191,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         request: AddSuggestionRequest,
-        scope: AuthScopeSnapshot?,
+        scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
         client.post("$BASE/rooms/$roomId/suggestions") {
             pin(scope)
@@ -205,7 +205,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         suggestionId: String,
-        scope: AuthScopeSnapshot?,
+        scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
         client.delete("$BASE/rooms/$roomId/suggestions/$suggestionId") {
             pin(scope)
@@ -217,7 +217,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         suggestionId: String,
-        scope: AuthScopeSnapshot?,
+        scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
         client.post("$BASE/rooms/$roomId/suggestions/$suggestionId/vote") {
             pin(scope)
@@ -229,7 +229,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         suggestionId: String,
-        scope: AuthScopeSnapshot?,
+        scope: AuthScopeSnapshot,
     ): ApiResult<SuggestionsResponse> = safeApiCall {
         client.delete("$BASE/rooms/$roomId/suggestions/$suggestionId/vote") {
             pin(scope)
@@ -241,7 +241,7 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         roomId: String,
         roomToken: String,
         request: PromoteSuggestionRequest,
-        scope: AuthScopeSnapshot?,
+        scope: AuthScopeSnapshot,
     ): ApiResult<RoomResponse> = safeApiCall {
         client.post("$BASE/rooms/$roomId/suggestions/promote") {
             pin(scope)
@@ -255,10 +255,8 @@ class DefaultWatchTogetherApi(private val client: HttpClient) : WatchTogetherApi
         const val BASE = "/api/v1/watch-together"
     }
 
-    private fun io.ktor.client.request.HttpRequestBuilder.pin(scope: AuthScopeSnapshot?) {
-        if (scope != null) {
-            authScope(scope)
-            requireSiloAuth()
-        }
+    private fun io.ktor.client.request.HttpRequestBuilder.pin(scope: AuthScopeSnapshot) {
+        authScope(scope)
+        requireSiloAuth()
     }
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
@@ -97,6 +97,8 @@ class WatchTogetherRepository(
     private var binding: RoomBinding? = null
     private var terminalGeneration: Long? = null
     private var realtimeGeneration: Long? = null
+    private var nextConnectionOwner = 0L
+    private var activeConnectionOwner: Long? = null
     private val _roomSnapshot = MutableStateFlow<RoomSnapshot?>(null)
     private val _suggestions = MutableStateFlow<List<Suggestion>>(emptyList())
 
@@ -223,7 +225,8 @@ class WatchTogetherRepository(
 
     suspend fun closeRoom(): ApiResult<Unit> {
         val lease = activeBinding() ?: return missingRoom()
-        return api.closeRoom(lease.roomId, lease.roomToken, lease.authScope)
+        val result = api.closeRoom(lease.roomId, lease.roomToken, lease.authScope)
+        return if (isCurrent(lease)) result else obsoleteRoomRequest()
     }
 
     // ---- REST: suggestions ----------------------------------------------------
@@ -250,24 +253,26 @@ class WatchTogetherRepository(
         val lease = activeBinding() ?: return missingRoom()
         val r = api.vote(lease.roomId, lease.roomToken, suggestionId, lease.authScope)
         if (r !is ApiResult.Success) return r
-        stateMutex.withLock {
-            if (!isCurrentLocked(lease)) return r
+        val published = stateMutex.withLock {
+            if (!isCurrentLocked(lease)) return@withLock false
             votedIds.add(suggestionId)
             applySuggestions(r.data.suggestions, fromBroadcast = false)
+            true
         }
-        return r
+        return if (published) r else obsoleteRoomRequest()
     }
 
     suspend fun unvote(suggestionId: String): ApiResult<SuggestionsResponse> {
         val lease = activeBinding() ?: return missingRoom()
         val r = api.unvote(lease.roomId, lease.roomToken, suggestionId, lease.authScope)
         if (r !is ApiResult.Success) return r
-        stateMutex.withLock {
-            if (!isCurrentLocked(lease)) return r
+        val published = stateMutex.withLock {
+            if (!isCurrentLocked(lease)) return@withLock false
             votedIds.remove(suggestionId)
             applySuggestions(r.data.suggestions, fromBroadcast = false)
+            true
         }
-        return r
+        return if (published) r else obsoleteRoomRequest()
     }
 
     suspend fun promoteSuggestion(request: PromoteSuggestionRequest): ApiResult<RoomResponse> {
@@ -289,10 +294,12 @@ class WatchTogetherRepository(
     ): ApiResult<RoomResponse> {
         if (result !is ApiResult.Success) return result
         if (result.data.room.roomId != lease.roomId) return invalidRoomResponse()
-        stateMutex.withLock {
-            if (isCurrentLocked(lease)) _roomSnapshot.value = result.data.room
+        val published = stateMutex.withLock {
+            if (!isCurrentLocked(lease)) return@withLock false
+            _roomSnapshot.value = result.data.room
+            true
         }
-        return result
+        return if (published) result else obsoleteRoomRequest()
     }
 
     private suspend fun publishSuggestionsResponse(
@@ -300,10 +307,12 @@ class WatchTogetherRepository(
         result: ApiResult<SuggestionsResponse>,
     ): ApiResult<SuggestionsResponse> {
         if (result !is ApiResult.Success) return result
-        stateMutex.withLock {
-            if (isCurrentLocked(lease)) applySuggestions(result.data.suggestions, fromBroadcast = false)
+        val published = stateMutex.withLock {
+            if (!isCurrentLocked(lease)) return@withLock false
+            applySuggestions(result.data.suggestions, fromBroadcast = false)
+            true
         }
-        return result
+        return if (published) result else obsoleteRoomRequest()
     }
 
     private fun invalidRoomResponse(): ApiResult.Error =
@@ -340,7 +349,9 @@ class WatchTogetherRepository(
             realtime.takeIf {
                 current != null &&
                     terminalGeneration != current.generation &&
-                    realtimeGeneration == current.generation
+                    realtimeGeneration == current.generation &&
+                    activeConnectionOwner != null &&
+                    _connectionState.value.writable
             }
         }
 
@@ -385,53 +396,57 @@ class WatchTogetherRepository(
     suspend fun connect(roomId: String) {
         val lease = activeBinding()?.takeIf { it.roomId == roomId } ?: return
         val client = realtimeFactory() ?: return
-        stateMutex.withLock {
+        val owner = stateMutex.withLock {
             if (!isCurrentLocked(lease)) return
+            val newOwner = ++nextConnectionOwner
+            activeConnectionOwner = newOwner
             realtime = client
             realtimeGeneration = lease.generation
             _roomClosedReason.value = null
+            newOwner
         }
         var backoffIndex = 0
         var failures = 0
         while (true) {
+            if (!isCurrent(lease, owner)) break
             var closedByServer = false
             var openedAtMs: Long? = null
             var sawSnapshot = false
             try {
-                client.connect(lease.roomId, lease.roomToken).collect { event ->
-                    if (!isCurrent(lease)) throw ObsoleteBinding
+                client.connect(lease.roomId, lease.roomToken, lease.authScope).collect { event ->
+                    if (!isCurrent(lease, owner)) throw ObsoleteBinding
                     if (event is RoomRealtimeEvent.Closed) {
                         // Any server-initiated close (with or without a reason) is terminal.
                         // The event flow (a hot SharedFlow) never completes on its
                         // own, so we stop collecting by throwing a private sentinel.
                         closedByServer = true
                         stateMutex.withLock {
-                            if (isCurrentLocked(lease)) {
+                            if (isCurrentOwnerLocked(lease, owner)) {
                                 terminalGeneration = lease.generation
-                                _roomClosedReason.value = event.reason
+                                _roomClosedReason.value = event.reason ?: "room_closed"
                                 _roomSnapshot.value = null
                             }
                         }
                         throw ServerClosed
                     } else if (event is RoomRealtimeEvent.TransportTerminated) {
-                        markNotWritable(lease)
+                        markNotWritable(lease, owner)
                         throw TransportEnded
                     } else if (event is RoomRealtimeEvent.Opened) {
                         openedAtMs = monotonicNowMs()
-                        markOpened(lease)
+                        markOpened(lease, owner)
                     } else if (event is RoomRealtimeEvent.SnapshotEvent) {
                         sawSnapshot = true
                     }
-                    fold(lease, event)
+                    fold(lease, owner, event)
                 }
-                markNotWritable(lease)
+                markNotWritable(lease, owner)
                 if (isStableAttempt(openedAtMs, sawSnapshot)) {
                     failures = 0
                     backoffIndex = 0
                 }
                 failures++
             } catch (e: CancellationException) {
-                clearRealtimeIfCurrent(lease, client)
+                clearRealtimeIfCurrent(lease, client, owner)
                 throw e
             } catch (_: ObsoleteBinding) {
                 break
@@ -447,10 +462,10 @@ class WatchTogetherRepository(
                 failures++
             }
             if (closedByServer) break
-            if (!isCurrent(lease)) break
+            if (!isCurrent(lease, owner)) break
             if (failures >= MAX_RECONNECT_ATTEMPTS) {
                 stateMutex.withLock {
-                    if (isCurrentLocked(lease)) {
+                    if (isCurrentOwnerLocked(lease, owner)) {
                         terminalGeneration = lease.generation
                         _roomClosedReason.value = "connection_lost"
                         _roomSnapshot.value = null
@@ -461,28 +476,40 @@ class WatchTogetherRepository(
             delay(BACKOFF_MS[backoffIndex])
             backoffIndex = (backoffIndex + 1).coerceAtMost(BACKOFF_MS.lastIndex)
         }
-        clearRealtimeIfCurrent(lease, client)
+        clearRealtimeIfCurrent(lease, client, owner)
     }
 
     private suspend fun isCurrent(lease: RoomBinding): Boolean =
         stateMutex.withLock { isCurrentLocked(lease) }
 
+    private suspend fun isCurrent(lease: RoomBinding, owner: Long): Boolean =
+        stateMutex.withLock { isCurrentOwnerLocked(lease, owner) }
+
+    private fun isCurrentOwnerLocked(lease: RoomBinding, owner: Long): Boolean =
+        isCurrentLocked(lease) && activeConnectionOwner == owner
+
     private suspend fun clearRealtimeIfCurrent(
         lease: RoomBinding,
         client: WatchTogetherRealtimeClient,
+        owner: Long,
     ) {
         stateMutex.withLock {
-            if (realtime === client && realtimeGeneration == lease.generation) {
+            if (
+                realtime === client &&
+                realtimeGeneration == lease.generation &&
+                activeConnectionOwner == owner
+            ) {
                 realtime = null
                 realtimeGeneration = null
+                activeConnectionOwner = null
                 _connectionState.value = _connectionState.value.copy(writable = false)
             }
         }
     }
 
-    private suspend fun markOpened(lease: RoomBinding) {
+    private suspend fun markOpened(lease: RoomBinding, owner: Long) {
         stateMutex.withLock {
-            if (isCurrentLocked(lease)) {
+            if (isCurrentOwnerLocked(lease, owner)) {
                 val previous = _connectionState.value
                 _connectionState.value = WatchTogetherConnectionState(
                     generation = lease.generation,
@@ -493,9 +520,9 @@ class WatchTogetherRepository(
         }
     }
 
-    private suspend fun markNotWritable(lease: RoomBinding) {
+    private suspend fun markNotWritable(lease: RoomBinding, owner: Long) {
         stateMutex.withLock {
-            if (binding == lease) {
+            if (binding == lease && activeConnectionOwner == owner) {
                 _connectionState.value = _connectionState.value.copy(writable = false)
             }
         }
@@ -510,12 +537,13 @@ class WatchTogetherRepository(
     private object ObsoleteBinding : Throwable()
 
     /** Pure-ish fold of one realtime event into the state flows + side streams. */
-    private suspend fun fold(lease: RoomBinding, event: RoomRealtimeEvent) {
+    private suspend fun fold(lease: RoomBinding, owner: Long, event: RoomRealtimeEvent) {
         stateMutex.withLock {
-            if (!isCurrentLocked(lease)) return
+            if (!isCurrentOwnerLocked(lease, owner)) return
             when (event) {
                 RoomRealtimeEvent.Opened -> Unit
-                is RoomRealtimeEvent.SnapshotEvent -> _roomSnapshot.value = event.room
+                is RoomRealtimeEvent.SnapshotEvent ->
+                    if (event.room.roomId == lease.roomId) _roomSnapshot.value = event.room
                 is RoomRealtimeEvent.SuggestionsEvent -> applySuggestions(event.suggestions, fromBroadcast = true)
                 is RoomRealtimeEvent.TransportCommandEvent -> _transportCommands.tryEmit(
                     ScheduledTransportCommand(
@@ -553,6 +581,7 @@ class WatchTogetherRepository(
             votedIds.clear()
             realtime = null
             realtimeGeneration = null
+            activeConnectionOwner = null
             _connectionState.value = WatchTogetherConnectionState(generation = nextGeneration)
         }
     }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
@@ -13,6 +13,7 @@ import org.siloserver.silo.model.watchtogether.SuggestionsResponse
 import org.siloserver.silo.model.watchtogether.TransportCommand
 import org.siloserver.silo.model.watchtogether.UpdatePolicyRequest
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
 import org.siloserver.silo.network.RoomRealtimeEvent
 import org.siloserver.silo.network.WatchTogetherRealtimeClient
 import org.siloserver.silo.network.api.WatchTogetherApi
@@ -26,6 +27,9 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.time.TimeSource
 
 /**
  * A transport command paired with its `execute_at` already parsed to a
@@ -53,6 +57,12 @@ data class PongSample(
     val serverSentMs: Long?,
 )
 
+data class WatchTogetherConnectionState(
+    val generation: Long = 0L,
+    val epoch: Long = 0L,
+    val writable: Boolean = false,
+)
+
 /**
  * Singleton owner of one Watch Together room's state and websocket lifecycle.
  * The per-room WS IS the feature (no REST fallback); the REST calls are for
@@ -71,12 +81,29 @@ data class PongSample(
 class WatchTogetherRepository(
     private val api: WatchTogetherApi,
     private val realtimeFactory: () -> WatchTogetherRealtimeClient? = { null },
+    private val monotonicNowMs: () -> Long = { MONOTONIC_ORIGIN.elapsedNow().inWholeMilliseconds },
+    private val authScopeProvider: suspend () -> AuthScopeSnapshot? = { null },
 ) {
+    private data class RoomBinding(
+        val roomId: String,
+        val roomToken: String,
+        val authScope: AuthScopeSnapshot,
+        val generation: Long,
+    )
+
+    private val stateMutex = Mutex()
+    private var nextGeneration = 0L
+    private var latestRoomRequest = 0L
+    private var binding: RoomBinding? = null
+    private var terminalGeneration: Long? = null
+    private var realtimeGeneration: Long? = null
     private val _roomSnapshot = MutableStateFlow<RoomSnapshot?>(null)
     private val _suggestions = MutableStateFlow<List<Suggestion>>(emptyList())
 
     val roomSnapshot: StateFlow<RoomSnapshot?> = _roomSnapshot.asStateFlow()
     val suggestions: StateFlow<List<Suggestion>> = _suggestions.asStateFlow()
+    private val _connectionState = MutableStateFlow(WatchTogetherConnectionState())
+    val connectionState: StateFlow<WatchTogetherConnectionState> = _connectionState.asStateFlow()
 
     /**
      * Transport commands surfaced for the player binding to feed to its
@@ -131,78 +158,100 @@ class WatchTogetherRepository(
     private val votedIds = mutableSetOf<String>()
 
     @kotlin.concurrent.Volatile
-    private var roomToken: String = ""
-
-    @kotlin.concurrent.Volatile
     private var realtime: WatchTogetherRealtimeClient? = null
 
     // ---- REST: create / join (store the room token) ---------------------------
 
     suspend fun createRoom(request: CreateRoomRequest): ApiResult<RoomResponse> {
-        val r = api.createRoom(request)
-        if (r is ApiResult.Success) onRoomResponse(r.data)
-        return r
+        val scope = authScopeProvider() ?: return missingAuthScope()
+        val requestGeneration = beginRoomRequest()
+        val r = api.createRoom(request, scope)
+        if (authScopeProvider() != scope) return obsoleteRoomRequest()
+        return if (r is ApiResult.Success) installRoomResponse(r.data, scope, requestGeneration) else r
     }
 
     suspend fun joinRoom(request: JoinRoomRequest): ApiResult<RoomResponse> {
-        val r = api.joinRoom(request)
-        if (r is ApiResult.Success) onRoomResponse(r.data)
-        return r
+        val scope = authScopeProvider() ?: return missingAuthScope()
+        val requestGeneration = beginRoomRequest()
+        val r = api.joinRoom(request, scope)
+        if (authScopeProvider() != scope) return obsoleteRoomRequest()
+        return if (r is ApiResult.Success) installRoomResponse(r.data, scope, requestGeneration) else r
     }
 
-    private fun onRoomResponse(data: RoomResponse) {
-        if (data.roomAccessToken.isNotBlank()) roomToken = data.roomAccessToken
-        _roomSnapshot.value = data.room
+    private suspend fun beginRoomRequest(): Long = stateMutex.withLock { ++latestRoomRequest }
+
+    private suspend fun installRoomResponse(
+        data: RoomResponse,
+        scope: AuthScopeSnapshot,
+        requestGeneration: Long,
+    ): ApiResult<RoomResponse> {
+        if (data.room.roomId.isBlank() || data.roomAccessToken.isBlank()) {
+            return invalidRoomResponse()
+        }
+        stateMutex.withLock {
+            if (requestGeneration != latestRoomRequest) return obsoleteRoomRequest()
+            val installed = RoomBinding(
+                roomId = data.room.roomId,
+                roomToken = data.roomAccessToken,
+                authScope = scope,
+                generation = ++nextGeneration,
+            )
+            binding = installed
+            terminalGeneration = null
+            votedIds.clear()
+            _suggestions.value = emptyList()
+            _roomClosedReason.value = null
+            _roomSnapshot.value = data.room
+            _connectionState.value = WatchTogetherConnectionState(generation = installed.generation)
+        }
+        return ApiResult.Success(data)
     }
 
     // ---- REST: host management ------------------------------------------------
 
     suspend fun setSelection(request: SetSelectionRequest): ApiResult<RoomResponse> {
-        val roomId = _roomSnapshot.value?.roomId ?: ""
-        val r = api.setSelection(roomId, roomToken, request)
-        if (r is ApiResult.Success) _roomSnapshot.value = r.data.room
-        return r
+        val lease = activeBinding() ?: return missingRoom()
+        val r = api.setSelection(lease.roomId, lease.roomToken, request, lease.authScope)
+        return publishRoomResponse(lease, r)
     }
 
     suspend fun updatePolicy(request: UpdatePolicyRequest): ApiResult<RoomResponse> {
-        val roomId = _roomSnapshot.value?.roomId ?: ""
-        val r = api.updatePolicy(roomId, roomToken, request)
-        if (r is ApiResult.Success) _roomSnapshot.value = r.data.room
-        return r
+        val lease = activeBinding() ?: return missingRoom()
+        val r = api.updatePolicy(lease.roomId, lease.roomToken, request, lease.authScope)
+        return publishRoomResponse(lease, r)
     }
 
     suspend fun closeRoom(): ApiResult<Unit> {
-        val roomId = _roomSnapshot.value?.roomId ?: ""
-        return api.closeRoom(roomId, roomToken)
+        val lease = activeBinding() ?: return missingRoom()
+        return api.closeRoom(lease.roomId, lease.roomToken, lease.authScope)
     }
 
     // ---- REST: suggestions ----------------------------------------------------
 
     suspend fun refreshSuggestions(): ApiResult<SuggestionsResponse> {
-        val roomId = _roomSnapshot.value?.roomId ?: ""
-        val r = api.listSuggestions(roomId, roomToken)
-        if (r is ApiResult.Success) applySuggestions(r.data.suggestions, fromBroadcast = false)
-        return r
+        val lease = activeBinding() ?: return missingRoom()
+        val r = api.listSuggestions(lease.roomId, lease.roomToken, lease.authScope)
+        return publishSuggestionsResponse(lease, r)
     }
 
     suspend fun addSuggestion(request: AddSuggestionRequest): ApiResult<SuggestionsResponse> {
-        val roomId = _roomSnapshot.value?.roomId ?: ""
-        val r = api.addSuggestion(roomId, roomToken, request)
-        if (r is ApiResult.Success) applySuggestions(r.data.suggestions, fromBroadcast = false)
-        return r
+        val lease = activeBinding() ?: return missingRoom()
+        val r = api.addSuggestion(lease.roomId, lease.roomToken, request, lease.authScope)
+        return publishSuggestionsResponse(lease, r)
     }
 
     suspend fun deleteSuggestion(suggestionId: String): ApiResult<SuggestionsResponse> {
-        val roomId = _roomSnapshot.value?.roomId ?: ""
-        val r = api.deleteSuggestion(roomId, roomToken, suggestionId)
-        if (r is ApiResult.Success) applySuggestions(r.data.suggestions, fromBroadcast = false)
-        return r
+        val lease = activeBinding() ?: return missingRoom()
+        val r = api.deleteSuggestion(lease.roomId, lease.roomToken, suggestionId, lease.authScope)
+        return publishSuggestionsResponse(lease, r)
     }
 
     suspend fun vote(suggestionId: String): ApiResult<SuggestionsResponse> {
-        val roomId = _roomSnapshot.value?.roomId ?: ""
-        val r = api.vote(roomId, roomToken, suggestionId)
-        if (r is ApiResult.Success) {
+        val lease = activeBinding() ?: return missingRoom()
+        val r = api.vote(lease.roomId, lease.roomToken, suggestionId, lease.authScope)
+        if (r !is ApiResult.Success) return r
+        stateMutex.withLock {
+            if (!isCurrentLocked(lease)) return r
             votedIds.add(suggestionId)
             applySuggestions(r.data.suggestions, fromBroadcast = false)
         }
@@ -210,9 +259,11 @@ class WatchTogetherRepository(
     }
 
     suspend fun unvote(suggestionId: String): ApiResult<SuggestionsResponse> {
-        val roomId = _roomSnapshot.value?.roomId ?: ""
-        val r = api.unvote(roomId, roomToken, suggestionId)
-        if (r is ApiResult.Success) {
+        val lease = activeBinding() ?: return missingRoom()
+        val r = api.unvote(lease.roomId, lease.roomToken, suggestionId, lease.authScope)
+        if (r !is ApiResult.Success) return r
+        stateMutex.withLock {
+            if (!isCurrentLocked(lease)) return r
             votedIds.remove(suggestionId)
             applySuggestions(r.data.suggestions, fromBroadcast = false)
         }
@@ -220,11 +271,52 @@ class WatchTogetherRepository(
     }
 
     suspend fun promoteSuggestion(request: PromoteSuggestionRequest): ApiResult<RoomResponse> {
-        val roomId = _roomSnapshot.value?.roomId ?: ""
-        val r = api.promoteSuggestion(roomId, roomToken, request)
-        if (r is ApiResult.Success) _roomSnapshot.value = r.data.room
-        return r
+        val lease = activeBinding() ?: return missingRoom()
+        val r = api.promoteSuggestion(lease.roomId, lease.roomToken, request, lease.authScope)
+        return publishRoomResponse(lease, r)
     }
+
+    private suspend fun activeBinding(): RoomBinding? = stateMutex.withLock {
+        binding?.takeIf { terminalGeneration != it.generation }
+    }
+
+    private fun isCurrentLocked(lease: RoomBinding): Boolean =
+        binding == lease && terminalGeneration != lease.generation
+
+    private suspend fun publishRoomResponse(
+        lease: RoomBinding,
+        result: ApiResult<RoomResponse>,
+    ): ApiResult<RoomResponse> {
+        if (result !is ApiResult.Success) return result
+        if (result.data.room.roomId != lease.roomId) return invalidRoomResponse()
+        stateMutex.withLock {
+            if (isCurrentLocked(lease)) _roomSnapshot.value = result.data.room
+        }
+        return result
+    }
+
+    private suspend fun publishSuggestionsResponse(
+        lease: RoomBinding,
+        result: ApiResult<SuggestionsResponse>,
+    ): ApiResult<SuggestionsResponse> {
+        if (result !is ApiResult.Success) return result
+        stateMutex.withLock {
+            if (isCurrentLocked(lease)) applySuggestions(result.data.suggestions, fromBroadcast = false)
+        }
+        return result
+    }
+
+    private fun invalidRoomResponse(): ApiResult.Error =
+        ApiResult.Error(502, "invalid_room_response", "The room response was missing or mismatched.")
+
+    private fun missingRoom(): ApiResult.Error =
+        ApiResult.Error(409, "no_active_room", "No active Watch Together room.")
+
+    private fun missingAuthScope(): ApiResult.Error =
+        ApiResult.Error(401, "missing_auth_scope", "No authenticated Watch Together scope.")
+
+    private fun obsoleteRoomRequest(): ApiResult.Error =
+        ApiResult.Error(409, "obsolete_room_request", "The Watch Together identity changed.")
 
     /**
      * Publish suggestions, re-merging `voted_by_me` from the local [votedIds]
@@ -242,35 +334,45 @@ class WatchTogetherRepository(
 
     // ---- WS: client→server send passthroughs ----------------------------------
 
+    private suspend fun currentWritableRealtime(): WatchTogetherRealtimeClient? =
+        stateMutex.withLock {
+            val current = binding
+            realtime.takeIf {
+                current != null &&
+                    terminalGeneration != current.generation &&
+                    realtimeGeneration == current.generation
+            }
+        }
+
     suspend fun attachSession(sessionId: String): Boolean =
-        realtime?.attachSession(sessionId) ?: false
+        currentWritableRealtime()?.attachSession(sessionId) ?: false
 
     suspend fun transportRequest(
         action: String,
         positionSeconds: Double?,
         isPaused: Boolean,
-    ): Boolean = realtime?.transportRequest(action, positionSeconds, isPaused) ?: false
+    ): Boolean = currentWritableRealtime()?.transportRequest(action, positionSeconds, isPaused) ?: false
 
     suspend fun stateReport(
         sessionId: String,
         positionSeconds: Double,
         isPaused: Boolean,
-    ): Boolean = realtime?.stateReport(sessionId, positionSeconds, isPaused) ?: false
+    ): Boolean = currentWritableRealtime()?.stateReport(sessionId, positionSeconds, isPaused) ?: false
 
     suspend fun ready(
         sessionId: String,
         positionSeconds: Double,
         isPaused: Boolean,
-    ): Boolean = realtime?.ready(sessionId, positionSeconds, isPaused) ?: false
+    ): Boolean = currentWritableRealtime()?.ready(sessionId, positionSeconds, isPaused) ?: false
 
     suspend fun buffering(
         sessionId: String,
         positionSeconds: Double,
         isPaused: Boolean,
-    ): Boolean = realtime?.buffering(sessionId, positionSeconds, isPaused) ?: false
+    ): Boolean = currentWritableRealtime()?.buffering(sessionId, positionSeconds, isPaused) ?: false
 
     suspend fun ping(clientSentAt: String): Boolean =
-        realtime?.ping(clientSentAt) ?: false
+        currentWritableRealtime()?.ping(clientSentAt) ?: false
 
     // ---- WS lifecycle: connect + reconnect-with-backoff ------------------------
 
@@ -281,98 +383,178 @@ class WatchTogetherRepository(
      * [BACKOFF_MS]; a healthy event resets the index.
      */
     suspend fun connect(roomId: String) {
+        val lease = activeBinding()?.takeIf { it.roomId == roomId } ?: return
         val client = realtimeFactory() ?: return
-        realtime = client
-        _roomClosedReason.value = null // fresh connect: clear any stale close/error reason
+        stateMutex.withLock {
+            if (!isCurrentLocked(lease)) return
+            realtime = client
+            realtimeGeneration = lease.generation
+            _roomClosedReason.value = null
+        }
         var backoffIndex = 0
         var failures = 0
         while (true) {
             var closedByServer = false
+            var openedAtMs: Long? = null
+            var sawSnapshot = false
             try {
-                client.connect(roomId, roomToken).collect { event ->
+                client.connect(lease.roomId, lease.roomToken).collect { event ->
+                    if (!isCurrent(lease)) throw ObsoleteBinding
                     if (event is RoomRealtimeEvent.Closed) {
                         // Any server-initiated close (with or without a reason) is terminal.
                         // The event flow (a hot SharedFlow) never completes on its
                         // own, so we stop collecting by throwing a private sentinel.
                         closedByServer = true
-                        _roomClosedReason.value = event.reason // surface "host left" etc.
-                        _roomSnapshot.value = null
+                        stateMutex.withLock {
+                            if (isCurrentLocked(lease)) {
+                                terminalGeneration = lease.generation
+                                _roomClosedReason.value = event.reason
+                                _roomSnapshot.value = null
+                            }
+                        }
                         throw ServerClosed
-                    } else {
-                        backoffIndex = 0 // healthy traffic resets backoff to short delays
+                    } else if (event is RoomRealtimeEvent.TransportTerminated) {
+                        markNotWritable(lease)
+                        throw TransportEnded
+                    } else if (event is RoomRealtimeEvent.Opened) {
+                        openedAtMs = monotonicNowMs()
+                        markOpened(lease)
+                    } else if (event is RoomRealtimeEvent.SnapshotEvent) {
+                        sawSnapshot = true
                     }
-                    fold(event)
+                    fold(lease, event)
                 }
-                // Flow completed without throwing — this was a clean connection end.
-                // Only reset the failure counter on a genuinely clean completion so a
-                // server that emits one event then drops every attempt cannot reset
-                // failures to 0 and bypass the cap.
-                failures = 0
+                markNotWritable(lease)
+                if (isStableAttempt(openedAtMs, sawSnapshot)) {
+                    failures = 0
+                    backoffIndex = 0
+                }
+                failures++
             } catch (e: CancellationException) {
-                realtime = null
+                clearRealtimeIfCurrent(lease, client)
                 throw e
+            } catch (_: ObsoleteBinding) {
+                break
             } catch (_: ServerClosed) {
                 // terminal — handled below via closedByServer
             } catch (_: Throwable) {
                 // Any throw (including from a flapping server) counts as a failure,
                 // regardless of whether a healthy event arrived in the same attempt.
+                if (isStableAttempt(openedAtMs, sawSnapshot)) {
+                    failures = 0
+                    backoffIndex = 0
+                }
                 failures++
             }
             if (closedByServer) break
+            if (!isCurrent(lease)) break
             if (failures >= MAX_RECONNECT_ATTEMPTS) {
-                _roomClosedReason.value = "connection_lost"
-                _roomSnapshot.value = null
+                stateMutex.withLock {
+                    if (isCurrentLocked(lease)) {
+                        terminalGeneration = lease.generation
+                        _roomClosedReason.value = "connection_lost"
+                        _roomSnapshot.value = null
+                    }
+                }
                 break
             }
             delay(BACKOFF_MS[backoffIndex])
             backoffIndex = (backoffIndex + 1).coerceAtMost(BACKOFF_MS.lastIndex)
         }
-        realtime = null
+        clearRealtimeIfCurrent(lease, client)
     }
+
+    private suspend fun isCurrent(lease: RoomBinding): Boolean =
+        stateMutex.withLock { isCurrentLocked(lease) }
+
+    private suspend fun clearRealtimeIfCurrent(
+        lease: RoomBinding,
+        client: WatchTogetherRealtimeClient,
+    ) {
+        stateMutex.withLock {
+            if (realtime === client && realtimeGeneration == lease.generation) {
+                realtime = null
+                realtimeGeneration = null
+                _connectionState.value = _connectionState.value.copy(writable = false)
+            }
+        }
+    }
+
+    private suspend fun markOpened(lease: RoomBinding) {
+        stateMutex.withLock {
+            if (isCurrentLocked(lease)) {
+                val previous = _connectionState.value
+                _connectionState.value = WatchTogetherConnectionState(
+                    generation = lease.generation,
+                    epoch = if (previous.generation == lease.generation) previous.epoch + 1 else 1,
+                    writable = true,
+                )
+            }
+        }
+    }
+
+    private suspend fun markNotWritable(lease: RoomBinding) {
+        stateMutex.withLock {
+            if (binding == lease) {
+                _connectionState.value = _connectionState.value.copy(writable = false)
+            }
+        }
+    }
+
+    private fun isStableAttempt(openedAtMs: Long?, sawSnapshot: Boolean): Boolean =
+        sawSnapshot && openedAtMs != null && monotonicNowMs() - openedAtMs >= STABLE_CONNECTION_MS
 
     /** Sentinel to unwind the [connect] collect loop on a server `room_closed`. */
     private object ServerClosed : Throwable()
+    private object TransportEnded : Throwable()
+    private object ObsoleteBinding : Throwable()
 
     /** Pure-ish fold of one realtime event into the state flows + side streams. */
-    private fun fold(event: RoomRealtimeEvent) {
-        when (event) {
-            RoomRealtimeEvent.Opened -> Unit
-            is RoomRealtimeEvent.SnapshotEvent -> _roomSnapshot.value = event.room
-            is RoomRealtimeEvent.SuggestionsEvent -> applySuggestions(event.suggestions, fromBroadcast = true)
-            is RoomRealtimeEvent.TransportCommandEvent -> _transportCommands.tryEmit(
-                ScheduledTransportCommand(
-                    command = event.command,
-                    executeAtMs = parseRfc3339ToEpochMillis(event.command.executeAt),
-                ),
-            )
-            is RoomRealtimeEvent.Pong -> _pongs.tryEmit(
-                PongSample(
-                    clientSentMs = parseRfc3339ToEpochMillis(event.clientSentAt),
-                    serverReceivedMs = parseRfc3339ToEpochMillis(event.serverReceivedAt),
-                    serverSentMs = parseRfc3339ToEpochMillis(event.serverSentAt),
-                ),
-            )
-            is RoomRealtimeEvent.Closed -> { /* lifecycle handled in connect() */ }
-            is RoomRealtimeEvent.TransportTerminated -> Unit
-            is RoomRealtimeEvent.Error ->
-                // Transient, NON-terminal: a server `error` frame (e.g. a rejected
-                // transport_request) must be "ignored gracefully" per the design.
-                // It must NOT feed roomClosedReason — that is reserved for the
-                // terminal room_closed/ServerClosed path, which the player observes
-                // to exit. Folding errors here would eject the user on any transient
-                // rejection. Surface to the transient [errors] stream instead.
-                _errors.tryEmit(event.message.ifBlank { event.code })
+    private suspend fun fold(lease: RoomBinding, event: RoomRealtimeEvent) {
+        stateMutex.withLock {
+            if (!isCurrentLocked(lease)) return
+            when (event) {
+                RoomRealtimeEvent.Opened -> Unit
+                is RoomRealtimeEvent.SnapshotEvent -> _roomSnapshot.value = event.room
+                is RoomRealtimeEvent.SuggestionsEvent -> applySuggestions(event.suggestions, fromBroadcast = true)
+                is RoomRealtimeEvent.TransportCommandEvent -> _transportCommands.tryEmit(
+                    ScheduledTransportCommand(
+                        command = event.command,
+                        executeAtMs = parseRfc3339ToEpochMillis(event.command.executeAt),
+                    ),
+                )
+                is RoomRealtimeEvent.Pong -> _pongs.tryEmit(
+                    PongSample(
+                        clientSentMs = parseRfc3339ToEpochMillis(event.clientSentAt),
+                        serverReceivedMs = parseRfc3339ToEpochMillis(event.serverReceivedAt),
+                        serverSentMs = parseRfc3339ToEpochMillis(event.serverSentAt),
+                    ),
+                )
+                is RoomRealtimeEvent.Closed -> { /* lifecycle handled in connect() */ }
+                is RoomRealtimeEvent.TransportTerminated -> Unit
+                is RoomRealtimeEvent.Error ->
+                    // Transient, NON-terminal: a server `error` frame (e.g. a rejected
+                    // transport_request) must NOT feed roomClosedReason.
+                    _errors.tryEmit(event.message.ifBlank { event.code })
+            }
         }
     }
 
     /** Clear all room state on leave. The connect() loop ends via scope cancellation. */
-    fun reset() {
-        _roomSnapshot.value = null
-        _suggestions.value = emptyList()
-        _roomClosedReason.value = null
-        votedIds.clear()
-        roomToken = ""
-        realtime = null
+    suspend fun reset() {
+        stateMutex.withLock {
+            nextGeneration++
+            latestRoomRequest++
+            binding = null
+            terminalGeneration = null
+            _roomSnapshot.value = null
+            _suggestions.value = emptyList()
+            _roomClosedReason.value = null
+            votedIds.clear()
+            realtime = null
+            realtimeGeneration = null
+            _connectionState.value = WatchTogetherConnectionState(generation = nextGeneration)
+        }
     }
 
     companion object {
@@ -385,5 +567,7 @@ class WatchTogetherRepository(
          * loop gives up. Reset to zero on any healthy server event.
          */
         const val MAX_RECONNECT_ATTEMPTS = 6
+        const val STABLE_CONNECTION_MS = 30_000L
+        private val MONOTONIC_ORIGIN = TimeSource.Monotonic.markNow()
     }
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
@@ -18,6 +18,7 @@ import org.siloserver.silo.network.RoomRealtimeEvent
 import org.siloserver.silo.network.WatchTogetherRealtimeClient
 import org.siloserver.silo.network.api.WatchTogetherApi
 import org.siloserver.silo.util.parseRfc3339ToEpochMillis
+import org.siloserver.silo.watchtogether.RoomSessionRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
@@ -83,7 +84,7 @@ class WatchTogetherRepository(
     private val realtimeFactory: () -> WatchTogetherRealtimeClient? = { null },
     private val monotonicNowMs: () -> Long = { MONOTONIC_ORIGIN.elapsedNow().inWholeMilliseconds },
     private val authScopeProvider: suspend () -> AuthScopeSnapshot? = { null },
-) {
+) : RoomSessionRepository {
     private data class RoomBinding(
         val roomId: String,
         val roomToken: String,
@@ -102,7 +103,7 @@ class WatchTogetherRepository(
     private val _roomSnapshot = MutableStateFlow<RoomSnapshot?>(null)
     private val _suggestions = MutableStateFlow<List<Suggestion>>(emptyList())
 
-    val roomSnapshot: StateFlow<RoomSnapshot?> = _roomSnapshot.asStateFlow()
+    override val roomSnapshot: StateFlow<RoomSnapshot?> = _roomSnapshot.asStateFlow()
     val suggestions: StateFlow<List<Suggestion>> = _suggestions.asStateFlow()
     private val _connectionState = MutableStateFlow(WatchTogetherConnectionState())
     val connectionState: StateFlow<WatchTogetherConnectionState> = _connectionState.asStateFlow()
@@ -140,7 +141,7 @@ class WatchTogetherRepository(
      * this (they would eject the user) — see [errors].
      */
     private val _roomClosedReason = MutableStateFlow<String?>(null)
-    val roomClosedReason: StateFlow<String?> = _roomClosedReason.asStateFlow()
+    override val roomClosedReason: StateFlow<String?> = _roomClosedReason.asStateFlow()
 
     /**
      * Transient, non-terminal server `error` frames (e.g. a rejected
@@ -223,7 +224,7 @@ class WatchTogetherRepository(
         return publishRoomResponse(lease, r)
     }
 
-    suspend fun closeRoom(): ApiResult<Unit> {
+    override suspend fun closeRoom(): ApiResult<Unit> {
         val lease = activeBinding() ?: return missingRoom()
         val result = api.closeRoom(lease.roomId, lease.roomToken, lease.authScope)
         return if (isCurrent(lease)) result else obsoleteRoomRequest()
@@ -393,7 +394,7 @@ class WatchTogetherRepository(
      * server `room_closed` arrives (which stops reconnecting). Backoff steps are
      * [BACKOFF_MS]; a healthy event resets the index.
      */
-    suspend fun connect(roomId: String) {
+    override suspend fun connect(roomId: String) {
         val lease = activeBinding()?.takeIf { it.roomId == roomId } ?: return
         val client = realtimeFactory() ?: return
         val owner = stateMutex.withLock {
@@ -577,7 +578,7 @@ class WatchTogetherRepository(
     }
 
     /** Clear all room state on leave. The connect() loop ends via scope cancellation. */
-    suspend fun reset() {
+    override suspend fun reset() {
         stateMutex.withLock {
             nextGeneration++
             latestRoomRequest++

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
@@ -402,6 +402,10 @@ class WatchTogetherRepository(
             activeConnectionOwner = newOwner
             realtime = client
             realtimeGeneration = lease.generation
+            _connectionState.value = _connectionState.value.copy(
+                generation = lease.generation,
+                writable = false,
+            )
             _roomClosedReason.value = null
             newOwner
         }
@@ -434,7 +438,10 @@ class WatchTogetherRepository(
                     } else if (event is RoomRealtimeEvent.Opened) {
                         openedAtMs = monotonicNowMs()
                         markOpened(lease, owner)
-                    } else if (event is RoomRealtimeEvent.SnapshotEvent) {
+                    } else if (
+                        event is RoomRealtimeEvent.SnapshotEvent &&
+                        event.room.roomId == lease.roomId
+                    ) {
                         sawSnapshot = true
                     }
                     fold(lease, owner, event)
@@ -455,6 +462,7 @@ class WatchTogetherRepository(
             } catch (_: Throwable) {
                 // Any throw (including from a flapping server) counts as a failure,
                 // regardless of whether a healthy event arrived in the same attempt.
+                markNotWritable(lease, owner)
                 if (isStableAttempt(openedAtMs, sawSnapshot)) {
                     failures = 0
                     backoffIndex = 0

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
@@ -18,6 +18,7 @@ import org.siloserver.silo.network.RoomRealtimeEvent
 import org.siloserver.silo.network.WatchTogetherRealtimeClient
 import org.siloserver.silo.network.api.WatchTogetherApi
 import org.siloserver.silo.util.parseRfc3339ToEpochMillis
+import org.siloserver.silo.watchtogether.RoomDeliveryLatch
 import org.siloserver.silo.watchtogether.RoomSessionRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.BufferOverflow
@@ -41,6 +42,7 @@ import kotlin.time.TimeSource
 data class ScheduledTransportCommand(
     val command: TransportCommand,
     val executeAtMs: Long?,
+    val connection: WatchTogetherConnectionState,
 )
 
 /**
@@ -85,6 +87,9 @@ class WatchTogetherRepository(
     private val monotonicNowMs: () -> Long = { MONOTONIC_ORIGIN.elapsedNow().inWholeMilliseconds },
     private val authScopeProvider: suspend () -> AuthScopeSnapshot? = { null },
 ) : RoomSessionRepository {
+    /** Successful delivery state follows the process connection, not a UI controller. */
+    val roomDeliveryLatch = RoomDeliveryLatch()
+
     private data class RoomBinding(
         val roomId: String,
         val roomToken: String,
@@ -155,6 +160,11 @@ class WatchTogetherRepository(
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     val errors: SharedFlow<String> = _errors.asSharedFlow()
+
+    /** Surface a local delivery failure through the same non-terminal UI path. */
+    fun reportDeliveryFailure(message: String) {
+        if (message.isNotBlank()) _errors.tryEmit(message)
+    }
 
     // Locally-tracked vote set: ids the local user has voted for. Used to
     // re-merge voted_by_me into broadcast suggestion lists (which force false).
@@ -558,6 +568,7 @@ class WatchTogetherRepository(
                     ScheduledTransportCommand(
                         command = event.command,
                         executeAtMs = parseRfc3339ToEpochMillis(event.command.executeAt),
+                        connection = _connectionState.value,
                     ),
                 )
                 is RoomRealtimeEvent.Pong -> _pongs.tryEmit(

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
@@ -242,20 +242,35 @@ class WatchTogetherRepository(
 
     // ---- WS: client→server send passthroughs ----------------------------------
 
-    suspend fun attachSession(sessionId: String) { realtime?.attachSession(sessionId) }
-    suspend fun transportRequest(action: String, positionSeconds: Double?, isPaused: Boolean) {
-        realtime?.transportRequest(action, positionSeconds, isPaused)
-    }
-    suspend fun stateReport(sessionId: String, positionSeconds: Double, isPaused: Boolean) {
-        realtime?.stateReport(sessionId, positionSeconds, isPaused)
-    }
-    suspend fun ready(sessionId: String, positionSeconds: Double, isPaused: Boolean) {
-        realtime?.ready(sessionId, positionSeconds, isPaused)
-    }
-    suspend fun buffering(sessionId: String, positionSeconds: Double, isPaused: Boolean) {
-        realtime?.buffering(sessionId, positionSeconds, isPaused)
-    }
-    suspend fun ping(clientSentAt: String) { realtime?.ping(clientSentAt) }
+    suspend fun attachSession(sessionId: String): Boolean =
+        realtime?.attachSession(sessionId) ?: false
+
+    suspend fun transportRequest(
+        action: String,
+        positionSeconds: Double?,
+        isPaused: Boolean,
+    ): Boolean = realtime?.transportRequest(action, positionSeconds, isPaused) ?: false
+
+    suspend fun stateReport(
+        sessionId: String,
+        positionSeconds: Double,
+        isPaused: Boolean,
+    ): Boolean = realtime?.stateReport(sessionId, positionSeconds, isPaused) ?: false
+
+    suspend fun ready(
+        sessionId: String,
+        positionSeconds: Double,
+        isPaused: Boolean,
+    ): Boolean = realtime?.ready(sessionId, positionSeconds, isPaused) ?: false
+
+    suspend fun buffering(
+        sessionId: String,
+        positionSeconds: Double,
+        isPaused: Boolean,
+    ): Boolean = realtime?.buffering(sessionId, positionSeconds, isPaused) ?: false
+
+    suspend fun ping(clientSentAt: String): Boolean =
+        realtime?.ping(clientSentAt) ?: false
 
     // ---- WS lifecycle: connect + reconnect-with-backoff ------------------------
 
@@ -321,6 +336,7 @@ class WatchTogetherRepository(
     /** Pure-ish fold of one realtime event into the state flows + side streams. */
     private fun fold(event: RoomRealtimeEvent) {
         when (event) {
+            RoomRealtimeEvent.Opened -> Unit
             is RoomRealtimeEvent.SnapshotEvent -> _roomSnapshot.value = event.room
             is RoomRealtimeEvent.SuggestionsEvent -> applySuggestions(event.suggestions, fromBroadcast = true)
             is RoomRealtimeEvent.TransportCommandEvent -> _transportCommands.tryEmit(
@@ -337,6 +353,7 @@ class WatchTogetherRepository(
                 ),
             )
             is RoomRealtimeEvent.Closed -> { /* lifecycle handled in connect() */ }
+            is RoomRealtimeEvent.TransportTerminated -> Unit
             is RoomRealtimeEvent.Error ->
                 // Transient, NON-terminal: a server `error` frame (e.g. a rejected
                 // transport_request) must be "ignored gracefully" per the design.

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
@@ -20,6 +20,8 @@ import org.siloserver.silo.network.api.WatchTogetherApi
 import org.siloserver.silo.util.parseRfc3339ToEpochMillis
 import org.siloserver.silo.watchtogether.RoomDeliveryLatch
 import org.siloserver.silo.watchtogether.RoomSessionRepository
+import org.siloserver.silo.watchtogether.RoomTransportIntent
+import org.siloserver.silo.watchtogether.roomTransportAuthorized
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
@@ -66,6 +68,15 @@ data class WatchTogetherConnectionState(
     val writable: Boolean = false,
 )
 
+/** Immutable, atomically-published authority for one room + physical socket. */
+class RoomTransportAuthorization internal constructor(
+    val roomId: String,
+    val generation: Long,
+    val connectionOwner: Long?,
+    val realtimeConnectionId: Long?,
+    val snapshot: RoomSnapshot,
+)
+
 /**
  * Singleton owner of one Watch Together room's state and websocket lifecycle.
  * The per-room WS IS the feature (no REST fallback); the REST calls are for
@@ -103,6 +114,7 @@ class WatchTogetherRepository(
     private var binding: RoomBinding? = null
     private var terminalGeneration: Long? = null
     private var realtimeGeneration: Long? = null
+    private var realtimeConnectionId: Long? = null
     private var nextConnectionOwner = 0L
     private var activeConnectionOwner: Long? = null
     private val _roomSnapshot = MutableStateFlow<RoomSnapshot?>(null)
@@ -112,6 +124,11 @@ class WatchTogetherRepository(
     val suggestions: StateFlow<List<Suggestion>> = _suggestions.asStateFlow()
     private val _connectionState = MutableStateFlow(WatchTogetherConnectionState())
     val connectionState: StateFlow<WatchTogetherConnectionState> = _connectionState.asStateFlow()
+    @kotlin.concurrent.Volatile
+    private var transportAuthorization: RoomTransportAuthorization? = null
+
+    /** One atomic read; never pair independently-read snapshot/generation values. */
+    fun currentTransportAuthorization(): RoomTransportAuthorization? = transportAuthorization
 
     /**
      * Transport commands surfaced for the player binding to feed to its
@@ -188,7 +205,31 @@ class WatchTogetherRepository(
         val requestGeneration = beginRoomRequest()
         val r = api.joinRoom(request, scope)
         if (authScopeProvider() != scope) return obsoleteRoomRequest()
-        return if (r is ApiResult.Success) installRoomResponse(r.data, scope, requestGeneration) else r
+        if (r !is ApiResult.Success) return r
+        val installed = installRoomResponse(r.data, scope, requestGeneration)
+        if (installed !is ApiResult.Success) return installed
+
+        // The realtime handshake's initial event is a room snapshot; it does
+        // not replay suggestions that existed before this member connected.
+        // Hydrate them while the join lease is current so a re-entered lobby
+        // does not render an empty vote list until somebody mutates it.
+        val lease = stateMutex.withLock {
+            binding?.takeIf { current ->
+                latestRoomRequest == requestGeneration &&
+                    current.roomId == r.data.room.roomId &&
+                    isCurrentLocked(current)
+            }
+        } ?: return obsoleteRoomRequest()
+        publishSuggestionsResponse(
+            lease,
+            api.listSuggestions(lease.roomId, lease.roomToken, lease.authScope),
+            expectedRoomRequest = requestGeneration,
+        )
+        val stillCurrent = stateMutex.withLock {
+            latestRoomRequest == requestGeneration && isCurrentLocked(lease)
+        }
+        if (!stillCurrent) return obsoleteRoomRequest()
+        return installed
     }
 
     private suspend fun beginRoomRequest(): Long = stateMutex.withLock { ++latestRoomRequest }
@@ -216,6 +257,8 @@ class WatchTogetherRepository(
             _roomClosedReason.value = null
             _roomSnapshot.value = data.room
             _connectionState.value = WatchTogetherConnectionState(generation = installed.generation)
+            realtimeConnectionId = null
+            refreshTransportAuthorizationLocked()
         }
         return ApiResult.Success(data)
     }
@@ -299,6 +342,29 @@ class WatchTogetherRepository(
     private fun isCurrentLocked(lease: RoomBinding): Boolean =
         binding == lease && terminalGeneration != lease.generation
 
+    private fun refreshTransportAuthorizationLocked() {
+        val current = binding
+        val snapshot = _roomSnapshot.value
+        val owner = activeConnectionOwner
+        val connectionId = realtimeConnectionId
+        transportAuthorization = if (
+            current != null &&
+            snapshot != null &&
+            isCurrentLocked(current) &&
+            snapshot.roomId == current.roomId
+        ) {
+            RoomTransportAuthorization(
+                roomId = current.roomId,
+                generation = current.generation,
+                connectionOwner = owner,
+                realtimeConnectionId = connectionId,
+                snapshot = snapshot,
+            )
+        } else {
+            null
+        }
+    }
+
     private suspend fun publishRoomResponse(
         lease: RoomBinding,
         result: ApiResult<RoomResponse>,
@@ -308,6 +374,7 @@ class WatchTogetherRepository(
         val published = stateMutex.withLock {
             if (!isCurrentLocked(lease)) return@withLock false
             _roomSnapshot.value = result.data.room
+            refreshTransportAuthorizationLocked()
             true
         }
         return if (published) result else obsoleteRoomRequest()
@@ -316,10 +383,16 @@ class WatchTogetherRepository(
     private suspend fun publishSuggestionsResponse(
         lease: RoomBinding,
         result: ApiResult<SuggestionsResponse>,
+        expectedRoomRequest: Long? = null,
     ): ApiResult<SuggestionsResponse> {
         if (result !is ApiResult.Success) return result
         val published = stateMutex.withLock {
-            if (!isCurrentLocked(lease)) return@withLock false
+            if (
+                !isCurrentLocked(lease) ||
+                (expectedRoomRequest != null && latestRoomRequest != expectedRoomRequest)
+            ) {
+                return@withLock false
+            }
             applySuggestions(result.data.suggestions, fromBroadcast = false)
             true
         }
@@ -375,6 +448,49 @@ class WatchTogetherRepository(
         isPaused: Boolean,
     ): Boolean = currentWritableRealtime()?.transportRequest(action, positionSeconds, isPaused) ?: false
 
+    /**
+     * Send a user transport intent only while the exact room generation that
+     * authorized it is still current. Authority is rechecked under the same
+     * lock that guards room replacement, so a delayed UI coroutine cannot send
+     * an old room's command through a replacement room or changed policy.
+     */
+    suspend fun transportRequestForAuthorization(
+        authorization: RoomTransportAuthorization,
+        intent: RoomTransportIntent,
+        action: String,
+        positionSeconds: Double?,
+        isPaused: Boolean,
+    ): Boolean {
+        val target = stateMutex.withLock {
+            val current = binding ?: return@withLock null
+            val snapshot = _roomSnapshot.value ?: return@withLock null
+            val currentRealtime = realtime ?: return@withLock null
+            val connectionId = authorization.realtimeConnectionId ?: return@withLock null
+            val connectionOwner = authorization.connectionOwner ?: return@withLock null
+            if (
+                transportAuthorization != authorization ||
+                !isCurrentLocked(current) ||
+                current.generation != authorization.generation ||
+                current.roomId != authorization.roomId ||
+                snapshot != authorization.snapshot ||
+                !roomTransportAuthorized(snapshot, intent) ||
+                realtimeGeneration != current.generation ||
+                activeConnectionOwner != connectionOwner ||
+                realtimeConnectionId != connectionId ||
+                !_connectionState.value.writable
+            ) {
+                return@withLock null
+            }
+            currentRealtime to connectionId
+        } ?: return false
+        return target.first.transportRequestOnConnection(
+            connectionId = target.second,
+            action = action,
+            positionSeconds = positionSeconds,
+            isPaused = isPaused,
+        )
+    }
+
     suspend fun stateReport(
         sessionId: String,
         positionSeconds: Double,
@@ -413,11 +529,13 @@ class WatchTogetherRepository(
             activeConnectionOwner = newOwner
             realtime = client
             realtimeGeneration = lease.generation
+            realtimeConnectionId = null
             _connectionState.value = _connectionState.value.copy(
                 generation = lease.generation,
                 writable = false,
             )
             _roomClosedReason.value = null
+            refreshTransportAuthorizationLocked()
             newOwner
         }
         var backoffIndex = 0
@@ -440,6 +558,7 @@ class WatchTogetherRepository(
                                 terminalGeneration = lease.generation
                                 _roomClosedReason.value = event.reason ?: "room_closed"
                                 _roomSnapshot.value = null
+                                refreshTransportAuthorizationLocked()
                             }
                         }
                         throw ServerClosed
@@ -448,7 +567,7 @@ class WatchTogetherRepository(
                         throw TransportEnded
                     } else if (event is RoomRealtimeEvent.Opened) {
                         openedAtMs = monotonicNowMs()
-                        markOpened(lease, owner)
+                        markOpened(lease, owner, client.currentConnectionId())
                     } else if (
                         event is RoomRealtimeEvent.SnapshotEvent &&
                         event.room.roomId == lease.roomId
@@ -488,6 +607,7 @@ class WatchTogetherRepository(
                         terminalGeneration = lease.generation
                         _roomClosedReason.value = "connection_lost"
                         _roomSnapshot.value = null
+                        refreshTransportAuthorizationLocked()
                     }
                 }
                 break
@@ -520,21 +640,29 @@ class WatchTogetherRepository(
             ) {
                 realtime = null
                 realtimeGeneration = null
+                realtimeConnectionId = null
                 activeConnectionOwner = null
                 _connectionState.value = _connectionState.value.copy(writable = false)
+                refreshTransportAuthorizationLocked()
             }
         }
     }
 
-    private suspend fun markOpened(lease: RoomBinding, owner: Long) {
+    private suspend fun markOpened(
+        lease: RoomBinding,
+        owner: Long,
+        connectionId: Long?,
+    ) {
         stateMutex.withLock {
             if (isCurrentOwnerLocked(lease, owner)) {
+                realtimeConnectionId = connectionId
                 val previous = _connectionState.value
                 _connectionState.value = WatchTogetherConnectionState(
                     generation = lease.generation,
                     epoch = if (previous.generation == lease.generation) previous.epoch + 1 else 1,
                     writable = true,
                 )
+                refreshTransportAuthorizationLocked()
             }
         }
     }
@@ -543,6 +671,8 @@ class WatchTogetherRepository(
         stateMutex.withLock {
             if (binding == lease && activeConnectionOwner == owner) {
                 _connectionState.value = _connectionState.value.copy(writable = false)
+                realtimeConnectionId = null
+                refreshTransportAuthorizationLocked()
             }
         }
     }
@@ -562,7 +692,10 @@ class WatchTogetherRepository(
             when (event) {
                 RoomRealtimeEvent.Opened -> Unit
                 is RoomRealtimeEvent.SnapshotEvent ->
-                    if (event.room.roomId == lease.roomId) _roomSnapshot.value = event.room
+                    if (event.room.roomId == lease.roomId) {
+                        _roomSnapshot.value = event.room
+                        refreshTransportAuthorizationLocked()
+                    }
                 is RoomRealtimeEvent.SuggestionsEvent -> applySuggestions(event.suggestions, fromBroadcast = true)
                 is RoomRealtimeEvent.TransportCommandEvent -> _transportCommands.tryEmit(
                     ScheduledTransportCommand(
@@ -601,8 +734,10 @@ class WatchTogetherRepository(
             votedIds.clear()
             realtime = null
             realtimeGeneration = null
+            realtimeConnectionId = null
             activeConnectionOwner = null
             _connectionState.value = WatchTogetherConnectionState(generation = nextGeneration)
+            refreshTransportAuthorizationLocked()
         }
     }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomDeliveryLatch.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomDeliveryLatch.kt
@@ -1,0 +1,130 @@
+package org.siloserver.silo.watchtogether
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.TransportCommand
+import org.siloserver.silo.repository.WatchTogetherConnectionState
+
+data class RoomDeliveryKey(
+    val connectionGeneration: Long,
+    val connectionEpoch: Long,
+    val playbackSessionId: String,
+)
+
+/**
+ * Successful-delivery latches for one player controller.
+ *
+ * Failed sends never advance a latch, so a caller can retry. Reconnection
+ * changes the epoch and therefore re-arms attach/readiness even when the room
+ * snapshot and local buffering state are otherwise identical.
+ */
+class RoomDeliveryLatch {
+    private var attached: RoomDeliveryKey? = null
+    private var readiness: Pair<RoomDeliveryKey, Boolean>? = null
+
+    fun keyOrNull(
+        connection: WatchTogetherConnectionState,
+        playbackSessionId: String?,
+    ): RoomDeliveryKey? =
+        playbackSessionId
+            ?.takeIf { it.isNotBlank() && connection.writable }
+            ?.let {
+                RoomDeliveryKey(
+                    connectionGeneration = connection.generation,
+                    connectionEpoch = connection.epoch,
+                    playbackSessionId = it,
+                )
+            }
+
+    fun needsAttach(key: RoomDeliveryKey): Boolean = attached != key
+
+    fun isAttached(key: RoomDeliveryKey?): Boolean = key != null && attached == key
+
+    fun recordAttach(key: RoomDeliveryKey, delivered: Boolean) {
+        if (delivered) attached = key
+    }
+
+    fun needsReadiness(key: RoomDeliveryKey, buffering: Boolean): Boolean =
+        readiness != key to buffering
+
+    fun recordReadiness(key: RoomDeliveryKey, buffering: Boolean, delivered: Boolean) {
+        if (delivered) readiness = key to buffering
+    }
+}
+
+/**
+ * Starts each accepted command independently so an execute-at delay cannot
+ * prevent the transport collector from accepting a newer command.
+ */
+class RoomCommandDispatcher(
+    private val scope: CoroutineScope,
+) {
+    fun dispatch(block: suspend () -> Unit) {
+        scope.launch { block() }
+    }
+}
+
+class RoomPendingExecutionToken internal constructor()
+
+/** Per-command pending ownership; finishing one command cannot clear another. */
+class RoomPendingExecutions {
+    private val deadlines = MutableStateFlow<Map<RoomPendingExecutionToken, Long>>(emptyMap())
+
+    fun record(executeAtMs: Long): RoomPendingExecutionToken {
+        val token = RoomPendingExecutionToken()
+        deadlines.update { it + (token to executeAtMs) }
+        return token
+    }
+
+    fun finish(token: RoomPendingExecutionToken) {
+        deadlines.update { it - token }
+    }
+
+    fun nearestTo(nowMs: Long): Long? =
+        deadlines.value.values.minByOrNull { deadline ->
+            kotlin.math.abs(deadline - nowMs)
+        }
+}
+
+/**
+ * A replaceable controller owns child collectors but never the process room
+ * lease. Disposing it cancels only these child jobs.
+ */
+class RoomControllerLifetime(parentScope: CoroutineScope) {
+    private val job = SupervisorJob(parentScope.coroutineContext[Job])
+    val scope = CoroutineScope(parentScope.coroutineContext + job)
+
+    fun dispose() {
+        job.cancel()
+    }
+}
+
+/**
+ * Revalidate a delayed command immediately before touching the player. This
+ * prevents a command accepted for playback session A from seeking/pausing a
+ * replacement session B after its execute-at delay.
+ */
+fun scheduledCommandStillCurrent(
+    command: TransportCommand,
+    acceptedPlaybackSessionId: String?,
+    acceptedRoomId: String,
+    acceptedConnection: WatchTogetherConnectionState,
+    currentPlaybackSessionId: String?,
+    currentRoom: RoomSnapshot?,
+    currentConnection: WatchTogetherConnectionState,
+): Boolean =
+    !acceptedPlaybackSessionId.isNullOrBlank() &&
+        currentPlaybackSessionId == acceptedPlaybackSessionId &&
+        (command.sessionId.isBlank() || command.sessionId == acceptedPlaybackSessionId) &&
+        acceptedRoomId.isNotBlank() &&
+        currentRoom?.roomId == acceptedRoomId &&
+        currentRoom.selectionRevision == command.selectionRevision &&
+        acceptedConnection.writable &&
+        currentConnection.writable &&
+        currentConnection.generation == acceptedConnection.generation &&
+        currentConnection.epoch == acceptedConnection.epoch

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomEntryUiPolicy.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomEntryUiPolicy.kt
@@ -1,0 +1,7 @@
+package org.siloserver.silo.watchtogether
+
+/**
+ * A create/join operation installs a process-scoped room binding on success.
+ * Keep its observer visible until that mutation resolves.
+ */
+fun canDismissRoomEntry(isBusy: Boolean): Boolean = !isBusy

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomSession.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomSession.kt
@@ -1,0 +1,116 @@
+package org.siloserver.silo.watchtogether
+
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.IdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionPhase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Narrow room lifecycle port so the application-scoped owner can be tested
+ * independently from REST and websocket implementations.
+ */
+interface RoomSessionRepository {
+    val roomSnapshot: StateFlow<RoomSnapshot?>
+    val roomClosedReason: StateFlow<String?>
+
+    suspend fun connect(roomId: String)
+    suspend fun reset()
+    suspend fun closeRoom(): ApiResult<Unit>
+}
+
+/** A Watch Together room, not a device-local episode queue, owns title changes. */
+fun shouldNavigateToLocalNext(inWatchTogetherRoom: Boolean): Boolean =
+    !inWatchTogetherRoom
+
+/**
+ * The single application-scoped owner of a Watch Together connection.
+ *
+ * Screen scopes adopt this session; they never own the socket. Replacement
+ * and leave are serialized, and the previous job is joined before repository
+ * state can be reused by another room.
+ */
+class RoomSession(
+    private val repository: RoomSessionRepository,
+    private val scope: CoroutineScope,
+    identityTransitions: IdentityTransitionBarrier,
+) {
+    private val mutex = Mutex()
+    private var connectionJob: Job? = null
+    private var connectedRoomId: String? = null
+
+    val room: StateFlow<RoomSnapshot?> = repository.roomSnapshot
+    val closedReason: StateFlow<String?> = repository.roomClosedReason
+
+    init {
+        identityTransitions.installGate { transition ->
+            if (transition.phase == IdentityTransitionPhase.WILL_CHANGE) {
+                leave()
+            }
+        }
+    }
+
+    /**
+     * UI-facing entry point. The returned job is owned by the process scope, so
+     * navigation cannot cancel a queued replacement midway through teardown.
+     */
+    fun adopt(roomId: String): Job =
+        scope.launch(start = CoroutineStart.UNDISPATCHED) { enter(roomId) }
+
+    /**
+     * UI-facing durable departure. If requested, close is attempted while the
+     * current lease is still live; teardown then joins the socket and resets
+     * state even if the initiating screen disappears.
+     */
+    fun depart(closeRoom: Boolean = false): Job =
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            mutex.withLock {
+                if (closeRoom && connectedRoomId != null) {
+                    try {
+                        repository.closeRoom()
+                    } finally {
+                        leaveLocked()
+                    }
+                } else {
+                    leaveLocked()
+                }
+            }
+        }
+
+    suspend fun enter(roomId: String) {
+        if (roomId.isBlank()) return
+        mutex.withLock {
+            if (connectedRoomId == roomId && connectionJob?.isActive == true) return
+            connectionJob?.cancelAndJoin()
+            connectedRoomId = roomId
+            // Establish repository ownership before enter() returns. Without
+            // UNDISTPATCHED, a concurrent replacement can cancel a queued job
+            // before it ever installs its connection owner.
+            connectionJob = scope.launch(start = CoroutineStart.UNDISPATCHED) {
+                repository.connect(roomId)
+            }
+        }
+    }
+
+    suspend fun leave() {
+        mutex.withLock {
+            leaveLocked()
+        }
+    }
+
+    suspend fun isActive(): Boolean = mutex.withLock { connectionJob?.isActive == true }
+
+    private suspend fun leaveLocked() {
+        connectionJob?.cancelAndJoin()
+        connectionJob = null
+        connectedRoomId = null
+        repository.reset()
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomTransportAuthority.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomTransportAuthority.kt
@@ -8,6 +8,19 @@ import org.siloserver.silo.model.watchtogether.RoomSnapshot
 enum class RoomTransportIntent { PlayPause, Seek }
 
 /**
+ * Reconciliation required when a platform media control changes the local
+ * player directly instead of entering through the in-app room controls.
+ *
+ * [restorePlayWhenReady] immediately returns the player to the server-owned
+ * room state. [requestIsPaused] is non-null only when the member is authorized
+ * to ask the room to adopt the attempted state.
+ */
+data class ExternalPlayPauseDecision(
+    val restorePlayWhenReady: Boolean,
+    val requestIsPaused: Boolean?,
+)
+
+/**
  * Single source of truth for Watch Together transport authority, shared across
  * mobile and TV. Mirrors silo-server `internal/watchtogether/service.go`:
  *  - no transport outside the [RoomPhase.Playing] phase;
@@ -25,4 +38,31 @@ fun roomTransportAuthorized(snapshot: RoomSnapshot?, intent: RoomTransportIntent
         RoomTransportIntent.Seek -> snapshot.selfRole == MemberRole.Host && snapshot.selfCanControlTransport
         RoomTransportIntent.PlayPause -> snapshot.selfCanControlTransport
     }
+}
+
+/**
+ * Keeps notification, headset, Bluetooth, and other MediaSession controls from
+ * creating a local-only fork from Watch Together playback.
+ *
+ * Every external toggle is first restored to the authoritative room state. An
+ * authorized toggle is then requested through the room and will be applied to
+ * every participant by the resulting scheduled transport command.
+ */
+fun externalPlayPauseDecision(
+    snapshot: RoomSnapshot?,
+    localPlayWhenReady: Boolean,
+): ExternalPlayPauseDecision? {
+    if (snapshot == null || snapshot.phase != RoomPhase.Playing) return null
+    val authoritativePlayWhenReady = !snapshot.isPaused
+    if (localPlayWhenReady == authoritativePlayWhenReady) return null
+    return ExternalPlayPauseDecision(
+        restorePlayWhenReady = authoritativePlayWhenReady,
+        requestIsPaused = if (
+            roomTransportAuthorized(snapshot, RoomTransportIntent.PlayPause)
+        ) {
+            !localPlayWhenReady
+        } else {
+            null
+        },
+    )
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomVote.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomVote.kt
@@ -1,0 +1,18 @@
+package org.siloserver.silo.watchtogether
+
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.Suggestion
+
+/**
+ * Returns the winner from the server-ordered suggestion list.
+ *
+ * The server sorts by vote count and then age, so the first suggestion wins
+ * only after somebody has voted. An unvoted list intentionally has no winner.
+ */
+fun roomVoteWinner(suggestions: List<Suggestion>): Suggestion? =
+    suggestions.firstOrNull()?.takeIf { it.voteCount > 0 }
+
+/** Whether this room decides its selection by vote. */
+fun RoomSnapshot?.isVoteRoom(): Boolean =
+    this != null && selectionMode == RoomSelectionMode.Vote

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/catalog/CatalogTrackSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/catalog/CatalogTrackSerializationTest.kt
@@ -54,4 +54,22 @@ class CatalogTrackSerializationTest {
 
         assertEquals("tv", track.colorRange)
     }
+
+    @Test
+    fun `VideoTrack decodes server rational frame rate`() {
+        val source = """{"codec":"h264","frame_rate":"30000/1001"}"""
+
+        val track = json.decodeFromString<VideoTrack>(source)
+
+        assertEquals(29.97002997002997, track.frameRate)
+    }
+
+    @Test
+    fun `VideoTrack keeps accepting numeric frame rate`() {
+        val source = """{"codec":"h264","frame_rate":30.0}"""
+
+        val track = json.decodeFromString<VideoTrack>(source)
+
+        assertEquals(30.0, track.frameRate)
+    }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/feature/ClientSurfacePolicyTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/feature/ClientSurfacePolicyTest.kt
@@ -1,11 +1,11 @@
 package org.siloserver.silo.model.feature
 
 import kotlin.test.Test
-import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ClientSurfacePolicyTest {
     @Test
-    fun watchTogetherCodeStaysPresentButHiddenFromUserMenus() {
-        assertFalse(CLIENT_WATCH_TOGETHER_SURFACE_ENABLED)
+    fun watchTogetherIsExposedInTheDetailOverflows() {
+        assertTrue(CLIENT_WATCH_TOGETHER_SURFACE_ENABLED)
     }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/HttpOriginPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/HttpOriginPolicyTest.kt
@@ -26,6 +26,22 @@ class HttpOriginPolicyTest {
     }
 
     @Test
+    fun webSocketSchemesUseTheirCorrespondingHttpOriginsForConsent() = runTest {
+        val consent = object : CleartextOriginConsent {
+            override suspend fun isApproved(origin: String): Boolean =
+                origin == "http://silo.example"
+        }
+
+        assertFalse(consent.requiresApproval("ws://SILO.EXAMPLE:80/rooms/r/ws?room_token=secret"))
+        assertTrue(consent.requiresApproval("ws://silo.example:8090/rooms/r/ws"))
+        assertFalse(consent.requiresApproval("wss://silo.example/rooms/r/ws"))
+        assertEquals("http://silo.example", canonicalHttpOrigin("ws://SILO.EXAMPLE:80/rooms/r/ws"))
+        assertEquals("https://silo.example", canonicalHttpOrigin("wss://SILO.EXAMPLE:443/rooms/r/ws"))
+        assertTrue(isSameHttpOrigin("http://silo.example", "ws://silo.example/rooms/r/ws"))
+        assertTrue(isSameHttpOrigin("https://silo.example", "wss://silo.example/rooms/r/ws"))
+    }
+
+    @Test
     fun defaultPortsAndCaseNormalize() {
         assertTrue(isSameHttpOrigin("HTTPS://Silo.Example", "https://silo.example:443/a"))
         assertTrue(isSameHttpOrigin("http://silo.example", "http://SILO.EXAMPLE:80/a"))

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/IdentityTransitionBarrierTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/IdentityTransitionBarrierTest.kt
@@ -29,6 +29,20 @@ class IdentityTransitionBarrierTest {
     }
 
     @Test
+    fun allInstalledPrivacyGatesRunBeforeMutation() = runTest {
+        val barrier = DefaultIdentityTransitionBarrier()
+        val timeline = mutableListOf<String>()
+        barrier.installGate { timeline += "diagnostics" }
+        barrier.installGate { timeline += "room" }
+
+        barrier.changing(IdentityTransitionKind.PROFILE_SWITCH) {
+            timeline += "mutation"
+        }
+
+        assertEquals(listOf("diagnostics", "room", "mutation"), timeline)
+    }
+
+    @Test
     fun didChangeIsEmittedWhenMutationFails() = runTest {
         val barrier = DefaultIdentityTransitionBarrier()
         val observed = mutableListOf<IdentityTransition>()

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/SiloAuthPluginPinTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/SiloAuthPluginPinTest.kt
@@ -54,6 +54,36 @@ class SiloAuthPluginPinTest {
     }
 
     @Test
+    fun unapprovedCleartextWebSocketIsBlockedBeforeCredentialsReachEngine() = runTest {
+        var engineCalled = false
+        val tokenManager = TokenManagerImpl().apply {
+            setServerUrl("http://silo.lan")
+            saveTokens("access", "refresh", 3600)
+            setProfileId("profile")
+            setProfileToken("profile-token")
+        }
+        val client = HttpClient(
+            MockEngine {
+                engineCalled = true
+                respond("{}", HttpStatusCode.OK)
+            },
+        ) {
+            install(SiloAuthPlugin) {
+                this.tokenManager = tokenManager
+                this.cleartextOriginConsent = object : CleartextOriginConsent {
+                    override suspend fun isApproved(origin: String): Boolean = false
+                }
+            }
+        }
+
+        assertFailsWith<CleartextOriginNotApprovedException> {
+            client.get("ws://silo.lan/api/v1/watch-together/rooms/r/ws?room_token=secret")
+        }
+        assertEquals(false, engineCalled)
+        client.close()
+    }
+
+    @Test
     fun unauthenticatedLoginPostStillRequiresCleartextApproval() = runTest {
         var engineCalled = false
         val tokenManager = TokenManagerImpl().apply { setServerUrl("http://silo.lan") }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClientTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClientTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -84,6 +85,31 @@ class WatchTogetherRealtimeClientTest {
 
         assertEquals(1, events.size)
         assertIs<RoomRealtimeEvent.Opened>(events.single())
+    }
+
+    @Test
+    fun `collector cancellation joins physical socket close before completing`() = runTest {
+        val connection = FakeConnection()
+        val closeGate = CompletableDeferred<Unit>()
+        connection.closeGate = closeGate
+        val opened = CompletableDeferred<Unit>()
+        val job = launch {
+            client(FakeConnector(connection))
+                .connect("room-1", "room-token")
+                .collect {
+                    if (it is RoomRealtimeEvent.Opened) opened.complete(Unit)
+                }
+        }
+        opened.await()
+
+        job.cancel()
+        runCurrent()
+
+        assertTrue(connection.closeStarted.isCompleted)
+        assertFalse(job.isCompleted)
+        closeGate.complete(Unit)
+        job.join()
+        assertTrue(connection.closed)
     }
 
     @Test
@@ -307,6 +333,9 @@ class WatchTogetherRealtimeClientTest {
         val incoming = Channel<String>(Channel.UNLIMITED)
         val sent = mutableListOf<String>()
         var sendFailure: Throwable? = null
+        val closeStarted = CompletableDeferred<Unit>()
+        var closeGate: CompletableDeferred<Unit>? = null
+        var closed = false
 
         override suspend fun receiveText(): String? {
             val result = incoming.receiveCatching()
@@ -320,7 +349,10 @@ class WatchTogetherRealtimeClientTest {
         }
 
         override suspend fun close() {
+            closeStarted.complete(Unit)
+            closeGate?.await()
             incoming.cancel(CancellationException("test connection closed"))
+            closed = true
         }
     }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClientTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClientTest.kt
@@ -1,0 +1,236 @@
+package org.siloserver.silo.network
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WatchTogetherRealtimeClientTest {
+
+    @Test
+    fun `normal socket EOF is transport termination not protocol room close`() = runTest {
+        val connection = FakeConnection().apply { incoming.close() }
+        val client = client(FakeConnector(connection))
+
+        val events = mutableListOf<RoomRealtimeEvent>()
+        client.connect("room-1", "room-token").collect(events::add)
+
+        assertIs<RoomRealtimeEvent.Opened>(events[0])
+        assertIs<RoomRealtimeEvent.TransportTerminated>(events[1])
+        assertNull(events[1].let { it as RoomRealtimeEvent.TransportTerminated }.cause)
+        assertTrue(events.none { it is RoomRealtimeEvent.Closed })
+    }
+
+    @Test
+    fun `socket receive failure is typed transport termination not protocol room close`() = runTest {
+        val connection = FakeConnection().apply {
+            incoming.close(IllegalStateException("socket broke"))
+        }
+        val client = client(FakeConnector(connection))
+
+        val events = mutableListOf<RoomRealtimeEvent>()
+        client.connect("room-1", "room-token").collect(events::add)
+
+        val terminated = assertIs<RoomRealtimeEvent.TransportTerminated>(events.last())
+        assertEquals("socket broke", terminated.cause?.message)
+        assertTrue(events.none { it is RoomRealtimeEvent.Closed })
+    }
+
+    @Test
+    fun `handshake failure is typed transport termination not protocol room close`() = runTest {
+        val client = client(
+            object : WatchTogetherSocketConnector {
+                override suspend fun open(url: String): WatchTogetherSocketConnection {
+                    throw IllegalStateException("handshake rejected")
+                }
+            },
+        )
+
+        val events = mutableListOf<RoomRealtimeEvent>()
+        client.connect("room-1", "room-token").collect(events::add)
+
+        val terminated = assertIs<RoomRealtimeEvent.TransportTerminated>(events.single())
+        assertEquals("handshake rejected", terminated.cause?.message)
+    }
+
+    @Test
+    fun `collector cancellation emits no transport or protocol close`() = runTest {
+        val connection = FakeConnection()
+        val opened = CompletableDeferred<Unit>()
+        val events = mutableListOf<RoomRealtimeEvent>()
+        val job = launch {
+            client(FakeConnector(connection))
+                .connect("room-1", "room-token")
+                .collect {
+                    events += it
+                    if (it is RoomRealtimeEvent.Opened) opened.complete(Unit)
+                }
+        }
+        opened.await()
+
+        job.cancelAndJoin()
+
+        assertEquals(1, events.size)
+        assertIs<RoomRealtimeEvent.Opened>(events.single())
+    }
+
+    @Test
+    fun `sends report delivery only while a writable connection is current`() = runTest {
+        val connection = FakeConnection()
+        val client = client(FakeConnector(connection))
+        assertFalse(client.attachSession("session-before-open"))
+
+        val opened = CompletableDeferred<Unit>()
+        val job = launch {
+            client.connect("room-1", "room-token").collect {
+                if (it is RoomRealtimeEvent.Opened) opened.complete(Unit)
+            }
+        }
+        opened.await()
+
+        assertTrue(client.attachSession("session-1"))
+        assertTrue(client.transportRequest("seek", 12.5, false))
+        assertTrue(client.stateReport("session-1", 13.5, false))
+        assertTrue(client.ready("session-1", 14.5, false))
+        assertTrue(client.buffering("session-1", 15.5, true))
+        assertTrue(client.ping("2026-07-27T10:00:00Z"))
+        assertEquals(
+            listOf(
+                "attach_session",
+                "transport_request",
+                "state_report",
+                "ready",
+                "buffering",
+                "ping",
+            ),
+            connection.sent.map { SiloJson.parseToJsonElement(it).jsonObject.getValue("type").jsonPrimitive.content },
+        )
+
+        connection.sendFailure = IllegalStateException("closed")
+        assertFalse(client.ping("2026-07-27T10:00:01Z"))
+        job.cancelAndJoin()
+        assertFalse(client.attachSession("session-after-close"))
+    }
+
+    @Test
+    fun `old connection finalizer cannot clear a writable replacement`() = runTest {
+        val first = FakeConnection()
+        val second = FakeConnection()
+        val connector = FakeConnector(first, second)
+        val client = client(connector)
+        val firstOpened = CompletableDeferred<Unit>()
+        val secondOpened = CompletableDeferred<Unit>()
+        val firstJob = launch {
+            client.connect("room-1", "room-token").collect {
+                if (it is RoomRealtimeEvent.Opened) firstOpened.complete(Unit)
+            }
+        }
+        firstOpened.await()
+        val secondJob = launch {
+            client.connect("room-1", "room-token").collect {
+                if (it is RoomRealtimeEvent.Opened) secondOpened.complete(Unit)
+            }
+        }
+        secondOpened.await()
+
+        firstJob.cancelAndJoin()
+        assertTrue(client.ping("replacement-ping"))
+        assertTrue(first.sent.isEmpty())
+        assertEquals(1, second.sent.size)
+
+        secondJob.cancelAndJoin()
+    }
+
+    @Test
+    fun `connection URL encodes room path and excludes access JWT`() = runTest {
+        val connection = FakeConnection()
+        val connector = FakeConnector(connection)
+        val client = client(
+            connector = connector,
+            accessToken = "ACCESS_SECRET",
+            profileId = "profile id",
+            profileToken = "profile&secret",
+        )
+        val opened = CompletableDeferred<Unit>()
+        val job = launch {
+            client.connect("room/with ?#", "room&secret").collect {
+                if (it is RoomRealtimeEvent.Opened) opened.complete(Unit)
+            }
+        }
+        opened.await()
+
+        val url = connector.urls.single()
+        assertTrue(url.startsWith("/api/v1/watch-together/rooms/room%2Fwith%20%3F%23/ws?"))
+        assertFalse(url.contains("ACCESS_SECRET"))
+        assertFalse(url.contains("token=ACCESS_SECRET"))
+        assertTrue(url.contains("room_token=room%26secret"))
+        assertTrue(url.contains("profile_id=profile%20id"))
+        assertTrue(url.contains("profile_token=profile%26secret"))
+
+        job.cancelAndJoin()
+    }
+
+    private suspend fun client(
+        connector: WatchTogetherSocketConnector,
+        accessToken: String = "access",
+        profileId: String = "profile",
+        profileToken: String = "profile-token",
+    ): DefaultWatchTogetherRealtimeClient {
+        val tokens = TokenManagerImpl().apply {
+            saveTokens(accessToken, "refresh", 3_600)
+            setProfileId(profileId)
+            setProfileToken(profileToken)
+        }
+        return DefaultWatchTogetherRealtimeClient(
+            tokenManager = tokens,
+            socketConnector = connector,
+        )
+    }
+
+    private class FakeConnector(
+        vararg connections: FakeConnection,
+    ) : WatchTogetherSocketConnector {
+        private val connections = Channel<FakeConnection>(Channel.UNLIMITED).apply {
+            connections.forEach { trySend(it) }
+        }
+        val urls = mutableListOf<String>()
+
+        override suspend fun open(url: String): WatchTogetherSocketConnection {
+            urls += url
+            return connections.receive()
+        }
+    }
+
+    private class FakeConnection : WatchTogetherSocketConnection {
+        val incoming = Channel<String>(Channel.UNLIMITED)
+        val sent = mutableListOf<String>()
+        var sendFailure: Throwable? = null
+
+        override suspend fun receiveText(): String? {
+            val result = incoming.receiveCatching()
+            result.exceptionOrNull()?.let { throw it }
+            return result.getOrNull()
+        }
+
+        override suspend fun sendText(text: String) {
+            sendFailure?.let { throw it }
+            sent += text
+        }
+
+        override suspend fun close() {
+            incoming.cancel(CancellationException("test connection closed"))
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClientTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClientTest.kt
@@ -21,6 +21,36 @@ import kotlin.test.assertTrue
 class WatchTogetherRealtimeClientTest {
 
     @Test
+    fun `socket request string never exposes query credentials or profile token`() {
+        val request = WatchTogetherSocketRequest(
+            url = "/rooms/room-1/ws?room_token=room-secret&profile_token=profile-secret",
+            authScope = AuthScopeSnapshot(
+                serverId = "aHR0cHM6Ly9wcml2YXRlLXNpbG8uZXhhbXBsZQ",
+                profileId = "private-profile-id",
+                serverUrl = "https://user:url-secret@private-silo.example/path?api_key=url-query-secret",
+                profileToken = "profile-secret",
+                credentialGenerationId = "credential-generation-secret",
+                identityGeneration = 987654321L,
+                credentialEpoch = 123456789L,
+            ),
+        )
+
+        val rendered = request.toString()
+
+        assertFalse(rendered.contains("room-secret"))
+        assertFalse(rendered.contains("profile-secret"))
+        assertFalse(rendered.contains("aHR0cHM6Ly9wcml2YXRlLXNpbG8uZXhhbXBsZQ"))
+        assertFalse(rendered.contains("private-profile-id"))
+        assertFalse(rendered.contains("private-silo.example"))
+        assertFalse(rendered.contains("url-secret"))
+        assertFalse(rendered.contains("url-query-secret"))
+        assertFalse(rendered.contains("credential-generation-secret"))
+        assertFalse(rendered.contains("987654321"))
+        assertFalse(rendered.contains("123456789"))
+        assertTrue(rendered.contains("<redacted>"))
+    }
+
+    @Test
     fun `normal socket EOF is transport termination not protocol room close`() = runTest {
         val connection = FakeConnection().apply { incoming.close() }
         val client = client(FakeConnector(connection))
@@ -148,6 +178,37 @@ class WatchTogetherRealtimeClientTest {
         assertFalse(client.ping("2026-07-27T10:00:01Z"))
         job.cancelAndJoin()
         assertFalse(client.attachSession("session-after-close"))
+    }
+
+    @Test
+    fun `connection scoped transport never crosses into a replacement socket`() = runTest {
+        val first = FakeConnection()
+        val second = FakeConnection()
+        val client = client(FakeConnector(first, second))
+        val firstOpened = CompletableDeferred<Unit>()
+        val firstJob = launch {
+            client.connect("room-1", "room-token-1").collect {
+                if (it is RoomRealtimeEvent.Opened) firstOpened.complete(Unit)
+            }
+        }
+        firstOpened.await()
+        val firstId = requireNotNull(client.currentConnectionId())
+
+        val secondOpened = CompletableDeferred<Unit>()
+        val secondJob = launch {
+            client.connect("room-2", "room-token-2").collect {
+                if (it is RoomRealtimeEvent.Opened) secondOpened.complete(Unit)
+            }
+        }
+        secondOpened.await()
+        val secondId = requireNotNull(client.currentConnectionId())
+
+        assertFalse(client.transportRequestOnConnection(firstId, "pause", 12.0, true))
+        assertTrue(client.transportRequestOnConnection(secondId, "pause", 12.0, true))
+        assertTrue(first.sent.isEmpty())
+        assertEquals(1, second.sent.size)
+        firstJob.cancelAndJoin()
+        secondJob.cancelAndJoin()
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClientTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClientTest.kt
@@ -209,6 +209,51 @@ class WatchTogetherRealtimeClientTest {
         assertTrue(connector.requests.isEmpty())
     }
 
+    @Test
+    fun `explicit room scope wins over a different live identity without snapshot reads`() = runTest {
+        val scopeA = AuthScopeSnapshot(
+            serverId = "server-a",
+            profileId = "profile-a",
+            serverUrl = "https://a.example",
+            profileToken = "PROFILE_A",
+            identityGeneration = 1L,
+        )
+        val scopeB = AuthScopeSnapshot(
+            serverId = "server-b",
+            profileId = "profile-b",
+            serverUrl = "https://b.example",
+            profileToken = "PROFILE_B",
+            identityGeneration = 2L,
+        )
+        var snapshotReads = 0
+        val delegate = TokenManagerImpl()
+        val tokens = object : TokenManager by delegate {
+            override suspend fun snapshotCurrentScope(): AuthScopeSnapshot {
+                snapshotReads++
+                return scopeB
+            }
+
+            override suspend fun getAccessTokenForScope(scope: AuthScopeSnapshot): String? =
+                "ACCESS_A".takeIf { scope == scopeA }
+        }
+        val connection = FakeConnection().apply { incoming.close() }
+        val connector = FakeConnector(connection)
+        val client = DefaultWatchTogetherRealtimeClient(
+            tokenManager = tokens,
+            socketConnector = connector,
+        )
+
+        client.connect("room-a", "ROOM_A", scopeA).collect { }
+
+        assertEquals(0, snapshotReads)
+        val request = connector.requests.single()
+        assertEquals(scopeA, request.authScope)
+        assertTrue(request.url.contains("profile_id=profile-a"))
+        assertTrue(request.url.contains("profile_token=PROFILE_A"))
+        assertFalse(request.url.contains("profile-b"))
+        assertFalse(request.url.contains("PROFILE_B"))
+    }
+
     private suspend fun client(
         connector: WatchTogetherSocketConnector,
         accessToken: String = "access",

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClientTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClientTest.kt
@@ -52,7 +52,7 @@ class WatchTogetherRealtimeClientTest {
     fun `handshake failure is typed transport termination not protocol room close`() = runTest {
         val client = client(
             object : WatchTogetherSocketConnector {
-                override suspend fun open(url: String): WatchTogetherSocketConnection {
+                override suspend fun open(request: WatchTogetherSocketRequest): WatchTogetherSocketConnection {
                     throw IllegalStateException("handshake rejected")
                 }
             },
@@ -171,15 +171,42 @@ class WatchTogetherRealtimeClientTest {
         }
         opened.await()
 
-        val url = connector.urls.single()
+        val request = connector.requests.single()
+        val url = request.url
         assertTrue(url.startsWith("/api/v1/watch-together/rooms/room%2Fwith%20%3F%23/ws?"))
         assertFalse(url.contains("ACCESS_SECRET"))
         assertFalse(url.contains("token=ACCESS_SECRET"))
         assertTrue(url.contains("room_token=room%26secret"))
         assertTrue(url.contains("profile_id=profile%20id"))
         assertTrue(url.contains("profile_token=profile%26secret"))
+        assertEquals("profile id", request.authScope.profileId)
+        assertEquals("profile&secret", request.authScope.profileToken)
 
         job.cancelAndJoin()
+    }
+
+    @Test
+    fun `missing access token for captured scope fails before connector opens`() = runTest {
+        val scope = AuthScopeSnapshot(
+            serverId = "server-a",
+            profileId = "profile-a",
+            serverUrl = "https://a.example",
+            profileToken = "PROFILE_A",
+        )
+        val tokens = SnapshotTokenManager(scope, accessToken = null)
+        val connector = FakeConnector(FakeConnection())
+        val client = DefaultWatchTogetherRealtimeClient(
+            tokenManager = tokens,
+            socketConnector = connector,
+        )
+
+        val events = mutableListOf<RoomRealtimeEvent>()
+        client.connect("room-a", "ROOM_A").collect(events::add)
+
+        val terminated = assertIs<RoomRealtimeEvent.TransportTerminated>(events.single())
+        assertEquals("missing_auth_scope", terminated.cause?.message)
+        assertEquals(1, tokens.snapshotReads)
+        assertTrue(connector.requests.isEmpty())
     }
 
     private suspend fun client(
@@ -188,11 +215,13 @@ class WatchTogetherRealtimeClientTest {
         profileId: String = "profile",
         profileToken: String = "profile-token",
     ): DefaultWatchTogetherRealtimeClient {
-        val tokens = TokenManagerImpl().apply {
-            saveTokens(accessToken, "refresh", 3_600)
-            setProfileId(profileId)
-            setProfileToken(profileToken)
-        }
+        val scope = AuthScopeSnapshot(
+            serverId = "server",
+            profileId = profileId,
+            serverUrl = "http://localhost:8090",
+            profileToken = profileToken,
+        )
+        val tokens = SnapshotTokenManager(scope, accessToken)
         return DefaultWatchTogetherRealtimeClient(
             tokenManager = tokens,
             socketConnector = connector,
@@ -205,12 +234,28 @@ class WatchTogetherRealtimeClientTest {
         private val connections = Channel<FakeConnection>(Channel.UNLIMITED).apply {
             connections.forEach { trySend(it) }
         }
-        val urls = mutableListOf<String>()
+        val requests = mutableListOf<WatchTogetherSocketRequest>()
 
-        override suspend fun open(url: String): WatchTogetherSocketConnection {
-            urls += url
+        override suspend fun open(request: WatchTogetherSocketRequest): WatchTogetherSocketConnection {
+            requests += request
             return connections.receive()
         }
+    }
+
+    private class SnapshotTokenManager(
+        private val scope: AuthScopeSnapshot,
+        private val accessToken: String?,
+        private val delegate: TokenManager = TokenManagerImpl(),
+    ) : TokenManager by delegate {
+        var snapshotReads = 0
+
+        override suspend fun snapshotCurrentScope(): AuthScopeSnapshot {
+            snapshotReads += 1
+            return scope
+        }
+
+        override suspend fun getAccessTokenForScope(scope: AuthScopeSnapshot): String? =
+            accessToken?.takeIf { scope == this.scope }
     }
 
     private class FakeConnection : WatchTogetherSocketConnection {

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/WatchTogetherApiTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/WatchTogetherApiTest.kt
@@ -7,6 +7,7 @@ import org.siloserver.silo.model.watchtogether.PromoteSuggestionRequest
 import org.siloserver.silo.model.watchtogether.SetSelectionRequest
 import org.siloserver.silo.model.watchtogether.UpdatePolicyRequest
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
 import org.siloserver.silo.network.SiloJson
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -25,6 +26,12 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class WatchTogetherApiTest {
+    private val scope = AuthScopeSnapshot(
+        serverId = "server-1",
+        profileId = "profile-1",
+        serverUrl = "https://silo.example",
+        profileToken = "profile-token",
+    )
 
     private class Captured {
         var method: HttpMethod? = null
@@ -71,7 +78,7 @@ class WatchTogetherApiTest {
             status = HttpStatusCode.Created,
             responseBody = """{"room":$roomJson,"room_access_token":"jwt-1"}""",
         )
-        val r = api.createRoom(CreateRoomRequest(selectionMode = "vote"))
+        val r = api.createRoom(CreateRoomRequest(selectionMode = "vote"), scope)
         assertEquals(HttpMethod.Post, captured.method)
         assertEquals("/api/v1/watch-together/rooms", captured.path)
         assertEquals(setOf("selection_mode"), SiloJson.parseToJsonElement(captured.body).jsonObject.keys)
@@ -82,7 +89,7 @@ class WatchTogetherApiTest {
     @Test
     fun `joinRoom posts code and decodes room`() = runTest {
         val (api, captured) = api(responseBody = """{"room":$roomJson,"room_access_token":"jwt-2"}""")
-        val r = api.joinRoom(JoinRoomRequest(code = "ABCD1234"))
+        val r = api.joinRoom(JoinRoomRequest(code = "ABCD1234"), scope)
         assertEquals(HttpMethod.Post, captured.method)
         assertEquals("/api/v1/watch-together/join", captured.path)
         assertIs<ApiResult.Success<*>>(r)
@@ -92,7 +99,7 @@ class WatchTogetherApiTest {
     @Test
     fun `getRoom passes room_token query`() = runTest {
         val (api, captured) = api(responseBody = """{"room":$roomJson}""")
-        api.getRoom("room-1", "jwt-room")
+        api.getRoom("room-1", "jwt-room", scope)
         assertEquals(HttpMethod.Get, captured.method)
         assertEquals("/api/v1/watch-together/rooms/room-1", captured.path)
         assertEquals("jwt-room", captured.query["room_token"])
@@ -101,7 +108,7 @@ class WatchTogetherApiTest {
     @Test
     fun `setSelection puts content_id with room_token query`() = runTest {
         val (api, captured) = api(responseBody = """{"room":$roomJson}""")
-        api.setSelection("room-1", "jwt-room", SetSelectionRequest(contentId = "tt-9", fileId = 3))
+        api.setSelection("room-1", "jwt-room", SetSelectionRequest(contentId = "tt-9", fileId = 3), scope)
         assertEquals(HttpMethod.Put, captured.method)
         assertEquals("/api/v1/watch-together/rooms/room-1/selection", captured.path)
         assertEquals("jwt-room", captured.query["room_token"])
@@ -112,7 +119,12 @@ class WatchTogetherApiTest {
     @Test
     fun `updatePolicy patches policy with room_token query`() = runTest {
         val (api, captured) = api(responseBody = """{"room":$roomJson}""")
-        api.updatePolicy("room-1", "jwt-room", UpdatePolicyRequest(guestControlPolicy = "guest_play_pause"))
+        api.updatePolicy(
+            "room-1",
+            "jwt-room",
+            UpdatePolicyRequest(guestControlPolicy = "guest_play_pause"),
+            scope,
+        )
         assertEquals(HttpMethod.Patch, captured.method)
         assertEquals("/api/v1/watch-together/rooms/room-1/policy", captured.path)
         assertEquals("jwt-room", captured.query["room_token"])
@@ -121,7 +133,7 @@ class WatchTogetherApiTest {
     @Test
     fun `closeRoom deletes and maps 204 to Unit with room_token query`() = runTest {
         val (api, captured) = api(status = HttpStatusCode.NoContent, responseBody = "")
-        val r = api.closeRoom("room-1", "jwt-room")
+        val r = api.closeRoom("room-1", "jwt-room", scope)
         assertEquals(HttpMethod.Delete, captured.method)
         assertEquals("/api/v1/watch-together/rooms/room-1", captured.path)
         assertEquals("jwt-room", captured.query["room_token"])
@@ -131,7 +143,7 @@ class WatchTogetherApiTest {
     @Test
     fun `listSuggestions gets suggestions with room_token query`() = runTest {
         val (api, captured) = api(responseBody = """{"suggestions":[]}""")
-        api.listSuggestions("room-1", "jwt-room")
+        api.listSuggestions("room-1", "jwt-room", scope)
         assertEquals(HttpMethod.Get, captured.method)
         assertEquals("/api/v1/watch-together/rooms/room-1/suggestions", captured.path)
         assertEquals("jwt-room", captured.query["room_token"])
@@ -146,6 +158,7 @@ class WatchTogetherApiTest {
         api.addSuggestion(
             "room-1", "jwt-room",
             AddSuggestionRequest(contentId = "c", contentType = "movie", title = "T"),
+            scope,
         )
         assertEquals(HttpMethod.Post, captured.method)
         assertEquals("/api/v1/watch-together/rooms/room-1/suggestions", captured.path)
@@ -155,7 +168,7 @@ class WatchTogetherApiTest {
     @Test
     fun `deleteSuggestion deletes suggestion path with room_token query`() = runTest {
         val (api, captured) = api(responseBody = """{"suggestions":[]}""")
-        api.deleteSuggestion("room-1", "jwt-room", "sug-5")
+        api.deleteSuggestion("room-1", "jwt-room", "sug-5", scope)
         assertEquals(HttpMethod.Delete, captured.method)
         assertEquals("/api/v1/watch-together/rooms/room-1/suggestions/sug-5", captured.path)
         assertEquals("jwt-room", captured.query["room_token"])
@@ -164,7 +177,7 @@ class WatchTogetherApiTest {
     @Test
     fun `vote posts vote path with room_token query`() = runTest {
         val (api, captured) = api(responseBody = """{"suggestions":[]}""")
-        api.vote("room-1", "jwt-room", "sug-5")
+        api.vote("room-1", "jwt-room", "sug-5", scope)
         assertEquals(HttpMethod.Post, captured.method)
         assertEquals("/api/v1/watch-together/rooms/room-1/suggestions/sug-5/vote", captured.path)
         assertEquals("jwt-room", captured.query["room_token"])
@@ -173,7 +186,7 @@ class WatchTogetherApiTest {
     @Test
     fun `unvote deletes vote path with room_token query`() = runTest {
         val (api, captured) = api(responseBody = """{"suggestions":[]}""")
-        api.unvote("room-1", "jwt-room", "sug-5")
+        api.unvote("room-1", "jwt-room", "sug-5", scope)
         assertEquals(HttpMethod.Delete, captured.method)
         assertEquals("/api/v1/watch-together/rooms/room-1/suggestions/sug-5/vote", captured.path)
         assertEquals("jwt-room", captured.query["room_token"])
@@ -182,7 +195,12 @@ class WatchTogetherApiTest {
     @Test
     fun `promote posts suggestion_id with room_token query and decodes room`() = runTest {
         val (api, captured) = api(responseBody = """{"room":$roomJson}""")
-        api.promoteSuggestion("room-1", "jwt-room", PromoteSuggestionRequest(suggestionId = "sug-5"))
+        api.promoteSuggestion(
+            "room-1",
+            "jwt-room",
+            PromoteSuggestionRequest(suggestionId = "sug-5"),
+            scope,
+        )
         assertEquals(HttpMethod.Post, captured.method)
         assertEquals("/api/v1/watch-together/rooms/room-1/suggestions/promote", captured.path)
         assertEquals("jwt-room", captured.query["room_token"])
@@ -196,7 +214,7 @@ class WatchTogetherApiTest {
             status = HttpStatusCode.Conflict,
             responseBody = """{"error":"conflict","message":"Already voted"}""",
         )
-        val r = api.vote("room-1", "jwt-room", "sug-5")
+        val r = api.vote("room-1", "jwt-room", "sug-5", scope)
         assertIs<ApiResult.Error>(r)
         assertEquals(409, r.code)
         assertEquals("Already voted", r.message)
@@ -208,7 +226,7 @@ class WatchTogetherApiTest {
             status = HttpStatusCode.Gone,
             responseBody = """{"error":"gone","message":"Room is no longer active"}""",
         )
-        val r = api.joinRoom(JoinRoomRequest(code = "DEAD0000"))
+        val r = api.joinRoom(JoinRoomRequest(code = "DEAD0000"), scope)
         assertIs<ApiResult.Error>(r)
         assertEquals(410, r.code)
         assertEquals("Room is no longer active", r.message)

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/WatchTogetherApiTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/WatchTogetherApiTest.kt
@@ -175,6 +175,19 @@ class WatchTogetherApiTest {
     }
 
     @Test
+    fun `room and suggestion identifiers are encoded as path segments`() = runTest {
+        val (api, captured) = api(responseBody = """{"suggestions":[]}""")
+
+        api.deleteSuggestion("room/with ?#", "jwt-room", "suggestion/with ?#", scope)
+
+        assertEquals(
+            "/api/v1/watch-together/rooms/room%2Fwith%20%3F%23/suggestions/" +
+                "suggestion%2Fwith%20%3F%23",
+            captured.path,
+        )
+    }
+
+    @Test
     fun `vote posts vote path with room_token query`() = runTest {
         val (api, captured) = api(responseBody = """{"suggestions":[]}""")
         api.vote("room-1", "jwt-room", "sug-5", scope)

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.advanceTimeBy
@@ -137,6 +139,9 @@ class WatchTogetherRepositoryTest {
         var failConnect = false
         var terminateImmediately = false
         var attachCount = 0
+        val transportActions = mutableListOf<String>()
+        val readySessions = mutableListOf<String>()
+        val bufferingSessions = mutableListOf<String>()
         var connectBehavior: ((Int) -> Flow<RoomRealtimeEvent>)? = null
         /**
          * When non-null, each connect attempt emits this one event and then throws.
@@ -174,10 +179,19 @@ class WatchTogetherRepositoryTest {
             attachCount++
             return true
         }
-        override suspend fun transportRequest(action: String, positionSeconds: Double?, isPaused: Boolean) = true
+        override suspend fun transportRequest(action: String, positionSeconds: Double?, isPaused: Boolean): Boolean {
+            transportActions += action
+            return true
+        }
         override suspend fun stateReport(sessionId: String, positionSeconds: Double, isPaused: Boolean) = true
-        override suspend fun ready(sessionId: String, positionSeconds: Double, isPaused: Boolean) = true
-        override suspend fun buffering(sessionId: String, positionSeconds: Double, isPaused: Boolean) = true
+        override suspend fun ready(sessionId: String, positionSeconds: Double, isPaused: Boolean): Boolean {
+            readySessions += sessionId
+            return true
+        }
+        override suspend fun buffering(sessionId: String, positionSeconds: Double, isPaused: Boolean): Boolean {
+            bufferingSessions += sessionId
+            return true
+        }
         override suspend fun ping(clientSentAt: String) = true
     }
 
@@ -377,6 +391,92 @@ class WatchTogetherRepositoryTest {
 
         assertEquals(0, realtime.connectCount)
         job.cancel()
+    }
+
+    @Test
+    fun `local delivery failure is surfaced as a non terminal room error`() = runTest {
+        val repository = repo()
+        val error = async { repository.errors.first() }
+        runCurrent()
+
+        repository.reportDeliveryFailure("room_transport_unavailable")
+
+        assertEquals("room_transport_unavailable", error.await())
+        assertNull(repository.roomClosedReason.value)
+    }
+
+    @Test
+    fun `controller recreation shares successful delivery state for the same epoch`() = runTest {
+        val repository = repo()
+        val key = repository.roomDeliveryLatch.keyOrNull(
+            WatchTogetherConnectionState(generation = 7, epoch = 2, writable = true),
+            "playback-1",
+        )!!
+
+        repository.roomDeliveryLatch.recordAttach(key, delivered = true)
+
+        assertTrue(repository.roomDeliveryLatch.isAttached(key))
+        assertTrue(!repository.roomDeliveryLatch.needsAttach(key))
+    }
+
+    @Test
+    fun `two participants independently receive room state commands and terminal close`() = runTest {
+        val sharedSnapshot = snapshot(memberCount = 2)
+        val response = ApiResult.Success(RoomResponse(sharedSnapshot, "jwt-room"))
+        val hostRealtime = FakeRealtime()
+        val guestRealtime = FakeRealtime()
+        val host = repo(api = FakeApi(response), realtime = hostRealtime)
+        val guest = repo(api = FakeApi(response), realtime = guestRealtime)
+        host.createRoom(CreateRoomRequest())
+        guest.createRoom(CreateRoomRequest())
+        val hostCommand = async { host.transportCommands.first() }
+        val guestCommand = async { guest.transportCommands.first() }
+        val hostConnection = launch { host.connect("room-1") }
+        val guestConnection = launch { guest.connect("room-1") }
+        runCurrent()
+        val command = org.siloserver.silo.model.watchtogether.TransportCommand(
+            commandId = "cmd-1",
+            sessionId = "playback-1",
+            selectionRevision = sharedSnapshot.selectionRevision,
+            action = org.siloserver.silo.model.watchtogether.TransportAction.Seek,
+            positionSeconds = 42.0,
+            executeAt = "2026-07-27T12:00:00Z",
+        )
+
+        hostRealtime.events.emit(RoomRealtimeEvent.Opened)
+        guestRealtime.events.emit(RoomRealtimeEvent.Opened)
+        hostRealtime.events.emit(RoomRealtimeEvent.SnapshotEvent(sharedSnapshot))
+        guestRealtime.events.emit(RoomRealtimeEvent.SnapshotEvent(sharedSnapshot))
+        hostRealtime.events.emit(RoomRealtimeEvent.TransportCommandEvent(command))
+        guestRealtime.events.emit(RoomRealtimeEvent.TransportCommandEvent(command))
+        runCurrent()
+
+        assertEquals(sharedSnapshot, host.roomSnapshot.value)
+        assertEquals(sharedSnapshot, guest.roomSnapshot.value)
+        val hostScheduled = hostCommand.await()
+        val guestScheduled = guestCommand.await()
+        assertEquals(command, hostScheduled.command)
+        assertEquals(command, guestScheduled.command)
+        assertEquals(host.connectionState.value, hostScheduled.connection)
+        assertEquals(guest.connectionState.value, guestScheduled.connection)
+        assertTrue(host.attachSession("host-playback"))
+        assertTrue(guest.attachSession("guest-playback"))
+        assertTrue(host.transportRequest("pause", 42.0, true))
+        assertTrue(guest.transportRequest("play", 42.0, false))
+        assertTrue(host.buffering("host-playback", 42.0, true))
+        assertTrue(guest.ready("guest-playback", 42.0, false))
+        assertEquals(listOf("pause"), hostRealtime.transportActions)
+        assertEquals(listOf("play"), guestRealtime.transportActions)
+
+        hostRealtime.events.emit(RoomRealtimeEvent.Closed("host_left"))
+        guestRealtime.events.emit(RoomRealtimeEvent.Closed("host_left"))
+        hostConnection.join()
+        guestConnection.join()
+
+        assertEquals("host_left", host.roomClosedReason.value)
+        assertEquals("host_left", guest.roomClosedReason.value)
+        assertEquals(1, hostRealtime.connectCount)
+        assertEquals(1, guestRealtime.connectCount)
     }
 
     @Test
@@ -695,6 +795,46 @@ class WatchTogetherRepositoryTest {
         assertTrue(!r.connectionState.value.writable)
         assertTrue(!r.attachSession("during-backoff"))
         assertEquals(0, realtime.attachCount)
+        job.cancel()
+    }
+
+    @Test
+    fun `queued transport command retains the exact epoch that emitted it across reconnect`() = runTest {
+        val command = org.siloserver.silo.model.watchtogether.TransportCommand(
+            commandId = "epoch-1-command",
+            sessionId = "playback-1",
+            selectionRevision = 1,
+            executeAt = "2026-07-27T12:00:00Z",
+        )
+        val realtime = FakeRealtime().apply {
+            connectBehavior = { attempt ->
+                if (attempt == 1) {
+                    flow {
+                        emit(RoomRealtimeEvent.Opened)
+                        emit(RoomRealtimeEvent.TransportCommandEvent(command))
+                        emit(RoomRealtimeEvent.TransportTerminated())
+                    }
+                } else {
+                    events.asSharedFlow()
+                }
+            }
+        }
+        val r = repo(realtime = realtime)
+        r.createRoom(CreateRoomRequest())
+        val received = async { r.transportCommands.first() }
+        val job = launch { r.connect("room-1") }
+        runCurrent()
+        val scheduled = received.await()
+
+        assertEquals(1L, scheduled.connection.epoch)
+        assertTrue(!r.connectionState.value.writable)
+        advanceTimeBy(500)
+        runCurrent()
+        realtime.events.emit(RoomRealtimeEvent.Opened)
+        runCurrent()
+
+        assertEquals(2L, r.connectionState.value.epoch)
+        assertTrue(scheduled.connection != r.connectionState.value)
         job.cancel()
     }
 

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
@@ -11,6 +11,7 @@ import org.siloserver.silo.model.watchtogether.Suggestion
 import org.siloserver.silo.model.watchtogether.SuggestionsResponse
 import org.siloserver.silo.model.watchtogether.UpdatePolicyRequest
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
 import org.siloserver.silo.network.RoomRealtimeEvent
 import org.siloserver.silo.network.WatchTogetherRealtimeClient
 import org.siloserver.silo.network.api.WatchTogetherApi
@@ -18,11 +19,14 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -47,30 +51,78 @@ class WatchTogetherRepositoryTest {
         ),
     ) : WatchTogetherApi {
         var lastRoomToken: String? = null
+        var lastRoomId: String? = null
         var lastSelection: SetSelectionRequest? = null
-        override suspend fun createRoom(request: CreateRoomRequest) = createResponse
-        override suspend fun joinRoom(request: JoinRoomRequest) = createResponse
-        override suspend fun getRoom(roomId: String, roomToken: String) = createResponse.also { lastRoomToken = roomToken }
-        override suspend fun setSelection(roomId: String, roomToken: String, request: SetSelectionRequest): ApiResult<RoomResponse> {
-            lastRoomToken = roomToken; lastSelection = request; return createResponse
+        var lastAuthScope: AuthScopeSnapshot? = null
+        var createResult: CompletableDeferred<ApiResult<RoomResponse>>? = null
+        var selectionResult: CompletableDeferred<ApiResult<RoomResponse>>? = null
+        override suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot?): ApiResult<RoomResponse> {
+            lastAuthScope = scope
+            return createResult?.await() ?: createResponse
         }
-        override suspend fun updatePolicy(roomId: String, roomToken: String, request: UpdatePolicyRequest) =
-            createResponse.also { lastRoomToken = roomToken }
-        override suspend fun closeRoom(roomId: String, roomToken: String): ApiResult<Unit> {
-            lastRoomToken = roomToken; return ApiResult.Success(Unit)
+        override suspend fun joinRoom(request: JoinRoomRequest, scope: AuthScopeSnapshot?) =
+            createResponse.also { lastAuthScope = scope }
+        override suspend fun getRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot?) =
+            createResponse.also { lastRoomToken = roomToken; lastAuthScope = scope }
+        override suspend fun setSelection(
+            roomId: String,
+            roomToken: String,
+            request: SetSelectionRequest,
+            scope: AuthScopeSnapshot?,
+        ): ApiResult<RoomResponse> {
+            lastRoomId = roomId
+            lastRoomToken = roomToken
+            lastSelection = request
+            lastAuthScope = scope
+            return selectionResult?.await() ?: createResponse
         }
-        override suspend fun listSuggestions(roomId: String, roomToken: String) =
-            ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken }
-        override suspend fun addSuggestion(roomId: String, roomToken: String, request: AddSuggestionRequest) =
-            ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken }
-        override suspend fun deleteSuggestion(roomId: String, roomToken: String, suggestionId: String) =
-            ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken }
-        override suspend fun vote(roomId: String, roomToken: String, suggestionId: String) =
-            ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken }
-        override suspend fun unvote(roomId: String, roomToken: String, suggestionId: String) =
-            ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken }
-        override suspend fun promoteSuggestion(roomId: String, roomToken: String, request: PromoteSuggestionRequest) =
-            createResponse.also { lastRoomToken = roomToken }
+        override suspend fun updatePolicy(
+            roomId: String,
+            roomToken: String,
+            request: UpdatePolicyRequest,
+            scope: AuthScopeSnapshot?,
+        ) = createResponse.also { lastRoomToken = roomToken; lastAuthScope = scope }
+        override suspend fun closeRoom(
+            roomId: String,
+            roomToken: String,
+            scope: AuthScopeSnapshot?,
+        ): ApiResult<Unit> {
+            lastRoomToken = roomToken
+            lastAuthScope = scope
+            return ApiResult.Success(Unit)
+        }
+        override suspend fun listSuggestions(roomId: String, roomToken: String, scope: AuthScopeSnapshot?) =
+            ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
+        override suspend fun addSuggestion(
+            roomId: String,
+            roomToken: String,
+            request: AddSuggestionRequest,
+            scope: AuthScopeSnapshot?,
+        ) = ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
+        override suspend fun deleteSuggestion(
+            roomId: String,
+            roomToken: String,
+            suggestionId: String,
+            scope: AuthScopeSnapshot?,
+        ) = ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
+        override suspend fun vote(
+            roomId: String,
+            roomToken: String,
+            suggestionId: String,
+            scope: AuthScopeSnapshot?,
+        ) = ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
+        override suspend fun unvote(
+            roomId: String,
+            roomToken: String,
+            suggestionId: String,
+            scope: AuthScopeSnapshot?,
+        ) = ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
+        override suspend fun promoteSuggestion(
+            roomId: String,
+            roomToken: String,
+            request: PromoteSuggestionRequest,
+            scope: AuthScopeSnapshot?,
+        ) = createResponse.also { lastRoomToken = roomToken; lastAuthScope = scope }
     }
 
     private class FakeRealtime(
@@ -79,6 +131,9 @@ class WatchTogetherRepositoryTest {
         var connectCount = 0
         /** When true, the returned flow throws immediately on collection. */
         var failConnect = false
+        var terminateImmediately = false
+        var attachCount = 0
+        var connectBehavior: ((Int) -> Flow<RoomRealtimeEvent>)? = null
         /**
          * When non-null, each connect attempt emits this one event and then throws.
          * Models a flapping server: healthy traffic is observed but the connection
@@ -88,7 +143,14 @@ class WatchTogetherRepositoryTest {
         var flappingEvent: RoomRealtimeEvent? = null
         override fun connect(roomId: String, roomToken: String): Flow<RoomRealtimeEvent> {
             connectCount++
+            connectedRoomIds += roomId
+            connectedRoomTokens += roomToken
+            connectBehavior?.let { return it(connectCount) }
             if (failConnect) return flow { throw IllegalStateException("boom") }
+            if (terminateImmediately) return flow {
+                emit(RoomRealtimeEvent.Opened)
+                emit(RoomRealtimeEvent.TransportTerminated())
+            }
             val flapEvent = flappingEvent
             if (flapEvent != null) return flow {
                 emit(flapEvent)
@@ -96,7 +158,12 @@ class WatchTogetherRepositoryTest {
             }
             return events.asSharedFlow()
         }
-        override suspend fun attachSession(sessionId: String) = true
+        val connectedRoomIds = mutableListOf<String>()
+        val connectedRoomTokens = mutableListOf<String>()
+        override suspend fun attachSession(sessionId: String): Boolean {
+            attachCount++
+            return true
+        }
         override suspend fun transportRequest(action: String, positionSeconds: Double?, isPaused: Boolean) = true
         override suspend fun stateReport(sessionId: String, positionSeconds: Double, isPaused: Boolean) = true
         override suspend fun ready(sessionId: String, positionSeconds: Double, isPaused: Boolean) = true
@@ -104,10 +171,23 @@ class WatchTogetherRepositoryTest {
         override suspend fun ping(clientSentAt: String) = true
     }
 
+    private val scopeA = AuthScopeSnapshot(
+        serverId = "server-a",
+        profileId = "profile-a",
+        serverUrl = "https://a.example",
+        profileToken = "profile-token-a",
+        identityGeneration = 1L,
+    )
+
     private fun repo(
         api: FakeApi = FakeApi(),
         realtime: FakeRealtime = FakeRealtime(),
-    ) = WatchTogetherRepository(api = api, realtimeFactory = { realtime })
+        authScopeProvider: suspend () -> AuthScopeSnapshot? = { scopeA },
+    ) = WatchTogetherRepository(
+        api = api,
+        realtimeFactory = { realtime },
+        authScopeProvider = authScopeProvider,
+    )
 
     // ---- create stores room token -------------------------------------------
 
@@ -119,6 +199,158 @@ class WatchTogetherRepositoryTest {
         r.setSelection(SetSelectionRequest(contentId = "tt-9"))
         assertEquals("jwt-room", api.lastRoomToken)
         assertEquals("tt-9", api.lastSelection?.contentId)
+    }
+
+    @Test
+    fun `room binding retains the auth scope captured when it was created`() = runTest {
+        val api = FakeApi()
+        var currentScope = scopeA
+        val r = repo(api = api, authScopeProvider = { currentScope })
+        r.createRoom(CreateRoomRequest())
+        currentScope = scopeA.copy(
+            serverId = "server-b",
+            serverUrl = "https://b.example",
+            identityGeneration = 2L,
+        )
+
+        r.setSelection(SetSelectionRequest(contentId = "tt-9"))
+
+        assertEquals(scopeA, api.lastAuthScope)
+    }
+
+    @Test
+    fun `create response cannot mint a room after the auth identity changes`() = runTest {
+        val api = FakeApi()
+        val pending = CompletableDeferred<ApiResult<RoomResponse>>()
+        api.createResult = pending
+        var currentScope = scopeA
+        val r = repo(api = api, authScopeProvider = { currentScope })
+        val create = launch { r.createRoom(CreateRoomRequest()) }
+        runCurrent()
+        currentScope = scopeA.copy(identityGeneration = 2L)
+
+        pending.complete(api.createResponse)
+        create.join()
+
+        assertNull(r.roomSnapshot.value)
+    }
+
+    @Test
+    fun `blank room token fails closed without replacing the active room`() = runTest {
+        val api = FakeApi()
+        val r = repo(api = api)
+        r.createRoom(CreateRoomRequest())
+        api.createResponse = ApiResult.Success(
+            RoomResponse(RoomSnapshot(roomId = "room-2", code = "EFGH5678"), ""),
+        )
+
+        val result = r.createRoom(CreateRoomRequest())
+
+        assertIs<ApiResult.Error>(result)
+        assertEquals("room-1", r.roomSnapshot.value?.roomId)
+        r.setSelection(SetSelectionRequest(contentId = "still-a"))
+        assertEquals("room-1", api.lastRoomId)
+        assertEquals("jwt-room", api.lastRoomToken)
+    }
+
+    @Test
+    fun `mismatched room response fails closed without replacing the active room`() = runTest {
+        val api = FakeApi()
+        val r = repo(api = api)
+        r.createRoom(CreateRoomRequest())
+        api.createResponse = ApiResult.Success(
+            RoomResponse(RoomSnapshot(roomId = "", code = "EFGH5678"), "jwt-room-2"),
+        )
+
+        val result = r.createRoom(CreateRoomRequest())
+
+        assertIs<ApiResult.Error>(result)
+        assertEquals("room-1", r.roomSnapshot.value?.roomId)
+    }
+
+    @Test
+    fun `room scoped response for another room is rejected`() = runTest {
+        val api = FakeApi()
+        val r = repo(api = api)
+        r.createRoom(CreateRoomRequest())
+        api.createResponse = ApiResult.Success(
+            RoomResponse(RoomSnapshot(roomId = "room-2", code = "EFGH5678"), "jwt-room-2"),
+        )
+
+        val result = r.setSelection(SetSelectionRequest(contentId = "wrong-room"))
+
+        assertIs<ApiResult.Error>(result)
+        assertEquals("room-1", r.roomSnapshot.value?.roomId)
+    }
+
+    @Test
+    fun `create fails closed when there is no authenticated scope`() = runTest {
+        val r = repo(authScopeProvider = { null })
+
+        val result = r.createRoom(CreateRoomRequest())
+
+        assertIs<ApiResult.Error>(result)
+        assertNull(r.roomSnapshot.value)
+    }
+
+    @Test
+    fun `connect rejects a room id that does not match the active binding`() = runTest {
+        val realtime = FakeRealtime()
+        val r = repo(realtime = realtime)
+        r.createRoom(CreateRoomRequest())
+
+        val job = launch { r.connect("room-2") }
+        runCurrent()
+
+        assertEquals(0, realtime.connectCount)
+        job.cancel()
+    }
+
+    @Test
+    fun `late room A REST completion cannot overwrite replacement room B`() = runTest {
+        val api = FakeApi()
+        val r = repo(api = api)
+        r.createRoom(CreateRoomRequest())
+        val pending = CompletableDeferred<ApiResult<RoomResponse>>()
+        api.selectionResult = pending
+        val stale = launch { r.setSelection(SetSelectionRequest(contentId = "late-a")) }
+        runCurrent()
+
+        api.selectionResult = null
+        api.createResponse = ApiResult.Success(
+            RoomResponse(RoomSnapshot(roomId = "room-2", code = "EFGH5678"), "jwt-room-2"),
+        )
+        r.createRoom(CreateRoomRequest())
+        pending.complete(
+            ApiResult.Success(
+                RoomResponse(RoomSnapshot(roomId = "room-1", selectionRevision = 99), "jwt-room"),
+            ),
+        )
+        stale.join()
+
+        assertEquals("room-2", r.roomSnapshot.value?.roomId)
+    }
+
+    @Test
+    fun `late room A socket event cannot overwrite replacement room B`() = runTest {
+        val api = FakeApi()
+        val realtime = FakeRealtime()
+        val r = repo(api = api, realtime = realtime)
+        r.createRoom(CreateRoomRequest())
+        val oldConnection = launch { r.connect("room-1") }
+        runCurrent()
+
+        api.createResponse = ApiResult.Success(
+            RoomResponse(RoomSnapshot(roomId = "room-2", code = "EFGH5678"), "jwt-room-2"),
+        )
+        r.createRoom(CreateRoomRequest())
+        realtime.events.emit(RoomRealtimeEvent.SnapshotEvent(snapshot(roomId = "room-1", revision = 99)))
+        advanceUntilIdle()
+
+        assertEquals("room-2", r.roomSnapshot.value?.roomId)
+        assertTrue(oldConnection.isCompleted)
+        assertTrue(!r.attachSession("session-b"))
+        assertEquals(0, realtime.attachCount)
     }
 
     // ---- snapshot fold --------------------------------------------------------
@@ -203,8 +435,9 @@ class WatchTogetherRepositoryTest {
         assertTrue(r.suggestions.value.isEmpty())
         // After reset the room token is gone; a room-scoped call must not reuse it.
         api.lastRoomToken = null
-        r.setSelection(SetSelectionRequest(contentId = "x"))
-        assertEquals("", api.lastRoomToken) // repository passes empty token when none stored
+        val result = r.setSelection(SetSelectionRequest(contentId = "x"))
+        assertIs<ApiResult.Error>(result)
+        assertNull(api.lastRoomToken) // fail fast: no request is sent with an empty token
         job.cancel()
     }
 
@@ -272,6 +505,11 @@ class WatchTogetherRepositoryTest {
         advanceUntilIdle()
         assertEquals(1, realtime.connectCount)
         assertTrue(job.isCompleted || job.isCancelled)
+
+        // A terminal binding is tombstoned. Reusing the old room id cannot
+        // create a fresh connection without a new successful create/join.
+        r.connect("room-1")
+        assertEquals(1, realtime.connectCount)
     }
 
     @Test
@@ -308,6 +546,60 @@ class WatchTogetherRepositoryTest {
         assertEquals(WatchTogetherRepository.MAX_RECONNECT_ATTEMPTS, realtime.connectCount)
         // Stale room state must not be observable after giving up.
         assertNull(r.roomSnapshot.value)
+    }
+
+    @Test
+    fun `physical transport termination reconnects and counts toward the cap`() = runTest {
+        val realtime = FakeRealtime().apply { terminateImmediately = true }
+        val r = repo(realtime = realtime)
+        r.createRoom(CreateRoomRequest())
+
+        val job = launch { r.connect("room-1") }
+        advanceUntilIdle()
+
+        assertTrue(job.isCompleted)
+        assertEquals(WatchTogetherRepository.MAX_RECONNECT_ATTEMPTS, realtime.connectCount)
+        assertEquals("connection_lost", r.roomClosedReason.value)
+        assertTrue(!r.connectionState.value.writable)
+        assertEquals(
+            WatchTogetherRepository.MAX_RECONNECT_ATTEMPTS.toLong(),
+            r.connectionState.value.epoch,
+        )
+    }
+
+    @Test
+    fun `snapshot plus thirty stable seconds resets the reconnect failure window`() = runTest {
+        var nowMs = 0L
+        val realtime = FakeRealtime().apply {
+            connectBehavior = { attempt ->
+                when {
+                    attempt <= 5 -> flow { throw IllegalStateException("early failure") }
+                    attempt == 6 -> flow {
+                        emit(RoomRealtimeEvent.Opened)
+                        nowMs = WatchTogetherRepository.STABLE_CONNECTION_MS
+                        emit(RoomRealtimeEvent.SnapshotEvent(snapshot()))
+                        emit(RoomRealtimeEvent.TransportTerminated())
+                    }
+                    attempt <= 10 -> flow { throw IllegalStateException("later failure") }
+                    else -> events.asSharedFlow()
+                }
+            }
+        }
+        val r = WatchTogetherRepository(
+            api = FakeApi(),
+            realtimeFactory = { realtime },
+            monotonicNowMs = { nowMs },
+            authScopeProvider = { scopeA },
+        )
+        r.createRoom(CreateRoomRequest())
+
+        val job = launch { r.connect("room-1") }
+        advanceUntilIdle()
+
+        assertEquals(11, realtime.connectCount)
+        assertTrue(job.isActive)
+        assertNull(r.roomClosedReason.value)
+        job.cancel()
     }
 
     // ---- flapping server hits the cap (regression for Issue 1) -----------------

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -56,19 +57,19 @@ class WatchTogetherRepositoryTest {
         var lastAuthScope: AuthScopeSnapshot? = null
         var createResult: CompletableDeferred<ApiResult<RoomResponse>>? = null
         var selectionResult: CompletableDeferred<ApiResult<RoomResponse>>? = null
-        override suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot?): ApiResult<RoomResponse> {
+        override suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot): ApiResult<RoomResponse> {
             lastAuthScope = scope
             return createResult?.await() ?: createResponse
         }
-        override suspend fun joinRoom(request: JoinRoomRequest, scope: AuthScopeSnapshot?) =
+        override suspend fun joinRoom(request: JoinRoomRequest, scope: AuthScopeSnapshot) =
             createResponse.also { lastAuthScope = scope }
-        override suspend fun getRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot?) =
+        override suspend fun getRoom(roomId: String, roomToken: String, scope: AuthScopeSnapshot) =
             createResponse.also { lastRoomToken = roomToken; lastAuthScope = scope }
         override suspend fun setSelection(
             roomId: String,
             roomToken: String,
             request: SetSelectionRequest,
-            scope: AuthScopeSnapshot?,
+            scope: AuthScopeSnapshot,
         ): ApiResult<RoomResponse> {
             lastRoomId = roomId
             lastRoomToken = roomToken
@@ -80,48 +81,48 @@ class WatchTogetherRepositoryTest {
             roomId: String,
             roomToken: String,
             request: UpdatePolicyRequest,
-            scope: AuthScopeSnapshot?,
+            scope: AuthScopeSnapshot,
         ) = createResponse.also { lastRoomToken = roomToken; lastAuthScope = scope }
         override suspend fun closeRoom(
             roomId: String,
             roomToken: String,
-            scope: AuthScopeSnapshot?,
+            scope: AuthScopeSnapshot,
         ): ApiResult<Unit> {
             lastRoomToken = roomToken
             lastAuthScope = scope
             return ApiResult.Success(Unit)
         }
-        override suspend fun listSuggestions(roomId: String, roomToken: String, scope: AuthScopeSnapshot?) =
+        override suspend fun listSuggestions(roomId: String, roomToken: String, scope: AuthScopeSnapshot) =
             ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
         override suspend fun addSuggestion(
             roomId: String,
             roomToken: String,
             request: AddSuggestionRequest,
-            scope: AuthScopeSnapshot?,
+            scope: AuthScopeSnapshot,
         ) = ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
         override suspend fun deleteSuggestion(
             roomId: String,
             roomToken: String,
             suggestionId: String,
-            scope: AuthScopeSnapshot?,
+            scope: AuthScopeSnapshot,
         ) = ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
         override suspend fun vote(
             roomId: String,
             roomToken: String,
             suggestionId: String,
-            scope: AuthScopeSnapshot?,
+            scope: AuthScopeSnapshot,
         ) = ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
         override suspend fun unvote(
             roomId: String,
             roomToken: String,
             suggestionId: String,
-            scope: AuthScopeSnapshot?,
+            scope: AuthScopeSnapshot,
         ) = ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
         override suspend fun promoteSuggestion(
             roomId: String,
             roomToken: String,
             request: PromoteSuggestionRequest,
-            scope: AuthScopeSnapshot?,
+            scope: AuthScopeSnapshot,
         ) = createResponse.also { lastRoomToken = roomToken; lastAuthScope = scope }
     }
 
@@ -141,10 +142,15 @@ class WatchTogetherRepositoryTest {
          * failures were reset per-event rather than per-clean-completion.
          */
         var flappingEvent: RoomRealtimeEvent? = null
-        override fun connect(roomId: String, roomToken: String): Flow<RoomRealtimeEvent> {
+        override fun connect(
+            roomId: String,
+            roomToken: String,
+            authScope: AuthScopeSnapshot?,
+        ): Flow<RoomRealtimeEvent> {
             connectCount++
             connectedRoomIds += roomId
             connectedRoomTokens += roomToken
+            connectedAuthScopes += authScope
             connectBehavior?.let { return it(connectCount) }
             if (failConnect) return flow { throw IllegalStateException("boom") }
             if (terminateImmediately) return flow {
@@ -160,6 +166,7 @@ class WatchTogetherRepositoryTest {
         }
         val connectedRoomIds = mutableListOf<String>()
         val connectedRoomTokens = mutableListOf<String>()
+        val connectedAuthScopes = mutableListOf<AuthScopeSnapshot?>()
         override suspend fun attachSession(sessionId: String): Boolean {
             attachCount++
             return true
@@ -216,6 +223,45 @@ class WatchTogetherRepositoryTest {
         r.setSelection(SetSelectionRequest(contentId = "tt-9"))
 
         assertEquals(scopeA, api.lastAuthScope)
+    }
+
+    @Test
+    fun `realtime reconnect uses the auth scope captured by the room binding`() = runTest {
+        val realtime = FakeRealtime()
+        var currentScope = scopeA
+        val r = repo(realtime = realtime, authScopeProvider = { currentScope })
+        r.createRoom(CreateRoomRequest())
+        currentScope = scopeA.copy(
+            serverId = "server-b",
+            serverUrl = "https://b.example",
+            identityGeneration = 2L,
+        )
+
+        val connection = launch { r.connect("room-1") }
+        runCurrent()
+
+        assertEquals(1, realtime.connectedAuthScopes.size)
+        assertEquals(scopeA, realtime.connectedAuthScopes.single())
+        connection.cancel()
+    }
+
+    @Test
+    fun `every reconnect attempt retains the room auth scope`() = runTest {
+        val realtime = FakeRealtime().apply {
+            connectBehavior = { attempt ->
+                if (attempt == 1) flow { throw IllegalStateException("drop") } else events.asSharedFlow()
+            }
+        }
+        val r = repo(realtime = realtime)
+        r.createRoom(CreateRoomRequest())
+        val connection = launch { r.connect("room-1") }
+        runCurrent()
+        advanceTimeBy(WatchTogetherRepository.BACKOFF_MS.first())
+        runCurrent()
+
+        assertEquals(2, realtime.connectedAuthScopes.size)
+        assertTrue(realtime.connectedAuthScopes.all { it == scopeA })
+        connection.cancel()
     }
 
     @Test
@@ -313,7 +359,10 @@ class WatchTogetherRepositoryTest {
         r.createRoom(CreateRoomRequest())
         val pending = CompletableDeferred<ApiResult<RoomResponse>>()
         api.selectionResult = pending
-        val stale = launch { r.setSelection(SetSelectionRequest(contentId = "late-a")) }
+        var staleResult: ApiResult<RoomResponse>? = null
+        val stale = launch {
+            staleResult = r.setSelection(SetSelectionRequest(contentId = "late-a"))
+        }
         runCurrent()
 
         api.selectionResult = null
@@ -329,6 +378,7 @@ class WatchTogetherRepositoryTest {
         stale.join()
 
         assertEquals("room-2", r.roomSnapshot.value?.roomId)
+        assertIs<ApiResult.Error>(staleResult)
     }
 
     @Test
@@ -366,6 +416,21 @@ class WatchTogetherRepositoryTest {
         advanceUntilIdle()
         assertEquals(5L, r.roomSnapshot.value?.selectionRevision)
         assertEquals(3, r.roomSnapshot.value?.memberCount)
+        job.cancel()
+    }
+
+    @Test
+    fun `snapshot for another room cannot replace the active room`() = runTest {
+        val realtime = FakeRealtime()
+        val r = repo(realtime = realtime)
+        r.createRoom(CreateRoomRequest())
+        val job = launch { r.connect("room-1") }
+        runCurrent()
+
+        realtime.events.emit(RoomRealtimeEvent.SnapshotEvent(snapshot(roomId = "room-2", revision = 9)))
+        runCurrent()
+
+        assertEquals("room-1", r.roomSnapshot.value?.roomId)
         job.cancel()
     }
 
@@ -525,7 +590,72 @@ class WatchTogetherRepositoryTest {
         realtime.events.emit(RoomRealtimeEvent.Closed(null))
         advanceUntilIdle()
         assertEquals(1, realtime.connectCount)
+        assertEquals("room_closed", r.roomClosedReason.value)
         assertTrue(job.isCompleted || job.isCancelled)
+    }
+
+    @Test
+    fun `replacement during reconnect backoff cannot open another stale socket`() = runTest {
+        val api = FakeApi()
+        val realtime = FakeRealtime().apply {
+            connectBehavior = { attempt ->
+                if (attempt == 1) flow { throw IllegalStateException("drop") } else events.asSharedFlow()
+            }
+        }
+        val r = repo(api = api, realtime = realtime)
+        r.createRoom(CreateRoomRequest())
+        val old = launch { r.connect("room-1") }
+        runCurrent() // first attempt failed and is waiting in its 500 ms backoff
+
+        api.createResponse = ApiResult.Success(
+            RoomResponse(RoomSnapshot(roomId = "room-2", code = "EFGH5678"), "jwt-room-2"),
+        )
+        r.createRoom(CreateRoomRequest())
+        advanceUntilIdle()
+
+        assertEquals(1, realtime.connectCount)
+        assertTrue(old.isCompleted)
+    }
+
+    @Test
+    fun `newest duplicate connect exclusively owns folds and writable state`() = runTest {
+        val first = FakeRealtime()
+        val second = FakeRealtime()
+        var factoryCall = 0
+        val r = WatchTogetherRepository(
+            api = FakeApi(),
+            realtimeFactory = { if (factoryCall++ == 0) first else second },
+            authScopeProvider = { scopeA },
+        )
+        r.createRoom(CreateRoomRequest())
+        val old = launch { r.connect("room-1") }
+        runCurrent()
+        val newest = launch { r.connect("room-1") }
+        runCurrent()
+
+        second.events.emit(RoomRealtimeEvent.Opened)
+        second.events.emit(RoomRealtimeEvent.SnapshotEvent(snapshot(revision = 2)))
+        runCurrent()
+        first.events.emit(RoomRealtimeEvent.SnapshotEvent(snapshot(revision = 99)))
+        runCurrent()
+
+        assertEquals(2L, r.roomSnapshot.value?.selectionRevision)
+        assertTrue(r.connectionState.value.writable)
+        assertTrue(old.isCompleted)
+        newest.cancel()
+    }
+
+    @Test
+    fun `send fails before the active connection reports writable`() = runTest {
+        val realtime = FakeRealtime()
+        val r = repo(realtime = realtime)
+        r.createRoom(CreateRoomRequest())
+        val job = launch { r.connect("room-1") }
+        runCurrent()
+
+        assertTrue(!r.attachSession("session-1"))
+        assertEquals(0, realtime.attachCount)
+        job.cancel()
     }
 
     // ---- reconnect gives up after max consecutive failures ----------------------

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
@@ -12,9 +12,12 @@ import org.siloserver.silo.model.watchtogether.SuggestionsResponse
 import org.siloserver.silo.model.watchtogether.UpdatePolicyRequest
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionKind
 import org.siloserver.silo.network.RoomRealtimeEvent
 import org.siloserver.silo.network.WatchTogetherRealtimeClient
 import org.siloserver.silo.network.api.WatchTogetherApi
+import org.siloserver.silo.watchtogether.RoomSession
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -279,6 +282,30 @@ class WatchTogetherRepositoryTest {
         create.join()
 
         assertNull(r.roomSnapshot.value)
+    }
+
+    @Test
+    fun `identity barrier invalidates a pending create before identity mutation`() = runTest {
+        val api = FakeApi()
+        val pending = CompletableDeferred<ApiResult<RoomResponse>>()
+        api.createResult = pending
+        val repository = repo(api = api)
+        val barrier = DefaultIdentityTransitionBarrier()
+        RoomSession(repository, backgroundScope, barrier)
+        var createResult: ApiResult<RoomResponse>? = null
+        val create = launch {
+            createResult = repository.createRoom(CreateRoomRequest())
+        }
+        runCurrent()
+
+        barrier.changing(IdentityTransitionKind.PROFILE_SWITCH) {
+            assertNull(repository.roomSnapshot.value)
+        }
+        pending.complete(api.createResponse)
+        create.join()
+
+        assertIs<ApiResult.Error>(createResult)
+        assertNull(repository.roomSnapshot.value)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
@@ -96,12 +96,12 @@ class WatchTogetherRepositoryTest {
             }
             return events.asSharedFlow()
         }
-        override suspend fun attachSession(sessionId: String) {}
-        override suspend fun transportRequest(action: String, positionSeconds: Double?, isPaused: Boolean) {}
-        override suspend fun stateReport(sessionId: String, positionSeconds: Double, isPaused: Boolean) {}
-        override suspend fun ready(sessionId: String, positionSeconds: Double, isPaused: Boolean) {}
-        override suspend fun buffering(sessionId: String, positionSeconds: Double, isPaused: Boolean) {}
-        override suspend fun ping(clientSentAt: String) {}
+        override suspend fun attachSession(sessionId: String) = true
+        override suspend fun transportRequest(action: String, positionSeconds: Double?, isPaused: Boolean) = true
+        override suspend fun stateReport(sessionId: String, positionSeconds: Double, isPaused: Boolean) = true
+        override suspend fun ready(sessionId: String, positionSeconds: Double, isPaused: Boolean) = true
+        override suspend fun buffering(sessionId: String, positionSeconds: Double, isPaused: Boolean) = true
+        override suspend fun ping(clientSentAt: String) = true
     }
 
     private fun repo(

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
@@ -630,8 +630,13 @@ class WatchTogetherRepositoryTest {
         r.createRoom(CreateRoomRequest())
         val old = launch { r.connect("room-1") }
         runCurrent()
+        first.events.emit(RoomRealtimeEvent.Opened)
+        runCurrent()
+        assertTrue(r.connectionState.value.writable)
         val newest = launch { r.connect("room-1") }
         runCurrent()
+        assertTrue(!r.attachSession("too-early"))
+        assertEquals(0, second.attachCount)
 
         second.events.emit(RoomRealtimeEvent.Opened)
         second.events.emit(RoomRealtimeEvent.SnapshotEvent(snapshot(revision = 2)))
@@ -643,6 +648,27 @@ class WatchTogetherRepositoryTest {
         assertTrue(r.connectionState.value.writable)
         assertTrue(old.isCompleted)
         newest.cancel()
+    }
+
+    @Test
+    fun `throw after opened marks the connection unwritable during backoff`() = runTest {
+        val realtime = FakeRealtime().apply {
+            connectBehavior = { attempt ->
+                if (attempt == 1) flow {
+                    emit(RoomRealtimeEvent.Opened)
+                    throw IllegalStateException("drop after open")
+                } else events.asSharedFlow()
+            }
+        }
+        val r = repo(realtime = realtime)
+        r.createRoom(CreateRoomRequest())
+        val job = launch { r.connect("room-1") }
+        runCurrent()
+
+        assertTrue(!r.connectionState.value.writable)
+        assertTrue(!r.attachSession("during-backoff"))
+        assertEquals(0, realtime.attachCount)
+        job.cancel()
     }
 
     @Test
@@ -730,6 +756,39 @@ class WatchTogetherRepositoryTest {
         assertTrue(job.isActive)
         assertNull(r.roomClosedReason.value)
         job.cancel()
+    }
+
+    @Test
+    fun `wrong room snapshot cannot reset the reconnect failure window`() = runTest {
+        var nowMs = 0L
+        val realtime = FakeRealtime().apply {
+            connectBehavior = { attempt ->
+                if (attempt < WatchTogetherRepository.MAX_RECONNECT_ATTEMPTS) {
+                    flow { throw IllegalStateException("early failure") }
+                } else {
+                    flow {
+                        emit(RoomRealtimeEvent.Opened)
+                        nowMs = WatchTogetherRepository.STABLE_CONNECTION_MS
+                        emit(RoomRealtimeEvent.SnapshotEvent(snapshot(roomId = "wrong-room")))
+                        emit(RoomRealtimeEvent.TransportTerminated())
+                    }
+                }
+            }
+        }
+        val r = WatchTogetherRepository(
+            api = FakeApi(),
+            realtimeFactory = { realtime },
+            monotonicNowMs = { nowMs },
+            authScopeProvider = { scopeA },
+        )
+        r.createRoom(CreateRoomRequest())
+
+        val job = launch { r.connect("room-1") }
+        advanceUntilIdle()
+
+        assertTrue(job.isCompleted)
+        assertEquals(WatchTogetherRepository.MAX_RECONNECT_ATTEMPTS, realtime.connectCount)
+        assertEquals("connection_lost", r.roomClosedReason.value)
     }
 
     // ---- flapping server hits the cap (regression for Issue 1) -----------------

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
@@ -18,6 +18,7 @@ import org.siloserver.silo.network.RoomRealtimeEvent
 import org.siloserver.silo.network.WatchTogetherRealtimeClient
 import org.siloserver.silo.network.api.WatchTogetherApi
 import org.siloserver.silo.watchtogether.RoomSession
+import org.siloserver.silo.watchtogether.RoomTransportIntent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -32,6 +33,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -62,6 +64,10 @@ class WatchTogetherRepositoryTest {
         var lastAuthScope: AuthScopeSnapshot? = null
         var createResult: CompletableDeferred<ApiResult<RoomResponse>>? = null
         var selectionResult: CompletableDeferred<ApiResult<RoomResponse>>? = null
+        var listSuggestionsResponse: ApiResult<SuggestionsResponse> =
+            ApiResult.Success(SuggestionsResponse())
+        var listSuggestionsResult: CompletableDeferred<ApiResult<SuggestionsResponse>>? = null
+        var listSuggestionsCalls = 0
         override suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot): ApiResult<RoomResponse> {
             lastAuthScope = scope
             return createResult?.await() ?: createResponse
@@ -98,7 +104,11 @@ class WatchTogetherRepositoryTest {
             return ApiResult.Success(Unit)
         }
         override suspend fun listSuggestions(roomId: String, roomToken: String, scope: AuthScopeSnapshot) =
-            ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
+            (listSuggestionsResult?.await() ?: listSuggestionsResponse).also {
+                listSuggestionsCalls++
+                lastRoomToken = roomToken
+                lastAuthScope = scope
+            }
         override suspend fun addSuggestion(
             roomId: String,
             roomToken: String,
@@ -142,6 +152,7 @@ class WatchTogetherRepositoryTest {
         val transportActions = mutableListOf<String>()
         val readySessions = mutableListOf<String>()
         val bufferingSessions = mutableListOf<String>()
+        var transportResultGate: CompletableDeferred<Boolean>? = null
         var connectBehavior: ((Int) -> Flow<RoomRealtimeEvent>)? = null
         /**
          * When non-null, each connect attempt emits this one event and then throws.
@@ -180,6 +191,17 @@ class WatchTogetherRepositoryTest {
             return true
         }
         override suspend fun transportRequest(action: String, positionSeconds: Double?, isPaused: Boolean): Boolean {
+            transportActions += action
+            return true
+        }
+        override suspend fun currentConnectionId(): Long? = connectCount.toLong().takeIf { it > 0L }
+        override suspend fun transportRequestOnConnection(
+            connectionId: Long,
+            action: String,
+            positionSeconds: Double?,
+            isPaused: Boolean,
+        ): Boolean {
+            transportResultGate?.let { return it.await() }
             transportActions += action
             return true
         }
@@ -223,6 +245,196 @@ class WatchTogetherRepositoryTest {
         r.setSelection(SetSelectionRequest(contentId = "tt-9"))
         assertEquals("jwt-room", api.lastRoomToken)
         assertEquals("tt-9", api.lastSelection?.contentId)
+    }
+
+    @Test
+    fun `join hydrates suggestions that predate the websocket connection`() = runTest {
+        val api = FakeApi().apply {
+            listSuggestionsResponse = ApiResult.Success(
+                SuggestionsResponse(suggestions = listOf(suggestion("existing"))),
+            )
+        }
+        val repository = repo(api = api)
+
+        val result = repository.joinRoom(JoinRoomRequest(code = "ABCD1234"))
+
+        assertIs<ApiResult.Success<RoomResponse>>(result)
+        assertEquals(1, api.listSuggestionsCalls)
+        assertEquals(listOf("existing"), repository.suggestions.value.map { it.id })
+    }
+
+    @Test
+    fun `join returns obsolete when its hydration lease is replaced by another room`() = runTest {
+        val hydration = CompletableDeferred<ApiResult<SuggestionsResponse>>()
+        val api = FakeApi().apply { listSuggestionsResult = hydration }
+        val repository = repo(api = api)
+        val joiningA = async { repository.joinRoom(JoinRoomRequest(code = "ABCD1234")) }
+        runCurrent()
+
+        api.createResponse = ApiResult.Success(
+            RoomResponse(RoomSnapshot(roomId = "room-2", code = "EFGH5678"), "jwt-room-2"),
+        )
+        assertIs<ApiResult.Success<RoomResponse>>(repository.createRoom(CreateRoomRequest()))
+        hydration.complete(ApiResult.Success(SuggestionsResponse(suggestions = listOf(suggestion("stale")))))
+
+        val staleResult = assertIs<ApiResult.Error>(joiningA.await())
+        assertEquals("obsolete_room_request", staleResult.error)
+        assertEquals("room-2", repository.roomSnapshot.value?.roomId)
+        assertTrue(repository.suggestions.value.isEmpty())
+    }
+
+    @Test
+    fun `join returns obsolete when a newer room request starts during hydration`() = runTest {
+        val hydration = CompletableDeferred<ApiResult<SuggestionsResponse>>()
+        val newerCreate = CompletableDeferred<ApiResult<RoomResponse>>()
+        val api = FakeApi().apply {
+            listSuggestionsResult = hydration
+            createResult = newerCreate
+        }
+        val repository = repo(api = api)
+        val joiningA = async { repository.joinRoom(JoinRoomRequest(code = "ABCD1234")) }
+        runCurrent()
+        val creatingB = async { repository.createRoom(CreateRoomRequest()) }
+        runCurrent()
+
+        hydration.complete(ApiResult.Success(SuggestionsResponse(suggestions = listOf(suggestion("stale")))))
+
+        val staleResult = assertIs<ApiResult.Error>(joiningA.await())
+        assertEquals("obsolete_room_request", staleResult.error)
+        assertTrue(repository.suggestions.value.isEmpty())
+        newerCreate.complete(
+            ApiResult.Success(
+                RoomResponse(RoomSnapshot(roomId = "room-2", code = "EFGH5678"), "jwt-room-2"),
+            ),
+        )
+        assertIs<ApiResult.Success<RoomResponse>>(creatingB.await())
+    }
+
+    @Test
+    fun `transport lease cannot send into a replacement room`() = runTest {
+        val api = FakeApi()
+        val realtime = FakeRealtime()
+        val repository = repo(api = api, realtime = realtime)
+        repository.createRoom(CreateRoomRequest())
+        val connection = launch { repository.connect("room-1") }
+        runCurrent()
+        realtime.events.emit(RoomRealtimeEvent.Opened)
+        runCurrent()
+        val authorizationA = requireNotNull(repository.currentTransportAuthorization())
+
+        api.createResponse = ApiResult.Success(
+            RoomResponse(
+                RoomSnapshot(
+                    roomId = "room-2",
+                    code = "EFGH5678",
+                    phase = org.siloserver.silo.model.watchtogether.RoomPhase.Playing,
+                    selfCanControlTransport = true,
+                ),
+                "jwt-room-2",
+            ),
+        )
+        repository.createRoom(CreateRoomRequest())
+
+        assertFalse(
+            repository.transportRequestForAuthorization(
+                authorization = authorizationA,
+                intent = RoomTransportIntent.PlayPause,
+                action = "pause",
+                positionSeconds = 42.0,
+                isPaused = true,
+            ),
+        )
+        assertTrue(realtime.transportActions.isEmpty())
+        connection.cancel()
+    }
+
+    @Test
+    fun `transport lease revalidates authority after policy changes in the same room`() = runTest {
+        val api = FakeApi().apply {
+            createResponse = ApiResult.Success(
+                RoomResponse(
+                    RoomSnapshot(
+                        roomId = "room-1",
+                        code = "ABCD1234",
+                        phase = org.siloserver.silo.model.watchtogether.RoomPhase.Playing,
+                        selfCanControlTransport = true,
+                    ),
+                    "jwt-room",
+                ),
+            )
+        }
+        val realtime = FakeRealtime()
+        val repository = repo(api = api, realtime = realtime)
+        repository.createRoom(CreateRoomRequest())
+        val connection = launch { repository.connect("room-1") }
+        runCurrent()
+        realtime.events.emit(RoomRealtimeEvent.Opened)
+        runCurrent()
+        val authorizationBeforePolicyChange = requireNotNull(repository.currentTransportAuthorization())
+        realtime.events.emit(
+            RoomRealtimeEvent.SnapshotEvent(
+                api.createResponse.let { (it as ApiResult.Success).data.room.copy(selfCanControlTransport = false) },
+            ),
+        )
+        runCurrent()
+
+        assertFalse(
+            repository.transportRequestForAuthorization(
+                authorization = authorizationBeforePolicyChange,
+                intent = RoomTransportIntent.PlayPause,
+                action = "pause",
+                positionSeconds = 42.0,
+                isPaused = true,
+            ),
+        )
+        assertTrue(realtime.transportActions.isEmpty())
+        connection.cancel()
+    }
+
+    @Test
+    fun `blocked physical send does not hold room replacement or reset mutex`() = runTest {
+        val api = FakeApi().apply {
+            createResponse = ApiResult.Success(
+                RoomResponse(
+                    RoomSnapshot(
+                        roomId = "room-1",
+                        code = "ABCD1234",
+                        phase = org.siloserver.silo.model.watchtogether.RoomPhase.Playing,
+                        selfCanControlTransport = true,
+                    ),
+                    "jwt-room",
+                ),
+            )
+        }
+        val realtime = FakeRealtime().apply {
+            transportResultGate = CompletableDeferred()
+        }
+        val repository = repo(api = api, realtime = realtime)
+        repository.createRoom(CreateRoomRequest())
+        val connection = launch { repository.connect("room-1") }
+        runCurrent()
+        realtime.events.emit(RoomRealtimeEvent.Opened)
+        runCurrent()
+        val authorization = requireNotNull(repository.currentTransportAuthorization())
+
+        val blockedSend = async {
+            repository.transportRequestForAuthorization(
+                authorization = authorization,
+                intent = RoomTransportIntent.PlayPause,
+                action = "pause",
+                positionSeconds = 42.0,
+                isPaused = true,
+            )
+        }
+        runCurrent()
+        val reset = async { repository.reset() }
+        runCurrent()
+
+        assertTrue(reset.isCompleted)
+        assertFalse(blockedSend.isCompleted)
+        realtime.transportResultGate?.complete(false)
+        assertFalse(blockedSend.await())
+        connection.cancel()
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomDeliveryLatchTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomDeliveryLatchTest.kt
@@ -1,0 +1,212 @@
+package org.siloserver.silo.watchtogether
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.TransportCommand
+import org.siloserver.silo.repository.WatchTogetherConnectionState
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RoomDeliveryLatchTest {
+    private val open1 = WatchTogetherConnectionState(generation = 7, epoch = 1, writable = true)
+    private val open2 = WatchTogetherConnectionState(generation = 7, epoch = 2, writable = true)
+
+    @Test
+    fun `attach is delivered once per connection epoch and playback session`() {
+        val latch = RoomDeliveryLatch()
+        val first = assertNotNull(latch.keyOrNull(open1, "session-a"))
+
+        assertTrue(latch.needsAttach(first))
+        latch.recordAttach(first, delivered = true)
+        assertFalse(latch.needsAttach(first))
+        assertTrue(latch.needsAttach(assertNotNull(latch.keyOrNull(open2, "session-a"))))
+        assertTrue(latch.needsAttach(assertNotNull(latch.keyOrNull(open2, "session-b"))))
+    }
+
+    @Test
+    fun `failed attach and readiness remain retryable`() {
+        val latch = RoomDeliveryLatch()
+        val key = assertNotNull(latch.keyOrNull(open1, "session-a"))
+
+        latch.recordAttach(key, delivered = false)
+        assertTrue(latch.needsAttach(key))
+        latch.recordReadiness(key, buffering = true, delivered = false)
+        assertTrue(latch.needsReadiness(key, buffering = true))
+    }
+
+    @Test
+    fun `readiness is keyed by epoch session and buffering value`() {
+        val latch = RoomDeliveryLatch()
+        val first = assertNotNull(latch.keyOrNull(open1, "session-a"))
+        latch.recordReadiness(first, buffering = false, delivered = true)
+
+        assertFalse(latch.needsReadiness(first, buffering = false))
+        assertTrue(latch.needsReadiness(first, buffering = true))
+        assertTrue(
+            latch.needsReadiness(
+                assertNotNull(latch.keyOrNull(open2, "session-a")),
+                buffering = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `non writable connection cannot mint a delivery key`() {
+        assertNull(
+            RoomDeliveryLatch().keyOrNull(
+                WatchTogetherConnectionState(generation = 7, epoch = 1, writable = false),
+                "session-a",
+            ),
+        )
+    }
+
+    @Test
+    fun `ping cannot start until a playback session has attached`() {
+        val latch = RoomDeliveryLatch()
+        val key = latch.keyOrNull(open1, null)
+
+        assertFalse(latch.isAttached(key))
+    }
+
+    @Test
+    fun `delayed command for session A cannot mutate replacement session B`() {
+        val command = TransportCommand(
+            commandId = "cmd-1",
+            sessionId = "session-a",
+            selectionRevision = 3,
+            executeAt = "2026-07-27T12:00:00Z",
+        )
+        val room = RoomSnapshot(roomId = "room-1", selectionRevision = 3)
+
+        assertTrue(
+            scheduledCommandStillCurrent(
+                command = command,
+                acceptedPlaybackSessionId = "session-a",
+                acceptedRoomId = "room-1",
+                acceptedConnection = open1,
+                currentPlaybackSessionId = "session-a",
+                currentRoom = room,
+                currentConnection = open1,
+            ),
+        )
+        assertFalse(
+            scheduledCommandStillCurrent(
+                command = command,
+                acceptedPlaybackSessionId = "session-a",
+                acceptedRoomId = "room-1",
+                acceptedConnection = open1,
+                currentPlaybackSessionId = "session-b",
+                currentRoom = room,
+                currentConnection = open1,
+            ),
+        )
+        assertFalse(
+            scheduledCommandStillCurrent(
+                command = command,
+                acceptedPlaybackSessionId = "session-a",
+                acceptedRoomId = "room-1",
+                acceptedConnection = open1,
+                currentPlaybackSessionId = "session-a",
+                currentRoom = room.copy(selectionRevision = 4),
+                currentConnection = open1,
+            ),
+        )
+    }
+
+    @Test
+    fun `delayed command for room A cannot mutate room B reusing session and revision`() {
+        val command = TransportCommand(
+            commandId = "cmd-1",
+            sessionId = "session-a",
+            selectionRevision = 3,
+            executeAt = "2026-07-27T12:00:00Z",
+        )
+        val replacementRoom = RoomSnapshot(roomId = "room-b", selectionRevision = 3)
+
+        assertFalse(
+            scheduledCommandStillCurrent(
+                command = command,
+                acceptedPlaybackSessionId = "session-a",
+                acceptedRoomId = "room-a",
+                acceptedConnection = open1,
+                currentPlaybackSessionId = "session-a",
+                currentRoom = replacementRoom,
+                currentConnection = open1.copy(generation = 8),
+            ),
+        )
+        assertFalse(
+            scheduledCommandStillCurrent(
+                command = command,
+                acceptedPlaybackSessionId = "session-a",
+                acceptedRoomId = "room-a",
+                acceptedConnection = open1,
+                currentPlaybackSessionId = "session-a",
+                currentRoom = replacementRoom.copy(roomId = "room-a"),
+                currentConnection = open2,
+            ),
+        )
+    }
+
+    @Test
+    fun `delayed command does not block a newer immediate command`() = runTest {
+        val dispatcher = RoomCommandDispatcher(backgroundScope)
+        val applied = mutableListOf<String>()
+
+        dispatcher.dispatch {
+            delay(1_000)
+            applied += "older-delayed"
+        }
+        dispatcher.dispatch {
+            applied += "newer-immediate"
+        }
+        runCurrent()
+
+        assertTrue(applied == listOf("newer-immediate"))
+        advanceTimeBy(1_000)
+        runCurrent()
+        assertTrue(applied == listOf("newer-immediate", "older-delayed"))
+    }
+
+    @Test
+    fun `finishing one repeated command preserves the other dispatch token`() {
+        val pending = RoomPendingExecutions()
+        val firstC1 = pending.record(executeAtMs = 1_000)
+        val c2 = pending.record(executeAtMs = 10)
+        val secondC1 = pending.record(executeAtMs = 1_000)
+
+        pending.finish(firstC1)
+        pending.finish(c2)
+
+        assertEquals(1_000, pending.nearestTo(nowMs = 0))
+        pending.finish(secondC1)
+        assertNull(pending.nearestTo(nowMs = 0))
+    }
+
+    @Test
+    fun `disposing controller lifetime cancels only its child collectors`() = runTest {
+        val lifetime = RoomControllerLifetime(backgroundScope)
+        var childFinished = false
+        lifetime.scope.launch {
+            try {
+                awaitCancellation()
+            } finally {
+                childFinished = true
+            }
+        }
+        runCurrent()
+
+        lifetime.dispose()
+        runCurrent()
+
+        assertTrue(childFinished)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomEntryUiPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomEntryUiPolicyTest.kt
@@ -1,0 +1,13 @@
+package org.siloserver.silo.watchtogether
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RoomEntryUiPolicyTest {
+    @Test
+    fun `entry can dismiss only while no room mutation is running`() {
+        assertTrue(canDismissRoomEntry(isBusy = false))
+        assertFalse(canDismissRoomEntry(isBusy = true))
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomSessionTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomSessionTest.kt
@@ -1,0 +1,212 @@
+package org.siloserver.silo.watchtogether
+
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionKind
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RoomSessionTest {
+    @Test
+    fun `local next up cannot replace an active Watch Together room`() {
+        assertTrue(!shouldNavigateToLocalNext(inWatchTogetherRoom = true))
+        assertTrue(shouldNavigateToLocalNext(inWatchTogetherRoom = false))
+    }
+
+    @Test
+    fun `lobby and player adoption of the same room reuses one socket`() = runTest {
+        val repository = FakeRoomSessionRepository()
+        val session = RoomSession(repository, backgroundScope, DefaultIdentityTransitionBarrier())
+
+        session.adopt("room-a").join()
+        session.adopt("room-a").join()
+        runCurrent()
+
+        assertEquals(listOf("room-a"), repository.started)
+        session.leave()
+    }
+
+    @Test
+    fun `replacement cancels and joins room A before room B starts`() = runTest {
+        val repository = FakeRoomSessionRepository()
+        val finalizerGate = CompletableDeferred<Unit>()
+        repository.finalizerGates["room-a"] = finalizerGate
+        val session = RoomSession(repository, backgroundScope, DefaultIdentityTransitionBarrier())
+        session.enter("room-a")
+        runCurrent()
+
+        val replacement = launch { session.enter("room-b") }
+        runCurrent()
+        assertEquals(listOf("room-a"), repository.started)
+        assertEquals(listOf("room-a"), repository.canceling)
+
+        finalizerGate.complete(Unit)
+        replacement.join()
+        runCurrent()
+
+        assertEquals(listOf("room-a", "room-b"), repository.started)
+        session.leave()
+    }
+
+    @Test
+    fun `concurrent enters serialize and newest room owns the connection`() = runTest {
+        val repository = FakeRoomSessionRepository()
+        val session = RoomSession(repository, backgroundScope, DefaultIdentityTransitionBarrier())
+
+        val first = launch { session.enter("room-a") }
+        val second = launch { session.enter("room-b") }
+        first.join()
+        second.join()
+        runCurrent()
+
+        assertEquals(listOf("room-a", "room-b"), repository.started)
+        assertEquals(listOf("room-a"), repository.canceling)
+        assertTrue(session.isActive())
+        session.leave()
+    }
+
+    @Test
+    fun `leave joins the connection before resetting repository state`() = runTest {
+        val repository = FakeRoomSessionRepository()
+        val finalizerGate = CompletableDeferred<Unit>()
+        repository.finalizerGates["room-a"] = finalizerGate
+        val session = RoomSession(repository, backgroundScope, DefaultIdentityTransitionBarrier())
+        session.enter("room-a")
+        runCurrent()
+
+        val leaving = launch { session.leave() }
+        runCurrent()
+        assertEquals(0, repository.resetCount)
+
+        finalizerGate.complete(Unit)
+        leaving.join()
+
+        assertEquals(1, repository.resetCount)
+        assertTrue(!session.isActive())
+    }
+
+    @Test
+    fun `durable departure survives cancellation of the initiating screen`() = runTest {
+        val repository = FakeRoomSessionRepository()
+        val finalizerGate = CompletableDeferred<Unit>()
+        repository.finalizerGates["room-a"] = finalizerGate
+        val session = RoomSession(repository, backgroundScope, DefaultIdentityTransitionBarrier())
+        session.adopt("room-a").join()
+
+        val screen = launch {
+            session.depart()
+        }
+        screen.join()
+        screen.cancel()
+        runCurrent()
+        assertEquals(0, repository.resetCount)
+
+        finalizerGate.complete(Unit)
+        runCurrent()
+
+        assertEquals(1, repository.resetCount)
+        assertTrue(!session.isActive())
+    }
+
+    @Test
+    fun `identity WILL_CHANGE cancels joins and resets before mutation`() = runTest {
+        val repository = FakeRoomSessionRepository()
+        val barrier = DefaultIdentityTransitionBarrier()
+        val session = RoomSession(repository, backgroundScope, barrier)
+        session.enter("room-a")
+        runCurrent()
+        var mutationObservedSafeState = false
+
+        barrier.changing(IdentityTransitionKind.SERVER_SWITCH) {
+            mutationObservedSafeState =
+                repository.canceling == listOf("room-a") && repository.resetCount == 1
+        }
+
+        assertTrue(mutationObservedSafeState)
+        assertTrue(!session.isActive())
+    }
+
+    @Test
+    fun `identity mutation waits for socket finalizer and reset`() = runTest {
+        val repository = FakeRoomSessionRepository()
+        val finalizerGate = CompletableDeferred<Unit>()
+        repository.finalizerGates["room-a"] = finalizerGate
+        val barrier = DefaultIdentityTransitionBarrier()
+        val session = RoomSession(repository, backgroundScope, barrier)
+        session.enter("room-a")
+        var mutationStarted = false
+
+        val transition = launch {
+            barrier.changing(IdentityTransitionKind.PROFILE_SWITCH) {
+                mutationStarted = true
+            }
+        }
+        runCurrent()
+
+        assertTrue(!mutationStarted)
+        assertEquals(0, repository.resetCount)
+        finalizerGate.complete(Unit)
+        transition.join()
+
+        assertTrue(mutationStarted)
+        assertEquals(1, repository.resetCount)
+    }
+
+    @Test
+    fun `every identity transition kind resets the room before mutation`() = runTest {
+        IdentityTransitionKind.entries.forEach { kind ->
+            val repository = FakeRoomSessionRepository()
+            val barrier = DefaultIdentityTransitionBarrier()
+            val session = RoomSession(repository, backgroundScope, barrier)
+            session.enter("room-${kind.name}")
+            var mutationObservedSafeState = false
+
+            barrier.changing(kind) {
+                mutationObservedSafeState =
+                    repository.canceling == listOf("room-${kind.name}") &&
+                        repository.resetCount == 1 &&
+                        !session.isActive()
+            }
+
+            assertTrue(mutationObservedSafeState, "room remained visible during $kind")
+        }
+    }
+
+    private class FakeRoomSessionRepository : RoomSessionRepository {
+        override val roomSnapshot = MutableStateFlow<RoomSnapshot?>(null)
+        override val roomClosedReason = MutableStateFlow<String?>(null)
+        val started = mutableListOf<String>()
+        val canceling = mutableListOf<String>()
+        val finalizerGates = mutableMapOf<String, CompletableDeferred<Unit>>()
+        var resetCount = 0
+
+        override suspend fun connect(roomId: String) {
+            started += roomId
+            try {
+                awaitCancellation()
+            } finally {
+                canceling += roomId
+                withContext(NonCancellable) {
+                    finalizerGates[roomId]?.await()
+                }
+            }
+        }
+
+        override suspend fun reset() {
+            resetCount++
+            roomSnapshot.value = null
+        }
+
+        override suspend fun closeRoom(): ApiResult<Unit> = ApiResult.Success(Unit)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomTransportAuthorityTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomTransportAuthorityTest.kt
@@ -5,7 +5,9 @@ import org.siloserver.silo.model.watchtogether.MemberRole
 import org.siloserver.silo.model.watchtogether.RoomPhase
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -62,5 +64,63 @@ class RoomTransportAuthorityTest {
     fun nullBlocked() {
         assertFalse(roomTransportAuthorized(null, RoomTransportIntent.PlayPause))
         assertFalse(roomTransportAuthorized(null, RoomTransportIntent.Seek))
+    }
+
+    @Test
+    fun guestHostOnlyExternalPauseIsRestoredWithoutRequest() {
+        val snapshot = fixture(
+            GuestControlPolicy.HostOnly,
+            MemberRole.Guest,
+            canControl = false,
+        ).copy(isPaused = false)
+
+        assertEquals(
+            ExternalPlayPauseDecision(
+                restorePlayWhenReady = true,
+                requestIsPaused = null,
+            ),
+            externalPlayPauseDecision(snapshot, localPlayWhenReady = false),
+        )
+    }
+
+    @Test
+    fun authorizedExternalPauseIsRestoredAndRequestedThroughRoom() {
+        val snapshot = fixture(
+            GuestControlPolicy.GuestPlayPause,
+            MemberRole.Guest,
+            canControl = true,
+        ).copy(isPaused = false)
+
+        assertEquals(
+            ExternalPlayPauseDecision(
+                restorePlayWhenReady = true,
+                requestIsPaused = true,
+            ),
+            externalPlayPauseDecision(snapshot, localPlayWhenReady = false),
+        )
+    }
+
+    @Test
+    fun roomAppliedStateDoesNotLoopBackIntoTransportRequest() {
+        val snapshot = fixture(
+            GuestControlPolicy.GuestPlayPause,
+            MemberRole.Guest,
+            canControl = true,
+        ).copy(isPaused = true)
+
+        assertNull(externalPlayPauseDecision(snapshot, localPlayWhenReady = false))
+    }
+
+    @Test
+    fun externalStateOutsidePlayingIsNotReconciled() {
+        val snapshot = fixture(
+            GuestControlPolicy.HostOnly,
+            MemberRole.Guest,
+            canControl = false,
+            phase = RoomPhase.Lobby,
+        )
+
+        assertNull(externalPlayPauseDecision(snapshot, localPlayWhenReady = false))
+        assertNull(externalPlayPauseDecision(null, localPlayWhenReady = false))
     }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomVoteTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomVoteTest.kt
@@ -1,0 +1,43 @@
+package org.siloserver.silo.watchtogether
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.Suggestion
+
+class RoomVoteTest {
+    @Test
+    fun `winner is the first server-ordered suggestion with votes`() {
+        val winner = suggestion("winner", votes = 3)
+        val runnerUp = suggestion("runner-up", votes = 2)
+
+        assertEquals(winner, roomVoteWinner(listOf(winner, runnerUp)))
+    }
+
+    @Test
+    fun `room with no votes has no winner`() {
+        assertNull(roomVoteWinner(listOf(suggestion("oldest", votes = 0))))
+        assertNull(roomVoteWinner(emptyList()))
+    }
+
+    @Test
+    fun `vote-room predicate follows the snapshot selection mode`() {
+        assertTrue(RoomSnapshot(roomId = "room", selectionMode = RoomSelectionMode.Vote).isVoteRoom())
+        assertFalse(RoomSnapshot(roomId = "room", selectionMode = RoomSelectionMode.HostPick).isVoteRoom())
+        assertFalse(null.isVoteRoom())
+    }
+
+    private fun suggestion(id: String, votes: Int) = Suggestion(
+        id = id,
+        roomId = "room",
+        contentId = "content-$id",
+        contentType = "movie",
+        title = id,
+        voteCount = votes,
+        createdAt = "2026-07-27T00:00:00Z",
+    )
+}


### PR DESCRIPTION
## Stack

- Base: #116 (`split/108-e-subtitles`)
- This is forward-split slice F of closed archival integration PR #108.
- Do not merge before the lower stack is reviewed and landed.

## Scope

- Production-safe Watch Together WebSocket reconnect semantics, immutable room/auth leases, exact physical-socket transport authorization, and application-scoped room ownership.
- Reachable phone/TV host, join, lobby, playback, voting, suggestion, policy, replacement, and close flows.
- Reconnect-safe attach/readiness/transport delivery, stale completion rejection, historical suggestion hydration, and external MediaSession/player authority reconciliation.
- Privacy hardening for auth snapshots and socket request rendering. The server V3 contract still requires room/profile credentials in the WebSocket query; the redundant access JWT is omitted and app logs/request string rendering redact credentials.
- Rational frame-rate decoding needed by the production catalog fixture.

## Live two-participant validation

Validated against local Silo API protocol V3 with distinct Host E2E and Guest E2E identities on:

- `Silo_TV` (`emulator-5554`)
- `Silo_Phone` (`emulator-5556`)

Covered create/join/handshake, attach ordering, host play/pause/seek, guest host-only rejection, guest-play-pause policy, host override, suggestions/voting/promotion, drift/buffering convergence, hard transport interruption and reconnect/rejoin, background/foreground, room/session replacement, host departure, and terminal room close.

The final on-device correction made the TV close confirmation a focusable popup with root-wide initial-focus tracking. D-pad Down remained on **Keep watching** without focus steal; Cancel preserved both participants; Close returned the host to detail and ejected the guest. Final phone/TV log scans found zero query-credential URLs, bearer tokens, JWT-shaped values, or raw auth snapshots.

No physical Shield device was touched.

## Review corrections

Independent lifecycle/concurrency/security review drove test-first fixes for:

- immutable room lease/generation races and late REST/socket completions;
- exact captured socket authorization across replacement and policy changes;
- non-blocking reset while transport I/O is blocked;
- single-flight external player reconciliation and TV lifecycle restoration;
- TV close-dialog modal focus ownership.

Final independent verdict: **Ready: Yes**; no remaining correctness, privacy/security, concurrency, or lifecycle blockers.

## Verification

- `./scripts/test-check-build-supply-chain.sh`
- `./scripts/check-build-supply-chain.sh`
- `./gradlew --no-daemon testDebugUnitTest :androidApp:assembleDebug :androidTvApp:assembleDebug --max-workers=1 --rerun-tasks` — 175/175 tasks executed, pass
- `./gradlew --no-daemon :androidTvApp:testDebugUnitTest :androidTvApp:assembleDebug --max-workers=1 --rerun-tasks` — 105/105 tasks executed, pass
- Final focused `TvWatchTogetherSurfaceSourceTest` + TV APK assembly — pass
- Two-emulator live matrix above
- `git diff --check`

## Traceability

The design, source mapping, and dependency order are in `docs/superpowers/plans/2026-07-27-pr108-slice-f-watch-together.md`.

PR #108 source intent mapped into this stack includes:

- feature entry: `9fe27a27`
- transport/send/open corrections: `323510a2`, `c6ba32ef`, `e171e011`
- lobby/invite/TV focus: `acfac18a`, `fca6d7c6`, `bc58049b`
- voting and empty vote rooms: `ea5756ec`, `8f36f7d2`, `923a1a7f`
- browsing suggestions: `530f9488`, `f91aa62e`
- application-scoped ownership intent: `864de27e`, `79b4278d`

The forward split preserves those behavioral contracts as a net vertical diff while the local commit sequence records the corrected architecture and review rounds.

## Slice G resolution

The planned final TV/catalog slice requires no additional stacked PR:

- TV request-detail behavior already landed through PR #107 (`41df0594`);
- manual TV Up Next behavior already landed through PR #110 (`da26f081`);
- mixed-library visibility already landed through PR #111 (`498a07fd`).

All three commits are ancestors of this head, and attempted cherry-picks were empty. Focused `MixedLibraryModeTest`, `TvRequestPresentationTest`, and `*TvPlayer*` verification passed. The local unpushed `split/108-g-tv-catalog` branch and restacked traceability commit `5dc9455a` are retained as the archival G resolution; no docs-only G PR was created. Its content and stable patch ID are identical to the pre-restack commit `b653253f`.

