### PR TITLE
feat: add Watch Together to profile menus

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MainAppTopBar.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MainAppTopBar.kt
@@ -54,6 +54,7 @@ fun MainAppTopBar(
     isProfileLoading: Boolean,
     onSearchClick: () -> Unit,
     onRequestsClick: (() -> Unit)? = null,
+    onWatchTogetherClick: (() -> Unit)?,
     onSettingsClick: () -> Unit,
     onSwitchProfileClick: () -> Unit,
     onSwitchServerClick: () -> Unit,
@@ -147,8 +148,17 @@ fun MainAppTopBar(
                                     onRequestsClick()
                                 },
                             )
-                            HorizontalDivider()
                         }
+                        if (onWatchTogetherClick != null) {
+                            DropdownMenuItem(
+                                text = { Text("Watch Together") },
+                                onClick = {
+                                    menuExpanded = false
+                                    onWatchTogetherClick()
+                                },
+                            )
+                        }
+                        HorizontalDivider()
                         DropdownMenuItem(
                             text = { Text("Settings") },
                             onClick = {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt
@@ -53,7 +53,9 @@ import org.siloserver.silo.android.ui.screens.libraries.LibrariesScreen
 import org.siloserver.silo.android.ui.screens.libraries.LibrariesSelectorSheet
 import org.siloserver.silo.android.ui.screens.libraries.LibrariesViewModel
 import org.siloserver.silo.android.ui.screens.recommendations.RecommendationsScreen
+import org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherMenuEntrySheet
 import org.siloserver.silo.cast.SiloCastPlaybackRequest
+import org.siloserver.silo.model.feature.CLIENT_WATCH_TOGETHER_SURFACE_ENABLED
 import org.siloserver.silo.model.navigation.MediaMode
 import org.siloserver.silo.model.navigation.MediaModeCapabilities
 import org.siloserver.silo.model.navigation.mobileMediaModeCapabilities
@@ -85,6 +87,7 @@ fun MainScreen(
     val siloCastController: SiloCastController = koinInject()
     val siloCastState by siloCastController.state.collectAsState()
     var showSiloCastTargetPicker by rememberSaveable { mutableStateOf(false) }
+    var showWatchTogetherEntry by rememberSaveable { mutableStateOf(false) }
 
     fun playVideo(contentId: String, fileId: Int? = null, resumePositionSeconds: Double? = null) {
         val launchedRemotely = siloCastController.launchOnConnectedTarget(
@@ -221,6 +224,12 @@ fun MainScreen(
     } else {
         null
     }
+    val watchTogetherMenuAction: (() -> Unit)? =
+        if (CLIENT_WATCH_TOGETHER_SURFACE_ENABLED) {
+            { showWatchTogetherEntry = true }
+        } else {
+            null
+        }
 
     Scaffold(
         bottomBar = {
@@ -292,6 +301,7 @@ fun MainScreen(
                             onRemoteDisconnectClick = { siloCastController.disconnect() },
                             isRemoteControlActive = siloCastState.hasActiveSession,
                             onRequestsClick = requestsMenuAction,
+                            onWatchTogetherClick = watchTogetherMenuAction,
                             onSettingsClick = { navController.navigate(Route.Settings.route) },
                             onSwitchProfileClick = {
                                 navController.navigate(Route.ProfileSelection.route)
@@ -318,6 +328,7 @@ fun MainScreen(
                             onLibrarySelectorClick = { showLibrarySelector = true },
                             onSearchClick = { navController.navigate(Route.Search().route) },
                             onRequestsClick = requestsMenuAction,
+                            onWatchTogetherClick = watchTogetherMenuAction,
                             onSettingsClick = { navController.navigate(Route.Settings.route) },
                             onSwitchProfileClick = {
                                 navController.navigate(Route.ProfileSelection.route)
@@ -393,6 +404,7 @@ fun MainScreen(
                     isProfileLoading = headerState.isLoading,
                     onSearchClick = { navController.navigate(Route.Search().route) },
                     onRequestsClick = requestsMenuAction,
+                    onWatchTogetherClick = watchTogetherMenuAction,
                     onSettingsClick = { navController.navigate(Route.Settings.route) },
                     onSwitchProfileClick = {
                         navController.navigate(Route.ProfileSelection.route)
@@ -445,6 +457,17 @@ fun MainScreen(
                 SiloCastTargetPickerSheet(
                     onDismiss = { showSiloCastTargetPicker = false },
                     controller = siloCastController,
+                )
+            }
+
+            if (showWatchTogetherEntry) {
+                WatchTogetherMenuEntrySheet(
+                    onNavigate = { route ->
+                        navController.navigate(route) {
+                            launchSingleTop = true
+                        }
+                    },
+                    onDismiss = { showWatchTogetherEntry = false },
                 )
             }
         }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
@@ -93,6 +93,7 @@ fun HomeScreen(
     onRemoteDisconnectClick: () -> Unit,
     isRemoteControlActive: Boolean,
     onRequestsClick: (() -> Unit)?,
+    onWatchTogetherClick: (() -> Unit)?,
     onSettingsClick: () -> Unit,
     onSwitchProfileClick: () -> Unit,
     onSwitchServerClick: () -> Unit,
@@ -241,6 +242,7 @@ fun HomeScreen(
             onRemoteDisconnectClick = onRemoteDisconnectClick,
             isRemoteControlActive = isRemoteControlActive,
             onRequestsClick = onRequestsClick,
+            onWatchTogetherClick = onWatchTogetherClick,
             onSettingsClick = onSettingsClick,
             onSwitchProfileClick = onSwitchProfileClick,
             onSwitchServerClick = onSwitchServerClick,
@@ -298,6 +300,7 @@ private fun HomeFloatingChrome(
     onRemoteDisconnectClick: () -> Unit,
     isRemoteControlActive: Boolean,
     onRequestsClick: (() -> Unit)?,
+    onWatchTogetherClick: (() -> Unit)?,
     onSettingsClick: () -> Unit,
     onSwitchProfileClick: () -> Unit,
     onSwitchServerClick: () -> Unit,
@@ -399,6 +402,7 @@ private fun HomeFloatingChrome(
                 HomeProfileMenu(
                     activeProfile = activeProfile,
                     onRequestsClick = onRequestsClick,
+                    onWatchTogetherClick = onWatchTogetherClick,
                     onSettingsClick = onSettingsClick,
                     onSwitchProfileClick = onSwitchProfileClick,
                     onSwitchServerClick = onSwitchServerClick,
@@ -445,6 +449,7 @@ private fun HomeChromeButton(
 private fun HomeProfileMenu(
     activeProfile: Profile?,
     onRequestsClick: (() -> Unit)?,
+    onWatchTogetherClick: (() -> Unit)?,
     onSettingsClick: () -> Unit,
     onSwitchProfileClick: () -> Unit,
     onSwitchServerClick: () -> Unit,
@@ -488,8 +493,17 @@ private fun HomeProfileMenu(
                         onRequestsClick()
                     },
                 )
-                HorizontalDivider()
             }
+            if (onWatchTogetherClick != null) {
+                DropdownMenuItem(
+                    text = { Text("Watch Together") },
+                    onClick = {
+                        menuExpanded = false
+                        onWatchTogetherClick()
+                    },
+                )
+            }
+            HorizontalDivider()
             DropdownMenuItem(
                 text = { Text("Settings") },
                 onClick = {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
@@ -623,6 +623,7 @@ fun LibrariesScreen(
     onLibrarySelectorClick: () -> Unit,
     onSearchClick: () -> Unit,
     onRequestsClick: (() -> Unit)?,
+    onWatchTogetherClick: (() -> Unit)?,
     onSettingsClick: () -> Unit,
     onSwitchProfileClick: () -> Unit,
     onSwitchServerClick: () -> Unit,
@@ -758,6 +759,7 @@ fun LibrariesScreen(
             onTabSelected = viewModel::selectTab,
             onSearchClick = onSearchClick,
             onRequestsClick = onRequestsClick,
+            onWatchTogetherClick = onWatchTogetherClick,
             onSettingsClick = onSettingsClick,
             onSwitchProfileClick = onSwitchProfileClick,
             onSwitchServerClick = onSwitchServerClick,
@@ -1176,6 +1178,7 @@ private fun LibrariesFloatingChrome(
     onTabSelected: (LibrariesSubtab) -> Unit,
     onSearchClick: () -> Unit,
     onRequestsClick: (() -> Unit)?,
+    onWatchTogetherClick: (() -> Unit)?,
     onSettingsClick: () -> Unit,
     onSwitchProfileClick: () -> Unit,
     onSwitchServerClick: () -> Unit,
@@ -1232,6 +1235,7 @@ private fun LibrariesFloatingChrome(
                 ChromeProfileMenu(
                     activeProfile = activeProfile,
                     onRequestsClick = onRequestsClick,
+                    onWatchTogetherClick = onWatchTogetherClick,
                     onSettingsClick = onSettingsClick,
                     onSwitchProfileClick = onSwitchProfileClick,
                     onSwitchServerClick = onSwitchServerClick,
@@ -1329,6 +1333,7 @@ private fun ChromeIconButton(
 private fun ChromeProfileMenu(
     activeProfile: Profile?,
     onRequestsClick: (() -> Unit)?,
+    onWatchTogetherClick: (() -> Unit)?,
     onSettingsClick: () -> Unit,
     onSwitchProfileClick: () -> Unit,
     onSwitchServerClick: () -> Unit,
@@ -1371,8 +1376,17 @@ private fun ChromeProfileMenu(
                         onRequestsClick()
                     },
                 )
-                HorizontalDivider()
             }
+            if (onWatchTogetherClick != null) {
+                DropdownMenuItem(
+                    text = { Text("Watch Together") },
+                    onClick = {
+                        menuExpanded = false
+                        onWatchTogetherClick()
+                    },
+                )
+            }
+            HorizontalDivider()
             DropdownMenuItem(
                 text = { Text("Settings") },
                 onClick = {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntrySheet.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntrySheet.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
-import org.siloserver.silo.model.watchtogether.RoomSelectionMode
 import org.siloserver.silo.watchtogether.canDismissRoomEntry
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -97,9 +96,7 @@ fun WatchTogetherEntrySheet(
                 ) { Text(if (state.busy) "Creating…" else "Host a room") }
 
                 OutlinedButton(
-                    onClick = {
-                        viewModel.host(contentId, fileId, RoomSelectionMode.Vote)
-                    },
+                    onClick = { viewModel.hostEmptyVoteRoom() },
                     enabled = !state.busy,
                     modifier = Modifier.fillMaxWidth(),
                 ) { Text("Host a vote room") }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModel.kt
@@ -5,16 +5,21 @@ import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.android.ui.navigation.Route
 import org.siloserver.silo.model.watchtogether.CreateRoomRequest
 import org.siloserver.silo.model.watchtogether.JoinRoomRequest
-import org.siloserver.silo.model.watchtogether.MemberRole
 import org.siloserver.silo.model.watchtogether.RoomSelectionMode
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.model.watchtogether.SetSelectionRequest
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.errorMessage
-import org.siloserver.silo.repository.WatchTogetherRepository
+import org.siloserver.silo.watchtogether.WatchTogetherEntryGateway
+import org.siloserver.silo.watchtogether.WatchTogetherEntryTarget
+import org.siloserver.silo.watchtogether.resumableWatchTogetherRoom
+import org.siloserver.silo.watchtogether.watchTogetherEntryTarget
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -26,16 +31,13 @@ import kotlinx.coroutines.launch
  * Kept top-level + pure so it is unit-testable without Compose or the repo.
  */
 fun watchTogetherDestination(room: RoomSnapshot): String =
-    if (!room.selectedContentId.isNullOrBlank() &&
-        !(room.selfRole == MemberRole.Host && room.memberCount <= 1)
-    ) {
-        Route.Player(
-            contentId = room.selectedContentId!!,
+    when (watchTogetherEntryTarget(room)) {
+        WatchTogetherEntryTarget.Player -> Route.Player(
+            contentId = requireNotNull(room.selectedContentId),
             fileId = room.selectedFileId,
             roomId = room.roomId,
         ).route
-    } else {
-        Route.WatchTogetherLobby(roomId = room.roomId).route
+        WatchTogetherEntryTarget.Lobby -> Route.WatchTogetherLobby(roomId = room.roomId).route
     }
 
 /**
@@ -43,13 +45,13 @@ fun watchTogetherDestination(room: RoomSnapshot): String =
  * the room selection) or joins an existing room by invite code, then resolves a
  * navigation [UiState.destination] the sheet observes.
  *
- * The repository stores the room JWT internally on create/join and reads the
+ * The gateway stores the room JWT internally on create/join and reads the
  * active roomId from its own snapshot, so [setSelection] takes only the request.
  * Create/join/selection all return a `{room, room_access_token}` [RoomResponse]
  * wrapper; the snapshot lives at `.data.room`.
  */
 class WatchTogetherEntryViewModel(
-    private val repository: WatchTogetherRepository,
+    private val gateway: WatchTogetherEntryGateway,
 ) : ViewModel() {
 
     data class UiState(
@@ -61,6 +63,13 @@ class WatchTogetherEntryViewModel(
 
     private val _uiState = MutableStateFlow(UiState())
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+    val currentRoom: StateFlow<RoomSnapshot?> = gateway.roomSnapshot
+        .map(::resumableWatchTogetherRoom)
+        .stateIn(
+            viewModelScope,
+            SharingStarted.Eagerly,
+            resumableWatchTogetherRoom(gateway.roomSnapshot.value),
+        )
 
     /** Host flow: create a room with this title pre-selected as the room selection. */
     fun host(
@@ -68,22 +77,22 @@ class WatchTogetherEntryViewModel(
         fileId: Int?,
         selectionMode: RoomSelectionMode = RoomSelectionMode.HostPick,
     ) {
+        if (selectionMode == RoomSelectionMode.Vote) {
+            hostEmptyVoteRoom()
+            return
+        }
         if (_uiState.value.busy) return
         _uiState.update { it.copy(busy = true, error = null) }
         viewModelScope.launch {
             when (
-                val created = repository.createRoom(
+                val created = gateway.createRoom(
                     CreateRoomRequest(selectionMode = selectionMode.wire),
                 )
             ) {
                 is ApiResult.Success -> {
-                    if (selectionMode == RoomSelectionMode.Vote) {
-                        finish(created.data.room)
-                        return@launch
-                    }
                     // Set this title as the room selection so everyone lands on it.
                     when (
-                        val sel = repository.setSelection(
+                        val sel = gateway.setSelection(
                             SetSelectionRequest(contentId = contentId, fileId = fileId),
                         )
                     ) {
@@ -98,13 +107,41 @@ class WatchTogetherEntryViewModel(
         }
     }
 
+    /** Host flow for the menu action: create an empty vote room, then enter its lobby. */
+    fun hostEmptyVoteRoom() {
+        if (_uiState.value.busy) return
+        _uiState.update { it.copy(busy = true, error = null) }
+        viewModelScope.launch {
+            when (
+                val created = gateway.createRoom(
+                    CreateRoomRequest(selectionMode = RoomSelectionMode.Vote.wire),
+                )
+            ) {
+                is ApiResult.Success -> finish(created.data.room)
+                is ApiResult.Error, is ApiResult.NetworkError ->
+                    fail(created.errorMessage("Failed to create room"))
+            }
+        }
+    }
+
+    /** Resume the valid room snapshot already held by the process session. */
+    fun resumeCurrentRoom() {
+        if (_uiState.value.busy) return
+        val room = resumableWatchTogetherRoom(gateway.roomSnapshot.value)
+        if (room == null) {
+            fail("Current room is no longer available")
+        } else {
+            finish(room)
+        }
+    }
+
     /** Join flow: resolve an invite code; route to player if a selection exists, else lobby. */
     fun joinByCode(code: String) {
         val trimmed = code.trim()
         if (_uiState.value.busy || trimmed.isBlank()) return
         _uiState.update { it.copy(busy = true, error = null) }
         viewModelScope.launch {
-            when (val joined = repository.joinRoom(JoinRoomRequest(code = trimmed))) {
+            when (val joined = gateway.joinRoom(JoinRoomRequest(code = trimmed))) {
                 is ApiResult.Success -> finish(joined.data.room)
                 is ApiResult.Error, is ApiResult.NetworkError ->
                     fail(joined.errorMessage("Could not join — check the code"))

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ExitToApp
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.HowToVote
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Button
@@ -88,11 +88,22 @@ fun WatchTogetherLobbyScreen(
             TopAppBar(
                 title = { Text("Watch Together") },
                 navigationIcon = {
-                    IconButton(onClick = { viewModel.leave(); onBack() }) {
-                        Icon(Icons.AutoMirrored.Filled.ExitToApp, contentDescription = "Leave room")
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back to browse",
+                        )
                     }
                 },
                 actions = {
+                    TextButton(
+                        onClick = {
+                            viewModel.leave()
+                            onBack()
+                        },
+                    ) {
+                        Text("Leave room")
+                    }
                     if (canManage) {
                         TextButton(onClick = { viewModel.closeRoom() }) { Text("Close") }
                     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySheet.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySheet.kt
@@ -1,0 +1,127 @@
+package org.siloserver.silo.android.ui.screens.watchtogether
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.koin.compose.viewmodel.koinViewModel
+import org.siloserver.silo.watchtogether.canDismissRoomEntry
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WatchTogetherMenuEntrySheet(
+    onNavigate: (String) -> Unit,
+    onDismiss: () -> Unit,
+    viewModel: WatchTogetherEntryViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val currentRoom by viewModel.currentRoom.collectAsState()
+    var code by rememberSaveable { mutableStateOf("") }
+    var showJoin by rememberSaveable { mutableStateOf(false) }
+    val latestBusy by rememberUpdatedState(state.busy)
+
+    LaunchedEffect(state.destination) {
+        val destination = state.destination ?: return@LaunchedEffect
+        viewModel.consumeDestination()
+        onDismiss()
+        onNavigate(destination)
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = {
+            if (canDismissRoomEntry(state.busy)) {
+                viewModel.clearError()
+                onDismiss()
+            }
+        },
+        sheetState = rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+            confirmValueChange = { target ->
+                target != SheetValue.Hidden || canDismissRoomEntry(latestBusy)
+            },
+        ),
+    ) {
+        Text(
+            text = "Watch Together",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+        )
+        HorizontalDivider()
+
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (!showJoin) {
+                if (currentRoom != null) {
+                    Button(
+                        onClick = { viewModel.resumeCurrentRoom() },
+                        enabled = !state.busy,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text("Resume current room") }
+                }
+                Button(
+                    onClick = { viewModel.hostEmptyVoteRoom() },
+                    enabled = !state.busy,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text(if (state.busy) "Creating…" else "Host a room") }
+                OutlinedButton(
+                    onClick = { viewModel.clearError(); showJoin = true },
+                    enabled = !state.busy,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Join by code") }
+            } else {
+                OutlinedTextField(
+                    value = code,
+                    onValueChange = {
+                        code = it.uppercase().filter(Char::isLetterOrDigit).take(8)
+                    },
+                    label = { Text("Invite code") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Button(
+                    onClick = { viewModel.joinByCode(code) },
+                    enabled = !state.busy && code.length >= 4,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    if (state.busy) CircularProgressIndicator(modifier = Modifier.size(18.dp))
+                    else Text("Join")
+                }
+                OutlinedButton(
+                    onClick = { viewModel.clearError(); showJoin = false },
+                    enabled = !state.busy,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Back") }
+            }
+            state.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+        }
+        Spacer(Modifier.height(24.dp))
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModelTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModelTest.kt
@@ -1,0 +1,145 @@
+package org.siloserver.silo.android.ui.screens.watchtogether
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.siloserver.silo.model.watchtogether.CreateRoomRequest
+import org.siloserver.silo.model.watchtogether.JoinRoomRequest
+import org.siloserver.silo.model.watchtogether.RoomPhase
+import org.siloserver.silo.model.watchtogether.RoomResponse
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.SetSelectionRequest
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.watchtogether.WatchTogetherEntryGateway
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = android.app.Application::class)
+class WatchTogetherEntryViewModelTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun emptyHostCreatesVoteRoomWithoutSelection() = runTest(dispatcher) {
+        val gateway = FakeGateway()
+        val viewModel = WatchTogetherEntryViewModel(gateway)
+
+        viewModel.hostEmptyVoteRoom()
+
+        assertEquals(listOf(CreateRoomRequest(RoomSelectionMode.Vote.wire)), gateway.createRequests)
+        assertEquals(emptyList(), gateway.selectionRequests)
+        assertEquals("watch_together/room-1", viewModel.uiState.value.destination)
+    }
+
+    @Test
+    fun resumeUsesCurrentRoomWithoutCreateOrJoin() = runTest(dispatcher) {
+        val room = RoomSnapshot(roomId = "room-1", phase = RoomPhase.Lobby)
+        val gateway = FakeGateway(room)
+        val viewModel = WatchTogetherEntryViewModel(gateway)
+
+        viewModel.resumeCurrentRoom()
+
+        assertEquals("watch_together/room-1", viewModel.uiState.value.destination)
+        assertEquals(emptyList(), gateway.createRequests)
+        assertEquals(emptyList(), gateway.joinRequests)
+    }
+
+    @Test
+    fun identityClearRemovesResumeState() = runTest(dispatcher) {
+        val gateway = FakeGateway(RoomSnapshot(roomId = "room-1", phase = RoomPhase.Lobby))
+        val viewModel = WatchTogetherEntryViewModel(gateway)
+
+        gateway.roomSnapshot.value = null
+
+        assertNull(viewModel.currentRoom.value)
+    }
+
+    @Test
+    fun titleHostStillSetsTheSelectedTitle() = runTest(dispatcher) {
+        val gateway = FakeGateway()
+        val viewModel = WatchTogetherEntryViewModel(gateway)
+
+        viewModel.host(contentId = "movie-1", fileId = 7)
+
+        assertEquals(
+            listOf(SetSelectionRequest(contentId = "movie-1", fileId = 7)),
+            gateway.selectionRequests,
+        )
+    }
+
+    @Test
+    fun joinByCodeTrimsAndUsesExistingErrorMapping() = runTest(dispatcher) {
+        val gateway = FakeGateway()
+        val viewModel = WatchTogetherEntryViewModel(gateway)
+
+        viewModel.joinByCode(" ABCD1234 ")
+        assertEquals(listOf(JoinRoomRequest(code = "ABCD1234")), gateway.joinRequests)
+
+        viewModel.consumeDestination()
+        gateway.joinResult = ApiResult.NetworkError(IllegalStateException("offline"))
+        viewModel.joinByCode("EFGH5678")
+        assertEquals("Network error. Check your connection.", viewModel.uiState.value.error)
+    }
+
+    private class FakeGateway(
+        room: RoomSnapshot? = null,
+    ) : WatchTogetherEntryGateway {
+        override val roomSnapshot = MutableStateFlow(room)
+        val createRequests = mutableListOf<CreateRoomRequest>()
+        val joinRequests = mutableListOf<JoinRoomRequest>()
+        val selectionRequests = mutableListOf<SetSelectionRequest>()
+        var joinResult: ApiResult<RoomResponse>? = null
+        var nextRoom = RoomSnapshot(
+            roomId = "room-1",
+            phase = RoomPhase.Lobby,
+            selectionMode = RoomSelectionMode.Vote,
+        )
+
+        override suspend fun createRoom(request: CreateRoomRequest): ApiResult<RoomResponse> {
+            createRequests += request
+            roomSnapshot.value = nextRoom
+            return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+        }
+
+        override suspend fun joinRoom(request: JoinRoomRequest): ApiResult<RoomResponse> {
+            joinRequests += request
+            joinResult?.let { return it }
+            roomSnapshot.value = nextRoom
+            return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+        }
+
+        override suspend fun setSelection(
+            request: SetSelectionRequest,
+        ): ApiResult<RoomResponse> {
+            selectionRequests += request
+            nextRoom = nextRoom.copy(
+                selectedContentId = request.contentId,
+                selectedFileId = request.fileId,
+            )
+            roomSnapshot.value = nextRoom
+            return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+        }
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyContinuitySourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyContinuitySourceTest.kt
@@ -1,0 +1,40 @@
+package org.siloserver.silo.android.ui.screens.watchtogether
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WatchTogetherLobbyContinuitySourceTest {
+    private val lobby = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyScreen.kt",
+    ).readText()
+    private val detail = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt",
+    ).readText()
+    private val movieDetail = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt",
+    ).readText()
+    private val seriesDetail = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt",
+    ).readText()
+
+    @Test
+    fun ordinaryBackBrowsesWithoutLeavingAndLeaveIsExplicit() {
+        val navigationIcon = lobby.substringAfter("navigationIcon = {").substringBefore("actions = {")
+        assertTrue(navigationIcon.contains("onClick = onBack"))
+        assertFalse(navigationIcon.contains("viewModel.leave()"))
+        assertTrue(lobby.contains("Text(\"Leave room\")"))
+        assertTrue(lobby.contains("viewModel.leave()"))
+    }
+
+    @Test
+    fun ownerControlsAndTitleSuggestionRemainReachable() {
+        assertTrue(lobby.contains("viewModel.vote(s.id)"))
+        assertTrue(lobby.contains("viewModel.promote(s.id)"))
+        assertTrue(lobby.contains("viewModel.closeRoom()"))
+        assertTrue(movieDetail.contains("Suggest to Watch Together"))
+        assertTrue(seriesDetail.contains("Suggest to Watch Together"))
+        assertTrue(detail.contains("suggestViewModel.suggest("))
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySourceTest.kt
@@ -1,0 +1,65 @@
+package org.siloserver.silo.android.ui.screens.watchtogether
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WatchTogetherMenuEntrySourceTest {
+    private fun source(path: String): String {
+        val moduleRelative = File("src/androidMain/kotlin/$path")
+        val projectRelative = File("androidApp/src/androidMain/kotlin/$path")
+        return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
+    }
+
+    private val topBar = source("org/siloserver/silo/android/ui/components/MainAppTopBar.kt")
+    private val home = source("org/siloserver/silo/android/ui/screens/home/HomeScreen.kt")
+    private val libraries = source("org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt")
+    private val main = source("org/siloserver/silo/android/ui/screens/MainScreen.kt")
+    private val menuSheet = source(
+        "org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySheet.kt",
+    )
+
+    @Test
+    fun everyPhoneProfileMenuPlacesWatchTogetherAfterRequestsAndBeforeSettings() {
+        listOf(topBar, home, libraries).forEach { text ->
+            val watch = text.indexOf("Text(\"Watch Together\")")
+            val requests = text.indexOf("Text(\"Requests\")")
+            val settings = text.indexOf("Text(\"Settings\")")
+            assertTrue(watch >= 0)
+            assertTrue(requests < 0 || requests < watch)
+            assertTrue(watch < settings)
+            if (requests >= 0) {
+                val watchMenuItem = text.lastIndexOf("DropdownMenuItem(", watch)
+                assertTrue(watchMenuItem > requests)
+                assertFalse(
+                    text.substring(
+                        startIndex = requests + "Text(\"Requests\")".length,
+                        endIndex = watchMenuItem,
+                    ).contains("DropdownMenuItem("),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun mainShellOwnsOneTransientEntrySheet() {
+        assertTrue(main.contains("var showWatchTogetherEntry by rememberSaveable"))
+        assertTrue(main.contains("WatchTogetherMenuEntrySheet("))
+        assertTrue(main.contains("CLIENT_WATCH_TOGETHER_SURFACE_ENABLED"))
+        assertTrue(main.contains("onWatchTogetherClick = watchTogetherMenuAction"))
+    }
+
+    @Test
+    fun sheetUsesOnlyTheExistingControllerAndNeverHandlesCredentials() {
+        assertTrue(menuSheet.contains("viewModel.hostEmptyVoteRoom()"))
+        assertTrue(menuSheet.contains("viewModel.resumeCurrentRoom()"))
+        assertTrue(menuSheet.contains("viewModel.joinByCode(code)"))
+        listOf("Resume current room", "Host a room", "Join by code").forEach { label ->
+            assertTrue(menuSheet.contains(label))
+        }
+        assertFalse(menuSheet.contains("WatchTogetherApi"))
+        assertFalse(menuSheet.contains("roomAccessToken"))
+        assertFalse(menuSheet.contains("HttpClient"))
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySourceTest.kt
@@ -59,7 +59,11 @@ class WatchTogetherMenuEntrySourceTest {
             assertTrue(menuSheet.contains(label))
         }
         assertFalse(menuSheet.contains("WatchTogetherApi"))
+        assertFalse(menuSheet.contains("room_token"))
         assertFalse(menuSheet.contains("roomAccessToken"))
+        assertFalse(menuSheet.contains("Authorization"))
+        assertFalse(menuSheet.contains("CleartextOriginConsent"))
         assertFalse(menuSheet.contains("HttpClient"))
+        assertTrue(menuSheet.contains("state.error"))
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -501,6 +501,11 @@ fun TvAppNavigation(
                         launchSingleTop = true
                     }
                 },
+                onOpenWatchTogether = { room ->
+                    navController.navigate(tvWatchTogetherDestination(room)) {
+                        launchSingleTop = true
+                    }
+                },
                 onOpenLibraryCollectionDetail = { libraryId, collectionId, title ->
                     navController.navigate(
                         TvRoute.LibraryCollectionDetail(libraryId, collectionId, title).route,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -46,8 +46,8 @@ import org.siloserver.silo.tv.ui.screens.settings.diagnostics.TvDiagnosticsPromp
 import org.siloserver.silo.tv.ui.screens.settings.diagnostics.TvDiagnosticsReportScreen
 import org.siloserver.silo.tv.ui.screens.settings.diagnostics.TvDiagnosticsSettingsScreen
 import org.siloserver.silo.tv.ui.screens.settings.diagnostics.TvDiagnosticsViewModel
-import org.siloserver.silo.model.watchtogether.MemberRole
 import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherLobbyScreen
+import org.siloserver.silo.tv.ui.screens.watchtogether.tvWatchTogetherDestination
 import org.siloserver.silo.common.overlays.ProvideCardOverlays
 import org.siloserver.silo.common.diagnostics.DiagnosticsLifecycleLogger
 import org.siloserver.silo.common.settings.LibraryPlaybackPrefsStore
@@ -682,24 +682,8 @@ fun TvAppNavigation(
                         launchSingleTop = true
                     }
                 },
-                // Watch Together: the entry dialog resolves a room snapshot; route
-                // host-with-selection straight to the synced player (carrying
-                // roomId), otherwise into the lobby to wait/vote/pick.
                 onWatchTogether = { snapshot ->
-                    val hostAlone =
-                        snapshot.selfRole == MemberRole.Host && snapshot.memberCount <= 1
-                    val target = if (!snapshot.selectedContentId.isNullOrBlank() && !hostAlone) {
-                        TvRoute.Player(
-                            contentId = snapshot.selectedContentId!!,
-                            fileId = snapshot.selectedFileId,
-                            roomId = snapshot.roomId,
-                            resumePositionSeconds = snapshot.anchorPositionSeconds
-                                .takeIf { it.isFinite() && it > 0.0 },
-                        ).route
-                    } else {
-                        TvRoute.WatchTogetherLobby(roomId = snapshot.roomId).route
-                    }
-                    navController.navigate(target)
+                    navController.navigate(tvWatchTogetherDestination(snapshot))
                 },
                 onOpenPerson = { personId ->
                     navController.navigate(TvRoute.PersonDetail(personId).route)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -101,7 +101,6 @@ import org.siloserver.silo.model.ebook.MediaRelatedItem
 import org.siloserver.silo.model.feature.CLIENT_WATCH_TOGETHER_SURFACE_ENABLED
 import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
-import org.siloserver.silo.model.watchtogether.RoomSelectionMode
 import org.siloserver.silo.tv.ui.components.TvDialogOption
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvHeroActionPill
@@ -1086,13 +1085,7 @@ private fun HeroActionRow(
                 isBusy = watchTogetherState.isBusy,
                 error = watchTogetherState.error,
                 onHost = { watchTogetherViewModel.createRoom(playContentId, playFileId) },
-                onHostVote = {
-                    watchTogetherViewModel.createRoom(
-                        playContentId,
-                        playFileId,
-                        RoomSelectionMode.Vote,
-                    )
-                },
+                onHostVote = watchTogetherViewModel::createEmptyVoteRoom,
                 onJoin = {
                     watchTogetherViewModel.clearError()
                     joinCodeOpen = true

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherDestination.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherDestination.kt
@@ -1,0 +1,20 @@
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.tv.ui.navigation.TvRoute
+import org.siloserver.silo.watchtogether.WatchTogetherEntryTarget
+import org.siloserver.silo.watchtogether.watchTogetherEntryTarget
+
+fun tvWatchTogetherDestination(room: RoomSnapshot): String =
+    when (watchTogetherEntryTarget(room)) {
+        WatchTogetherEntryTarget.Lobby ->
+            TvRoute.WatchTogetherLobby(room.roomId).route
+        WatchTogetherEntryTarget.Player ->
+            TvRoute.Player(
+                contentId = requireNotNull(room.selectedContentId),
+                fileId = room.selectedFileId,
+                roomId = room.roomId,
+                resumePositionSeconds = room.anchorPositionSeconds
+                    .takeIf { it.isFinite() && it > 0.0 },
+            ).route
+    }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyScreen.kt
@@ -107,10 +107,10 @@ fun TvWatchTogetherLobbyScreen(
     val suggestions by viewModel.suggestions.collectAsState()
     val closedReason by viewModel.roomClosedReason.collectAsState()
 
-    // Role drives only the cosmetic header label; mutating controls (and the
-    // host's room-closing Back behaviour) gate on the server's per-recipient
-    // management capability so a demoted/grace-period host (selfRole still
-    // "host" but management revoked) doesn't see dead buttons.
+    // Role drives only the cosmetic header label; mutating controls gate on
+    // the server's per-recipient management capability so a demoted/
+    // grace-period host (selfRole still "host" but management revoked) doesn't
+    // see dead buttons.
     val snapshot = room
     val isHostLabel = snapshot?.selfRole == MemberRole.Host
     val canManage = snapshot?.selfCanManageRoom == true
@@ -145,14 +145,9 @@ fun TvWatchTogetherLobbyScreen(
         }
     }
 
-    // User-initiated leave just drops our own connection and exits — matching
-    // mobile, where leaving the lobby never closes the room. A host closes the
-    // room for everyone via the explicit "Close room" action (below), which
-    // stays on screen until the server's room_closed broadcast reactively backs
-    // us out. (Auto-closing here raced the closeRoom call against viewModelScope
-    // cancellation on dispose, so the room often never actually closed.)
+    // Browsing away retains the process-scoped room connection. Leaving is an
+    // explicit action below; hosts close the room for everyone via "Close room".
     BackHandler(enabled = true) {
-        viewModel.leave()
         onBack()
     }
 
@@ -262,6 +257,17 @@ fun TvWatchTogetherLobbyScreen(
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             if (snapshot != null) {
+                TvDialogActionRow(
+                    title = "Browse titles",
+                    onClick = onBack,
+                )
+                TvDialogActionRow(
+                    title = "Leave room",
+                    onClick = {
+                        viewModel.leave()
+                        onBack()
+                    },
+                )
                 if (canManage) {
                     // Selection mode is fixed at room creation — shown read-only.
                     TvDialogCyclerRow(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntryDialog.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntryDialog.kt
@@ -1,0 +1,140 @@
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import org.siloserver.silo.tv.ui.components.rememberTvDialogInitialFocus
+import org.siloserver.silo.tv.ui.screens.player.TvDialogActionRow
+import org.siloserver.silo.tv.ui.theme.DarkBackground
+import org.siloserver.silo.watchtogether.canDismissRoomEntry
+
+enum class TvWatchTogetherMenuInitialAction {
+    Resume,
+    Host,
+}
+
+fun tvWatchTogetherMenuInitialAction(
+    canResume: Boolean,
+): TvWatchTogetherMenuInitialAction =
+    if (canResume) {
+        TvWatchTogetherMenuInitialAction.Resume
+    } else {
+        TvWatchTogetherMenuInitialAction.Host
+    }
+
+/**
+ * Focus-owning Watch Together entry popup launched from the authenticated
+ * profile dropdown. Resume is initially focused when a current room exists;
+ * otherwise Host owns initial focus.
+ */
+@Composable
+fun TvWatchTogetherMenuEntryDialog(
+    canResume: Boolean,
+    isBusy: Boolean,
+    error: String?,
+    onResume: () -> Unit,
+    onHost: () -> Unit,
+    onJoin: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val resumeFocus = remember { FocusRequester() }
+    val hostFocus = remember { FocusRequester() }
+    val initialAction = tvWatchTogetherMenuInitialAction(canResume)
+    val initialFocus = when (initialAction) {
+        TvWatchTogetherMenuInitialAction.Resume -> resumeFocus
+        TvWatchTogetherMenuInitialAction.Host -> hostFocus
+    }
+
+    Popup(
+        alignment = Alignment.Center,
+        onDismissRequest = {
+            if (canDismissRoomEntry(isBusy)) onDismiss()
+        },
+        properties = PopupProperties(
+            focusable = true,
+            dismissOnBackPress = canDismissRoomEntry(isBusy),
+            dismissOnClickOutside = canDismissRoomEntry(isBusy),
+            clippingEnabled = false,
+        ),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 36.dp, top = 50.dp, end = 36.dp, bottom = 42.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            val panelShape = RoundedCornerShape(14.dp)
+            Column(
+                modifier = Modifier
+                    .width(340.dp)
+                    .background(color = DarkBackground.copy(alpha = 0.68f), shape = panelShape)
+                    .border(0.6.dp, Color.White.copy(alpha = 0.20f), panelShape)
+                    .padding(horizontal = 14.dp, vertical = 14.dp)
+                    .then(rememberTvDialogInitialFocus(initialFocus)),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Text(
+                    text = "WATCH TOGETHER",
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontSize = 16.sp,
+                        letterSpacing = 1.1.sp,
+                        fontWeight = FontWeight.Bold,
+                    ),
+                    color = Color.White.copy(alpha = 0.58f),
+                    modifier = Modifier.padding(horizontal = 8.dp),
+                )
+
+                if (canResume) {
+                    TvDialogActionRow(
+                        title = "Resume current room",
+                        enabled = !isBusy,
+                        onClick = onResume,
+                        modifier = Modifier.focusRequester(resumeFocus),
+                    )
+                }
+
+                TvDialogActionRow(
+                    title = if (isBusy) "Working…" else "Host a room",
+                    enabled = !isBusy,
+                    onClick = onHost,
+                    modifier = Modifier.focusRequester(hostFocus),
+                )
+
+                TvDialogActionRow(
+                    title = "Join by code",
+                    enabled = !isBusy,
+                    onClick = onJoin,
+                )
+
+                error?.let { message ->
+                    Text(
+                        text = message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color(0xFFEF4444),
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModel.kt
@@ -9,10 +9,14 @@ import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.model.watchtogether.SetSelectionRequest
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.errorMessage
-import org.siloserver.silo.repository.WatchTogetherRepository
+import org.siloserver.silo.watchtogether.WatchTogetherEntryGateway
+import org.siloserver.silo.watchtogether.resumableWatchTogetherRoom
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -22,8 +26,8 @@ import kotlinx.coroutines.launch
  * then surfaces a one-shot [UiState.result] [RoomSnapshot] the detail screen routes
  * on (host-with-selection → synced player, no selection → lobby).
  *
- * The repository stores the room JWT internally on create/join and reads the
- * active roomId from its own snapshot, so [WatchTogetherRepository.setSelection]
+ * The gateway stores the room JWT internally on create/join and reads the
+ * active roomId from its own snapshot, so [WatchTogetherEntryGateway.setSelection]
  * takes only the request. createRoom does NOT auto-select, so the host flow must
  * createRoom THEN setSelection(contentId, fileId) so the host lands on the player.
  * The ordering is safe because createRoom synchronously stores the snapshot before
@@ -33,7 +37,7 @@ import kotlinx.coroutines.launch
  * Mirrors the mobile `WatchTogetherEntryViewModel` host()/joinByCode() shape.
  */
 class TvWatchTogetherViewModel(
-    private val repository: WatchTogetherRepository,
+    private val gateway: WatchTogetherEntryGateway,
 ) : ViewModel() {
 
     data class UiState(
@@ -45,6 +49,13 @@ class TvWatchTogetherViewModel(
 
     private val _uiState = MutableStateFlow(UiState())
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+    val currentRoom: StateFlow<RoomSnapshot?> = gateway.roomSnapshot
+        .map(::resumableWatchTogetherRoom)
+        .stateIn(
+            viewModelScope,
+            SharingStarted.Eagerly,
+            resumableWatchTogetherRoom(gateway.roomSnapshot.value),
+        )
 
     /** Host flow: create a room with this title pre-selected as the room selection. */
     fun createRoom(
@@ -52,26 +63,26 @@ class TvWatchTogetherViewModel(
         fileId: Int?,
         selectionMode: RoomSelectionMode = RoomSelectionMode.HostPick,
     ) {
+        if (selectionMode == RoomSelectionMode.Vote) {
+            createEmptyVoteRoom()
+            return
+        }
         if (_uiState.value.isBusy) return
         _uiState.update { it.copy(isBusy = true, error = null) }
         viewModelScope.launch {
             when (
-                val created = repository.createRoom(
+                val created = gateway.createRoom(
                     CreateRoomRequest(selectionMode = selectionMode.wire),
                 )
             ) {
                 is ApiResult.Success -> {
-                    if (selectionMode == RoomSelectionMode.Vote) {
-                        finish(created.data.room)
-                        return@launch
-                    }
                     // createRoom does NOT auto-select; set this title as the room
-                    // selection so the host lands on the synced player. The repo
+                    // selection so the host lands on the synced player. The gateway
                     // already stored the snapshot synchronously, so setSelection
                     // reads the right roomId/token.
                     if (created.data.room.selectedContentId.isNullOrBlank()) {
                         when (
-                            val sel = repository.setSelection(
+                            val sel = gateway.setSelection(
                                 SetSelectionRequest(contentId = contentId, fileId = fileId),
                             )
                         ) {
@@ -89,13 +100,41 @@ class TvWatchTogetherViewModel(
         }
     }
 
+    /** Host flow for the menu action: create an empty vote room, then enter its lobby. */
+    fun createEmptyVoteRoom() {
+        if (_uiState.value.isBusy) return
+        _uiState.update { it.copy(isBusy = true, error = null) }
+        viewModelScope.launch {
+            when (
+                val created = gateway.createRoom(
+                    CreateRoomRequest(selectionMode = RoomSelectionMode.Vote.wire),
+                )
+            ) {
+                is ApiResult.Success -> finish(created.data.room)
+                is ApiResult.Error, is ApiResult.NetworkError ->
+                    fail(created.errorMessage("Failed to create room"))
+            }
+        }
+    }
+
+    /** Resume the valid room snapshot already held by the process session. */
+    fun resumeCurrentRoom() {
+        if (_uiState.value.isBusy) return
+        val room = resumableWatchTogetherRoom(gateway.roomSnapshot.value)
+        if (room == null) {
+            fail("Current room is no longer available")
+        } else {
+            finish(room)
+        }
+    }
+
     /** Join flow: resolve an invite code; the screen routes to player or lobby. */
     fun joinRoom(code: String) {
         val trimmed = code.trim().uppercase()
         if (_uiState.value.isBusy || trimmed.isBlank()) return
         _uiState.update { it.copy(isBusy = true, error = null) }
         viewModelScope.launch {
-            when (val joined = repository.joinRoom(JoinRoomRequest(code = trimmed))) {
+            when (val joined = gateway.joinRoom(JoinRoomRequest(code = trimmed))) {
                 is ApiResult.Success -> finish(joined.data.room)
                 is ApiResult.Error, is ApiResult.NetworkError ->
                     fail(joined.errorMessage("Could not join — check the code"))

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -110,8 +110,10 @@ import org.siloserver.silo.common.ui.components.resolveAvatarUrl
 import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.model.admin.shouldShowClientAdminSurface
 import org.siloserver.silo.model.auth.isActingAdmin
+import org.siloserver.silo.model.feature.CLIENT_WATCH_TOGETHER_SURFACE_ENABLED
 import org.siloserver.silo.model.feature.RequestsFeatureStore
 import org.siloserver.silo.model.personal.UserLibrary
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.repository.AuthRepository
@@ -149,9 +151,13 @@ import org.siloserver.silo.tv.ui.screens.requests.TvRequestsScreen
 import org.siloserver.silo.tv.ui.screens.search.TvSearchScreen
 import org.siloserver.silo.tv.ui.screens.settings.TvManageSessionsScreen
 import org.siloserver.silo.tv.ui.screens.settings.TvSettingsScreen
+import org.siloserver.silo.tv.ui.screens.watchtogether.TvJoinCodeDialog
+import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherMenuEntryDialog
+import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherViewModel
 import org.siloserver.silo.tv.ui.theme.TvSkyline
 import org.siloserver.silo.tv.ui.util.visibleOnTv
 import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 
 /**
  * Main authenticated TV shell. Mirrors `TVMainTabView` on tvOS: a content
@@ -176,6 +182,7 @@ fun TvMainShell(
     onSwitchServer: () -> Unit,
     onPairDevice: () -> Unit,
     onPlayItem: (contentId: String, type: String?, resumePositionSeconds: Double?) -> Unit,
+    onOpenWatchTogether: (RoomSnapshot) -> Unit,
     onOpenPersonDetail: (personId: Long) -> Unit,
 ) {
     val nestedNav = rememberNavController()
@@ -194,6 +201,19 @@ fun TvMainShell(
     val activeServerEntry by serverRegistry.activeEntry.collectAsState()
     val tvLibraryScopeStore: TvLibraryScopeStore = koinInject()
     val serverUrl = rememberProfileServerUrl()
+    val watchTogetherViewModel = koinViewModel<TvWatchTogetherViewModel>()
+    val watchTogetherState by watchTogetherViewModel.uiState.collectAsState()
+    val currentWatchTogetherRoom by watchTogetherViewModel.currentRoom.collectAsState()
+    var watchTogetherEntryOpen by rememberSaveable { mutableStateOf(false) }
+    var watchTogetherJoinOpen by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(watchTogetherState.result) {
+        val room = watchTogetherState.result ?: return@LaunchedEffect
+        watchTogetherViewModel.consumeResult()
+        watchTogetherEntryOpen = false
+        watchTogetherJoinOpen = false
+        onOpenWatchTogether(room)
+    }
 
     // The raw list of libraries visible to this profile on TV, sorted by the
     // server's sort order (ebook-like libraries filtered out by visibleOnTv).
@@ -1290,6 +1310,12 @@ fun TvMainShell(
                     navigateToSecondary(TvMainRoute.Requests.route)
                     moveFocusToContent(TvMainRoute.Requests.route)
                 },
+                showWatchTogether = CLIENT_WATCH_TOGETHER_SURFACE_ENABLED,
+                onWatchTogether = {
+                    focusState.closeProfileMenuForContent()
+                    watchTogetherViewModel.clearError()
+                    watchTogetherEntryOpen = true
+                },
                 onSettings = {
                     // Keep focus on the dropdown row through the route fade.
                     // TvSettingsScreen closes the menu only after its General
@@ -1310,6 +1336,38 @@ fun TvMainShell(
                     )
                     .zIndex(2f),
             )
+        }
+
+        if (watchTogetherEntryOpen) {
+            if (watchTogetherJoinOpen) {
+                TvJoinCodeDialog(
+                    isBusy = watchTogetherState.isBusy,
+                    error = watchTogetherState.error,
+                    onJoin = watchTogetherViewModel::joinRoom,
+                    onDismiss = {
+                        watchTogetherViewModel.clearError()
+                        watchTogetherJoinOpen = false
+                    },
+                )
+            } else {
+                TvWatchTogetherMenuEntryDialog(
+                    canResume = currentWatchTogetherRoom != null,
+                    isBusy = watchTogetherState.isBusy,
+                    error = watchTogetherState.error,
+                    onResume = { watchTogetherViewModel.resumeCurrentRoom() },
+                    onHost = { watchTogetherViewModel.createEmptyVoteRoom() },
+                    onJoin = {
+                        watchTogetherViewModel.clearError()
+                        watchTogetherJoinOpen = true
+                    },
+                    onDismiss = {
+                        watchTogetherViewModel.clearError()
+                        watchTogetherEntryOpen = false
+                        watchTogetherJoinOpen = false
+                        focusState.dismissProfileMenu()
+                    },
+                )
+            }
         }
     }
 }
@@ -1482,8 +1540,8 @@ private fun cascadePanelOffset(
  * returns focus to the avatar via [onDismiss].
  *
  * Row set + order mirrors tvOS: Switch Profile · Watchlist · Favorites ·
- * History · Requests (feature-gated) · Settings · Switch Server · Sign Out.
- * Calendar is a top-level tab.
+ * History · Requests (server-gated) · Watch Together (client-policy-gated) ·
+ * Settings · Switch Server · Sign Out. Calendar is a top-level tab.
  */
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -1497,6 +1555,8 @@ private fun TvProfileDropdown(
     onHistory: () -> Unit,
     showRequests: Boolean,
     onRequests: () -> Unit,
+    showWatchTogether: Boolean,
+    onWatchTogether: () -> Unit,
     onSettings: () -> Unit,
     onSwitchServer: () -> Unit,
     onSignOut: () -> Unit,
@@ -1547,6 +1607,13 @@ private fun TvProfileDropdown(
                 label = "Requests",
                 icon = Icons.Filled.AutoAwesome,
                 onClick = onRequests,
+            )
+        }
+        if (showWatchTogether) {
+            ProfileDropdownRow(
+                label = "Watch Together",
+                icon = Icons.Filled.People,
+                onClick = onWatchTogether,
             )
         }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherDestinationTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherDestinationTest.kt
@@ -1,0 +1,49 @@
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import org.siloserver.silo.model.watchtogether.MemberRole
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.tv.ui.navigation.TvRoute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TvWatchTogetherDestinationTest {
+    @Test
+    fun emptyAndSoloHostRoomsUseLobby() {
+        assertEquals(
+            TvRoute.WatchTogetherLobby("room-1").route,
+            tvWatchTogetherDestination(RoomSnapshot(roomId = "room-1")),
+        )
+        assertEquals(
+            TvRoute.WatchTogetherLobby("room-1").route,
+            tvWatchTogetherDestination(
+                RoomSnapshot(
+                    roomId = "room-1",
+                    selectedContentId = "movie-1",
+                    selfRole = MemberRole.Host,
+                    memberCount = 1,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun selectedJoinedRoomUsesSyncedPlayer() {
+        val room = RoomSnapshot(
+            roomId = "room-1",
+            selectedContentId = "movie-1",
+            selectedFileId = 7,
+            selfRole = MemberRole.Guest,
+            memberCount = 2,
+            anchorPositionSeconds = 12.5,
+        )
+        assertEquals(
+            TvRoute.Player(
+                contentId = "movie-1",
+                fileId = 7,
+                roomId = "room-1",
+                resumePositionSeconds = 12.5,
+            ).route,
+            tvWatchTogetherDestination(room),
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyContinuitySourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyContinuitySourceTest.kt
@@ -1,0 +1,35 @@
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvWatchTogetherLobbyContinuitySourceTest {
+    private val lobby = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyScreen.kt",
+    ).readText()
+    private val detail = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
+    ).readText()
+
+    @Test
+    fun backAndBrowsePreserveRoomWhileLeaveIsExplicit() {
+        val backHandler = lobby.substringAfter("BackHandler(enabled = true)")
+            .substringBefore("Box(")
+        assertTrue(backHandler.contains("onBack()"))
+        assertFalse(backHandler.contains("viewModel.leave()"))
+        assertTrue(lobby.contains("title = \"Browse titles\""))
+        assertTrue(lobby.contains("title = \"Leave room\""))
+        assertTrue(lobby.contains("viewModel.leave()"))
+    }
+
+    @Test
+    fun existingOwnerAuthorityAndSuggestionPathRemain() {
+        assertTrue(lobby.contains("CloseRoomButton(onClick = viewModel::closeRoom)"))
+        assertTrue(lobby.contains("viewModel.vote(s.id)"))
+        assertTrue(lobby.contains("viewModel.promote(s.id)"))
+        assertTrue(detail.contains("Suggest to Watch Together"))
+        assertTrue(detail.contains("suggestViewModel.suggest("))
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntrySourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntrySourceTest.kt
@@ -54,8 +54,13 @@ class TvWatchTogetherMenuEntrySourceTest {
             assertTrue(dialog.contains(label))
         }
         assertFalse(dialog.contains("WatchTogetherApi"))
+        assertFalse(dialog.contains("room_token"))
         assertFalse(dialog.contains("roomAccessToken"))
+        assertFalse(dialog.contains("Authorization"))
+        assertFalse(dialog.contains("CleartextOriginConsent"))
         assertFalse(dialog.contains("HttpClient"))
+        assertTrue(shell.contains("error = watchTogetherState.error"))
+        assertTrue(dialog.contains("error?.let"))
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntrySourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntrySourceTest.kt
@@ -1,0 +1,72 @@
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvWatchTogetherMenuEntrySourceTest {
+    private val shell = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt",
+    ).readText()
+    private val dialog = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntryDialog.kt",
+    ).readText()
+
+    @Test
+    fun profileRowIsImmediatelyAfterRequestsAndBeforeSettings() {
+        val profile = shell.substringAfter("private fun TvProfileDropdown(")
+        val watch = profile.indexOf("label = \"Watch Together\"")
+        val requests = profile.indexOf("label = \"Requests\"")
+        val settings = profile.indexOf("label = \"Settings\"")
+        val watchRow = profile.lastIndexOf("ProfileDropdownRow(", startIndex = watch)
+        assertTrue(watch >= 0)
+        assertTrue(requests >= 0)
+        assertTrue(settings >= 0)
+        assertTrue(watchRow >= 0)
+        assertTrue(requests < watch)
+        assertTrue(watch < settings)
+        assertFalse(
+            profile.substring(
+                startIndex = requests + "label = \"Requests\"".length,
+                endIndex = watchRow,
+            ).contains("ProfileDropdownRow("),
+        )
+        assertTrue(shell.contains("CLIENT_WATCH_TOGETHER_SURFACE_ENABLED"))
+    }
+
+    @Test
+    fun popupOwnsFocusAndBackRestoresProfileFocus() {
+        assertTrue(dialog.contains("PopupProperties("))
+        assertTrue(dialog.contains("focusable = true"))
+        assertTrue(dialog.contains("rememberTvDialogInitialFocus(initialFocus)"))
+        assertTrue(shell.contains("focusState.closeProfileMenuForContent()"))
+        assertTrue(shell.contains("focusState.dismissProfileMenu()"))
+    }
+
+    @Test
+    fun menuSurfaceUsesExistingControllerAndNoCredentials() {
+        assertTrue(shell.contains("watchTogetherViewModel.createEmptyVoteRoom()"))
+        assertTrue(shell.contains("watchTogetherViewModel.resumeCurrentRoom()"))
+        assertTrue(shell.contains("TvJoinCodeDialog("))
+        listOf("Resume current room", "Host a room", "Join by code").forEach { label ->
+            assertTrue(dialog.contains(label))
+        }
+        assertFalse(dialog.contains("WatchTogetherApi"))
+        assertFalse(dialog.contains("roomAccessToken"))
+        assertFalse(dialog.contains("HttpClient"))
+    }
+
+    @Test
+    fun initialActionPrefersResumeOnlyWhenAvailable() {
+        assertEquals(
+            TvWatchTogetherMenuInitialAction.Resume,
+            tvWatchTogetherMenuInitialAction(canResume = true),
+        )
+        assertEquals(
+            TvWatchTogetherMenuInitialAction.Host,
+            tvWatchTogetherMenuInitialAction(canResume = false),
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherSurfaceSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherSurfaceSourceTest.kt
@@ -37,7 +37,7 @@ class TvWatchTogetherSurfaceSourceTest {
     fun aResolvedRoomReachesTheNavigationCallback() {
         assertTrue(itemDetailScreen.contains("onWatchTogether(room)"))
         assertTrue(itemDetailScreen.contains("watchTogetherViewModel.consumeResult()"))
-        assertTrue(appNavigation.contains("TvRoute.WatchTogetherLobby(roomId = snapshot.roomId).route"))
+        assertTrue(appNavigation.contains("tvWatchTogetherDestination(snapshot)"))
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModelTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModelTest.kt
@@ -1,0 +1,136 @@
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import org.siloserver.silo.model.watchtogether.CreateRoomRequest
+import org.siloserver.silo.model.watchtogether.JoinRoomRequest
+import org.siloserver.silo.model.watchtogether.RoomPhase
+import org.siloserver.silo.model.watchtogether.RoomResponse
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.SetSelectionRequest
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.watchtogether.WatchTogetherEntryGateway
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvWatchTogetherViewModelTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun emptyHostCreatesVoteRoomWithoutSelection() = runTest(dispatcher) {
+        val gateway = FakeGateway()
+        val viewModel = TvWatchTogetherViewModel(gateway)
+
+        viewModel.createEmptyVoteRoom()
+
+        assertEquals(
+            listOf(CreateRoomRequest(RoomSelectionMode.Vote.wire)),
+            gateway.createRequests,
+        )
+        assertEquals(emptyList(), gateway.selectionRequests)
+        assertEquals("room-1", viewModel.uiState.value.result?.roomId)
+    }
+
+    @Test
+    fun resumeUsesCurrentRoomWithoutNetworkCalls() = runTest(dispatcher) {
+        val room = RoomSnapshot(roomId = "room-1", phase = RoomPhase.Lobby)
+        val gateway = FakeGateway(room)
+        val viewModel = TvWatchTogetherViewModel(gateway)
+
+        viewModel.resumeCurrentRoom()
+
+        assertEquals(room, viewModel.uiState.value.result)
+        assertEquals(emptyList(), gateway.createRequests)
+        assertEquals(emptyList(), gateway.joinRequests)
+    }
+
+    @Test
+    fun joinCodeNormalizesAndKeepsExistingErrorCopy() = runTest(dispatcher) {
+        val gateway = FakeGateway()
+        val viewModel = TvWatchTogetherViewModel(gateway)
+
+        viewModel.joinRoom(" abcd1234 ")
+        assertEquals(listOf(JoinRoomRequest(code = "ABCD1234")), gateway.joinRequests)
+
+        viewModel.consumeResult()
+        gateway.joinResult = ApiResult.NetworkError(IllegalStateException("offline"))
+        viewModel.joinRoom("efgh5678")
+        assertEquals("Network error. Check your connection.", viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun titleDetailHostStillSetsSelection() = runTest(dispatcher) {
+        val gateway = FakeGateway()
+        val viewModel = TvWatchTogetherViewModel(gateway)
+
+        viewModel.createRoom(contentId = "movie-1", fileId = 7)
+
+        assertEquals(
+            listOf(SetSelectionRequest(contentId = "movie-1", fileId = 7)),
+            gateway.selectionRequests,
+        )
+    }
+
+    private class FakeGateway(
+        room: RoomSnapshot? = null,
+    ) : WatchTogetherEntryGateway {
+        override val roomSnapshot = MutableStateFlow(room)
+        val createRequests = mutableListOf<CreateRoomRequest>()
+        val joinRequests = mutableListOf<JoinRoomRequest>()
+        val selectionRequests = mutableListOf<SetSelectionRequest>()
+        var joinResult: ApiResult<RoomResponse>? = null
+        var nextRoom = RoomSnapshot(
+            roomId = "room-1",
+            phase = RoomPhase.Lobby,
+            selectionMode = RoomSelectionMode.Vote,
+        )
+
+        override suspend fun createRoom(
+            request: CreateRoomRequest,
+        ): ApiResult<RoomResponse> {
+            createRequests += request
+            roomSnapshot.value = nextRoom
+            return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+        }
+
+        override suspend fun joinRoom(
+            request: JoinRoomRequest,
+        ): ApiResult<RoomResponse> {
+            joinRequests += request
+            joinResult?.let { return it }
+            roomSnapshot.value = nextRoom
+            return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+        }
+
+        override suspend fun setSelection(
+            request: SetSelectionRequest,
+        ): ApiResult<RoomResponse> {
+            selectionRequests += request
+            nextRoom = nextRoom.copy(
+                selectedContentId = request.contentId,
+                selectedFileId = request.fileId,
+            )
+            roomSnapshot.value = nextRoom
+            return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+        }
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusStateTest.kt
@@ -191,6 +191,20 @@ class TvShellFocusStateTest {
     }
 
     @Test
+    fun closingMenuForPopupThenDismissingPopupRefocusesAvatar() {
+        val state = TvShellFocusState()
+        state.previewProfileMenu()
+        state.enterProfileMenu()
+        val before = state.profileFocusRequest
+
+        state.closeProfileMenuForContent()
+        assertEquals(before, state.profileFocusRequest)
+
+        state.dismissProfileMenu()
+        assertEquals(before + 1, state.profileFocusRequest)
+    }
+
+    @Test
     fun profileDwellPreviewsWithoutStealingFocusAndDownEnters() {
         val s = TvShellFocusState()
 

--- a/docs/superpowers/plans/2026-07-27-watch-together-user-menu-entry.md
+++ b/docs/superpowers/plans/2026-07-27-watch-together-user-menu-entry.md
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - Android phone and Android TV only; do not change Silo Server, Apple clients, or production proxy configuration.
-- Add **Watch Together** to the authenticated user/profile menu before **Requests** when Requests is present and before the settings/account divider.
+- Add **Watch Together** to the authenticated user/profile menu immediately after **Requests** when Requests is present; otherwise keep it in the same content/action group immediately before the settings/account divider.
 - The menu entry is a transient phone sheet or TV popup, not a persistent Watch Together home.
 - **Host a room** creates exactly one empty vote room with `selection_mode = "vote"` and must not call `setSelection`.
 - **Join by code** must continue to use the existing repository, validation, error mapping, and lobby/player destination rules.
@@ -541,14 +541,22 @@ class WatchTogetherMenuEntrySourceTest {
     )
 
     @Test
-    fun everyPhoneProfileMenuPlacesWatchTogetherBeforeRequestsAndSettings() {
+    fun everyPhoneProfileMenuPlacesWatchTogetherAfterRequestsAndBeforeSettings() {
         listOf(topBar, home, libraries).forEach { text ->
             val watch = text.indexOf("Text(\"Watch Together\")")
             val requests = text.indexOf("Text(\"Requests\")")
             val settings = text.indexOf("Text(\"Settings\")")
             assertTrue(watch >= 0)
-            assertTrue(requests < 0 || watch < requests)
+            assertTrue(requests < 0 || requests < watch)
             assertTrue(watch < settings)
+            if (requests >= 0) {
+                assertFalse(
+                    text.substring(
+                        startIndex = requests + "Text(\"Requests\")".length,
+                        endIndex = watch,
+                    ).contains("DropdownMenuItem("),
+                )
+            }
         }
     }
 
@@ -703,25 +711,27 @@ Add this exact parameter to `MainAppTopBar`, `HomeScreen`,
 onWatchTogetherClick: (() -> Unit)?,
 ```
 
-In all three menu implementations, insert this item before the conditional
-Requests item and keep one divider after the content-action group:
+In all three menu implementations, keep the conditional Requests item first,
+insert Watch Together immediately after it, and keep one divider after the
+content/action group. When Requests is absent, Watch Together is therefore the
+last content action before the divider:
 
 ```kotlin
-if (onWatchTogetherClick != null) {
-    DropdownMenuItem(
-        text = { Text("Watch Together") },
-        onClick = {
-            menuExpanded = false
-            onWatchTogetherClick()
-        },
-    )
-}
 if (onRequestsClick != null) {
     DropdownMenuItem(
         text = { Text("Requests") },
         onClick = {
             menuExpanded = false
             onRequestsClick()
+        },
+    )
+}
+if (onWatchTogetherClick != null) {
+    DropdownMenuItem(
+        text = { Text("Watch Together") },
+        onClick = {
+            menuExpanded = false
+            onWatchTogetherClick()
         },
     )
 }
@@ -1288,14 +1298,20 @@ class TvWatchTogetherMenuEntrySourceTest {
     ).readText()
 
     @Test
-    fun profileRowIsBeforeRequestsAndSettings() {
+    fun profileRowIsImmediatelyAfterRequestsAndBeforeSettings() {
         val profile = shell.substringAfter("private fun TvProfileDropdown(")
         val watch = profile.indexOf("label = \"Watch Together\"")
         val requests = profile.indexOf("label = \"Requests\"")
         val settings = profile.indexOf("label = \"Settings\"")
         assertTrue(watch >= 0)
-        assertTrue(watch < requests)
+        assertTrue(requests < watch)
         assertTrue(watch < settings)
+        assertFalse(
+            profile.substring(
+                startIndex = requests + "label = \"Requests\"".length,
+                endIndex = watch,
+            ).contains("ProfileDropdownRow("),
+        )
         assertTrue(shell.contains("CLIENT_WATCH_TOGETHER_SURFACE_ENABLED"))
     }
 
@@ -1512,7 +1528,9 @@ if (showWatchTogether) {
 }
 ```
 
-Place it after History and before Requests.
+Place it immediately after the conditional Requests row. When Requests is
+hidden, Watch Together remains after History and before the content/settings
+divider.
 
 Render `TvJoinCodeDialog` or `TvWatchTogetherMenuEntryDialog` after the profile
 dropdown:
@@ -2055,8 +2073,9 @@ then repeat the serial-scoped install.
 
 On the authenticated phone test profile:
 
-1. Open profile menus from Home, Libraries, and For You; verify Watch Together
-   appears before Requests and before Settings on each.
+1. Open profile menus from Home, Libraries, and For You; verify Requests appears
+   immediately before Watch Together when enabled, and Watch Together remains
+   immediately before the settings/account divider when Requests is disabled.
 2. Open the sheet; with no room verify Host receives the primary position,
    Join opens code input, Back returns to entry, and dismissal returns to the
    same tab.

--- a/docs/superpowers/plans/2026-07-27-watch-together-user-menu-entry.md
+++ b/docs/superpowers/plans/2026-07-27-watch-together-user-menu-entry.md
@@ -1,0 +1,2155 @@
+# Watch Together User-Menu Entry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a top-level Watch Together entry to the authenticated profile menu on Android phone and Android TV, supporting empty vote-room hosting, join by code, and same-process room resume while preserving the existing title-detail and room-authority behavior.
+
+**Architecture:** Add one narrow shared entry gateway and pure destination/resume policy over the existing `WatchTogetherRepository`; the current phone and TV entry ViewModels remain the platform orchestration points. Phone renders a Material modal sheet and TV renders a focusable popup, both routing into the existing lobby/player and `RoomSession`; no repository, socket, protocol, server endpoint, or persistent room store is added.
+
+**Tech Stack:** Kotlin 2.1, Kotlin Multiplatform shared module, coroutines and `StateFlow`, Koin, Jetpack Compose Material 3, Compose for TV Material 3, Navigation Compose, JUnit/kotlin-test, Robolectric for phone route tests, Gradle, ADB.
+
+## Global Constraints
+
+- Android phone and Android TV only; do not change Silo Server, Apple clients, or production proxy configuration.
+- Add **Watch Together** to the authenticated user/profile menu before **Requests** when Requests is present and before the settings/account divider.
+- The menu entry is a transient phone sheet or TV popup, not a persistent Watch Together home.
+- **Host a room** creates exactly one empty vote room with `selection_mode = "vote"` and must not call `setSelection`.
+- **Join by code** must continue to use the existing repository, validation, error mapping, and lobby/player destination rules.
+- **Resume current room** is visible only for a valid, non-terminal room in the same running process, server, and authenticated profile; do not add persistence or room discovery.
+- The room owner remains a full participant who may suggest, vote, apply the existing host override to any room-owned suggestion, and close the room for everyone.
+- Keep current server host semantics: no automatic host transfer, ownership election, original-host reclaim, or timeout changes.
+- After host logout, profile/server switch, process death, or unrecovered disconnect, the server may close the room after its existing host-disconnect timeout; the clients do not extend or replace that policy.
+- Navigation and backgrounding preserve the live process-scoped room; logout, profile/server switch, explicit Leave, terminal room closure, and process death clear local state through existing ownership boundaries.
+- Reuse `WatchTogetherRepository`, `RoomSession`, existing lobby/player routes, websocket/reconnect behavior, voting, auth scope, cleartext consent, and error handling.
+- Preserve the existing title-detail Watch Together entry and its preselected-title Host behavior.
+- Room credentials remain repository-private and must not enter UI state, route parameters, logs, or tests.
+- No changes to `WatchTogetherApi`, Watch Together wire models, websocket frames, or server/proxy configuration.
+
+---
+
+## Current `origin/main` map
+
+The plan is based on `origin/main` `e0917cbe8cc1b021f184954e1e7cc977c06f628e`.
+
+| Responsibility | Current file and seam |
+|---|---|
+| Shared room owner | `shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt:71-138,194-378,725-741` |
+| Process/session owner | `shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/RoomSession.kt:20-104` |
+| Identity teardown | `shared/src/commonMain/kotlin/org/siloserver/silo/network/IdentityTransitionBarrier.kt` and `RoomSession` transition gate |
+| Shared DI | `shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt:96-123` |
+| Phone entry controller | `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModel.kt:21-125` |
+| Phone title-detail sheet | `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntrySheet.kt:37-138` |
+| Phone profile menus | `MainAppTopBar.kt:52-181`, `HomeScreen.kt:84-100,291-305,444-525`, `LibrariesScreen.kt:617-630,1168-1183,1328-1408` |
+| Phone shell | `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt:120-451` |
+| Phone lobby | `WatchTogetherLobbyScreen.kt:45-203`, `WatchTogetherLobbyViewModel.kt:35-88` |
+| TV entry controller | `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModel.kt:18-113` |
+| TV title-detail dialog | `TvWatchTogetherEntryDialog.kt:31-113` and `TvItemDetailScreen.kt:1048-1104` |
+| TV profile menu/shell | `TvMainShell.kt:166-180,607-610,1270-1313,1478-1563` |
+| TV root navigation | `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt:480-545,630-712,875-900` |
+| TV lobby | `TvWatchTogetherLobbyScreen.kt:76-175,250-330,523-558`, `TvWatchTogetherLobbyViewModel.kt:17-83` |
+| Existing behavior tests | `WatchTogetherRepositoryTest.kt`, `RoomSessionTest.kt`, `WatchTogetherEntryDestinationTest.kt`, `TvWatchTogetherSurfaceSourceTest.kt`, `TvShellFocusStateTest.kt` |
+
+## Task 1: Shared entry policy and narrow repository gateway
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryPolicy.kt`
+- Create: `shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryGateway.kt`
+- Create: `shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryPolicyTest.kt`
+- Modify: `shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt:71-100,181-284`
+- Modify: `shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt:96-123`
+
+**Interfaces:**
+- Produces: `enum class WatchTogetherEntryTarget { Lobby, Player }`
+- Produces: `fun watchTogetherEntryTarget(room: RoomSnapshot): WatchTogetherEntryTarget`
+- Produces: `fun resumableWatchTogetherRoom(room: RoomSnapshot?): RoomSnapshot?`
+- Produces: `interface WatchTogetherEntryGateway` with `roomSnapshot`, `createRoom`, `joinRoom`, and `setSelection`
+- Preserves: the concrete singleton `WatchTogetherRepository`; the gateway is only a testable view of its existing methods.
+
+- [ ] **Step 1: Write the failing shared policy tests**
+
+```kotlin
+package org.siloserver.silo.watchtogether
+
+import org.siloserver.silo.model.watchtogether.MemberRole
+import org.siloserver.silo.model.watchtogether.RoomPhase
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class WatchTogetherEntryPolicyTest {
+    @Test
+    fun selectedGuestRoutesToPlayer() {
+        val room = RoomSnapshot(
+            roomId = "room-1",
+            selectedContentId = "movie-1",
+            selfRole = MemberRole.Guest,
+            memberCount = 2,
+        )
+        assertEquals(WatchTogetherEntryTarget.Player, watchTogetherEntryTarget(room))
+    }
+
+    @Test
+    fun emptyRoomAndSoloHostRouteToLobby() {
+        assertEquals(
+            WatchTogetherEntryTarget.Lobby,
+            watchTogetherEntryTarget(RoomSnapshot(roomId = "room-1")),
+        )
+        assertEquals(
+            WatchTogetherEntryTarget.Lobby,
+            watchTogetherEntryTarget(
+                RoomSnapshot(
+                    roomId = "room-1",
+                    selectedContentId = "movie-1",
+                    selfRole = MemberRole.Host,
+                    memberCount = 1,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun onlyNonTerminalNonBlankRoomIsResumable() {
+        assertNull(resumableWatchTogetherRoom(null))
+        assertNull(resumableWatchTogetherRoom(RoomSnapshot(roomId = "")))
+        assertNull(
+            resumableWatchTogetherRoom(
+                RoomSnapshot(roomId = "room-1", phase = RoomPhase.Ended),
+            ),
+        )
+        assertEquals(
+            "room-1",
+            resumableWatchTogetherRoom(
+                RoomSnapshot(roomId = "room-1", phase = RoomPhase.Lobby),
+            )?.roomId,
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run the policy test and verify RED**
+
+Run:
+
+```bash
+./gradlew :shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.watchtogether.WatchTogetherEntryPolicyTest'
+```
+
+Expected: FAIL to compile because `WatchTogetherEntryTarget`, `watchTogetherEntryTarget`, and `resumableWatchTogetherRoom` do not exist.
+
+- [ ] **Step 3: Implement the pure policy**
+
+```kotlin
+package org.siloserver.silo.watchtogether
+
+import org.siloserver.silo.model.watchtogether.MemberRole
+import org.siloserver.silo.model.watchtogether.RoomPhase
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+
+enum class WatchTogetherEntryTarget {
+    Lobby,
+    Player,
+}
+
+fun watchTogetherEntryTarget(room: RoomSnapshot): WatchTogetherEntryTarget =
+    if (
+        !room.selectedContentId.isNullOrBlank() &&
+        !(room.selfRole == MemberRole.Host && room.memberCount <= 1)
+    ) {
+        WatchTogetherEntryTarget.Player
+    } else {
+        WatchTogetherEntryTarget.Lobby
+    }
+
+fun resumableWatchTogetherRoom(room: RoomSnapshot?): RoomSnapshot? =
+    room?.takeIf { it.roomId.isNotBlank() && it.phase != RoomPhase.Ended }
+```
+
+- [ ] **Step 4: Add the narrow gateway and bind the existing singleton**
+
+```kotlin
+package org.siloserver.silo.watchtogether
+
+import org.siloserver.silo.model.watchtogether.CreateRoomRequest
+import org.siloserver.silo.model.watchtogether.JoinRoomRequest
+import org.siloserver.silo.model.watchtogether.RoomResponse
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.SetSelectionRequest
+import org.siloserver.silo.network.ApiResult
+import kotlinx.coroutines.flow.StateFlow
+
+interface WatchTogetherEntryGateway {
+    val roomSnapshot: StateFlow<RoomSnapshot?>
+    suspend fun createRoom(request: CreateRoomRequest): ApiResult<RoomResponse>
+    suspend fun joinRoom(request: JoinRoomRequest): ApiResult<RoomResponse>
+    suspend fun setSelection(request: SetSelectionRequest): ApiResult<RoomResponse>
+}
+```
+
+Change the repository declaration and existing members to implement the interface:
+
+```kotlin
+) : RoomSessionRepository, WatchTogetherEntryGateway {
+    override val roomSnapshot: StateFlow<RoomSnapshot?> = _roomSnapshot.asStateFlow()
+}
+```
+
+Add the `override` modifier to the existing `createRoom`, `joinRoom`, and
+`setSelection` declarations. Do not alter any statement inside those three
+existing method bodies; verify their body diff is empty.
+
+Bind the same singleton in `RepositoryModule.kt` immediately after its concrete
+registration:
+
+```kotlin
+import org.siloserver.silo.watchtogether.WatchTogetherEntryGateway
+
+single<WatchTogetherEntryGateway> { get<WatchTogetherRepository>() }
+```
+
+- [ ] **Step 5: Run shared tests and compile both clients**
+
+Run:
+
+```bash
+./gradlew \
+  :shared:testDebugUnitTest \
+  :androidApp:compileDebugKotlinAndroid \
+  :androidTvApp:compileDebugKotlinAndroid \
+  --max-workers=2
+```
+
+Expected: PASS; no new network or model source is compiled.
+
+- [ ] **Step 6: Commit the shared boundary**
+
+```bash
+git add \
+  shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryPolicy.kt \
+  shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryGateway.kt \
+  shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryPolicyTest.kt \
+  shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt \
+  shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
+git commit -m "refactor: define Watch Together entry boundary"
+```
+
+## Task 2: Phone entry controller behavior
+
+**Files:**
+- Create: `androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModelTest.kt`
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModel.kt:21-125`
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntrySheet.kt:92-112`
+
+**Interfaces:**
+- Consumes: `WatchTogetherEntryGateway`, `watchTogetherEntryTarget`, and `resumableWatchTogetherRoom`
+- Produces: `val currentRoom: StateFlow<RoomSnapshot?>`
+- Produces: `fun hostEmptyVoteRoom()`
+- Produces: `fun resumeCurrentRoom()`
+- Preserves: `fun host(contentId: String, fileId: Int?, selectionMode: RoomSelectionMode)` and `fun joinByCode(code: String)`
+
+- [ ] **Step 1: Write the phone ViewModel fake and RED tests**
+
+```kotlin
+package org.siloserver.silo.android.ui.screens.watchtogether
+
+import org.siloserver.silo.model.watchtogether.CreateRoomRequest
+import org.siloserver.silo.model.watchtogether.JoinRoomRequest
+import org.siloserver.silo.model.watchtogether.RoomPhase
+import org.siloserver.silo.model.watchtogether.RoomResponse
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.SetSelectionRequest
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.watchtogether.WatchTogetherEntryGateway
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WatchTogetherEntryViewModelTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun emptyHostCreatesVoteRoomWithoutSelection() = runTest(dispatcher) {
+        val gateway = FakeGateway()
+        val viewModel = WatchTogetherEntryViewModel(gateway)
+
+        viewModel.hostEmptyVoteRoom()
+
+        assertEquals(listOf(CreateRoomRequest(RoomSelectionMode.Vote.wire)), gateway.createRequests)
+        assertEquals(emptyList(), gateway.selectionRequests)
+        assertEquals("watch_together/room-1", viewModel.uiState.value.destination)
+    }
+
+    @Test
+    fun resumeUsesCurrentRoomWithoutCreateOrJoin() = runTest(dispatcher) {
+        val room = RoomSnapshot(roomId = "room-1", phase = RoomPhase.Lobby)
+        val gateway = FakeGateway(room)
+        val viewModel = WatchTogetherEntryViewModel(gateway)
+
+        viewModel.resumeCurrentRoom()
+
+        assertEquals("watch_together/room-1", viewModel.uiState.value.destination)
+        assertEquals(emptyList(), gateway.createRequests)
+        assertEquals(emptyList(), gateway.joinRequests)
+    }
+
+    @Test
+    fun identityClearRemovesResumeState() = runTest(dispatcher) {
+        val gateway = FakeGateway(RoomSnapshot(roomId = "room-1", phase = RoomPhase.Lobby))
+        val viewModel = WatchTogetherEntryViewModel(gateway)
+
+        gateway.roomSnapshot.value = null
+
+        assertNull(viewModel.currentRoom.value)
+    }
+
+    @Test
+    fun titleHostStillSetsTheSelectedTitle() = runTest(dispatcher) {
+        val gateway = FakeGateway()
+        val viewModel = WatchTogetherEntryViewModel(gateway)
+
+        viewModel.host(contentId = "movie-1", fileId = 7)
+
+        assertEquals(
+            listOf(SetSelectionRequest(contentId = "movie-1", fileId = 7)),
+            gateway.selectionRequests,
+        )
+    }
+
+    @Test
+    fun joinByCodeTrimsAndUsesExistingErrorMapping() = runTest(dispatcher) {
+        val gateway = FakeGateway()
+        val viewModel = WatchTogetherEntryViewModel(gateway)
+
+        viewModel.joinByCode(" ABCD1234 ")
+        assertEquals(listOf(JoinRoomRequest(code = "ABCD1234")), gateway.joinRequests)
+
+        viewModel.consumeDestination()
+        gateway.joinResult = ApiResult.NetworkError(IllegalStateException("offline"))
+        viewModel.joinByCode("EFGH5678")
+        assertEquals("Network error. Check your connection.", viewModel.uiState.value.error)
+    }
+
+    private class FakeGateway(
+        room: RoomSnapshot? = null,
+    ) : WatchTogetherEntryGateway {
+        override val roomSnapshot = MutableStateFlow(room)
+        val createRequests = mutableListOf<CreateRoomRequest>()
+        val joinRequests = mutableListOf<JoinRoomRequest>()
+        val selectionRequests = mutableListOf<SetSelectionRequest>()
+        var joinResult: ApiResult<RoomResponse>? = null
+        var nextRoom = RoomSnapshot(
+            roomId = "room-1",
+            phase = RoomPhase.Lobby,
+            selectionMode = RoomSelectionMode.Vote,
+        )
+
+        override suspend fun createRoom(request: CreateRoomRequest): ApiResult<RoomResponse> {
+            createRequests += request
+            roomSnapshot.value = nextRoom
+            return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+        }
+
+        override suspend fun joinRoom(request: JoinRoomRequest): ApiResult<RoomResponse> {
+            joinRequests += request
+            joinResult?.let { return it }
+            roomSnapshot.value = nextRoom
+            return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+        }
+
+        override suspend fun setSelection(
+            request: SetSelectionRequest,
+        ): ApiResult<RoomResponse> {
+            selectionRequests += request
+            nextRoom = nextRoom.copy(
+                selectedContentId = request.contentId,
+                selectedFileId = request.fileId,
+            )
+            roomSnapshot.value = nextRoom
+            return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the phone ViewModel test and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherEntryViewModelTest'
+```
+
+Expected: FAIL because the constructor still takes `WatchTogetherRepository`,
+and `hostEmptyVoteRoom`, `resumeCurrentRoom`, and `currentRoom` do not exist.
+
+- [ ] **Step 3: Implement the phone controller additions**
+
+Change the constructor to `WatchTogetherEntryGateway`, map current-room state
+through the shared policy, and add explicit menu actions:
+
+```kotlin
+class WatchTogetherEntryViewModel(
+    private val gateway: WatchTogetherEntryGateway,
+) : ViewModel() {
+    val currentRoom: StateFlow<RoomSnapshot?> = gateway.roomSnapshot
+        .map(::resumableWatchTogetherRoom)
+        .stateIn(
+            viewModelScope,
+            SharingStarted.Eagerly,
+            resumableWatchTogetherRoom(gateway.roomSnapshot.value),
+        )
+
+    fun hostEmptyVoteRoom() {
+        if (_uiState.value.busy) return
+        _uiState.update { it.copy(busy = true, error = null) }
+        viewModelScope.launch {
+            when (
+                val created = gateway.createRoom(
+                    CreateRoomRequest(selectionMode = RoomSelectionMode.Vote.wire),
+                )
+            ) {
+                is ApiResult.Success -> finish(created.data.room)
+                is ApiResult.Error, is ApiResult.NetworkError ->
+                    fail(created.errorMessage("Failed to create room"))
+            }
+        }
+    }
+
+    fun resumeCurrentRoom() {
+        if (_uiState.value.busy) return
+        val room = resumableWatchTogetherRoom(gateway.roomSnapshot.value)
+        if (room == null) {
+            fail("Current room is no longer available")
+        } else {
+            finish(room)
+        }
+    }
+}
+```
+
+Within existing `host`, delegate vote mode before starting HostPick work:
+
+```kotlin
+if (selectionMode == RoomSelectionMode.Vote) {
+    hostEmptyVoteRoom()
+    return
+}
+```
+
+Replace repository calls in this ViewModel with `gateway` calls. Keep
+`errorMessage`, the busy guard, one-shot destination consumption, and
+title-selection ordering unchanged. Change the title-detail sheet's
+`onHostVote` path to `viewModel.hostEmptyVoteRoom()` so it uses the explicit
+empty-vote action without dummy content.
+
+- [ ] **Step 4: Map phone routes through the shared target policy**
+
+Keep the public phone helper name stable:
+
+```kotlin
+fun watchTogetherDestination(room: RoomSnapshot): String =
+    when (watchTogetherEntryTarget(room)) {
+        WatchTogetherEntryTarget.Player -> Route.Player(
+            contentId = requireNotNull(room.selectedContentId),
+            fileId = room.selectedFileId,
+            roomId = room.roomId,
+        ).route
+        WatchTogetherEntryTarget.Lobby ->
+            Route.WatchTogetherLobby(roomId = room.roomId).route
+    }
+```
+
+- [ ] **Step 5: Run the focused phone entry tests**
+
+Run:
+
+```bash
+./gradlew :androidApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherEntryViewModelTest' \
+  --tests 'org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherEntryDestinationTest'
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the phone controller**
+
+```bash
+git add \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModel.kt \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntrySheet.kt \
+  androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryViewModelTest.kt
+git commit -m "feat: add phone Watch Together menu actions"
+```
+
+## Task 3: Phone transient sheet and all profile-menu rows
+
+**Files:**
+- Create: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySheet.kt`
+- Create: `androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySourceTest.kt`
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MainAppTopBar.kt:52-181`
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt:84-100,291-305,444-525`
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt:617-630,1168-1183,1328-1408`
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt:120-451`
+
+**Interfaces:**
+- Consumes: `WatchTogetherEntryViewModel.currentRoom`, `hostEmptyVoteRoom`, `resumeCurrentRoom`, and `joinByCode`
+- Produces: `@Composable fun WatchTogetherMenuEntrySheet(onNavigate: (String) -> Unit, onDismiss: () -> Unit, viewModel: WatchTogetherEntryViewModel = koinViewModel())`
+- Produces: `onWatchTogetherClick: (() -> Unit)?` through each phone chrome/profile-menu signature, supplied only when `CLIENT_WATCH_TOGETHER_SURFACE_ENABLED` is true.
+
+- [ ] **Step 1: Write the phone source-level RED tests**
+
+```kotlin
+package org.siloserver.silo.android.ui.screens.watchtogether
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WatchTogetherMenuEntrySourceTest {
+    private fun source(path: String) = File("src/androidMain/kotlin/$path").readText()
+
+    private val topBar = source("org/siloserver/silo/android/ui/components/MainAppTopBar.kt")
+    private val home = source("org/siloserver/silo/android/ui/screens/home/HomeScreen.kt")
+    private val libraries = source("org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt")
+    private val main = source("org/siloserver/silo/android/ui/screens/MainScreen.kt")
+    private val menuSheet = source(
+        "org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySheet.kt",
+    )
+
+    @Test
+    fun everyPhoneProfileMenuPlacesWatchTogetherBeforeRequestsAndSettings() {
+        listOf(topBar, home, libraries).forEach { text ->
+            val watch = text.indexOf("Text(\"Watch Together\")")
+            val requests = text.indexOf("Text(\"Requests\")")
+            val settings = text.indexOf("Text(\"Settings\")")
+            assertTrue(watch >= 0)
+            assertTrue(requests < 0 || watch < requests)
+            assertTrue(watch < settings)
+        }
+    }
+
+    @Test
+    fun mainShellOwnsOneTransientEntrySheet() {
+        assertTrue(main.contains("var showWatchTogetherEntry by rememberSaveable"))
+        assertTrue(main.contains("WatchTogetherMenuEntrySheet("))
+        assertTrue(main.contains("CLIENT_WATCH_TOGETHER_SURFACE_ENABLED"))
+        assertTrue(main.contains("onWatchTogetherClick = watchTogetherMenuAction"))
+    }
+
+    @Test
+    fun sheetUsesOnlyTheExistingControllerAndNeverHandlesCredentials() {
+        assertTrue(menuSheet.contains("viewModel.hostEmptyVoteRoom()"))
+        assertTrue(menuSheet.contains("viewModel.resumeCurrentRoom()"))
+        assertTrue(menuSheet.contains("viewModel.joinByCode(code)"))
+        listOf("Resume current room", "Host a room", "Join by code").forEach { label ->
+            assertTrue(menuSheet.contains(label))
+        }
+        assertFalse(menuSheet.contains("WatchTogetherApi"))
+        assertFalse(menuSheet.contains("roomAccessToken"))
+        assertFalse(menuSheet.contains("HttpClient"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the phone source test and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherMenuEntrySourceTest'
+```
+
+Expected: FAIL because the menu sheet/file, callbacks, and menu rows do not
+exist.
+
+- [ ] **Step 3: Implement the transient phone sheet**
+
+The new sheet must collect `uiState` and `currentRoom`, show Resume only when
+non-null, and retain the existing join-code rules:
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WatchTogetherMenuEntrySheet(
+    onNavigate: (String) -> Unit,
+    onDismiss: () -> Unit,
+    viewModel: WatchTogetherEntryViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val currentRoom by viewModel.currentRoom.collectAsState()
+    var code by rememberSaveable { mutableStateOf("") }
+    var showJoin by rememberSaveable { mutableStateOf(false) }
+    val latestBusy by rememberUpdatedState(state.busy)
+
+    LaunchedEffect(state.destination) {
+        val destination = state.destination ?: return@LaunchedEffect
+        viewModel.consumeDestination()
+        onDismiss()
+        onNavigate(destination)
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = {
+            if (canDismissRoomEntry(state.busy)) {
+                viewModel.clearError()
+                onDismiss()
+            }
+        },
+        sheetState = rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+            confirmValueChange = { target ->
+                target != SheetValue.Hidden || canDismissRoomEntry(latestBusy)
+            },
+        ),
+    ) {
+        if (!showJoin) {
+            if (currentRoom != null) {
+                Button(
+                    onClick = viewModel::resumeCurrentRoom,
+                    enabled = !state.busy,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Resume current room")
+                }
+            }
+            Button(
+                onClick = viewModel::hostEmptyVoteRoom,
+                enabled = !state.busy,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (state.busy) "Creating…" else "Host a room")
+            }
+            OutlinedButton(
+                onClick = {
+                    viewModel.clearError()
+                    showJoin = true
+                },
+                enabled = !state.busy,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Join by code")
+            }
+        } else {
+            OutlinedTextField(
+                value = code,
+                onValueChange = { code = it.uppercase().filter(Char::isLetterOrDigit).take(8) },
+                label = { Text("Invite code") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Button(
+                onClick = { viewModel.joinByCode(code) },
+                enabled = !state.busy && code.length >= 4,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (state.busy) "Joining…" else "Join")
+            }
+            OutlinedButton(
+                onClick = {
+                    viewModel.clearError()
+                    showJoin = false
+                },
+                enabled = !state.busy,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Back")
+            }
+        }
+        state.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+    }
+}
+```
+
+Render `Text("Watch Together")` with `titleMedium`, `FontWeight.Bold`, and
+`Modifier.padding(horizontal = 20.dp, vertical = 12.dp)`, followed by an
+`HorizontalDivider`. Wrap the action branch in a full-width `Column` with
+`Modifier.padding(20.dp)` and `Arrangement.spacedBy(12.dp)`, and end the sheet
+with `Spacer(Modifier.height(24.dp))`. Use an 18.dp
+`CircularProgressIndicator` for the busy Join button. Do not import
+network/API/token types.
+
+- [ ] **Step 4: Thread and render the phone menu action**
+
+Add this exact parameter to `MainAppTopBar`, `HomeScreen`,
+`HomeFloatingChrome`, `HomeProfileMenu`, `LibrariesScreen`,
+`LibrariesFloatingChrome`, and `ChromeProfileMenu`:
+
+```kotlin
+onWatchTogetherClick: (() -> Unit)?,
+```
+
+In all three menu implementations, insert this item before the conditional
+Requests item and keep one divider after the content-action group:
+
+```kotlin
+if (onWatchTogetherClick != null) {
+    DropdownMenuItem(
+        text = { Text("Watch Together") },
+        onClick = {
+            menuExpanded = false
+            onWatchTogetherClick()
+        },
+    )
+}
+if (onRequestsClick != null) {
+    DropdownMenuItem(
+        text = { Text("Requests") },
+        onClick = {
+            menuExpanded = false
+            onRequestsClick()
+        },
+    )
+}
+HorizontalDivider()
+```
+
+In `MainScreen`, add one saved surface flag and use one callback at all phone
+menu call sites:
+
+```kotlin
+import org.siloserver.silo.model.feature.CLIENT_WATCH_TOGETHER_SURFACE_ENABLED
+
+var showWatchTogetherEntry by rememberSaveable { mutableStateOf(false) }
+val watchTogetherMenuAction: (() -> Unit)? =
+    if (CLIENT_WATCH_TOGETHER_SURFACE_ENABLED) {
+        { showWatchTogetherEntry = true }
+    } else {
+        null
+    }
+```
+
+Pass:
+
+```kotlin
+onWatchTogetherClick = watchTogetherMenuAction,
+```
+
+Render beside the existing library and SiloCast sheets:
+
+```kotlin
+if (showWatchTogetherEntry) {
+    WatchTogetherMenuEntrySheet(
+        onNavigate = { route ->
+            navController.navigate(route) {
+                launchSingleTop = true
+            }
+        },
+        onDismiss = { showWatchTogetherEntry = false },
+    )
+}
+```
+
+- [ ] **Step 5: Run phone menu tests and compile**
+
+Run:
+
+```bash
+./gradlew \
+  :androidApp:testDebugUnitTest \
+  :androidApp:assembleDebug \
+  --tests 'org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherMenuEntrySourceTest' \
+  --max-workers=2
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the phone surface**
+
+```bash
+git add \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySheet.kt \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MainAppTopBar.kt \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt \
+  androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySourceTest.kt
+git commit -m "feat: add Watch Together to phone profile menus"
+```
+
+## Task 4: Phone browse-versus-leave continuity and owner authority
+
+**Files:**
+- Create: `androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyContinuitySourceTest.kt`
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyScreen.kt:75-167`
+
+**Interfaces:**
+- Consumes: existing `WatchTogetherLobbyViewModel.leave`, `vote`, `unvote`, `promote`, and `closeRoom`
+- Produces: ordinary Back/browse invokes `onBack()` without `leave()`
+- Produces: an explicit **Leave room** action invokes `viewModel.leave()` then `onBack()`
+- Preserves: host Close, suggestion vote/promote, and title-detail **Suggest to Watch Together**.
+
+- [ ] **Step 1: Write the phone lobby continuity RED test**
+
+```kotlin
+package org.siloserver.silo.android.ui.screens.watchtogether
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WatchTogetherLobbyContinuitySourceTest {
+    private val lobby = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyScreen.kt",
+    ).readText()
+    private val detail = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt",
+    ).readText()
+
+    @Test
+    fun ordinaryBackBrowsesWithoutLeavingAndLeaveIsExplicit() {
+        val navigationIcon = lobby.substringAfter("navigationIcon = {").substringBefore("actions = {")
+        assertTrue(navigationIcon.contains("onClick = onBack"))
+        assertFalse(navigationIcon.contains("viewModel.leave()"))
+        assertTrue(lobby.contains("Text(\"Leave room\")"))
+        assertTrue(lobby.contains("viewModel.leave()"))
+    }
+
+    @Test
+    fun ownerControlsAndTitleSuggestionRemainReachable() {
+        assertTrue(lobby.contains("viewModel.vote(s.id)"))
+        assertTrue(lobby.contains("viewModel.promote(s.id)"))
+        assertTrue(lobby.contains("viewModel.closeRoom()"))
+        assertTrue(detail.contains("Suggest to Watch Together"))
+        assertTrue(detail.contains("suggestViewModel.suggest("))
+    }
+}
+```
+
+- [ ] **Step 2: Run the continuity test and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherLobbyContinuitySourceTest'
+```
+
+Expected: FAIL because the visible navigation icon currently calls `leave()`
+and no explicit Leave row exists.
+
+- [ ] **Step 3: Separate browse/back from explicit Leave**
+
+Replace the top app bar navigation behavior with:
+
+```kotlin
+navigationIcon = {
+    IconButton(onClick = onBack) {
+        Icon(
+            Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = "Back to browse",
+        )
+    }
+},
+actions = {
+    TextButton(
+        onClick = {
+            viewModel.leave()
+            onBack()
+        },
+    ) {
+        Text("Leave room")
+    }
+    if (canManage) {
+        TextButton(onClick = { viewModel.closeRoom() }) {
+            Text("Close")
+        }
+    }
+},
+```
+
+Do not add any reset to `onCleared` or ordinary `onBack`; `RoomSession` remains
+the process owner while the user browses to a detail screen and submits the
+existing suggestion action.
+
+- [ ] **Step 4: Run phone Watch Together regression tests**
+
+Run:
+
+```bash
+./gradlew :androidApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.android.ui.screens.watchtogether.*'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit phone continuity**
+
+```bash
+git add \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyScreen.kt \
+  androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherLobbyContinuitySourceTest.kt
+git commit -m "fix: preserve phone room while browsing"
+```
+
+## Task 5: TV entry controller and shared destination routing
+
+**Files:**
+- Create: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherDestination.kt`
+- Create: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModelTest.kt`
+- Create: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherDestinationTest.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModel.kt:18-113`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt:1048-1104`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt:630-712`
+- Modify: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherSurfaceSourceTest.kt:31-43`
+
+**Interfaces:**
+- Consumes: `WatchTogetherEntryGateway`, `watchTogetherEntryTarget`, and `resumableWatchTogetherRoom`
+- Produces: `val currentRoom: StateFlow<RoomSnapshot?>`
+- Produces: `fun createEmptyVoteRoom()`
+- Produces: `fun resumeCurrentRoom()`
+- Produces: `fun tvWatchTogetherDestination(room: RoomSnapshot): String`
+- Preserves: title-bound `createRoom(contentId, fileId, selectionMode)` and `joinRoom(code)`.
+
+- [ ] **Step 1: Write the TV RED tests**
+
+Create `TvWatchTogetherViewModelTest` with an
+`UnconfinedTestDispatcher`, `Dispatchers.setMain`/`resetMain`, these tests, and
+the complete local fake below:
+
+```kotlin
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import org.siloserver.silo.model.watchtogether.CreateRoomRequest
+import org.siloserver.silo.model.watchtogether.JoinRoomRequest
+import org.siloserver.silo.model.watchtogether.RoomPhase
+import org.siloserver.silo.model.watchtogether.RoomResponse
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.SetSelectionRequest
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.watchtogether.WatchTogetherEntryGateway
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvWatchTogetherViewModelTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+@Test
+fun emptyHostCreatesVoteRoomWithoutSelection() = runTest(dispatcher) {
+    val gateway = FakeGateway()
+    val viewModel = TvWatchTogetherViewModel(gateway)
+
+    viewModel.createEmptyVoteRoom()
+
+    assertEquals(listOf(CreateRoomRequest(RoomSelectionMode.Vote.wire)), gateway.createRequests)
+    assertEquals(emptyList(), gateway.selectionRequests)
+    assertEquals("room-1", viewModel.uiState.value.result?.roomId)
+}
+
+@Test
+fun resumeUsesCurrentRoomWithoutNetworkCalls() = runTest(dispatcher) {
+    val room = RoomSnapshot(roomId = "room-1", phase = RoomPhase.Lobby)
+    val gateway = FakeGateway(room)
+    val viewModel = TvWatchTogetherViewModel(gateway)
+
+    viewModel.resumeCurrentRoom()
+
+    assertEquals(room, viewModel.uiState.value.result)
+    assertEquals(emptyList(), gateway.createRequests)
+    assertEquals(emptyList(), gateway.joinRequests)
+}
+
+@Test
+fun joinCodeNormalizesAndKeepsExistingErrorCopy() = runTest(dispatcher) {
+    val gateway = FakeGateway()
+    val viewModel = TvWatchTogetherViewModel(gateway)
+
+    viewModel.joinRoom(" abcd1234 ")
+    assertEquals(listOf(JoinRoomRequest(code = "ABCD1234")), gateway.joinRequests)
+
+    viewModel.consumeResult()
+    gateway.joinResult = ApiResult.NetworkError(IllegalStateException("offline"))
+    viewModel.joinRoom("efgh5678")
+    assertEquals("Network error. Check your connection.", viewModel.uiState.value.error)
+}
+
+@Test
+fun titleDetailHostStillSetsSelection() = runTest(dispatcher) {
+    val gateway = FakeGateway()
+    val viewModel = TvWatchTogetherViewModel(gateway)
+
+    viewModel.createRoom(contentId = "movie-1", fileId = 7)
+
+    assertEquals(
+        listOf(SetSelectionRequest(contentId = "movie-1", fileId = 7)),
+        gateway.selectionRequests,
+    )
+}
+
+private class FakeGateway(
+    room: RoomSnapshot? = null,
+) : WatchTogetherEntryGateway {
+    override val roomSnapshot = MutableStateFlow(room)
+    val createRequests = mutableListOf<CreateRoomRequest>()
+    val joinRequests = mutableListOf<JoinRoomRequest>()
+    val selectionRequests = mutableListOf<SetSelectionRequest>()
+    var joinResult: ApiResult<RoomResponse>? = null
+    var nextRoom = RoomSnapshot(
+        roomId = "room-1",
+        phase = RoomPhase.Lobby,
+        selectionMode = RoomSelectionMode.Vote,
+    )
+
+    override suspend fun createRoom(
+        request: CreateRoomRequest,
+    ): ApiResult<RoomResponse> {
+        createRequests += request
+        roomSnapshot.value = nextRoom
+        return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+    }
+
+    override suspend fun joinRoom(
+        request: JoinRoomRequest,
+    ): ApiResult<RoomResponse> {
+        joinRequests += request
+        joinResult?.let { return it }
+        roomSnapshot.value = nextRoom
+        return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+    }
+
+    override suspend fun setSelection(
+        request: SetSelectionRequest,
+    ): ApiResult<RoomResponse> {
+        selectionRequests += request
+        nextRoom = nextRoom.copy(
+            selectedContentId = request.contentId,
+            selectedFileId = request.fileId,
+        )
+        roomSnapshot.value = nextRoom
+        return ApiResult.Success(RoomResponse(nextRoom, "test-room-token"))
+    }
+}
+}
+```
+
+Add route-policy coverage:
+
+```kotlin
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import org.siloserver.silo.model.watchtogether.MemberRole
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.tv.ui.navigation.TvRoute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TvWatchTogetherDestinationTest {
+    @Test
+    fun emptyAndSoloHostRoomsUseLobby() {
+        assertEquals(
+            TvRoute.WatchTogetherLobby("room-1").route,
+            tvWatchTogetherDestination(RoomSnapshot(roomId = "room-1")),
+        )
+        assertEquals(
+            TvRoute.WatchTogetherLobby("room-1").route,
+            tvWatchTogetherDestination(
+                RoomSnapshot(
+                    roomId = "room-1",
+                    selectedContentId = "movie-1",
+                    selfRole = MemberRole.Host,
+                    memberCount = 1,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun selectedJoinedRoomUsesSyncedPlayer() {
+        val room = RoomSnapshot(
+            roomId = "room-1",
+            selectedContentId = "movie-1",
+            selectedFileId = 7,
+            selfRole = MemberRole.Guest,
+            memberCount = 2,
+            anchorPositionSeconds = 12.5,
+        )
+        assertEquals(
+            TvRoute.Player(
+                contentId = "movie-1",
+                fileId = 7,
+                roomId = "room-1",
+                resumePositionSeconds = 12.5,
+            ).route,
+            tvWatchTogetherDestination(room),
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run TV controller tests and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherViewModelTest' \
+  --tests 'org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherDestinationTest'
+```
+
+Expected: FAIL because the gateway constructor, menu methods, and destination
+helper do not exist.
+
+- [ ] **Step 3: Implement the TV controller additions**
+
+Mirror the phone controller names through TV's existing naming:
+
+```kotlin
+class TvWatchTogetherViewModel(
+    private val gateway: WatchTogetherEntryGateway,
+) : ViewModel() {
+    val currentRoom: StateFlow<RoomSnapshot?> = gateway.roomSnapshot
+        .map(::resumableWatchTogetherRoom)
+        .stateIn(
+            viewModelScope,
+            SharingStarted.Eagerly,
+            resumableWatchTogetherRoom(gateway.roomSnapshot.value),
+        )
+
+    fun createEmptyVoteRoom() {
+        if (_uiState.value.isBusy) return
+        _uiState.update { it.copy(isBusy = true, error = null) }
+        viewModelScope.launch {
+            when (
+                val created = gateway.createRoom(
+                    CreateRoomRequest(selectionMode = RoomSelectionMode.Vote.wire),
+                )
+            ) {
+                is ApiResult.Success -> finish(created.data.room)
+                is ApiResult.Error, is ApiResult.NetworkError ->
+                    fail(created.errorMessage("Failed to create room"))
+            }
+        }
+    }
+
+    fun resumeCurrentRoom() {
+        if (_uiState.value.isBusy) return
+        val room = resumableWatchTogetherRoom(gateway.roomSnapshot.value)
+        if (room == null) {
+            fail("Current room is no longer available")
+        } else {
+            finish(room)
+        }
+    }
+}
+```
+
+Delegate `RoomSelectionMode.Vote` in existing `createRoom` to
+`createEmptyVoteRoom`, replace repository calls with gateway calls, and keep
+the title HostPick sequence unchanged.
+
+- [ ] **Step 4: Implement one TV destination helper and use it from detail**
+
+```kotlin
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.tv.ui.navigation.TvRoute
+import org.siloserver.silo.watchtogether.WatchTogetherEntryTarget
+import org.siloserver.silo.watchtogether.watchTogetherEntryTarget
+
+fun tvWatchTogetherDestination(room: RoomSnapshot): String =
+    when (watchTogetherEntryTarget(room)) {
+        WatchTogetherEntryTarget.Lobby ->
+            TvRoute.WatchTogetherLobby(room.roomId).route
+        WatchTogetherEntryTarget.Player ->
+            TvRoute.Player(
+                contentId = requireNotNull(room.selectedContentId),
+                fileId = room.selectedFileId,
+                roomId = room.roomId,
+                resumePositionSeconds = room.anchorPositionSeconds
+                    .takeIf { it.isFinite() && it > 0.0 },
+            ).route
+    }
+```
+
+Replace the inline target calculation in `TvAppNavigation`'s existing detail
+callback with:
+
+```kotlin
+onWatchTogether = { snapshot ->
+    navController.navigate(tvWatchTogetherDestination(snapshot))
+},
+```
+
+Change the title-detail vote callback to `createEmptyVoteRoom()`; keep its
+normal Host callback title-bound.
+
+Update `TvWatchTogetherSurfaceSourceTest.aResolvedRoomReachesTheNavigationCallback`
+to assert:
+
+```kotlin
+assertTrue(appNavigation.contains("tvWatchTogetherDestination(snapshot)"))
+```
+
+- [ ] **Step 5: Run TV controller, route, and existing surface tests**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.tv.ui.screens.watchtogether.*'
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit TV controller/routing**
+
+```bash
+git add \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherDestination.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModel.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherViewModelTest.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherDestinationTest.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherSurfaceSourceTest.kt
+git commit -m "feat: add TV Watch Together menu actions"
+```
+
+## Task 6: TV profile row, focusable popup, and Back restoration
+
+**Files:**
+- Create: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntryDialog.kt`
+- Create: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntrySourceTest.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt:166-180,607-610,1270-1313,1478-1563`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt:480-545`
+- Modify: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusStateTest.kt`
+
+**Interfaces:**
+- Produces: `enum class TvWatchTogetherMenuInitialAction { Resume, Host }`
+- Produces: `fun tvWatchTogetherMenuInitialAction(canResume: Boolean): TvWatchTogetherMenuInitialAction`
+- Produces: `@Composable fun TvWatchTogetherMenuEntryDialog(...)`
+- Adds to `TvMainShell`: `onOpenWatchTogether: (RoomSnapshot) -> Unit`
+- Consumes: existing `TvJoinCodeDialog`, `TvWatchTogetherViewModel`, `TvProfileDropdown`, and `TvShellFocusState`.
+
+- [ ] **Step 1: Write TV popup/menu/focus RED tests**
+
+```kotlin
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvWatchTogetherMenuEntrySourceTest {
+    private val shell = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt",
+    ).readText()
+    private val dialog = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntryDialog.kt",
+    ).readText()
+
+    @Test
+    fun profileRowIsBeforeRequestsAndSettings() {
+        val profile = shell.substringAfter("private fun TvProfileDropdown(")
+        val watch = profile.indexOf("label = \"Watch Together\"")
+        val requests = profile.indexOf("label = \"Requests\"")
+        val settings = profile.indexOf("label = \"Settings\"")
+        assertTrue(watch >= 0)
+        assertTrue(watch < requests)
+        assertTrue(watch < settings)
+        assertTrue(shell.contains("CLIENT_WATCH_TOGETHER_SURFACE_ENABLED"))
+    }
+
+    @Test
+    fun popupOwnsFocusAndBackRestoresProfileFocus() {
+        assertTrue(dialog.contains("PopupProperties("))
+        assertTrue(dialog.contains("focusable = true"))
+        assertTrue(dialog.contains("rememberTvDialogInitialFocus(initialFocus)"))
+        assertTrue(shell.contains("focusState.closeProfileMenuForContent()"))
+        assertTrue(shell.contains("focusState.dismissProfileMenu()"))
+    }
+
+    @Test
+    fun menuSurfaceUsesExistingControllerAndNoCredentials() {
+        assertTrue(shell.contains("watchTogetherViewModel.createEmptyVoteRoom()"))
+        assertTrue(shell.contains("watchTogetherViewModel.resumeCurrentRoom()"))
+        assertTrue(shell.contains("TvJoinCodeDialog("))
+        listOf("Resume current room", "Host a room", "Join by code").forEach { label ->
+            assertTrue(dialog.contains(label))
+        }
+        assertFalse(dialog.contains("WatchTogetherApi"))
+        assertFalse(dialog.contains("roomAccessToken"))
+        assertFalse(dialog.contains("HttpClient"))
+    }
+
+    @Test
+    fun initialActionPrefersResumeOnlyWhenAvailable() {
+        assertEquals(
+            TvWatchTogetherMenuInitialAction.Resume,
+            tvWatchTogetherMenuInitialAction(canResume = true),
+        )
+        assertEquals(
+            TvWatchTogetherMenuInitialAction.Host,
+            tvWatchTogetherMenuInitialAction(canResume = false),
+        )
+    }
+}
+```
+
+Add a focus-state regression to `TvShellFocusStateTest`:
+
+```kotlin
+@Test
+fun closingMenuForPopupThenDismissingPopupRefocusesAvatar() {
+    val state = TvShellFocusState()
+    state.previewProfileMenu()
+    state.enterProfileMenu()
+    val before = state.profileFocusRequest
+
+    state.closeProfileMenuForContent()
+    assertEquals(before, state.profileFocusRequest)
+
+    state.dismissProfileMenu()
+    assertEquals(before + 1, state.profileFocusRequest)
+}
+```
+
+- [ ] **Step 2: Run TV popup tests and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherMenuEntrySourceTest' \
+  --tests 'org.siloserver.silo.tv.ui.shell.TvShellFocusStateTest'
+```
+
+Expected: FAIL because the dialog, row, callback, and initial-focus policy do
+not exist.
+
+- [ ] **Step 3: Implement the focused TV popup**
+
+```kotlin
+enum class TvWatchTogetherMenuInitialAction {
+    Resume,
+    Host,
+}
+
+fun tvWatchTogetherMenuInitialAction(
+    canResume: Boolean,
+): TvWatchTogetherMenuInitialAction =
+    if (canResume) {
+        TvWatchTogetherMenuInitialAction.Resume
+    } else {
+        TvWatchTogetherMenuInitialAction.Host
+    }
+```
+
+The popup uses stable requesters and selects the initial requester from the
+pure policy:
+
+```kotlin
+@Composable
+fun TvWatchTogetherMenuEntryDialog(
+    canResume: Boolean,
+    isBusy: Boolean,
+    error: String?,
+    onResume: () -> Unit,
+    onHost: () -> Unit,
+    onJoin: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val resumeFocus = remember { FocusRequester() }
+    val hostFocus = remember { FocusRequester() }
+    val initialAction = tvWatchTogetherMenuInitialAction(canResume)
+    val initialFocus = when (initialAction) {
+        TvWatchTogetherMenuInitialAction.Resume -> resumeFocus
+        TvWatchTogetherMenuInitialAction.Host -> hostFocus
+    }
+
+    Popup(
+        alignment = Alignment.Center,
+        onDismissRequest = {
+            if (canDismissRoomEntry(isBusy)) onDismiss()
+        },
+        properties = PopupProperties(
+            focusable = true,
+            dismissOnBackPress = canDismissRoomEntry(isBusy),
+            dismissOnClickOutside = canDismissRoomEntry(isBusy),
+            clippingEnabled = false,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .width(340.dp)
+                .then(rememberTvDialogInitialFocus(initialFocus)),
+        ) {
+            if (canResume) {
+                TvDialogActionRow(
+                    title = "Resume current room",
+                    enabled = !isBusy,
+                    onClick = onResume,
+                    modifier = Modifier.focusRequester(resumeFocus),
+                )
+            }
+            TvDialogActionRow(
+                title = if (isBusy) "Working…" else "Host a room",
+                enabled = !isBusy,
+                onClick = onHost,
+                modifier = Modifier.focusRequester(hostFocus),
+            )
+            TvDialogActionRow(
+                title = "Join by code",
+                enabled = !isBusy,
+                onClick = onJoin,
+            )
+            error?.let { Text(it, color = Color(0xFFEF4444)) }
+        }
+    }
+}
+```
+
+Wrap the column in a full-screen centered `Box` padded
+`start = 36.dp, top = 50.dp, end = 36.dp, bottom = 42.dp`. Give the 340.dp
+column a 14.dp rounded shape, `DarkBackground.copy(alpha = 0.68f)`, a 0.6.dp
+`Color.White.copy(alpha = 0.20f)` border, 14.dp horizontal/vertical padding,
+and 10.dp item spacing. Render the heading as `"WATCH TOGETHER"` using
+`labelMedium`, 16.sp, 1.1.sp letter spacing, bold weight, and white at 0.58
+alpha.
+
+- [ ] **Step 4: Wire popup state and the profile row into `TvMainShell`**
+
+Add the callback:
+
+```kotlin
+import org.koin.compose.viewmodel.koinViewModel
+import org.siloserver.silo.model.feature.CLIENT_WATCH_TOGETHER_SURFACE_ENABLED
+import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherMenuEntryDialog
+import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherViewModel
+
+onOpenWatchTogether: (RoomSnapshot) -> Unit,
+```
+
+Collect the existing controller and own transient flags in the shell:
+
+```kotlin
+val watchTogetherViewModel = koinViewModel<TvWatchTogetherViewModel>()
+val watchTogetherState by watchTogetherViewModel.uiState.collectAsState()
+val currentWatchTogetherRoom by watchTogetherViewModel.currentRoom.collectAsState()
+var watchTogetherEntryOpen by rememberSaveable { mutableStateOf(false) }
+var watchTogetherJoinOpen by rememberSaveable { mutableStateOf(false) }
+```
+
+Consume one-shot results:
+
+```kotlin
+LaunchedEffect(watchTogetherState.result) {
+    val room = watchTogetherState.result ?: return@LaunchedEffect
+    watchTogetherViewModel.consumeResult()
+    watchTogetherEntryOpen = false
+    watchTogetherJoinOpen = false
+    onOpenWatchTogether(room)
+}
+```
+
+Add `showWatchTogether: Boolean` and `onWatchTogether: () -> Unit` to
+`TvProfileDropdown`; pass
+`showWatchTogether = CLIENT_WATCH_TOGETHER_SURFACE_ENABLED`, and invoke
+`focusState.closeProfileMenuForContent()` before opening the popup. Insert:
+
+```kotlin
+onWatchTogether = {
+    focusState.closeProfileMenuForContent()
+    watchTogetherViewModel.clearError()
+    watchTogetherEntryOpen = true
+},
+
+if (showWatchTogether) {
+    ProfileDropdownRow(
+        label = "Watch Together",
+        icon = Icons.Filled.People,
+        onClick = onWatchTogether,
+    )
+}
+```
+
+Place it after History and before Requests.
+
+Render `TvJoinCodeDialog` or `TvWatchTogetherMenuEntryDialog` after the profile
+dropdown:
+
+```kotlin
+if (watchTogetherEntryOpen) {
+    if (watchTogetherJoinOpen) {
+        TvJoinCodeDialog(
+            isBusy = watchTogetherState.isBusy,
+            error = watchTogetherState.error,
+            onJoin = watchTogetherViewModel::joinRoom,
+            onDismiss = {
+                watchTogetherViewModel.clearError()
+                watchTogetherJoinOpen = false
+            },
+        )
+    } else {
+        TvWatchTogetherMenuEntryDialog(
+            canResume = currentWatchTogetherRoom != null,
+            isBusy = watchTogetherState.isBusy,
+            error = watchTogetherState.error,
+            onResume = watchTogetherViewModel::resumeCurrentRoom,
+            onHost = watchTogetherViewModel::createEmptyVoteRoom,
+            onJoin = {
+                watchTogetherViewModel.clearError()
+                watchTogetherJoinOpen = true
+            },
+            onDismiss = {
+                watchTogetherViewModel.clearError()
+                watchTogetherEntryOpen = false
+                watchTogetherJoinOpen = false
+                focusState.dismissProfileMenu()
+            },
+        )
+    }
+}
+```
+
+Switching from entry to join does not restore avatar focus; only dismissal of
+the outer entry popup does.
+
+- [ ] **Step 5: Route shell results through the existing root destinations**
+
+At the `TvMainShell` call in `TvAppNavigation`, pass:
+
+```kotlin
+onOpenWatchTogether = { room ->
+    navController.navigate(tvWatchTogetherDestination(room)) {
+        launchSingleTop = true
+    }
+},
+```
+
+Do not add a new `TvRoute`.
+
+- [ ] **Step 6: Run TV popup, shell focus, and compile gates**
+
+Run:
+
+```bash
+./gradlew \
+  :androidTvApp:testDebugUnitTest \
+  :androidTvApp:assembleDebug \
+  --tests 'org.siloserver.silo.tv.ui.screens.watchtogether.*' \
+  --tests 'org.siloserver.silo.tv.ui.shell.TvShellFocusStateTest' \
+  --max-workers=2
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the TV surface**
+
+```bash
+git add \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntryDialog.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntrySourceTest.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusStateTest.kt
+git commit -m "feat: add Watch Together to TV profile menu"
+```
+
+## Task 7: TV browse-versus-leave continuity and owner authority
+
+**Files:**
+- Create: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyContinuitySourceTest.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyScreen.kt:120-175,250-330`
+
+**Interfaces:**
+- Consumes: existing `onBack`, `TvWatchTogetherLobbyViewModel.leave`, `vote`, `unvote`, `promote`, and `closeRoom`
+- Produces: D-pad Back and **Browse titles** return without leaving.
+- Produces: explicit **Leave room** clears through `RoomSession.depart`.
+- Preserves: host Close, host override, suggestion voting, and title-detail suggestion entry.
+
+- [ ] **Step 1: Write the TV lobby continuity RED test**
+
+```kotlin
+package org.siloserver.silo.tv.ui.screens.watchtogether
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvWatchTogetherLobbyContinuitySourceTest {
+    private val lobby = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyScreen.kt",
+    ).readText()
+    private val detail = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
+    ).readText()
+
+    @Test
+    fun backAndBrowsePreserveRoomWhileLeaveIsExplicit() {
+        val backHandler = lobby.substringAfter("BackHandler(enabled = true)")
+            .substringBefore("Box(")
+        assertTrue(backHandler.contains("onBack()"))
+        assertFalse(backHandler.contains("viewModel.leave()"))
+        assertTrue(lobby.contains("title = \"Browse titles\""))
+        assertTrue(lobby.contains("title = \"Leave room\""))
+        assertTrue(lobby.contains("viewModel.leave()"))
+    }
+
+    @Test
+    fun existingOwnerAuthorityAndSuggestionPathRemain() {
+        assertTrue(lobby.contains("CloseRoomButton(onClick = viewModel::closeRoom)"))
+        assertTrue(lobby.contains("viewModel.vote(s.id)"))
+        assertTrue(lobby.contains("viewModel.promote(s.id)"))
+        assertTrue(detail.contains("Suggest to Watch Together"))
+        assertTrue(detail.contains("suggestViewModel.suggest("))
+    }
+}
+```
+
+- [ ] **Step 2: Run the TV continuity test and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherLobbyContinuitySourceTest'
+```
+
+Expected: FAIL because TV Back currently calls `leave()` and the two explicit
+rows do not exist.
+
+- [ ] **Step 3: Make TV Back browse and add explicit Browse/Leave rows**
+
+Change ordinary Back:
+
+```kotlin
+BackHandler(enabled = true) {
+    onBack()
+}
+```
+
+Before host-only policy/close controls, add:
+
+```kotlin
+TvDialogActionRow(
+    title = "Browse titles",
+    onClick = onBack,
+)
+TvDialogActionRow(
+    title = "Leave room",
+    onClick = {
+        viewModel.leave()
+        onBack()
+    },
+)
+```
+
+Keep the terminal `closedReason` effect calling `leave()` and keep the explicit
+host `CloseRoomButton`; those are teardown actions, unlike ordinary browse.
+
+- [ ] **Step 4: Run all TV Watch Together and focus tests**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.tv.ui.screens.watchtogether.*' \
+  --tests 'org.siloserver.silo.tv.ui.shell.TvShellFocusStateTest'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit TV continuity**
+
+```bash
+git add \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyScreen.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherLobbyContinuitySourceTest.kt
+git commit -m "fix: preserve TV room while browsing"
+```
+
+## Task 8: Preserve owner operations, identity teardown, auth, cleartext, and error boundaries
+
+**Files:**
+- Modify: `shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt:40-143,776-866`
+- Modify: `shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomSessionTest.kt:122-184`
+- Modify: `androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySourceTest.kt`
+- Modify: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntrySourceTest.kt`
+
+**Interfaces:**
+- Consumes only existing repository methods: `addSuggestion`, `vote`, `promoteSuggestion`, `closeRoom`, and identity-transition reset.
+- Produces test evidence that the top-level entry changes presentation only.
+- Must not modify `WatchTogetherApi.kt`, `WatchTogetherModels.kt`, `WatchTogetherRealtimeClient.kt`, `CleartextOriginConsent.kt`, or server/proxy files.
+
+- [ ] **Step 1: Add a repository authority characterization**
+
+Extend the existing `FakeApi` with counters for create, suggestion, vote,
+promote, and close, then add:
+
+```kotlin
+import org.siloserver.silo.model.watchtogether.MemberRole
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
+
+var createCalls = 0
+var addSuggestionCalls = 0
+var voteCalls = 0
+var promoteCalls = 0
+var closeCalls = 0
+
+override suspend fun createRoom(
+    request: CreateRoomRequest,
+    scope: AuthScopeSnapshot,
+): ApiResult<RoomResponse> {
+    createCalls++
+    lastAuthScope = scope
+    return createResult?.await() ?: createResponse
+}
+
+override suspend fun addSuggestion(
+    roomId: String,
+    roomToken: String,
+    request: AddSuggestionRequest,
+    scope: AuthScopeSnapshot,
+): ApiResult<SuggestionsResponse> {
+    addSuggestionCalls++
+    lastRoomToken = roomToken
+    lastAuthScope = scope
+    return ApiResult.Success(SuggestionsResponse())
+}
+
+override suspend fun vote(
+    roomId: String,
+    roomToken: String,
+    suggestionId: String,
+    scope: AuthScopeSnapshot,
+): ApiResult<SuggestionsResponse> {
+    voteCalls++
+    lastRoomToken = roomToken
+    lastAuthScope = scope
+    return ApiResult.Success(SuggestionsResponse())
+}
+
+override suspend fun promoteSuggestion(
+    roomId: String,
+    roomToken: String,
+    request: PromoteSuggestionRequest,
+    scope: AuthScopeSnapshot,
+): ApiResult<RoomResponse> {
+    promoteCalls++
+    lastRoomToken = roomToken
+    lastAuthScope = scope
+    return createResponse
+}
+
+override suspend fun closeRoom(
+    roomId: String,
+    roomToken: String,
+    scope: AuthScopeSnapshot,
+): ApiResult<Unit> {
+    closeCalls++
+    lastRoomToken = roomToken
+    lastAuthScope = scope
+    return ApiResult.Success(Unit)
+}
+
+@Test
+fun `empty vote room owner keeps existing suggestion vote override and close authority`() = runTest {
+    val api = FakeApi(
+        createResponse = ApiResult.Success(
+            RoomResponse(
+                room = RoomSnapshot(
+                    roomId = "room-1",
+                    selectionMode = RoomSelectionMode.Vote,
+                    selfRole = MemberRole.Host,
+                    selfCanManageRoom = true,
+                ),
+                roomAccessToken = "room-token",
+            ),
+        ),
+    )
+    val repository = WatchTogetherRepository(
+        api = api,
+        authScopeProvider = { scopeA },
+    )
+
+    repository.createRoom(CreateRoomRequest(selectionMode = RoomSelectionMode.Vote.wire))
+    repository.addSuggestion(
+        AddSuggestionRequest(
+            contentId = "movie-1",
+            contentType = "movie",
+            title = "Movie One",
+        ),
+    )
+    repository.vote("suggestion-1")
+    repository.promoteSuggestion(PromoteSuggestionRequest("suggestion-1"))
+    repository.closeRoom()
+
+    assertEquals(1, api.createCalls)
+    assertEquals(1, api.addSuggestionCalls)
+    assertEquals(1, api.voteCalls)
+    assertEquals(1, api.promoteCalls)
+    assertEquals(1, api.closeCalls)
+    assertEquals("room-token", api.lastRoomToken)
+}
+```
+
+This is characterization of current authority; it should pass without
+production changes.
+
+- [ ] **Step 2: Add an explicit same-profile/session lifecycle assertion**
+
+Add to `RoomSessionTest`:
+
+```kotlin
+@Test
+fun `room remains adopted until explicit leave or identity transition`() = runTest {
+    val repository = FakeRoomSessionRepository()
+    val barrier = DefaultIdentityTransitionBarrier()
+    val session = RoomSession(repository, backgroundScope, barrier)
+
+    session.adopt("room-a").join()
+    runCurrent()
+    assertTrue(session.isActive())
+    assertEquals(0, repository.resetCount)
+
+    barrier.changing(IdentityTransitionKind.PROFILE_SWITCH) {
+        assertTrue(!session.isActive())
+        assertEquals(1, repository.resetCount)
+    }
+}
+```
+
+Add a dedicated logout assertion so the profile-switch example is not treated
+as sufficient coverage for sign-out:
+
+```kotlin
+@Test
+fun `sign out clears the adopted room before identity mutation`() = runTest {
+    val repository = FakeRoomSessionRepository()
+    val barrier = DefaultIdentityTransitionBarrier()
+    val session = RoomSession(repository, backgroundScope, barrier)
+    session.adopt("room-a").join()
+    runCurrent()
+
+    barrier.changing(IdentityTransitionKind.SIGN_OUT) {
+        assertTrue(!session.isActive())
+        assertEquals(1, repository.resetCount)
+    }
+}
+```
+
+Retain the existing all-transition-kinds regression so `SERVER_SWITCH`,
+`PROFILE_SWITCH`, and future identity transition kinds remain covered as well.
+
+- [ ] **Step 3: Strengthen source boundary assertions**
+
+In both menu source tests, assert that the new UI files do not contain:
+
+```kotlin
+assertFalse(source.contains("room_token"))
+assertFalse(source.contains("roomAccessToken"))
+assertFalse(source.contains("Authorization"))
+assertFalse(source.contains("CleartextOriginConsent"))
+```
+
+Also assert error presentation still comes from each existing ViewModel state:
+
+```kotlin
+assertTrue(source.contains("state.error"))
+```
+
+- [ ] **Step 4: Run authority, lifecycle, cleartext, and entry error suites**
+
+Run:
+
+```bash
+./gradlew :shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.repository.WatchTogetherRepositoryTest' \
+  --tests 'org.siloserver.silo.watchtogether.RoomSessionTest'
+./gradlew :androidApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.android.ui.screens.auth.ServerSetupCleartextWarningTest' \
+  --tests 'org.siloserver.silo.android.ui.screens.watchtogether.*'
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.tv.ui.screens.auth.TvServerSetupCleartextWarningTest' \
+  --tests 'org.siloserver.silo.tv.ui.screens.watchtogether.*' \
+  --max-workers=2
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify no protocol, cleartext-policy, or server files changed**
+
+Run:
+
+```bash
+test -z "$(git diff --name-only origin/main...HEAD -- \
+  shared/src/commonMain/kotlin/org/siloserver/silo/network/api/WatchTogetherApi.kt \
+  shared/src/commonMain/kotlin/org/siloserver/silo/model/watchtogether/WatchTogetherModels.kt \
+  shared/src/commonMain/kotlin/org/siloserver/silo/network/WatchTogetherRealtimeClient.kt \
+  shared/src/commonMain/kotlin/org/siloserver/silo/network/CleartextOriginConsent.kt)"
+```
+
+Expected: exit 0 and no output.
+
+- [ ] **Step 6: Commit the preservation tests**
+
+```bash
+git add \
+  shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt \
+  shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomSessionTest.kt \
+  androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherMenuEntrySourceTest.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/watchtogether/TvWatchTogetherMenuEntrySourceTest.kt
+git commit -m "test: lock Watch Together menu boundaries"
+```
+
+## Task 9: Full verification, two-client device smoke, and review gate
+
+**Files:**
+- Verify only; do not create a tracked evidence file containing device IDs,
+  invite codes, tokens, URLs, or logs.
+
+**Interfaces:**
+- Consumes the complete feature from Tasks 1-8.
+- Produces fresh build/test/device evidence for review.
+
+- [ ] **Step 1: Run formatting/diff and supply-chain policy checks**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+./scripts/test-check-build-supply-chain.sh
+./scripts/check-build-supply-chain.sh
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Run focused tests once more**
+
+Run:
+
+```bash
+./gradlew :shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.watchtogether.WatchTogetherEntryPolicyTest' \
+  --tests 'org.siloserver.silo.repository.WatchTogetherRepositoryTest' \
+  --tests 'org.siloserver.silo.watchtogether.RoomSessionTest'
+./gradlew :androidApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.android.ui.screens.watchtogether.*' \
+  --max-workers=2
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.tv.ui.screens.watchtogether.*' \
+  --tests 'org.siloserver.silo.tv.ui.shell.TvShellFocusStateTest' \
+  --max-workers=2
+```
+
+Expected: PASS with zero failed tests.
+
+- [ ] **Step 3: Run the full unit and debug build gate**
+
+Run:
+
+```bash
+./gradlew \
+  test \
+  :androidApp:assembleDebug \
+  :androidTvApp:assembleDebug \
+  --max-workers=2
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Run minified release assembly for both clients**
+
+Use the repository-supported local signing path only:
+
+```bash
+./gradlew \
+  :androidApp:assembleRelease \
+  :androidTvApp:assembleRelease \
+  -PallowDebugReleaseSigning=true \
+  --max-workers=2
+```
+
+Expected: `BUILD SUCCESSFUL`. Do not expose keystore paths, passwords, or
+certificate material.
+
+- [ ] **Step 5: Start or select only dedicated test emulators**
+
+Prefer the existing `Silo_Phone` and `Silo_TV` AVDs and fixed serials:
+
+```bash
+"${ANDROID_HOME}/emulator/emulator" -avd Silo_TV -port 5554 -no-snapshot-save &
+"${ANDROID_HOME}/emulator/emulator" -avd Silo_Phone -port 5556 -no-snapshot-save &
+adb -s emulator-5554 wait-for-device
+adb -s emulator-5556 wait-for-device
+adb -s emulator-5554 shell getprop ro.build.characteristics
+adb -s emulator-5556 shell getprop ro.build.characteristics
+```
+
+Expected: `emulator-5554` reports TV characteristics and `emulator-5556`
+reports a phone profile. If either serial belongs to another running device,
+stop and choose unused even-numbered emulator ports; never issue an unscoped
+`adb install`, `adb shell`, clear-data, or uninstall command.
+
+- [ ] **Step 6: Install debug APKs only on the matching dedicated emulators**
+
+Run:
+
+```bash
+adb -s emulator-5556 install -r \
+  androidApp/build/outputs/apk/debug/androidApp-arm64-v8a-debug.apk
+adb -s emulator-5554 install -r \
+  androidTvApp/build/outputs/apk/debug/androidTvApp-arm64-v8a-debug.apk
+adb -s emulator-5556 shell am start \
+  -n org.siloserver.silo/.android.MainActivity
+adb -s emulator-5554 shell am start \
+  -n org.siloserver.silo/.tv.MainTvActivity
+```
+
+If the output APK names differ, resolve only within each module's
+`build/outputs/apk/debug/` directory with `find`, verify ABI using `apkanalyzer`,
+then repeat the serial-scoped install.
+
+- [ ] **Step 7: Execute the phone touch smoke matrix**
+
+On the authenticated phone test profile:
+
+1. Open profile menus from Home, Libraries, and For You; verify Watch Together
+   appears before Requests and before Settings on each.
+2. Open the sheet; with no room verify Host receives the primary position,
+   Join opens code input, Back returns to entry, and dismissal returns to the
+   same tab.
+3. Host a room; verify the lobby shows vote mode and no selected title.
+4. Use Back to browse without leaving, open a movie/episode detail, and verify
+   **Suggest to Watch Together** is present and can submit a suggestion.
+5. Reopen the profile menu; verify **Resume current room** appears and returns
+   to the same room.
+6. Verify the owner can vote, use the existing host override, and close the
+   room for everyone.
+7. Verify explicit **Leave room** removes Resume.
+8. Recreate a room, background/foreground the app, and verify Resume remains.
+9. Switch profile or log out on the dedicated test account and verify Resume is
+   absent after returning to an authenticated shell.
+10. Recreate a room, run
+    `adb -s emulator-5556 shell am force-stop org.siloserver.silo`, relaunch the
+    phone activity, and verify Resume is absent while persisted login/profile
+    data remains intact.
+11. Enter an invalid join code and verify the existing inline error appears
+    without navigation or crash.
+
+- [ ] **Step 8: Execute the TV D-pad and cross-client smoke matrix**
+
+On the authenticated TV test profile:
+
+1. Open the profile dropdown; verify Watch Together follows History and
+   precedes Requests/Settings.
+2. With no room, select the row and verify Host receives initial focus. Press
+   Back and verify focus returns to the profile avatar without entering content
+   behind the popup.
+3. Host an empty room and join it from the phone by code.
+4. Use TV Back or **Browse titles**; verify the room remains active. Open a
+   title detail and submit the existing **Suggest to Watch Together** action.
+5. Reopen the TV profile popup; verify Resume is first and initially focused.
+6. Resume the lobby; vote from both participants, verify the TV owner can
+   override any room-owned suggestion, then close the room and verify both
+   clients receive closure.
+7. Recreate a room, background and foreground TV with Home/Recent, and verify
+   Resume persists.
+8. Use explicit Leave and verify Resume disappears.
+9. Verify Join by code handles D-pad entry, Back-to-entry focus, invalid-code
+   errors, and selected-room routing to the synchronized player.
+10. Confirm the title-detail Watch Together action still hosts with that title
+    preselected rather than creating an empty room.
+11. Recreate a room, run
+    `adb -s emulator-5554 shell am force-stop org.siloserver.silo`, relaunch the
+    TV activity, and verify the process-scoped Resume action is absent.
+
+Do not alter production proxy settings or server host-timeout configuration.
+
+- [ ] **Step 9: Capture non-secret crash/ANR evidence**
+
+Run immediately after the smoke matrix:
+
+```bash
+adb -s emulator-5556 shell pidof org.siloserver.silo
+adb -s emulator-5554 shell pidof org.siloserver.silo
+adb -s emulator-5556 logcat -d -t 1500 |
+  rg -i 'FATAL EXCEPTION|ANR in org\.siloserver\.silo|am_crash.*org\.siloserver\.silo' || true
+adb -s emulator-5554 logcat -d -t 1500 |
+  rg -i 'FATAL EXCEPTION|ANR in org\.siloserver\.silo|am_crash.*org\.siloserver\.silo' || true
+```
+
+Expected: both PIDs exist and neither filtered log contains an app crash or
+ANR. Do not save raw logcat if it includes URLs, invite codes, or tokens.
+
+- [ ] **Step 10: Request independent code and security review**
+
+Ask the reviewer to inspect:
+
+- shared gateway/policy as a view over the existing singleton, not a second
+  owner;
+- empty vote-room creation for exactly one create and zero `setSelection`;
+- identity and explicit-leave teardown;
+- phone/TV route parity;
+- TV initial focus and Back restoration;
+- title-detail preselection regression;
+- absence of credentials, direct API calls, server/protocol changes, and
+  cleartext bypasses.
+
+Address findings test-first, rerun the smallest affected focused test, then
+rerun Steps 1-4.
+
+- [ ] **Step 11: Verify final branch state**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --decorate origin/main..HEAD
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+```
+
+Expected: clean worktree, the spec/plan plus small feature commits, and no
+uncommitted or generated files.

--- a/docs/superpowers/specs/2026-07-27-watch-together-user-menu-entry-design.md
+++ b/docs/superpowers/specs/2026-07-27-watch-together-user-menu-entry-design.md
@@ -20,9 +20,11 @@ other menu policy.
 
 ## User experience
 
-Both profile menus add a **Watch Together** row in their content/action group,
-before **Requests** when Requests is present and before the divider that
-precedes settings and account actions.
+Both profile menus add a **Watch Together** row in their content/action group.
+When **Requests** is present, Requests remains first and Watch Together appears
+immediately after it. When Requests is absent, Watch Together remains in the
+same content/action group immediately before the divider that precedes settings
+and account actions.
 
 Selecting the row closes the profile menu and opens a transient, dedicated
 Watch Together entry surface:
@@ -155,12 +157,14 @@ added.
 Focused automated coverage must establish:
 
 - **Phone menu visibility:** Watch Together is present in the authenticated
-  profile menu, invokes the entry surface, and does not disturb Requests or
-  account actions.
+  profile menu, invokes the entry surface, appears immediately after Requests
+  when Requests is present (or immediately before the settings/account divider
+  otherwise), and does not disturb account actions.
 - **TV menu visibility and focus:** the row is present in the profile dropdown;
-  opening it closes the dropdown; Resume is initially focused when present,
-  otherwise Host is; Back restores focus without leaking focus behind the
-  popup.
+  it follows Requests when Requests is present and otherwise ends the same
+  content/action group; opening it closes the dropdown; Resume is initially
+  focused when present, otherwise Host is; Back restores focus without leaking
+  focus behind the popup.
 - **Empty host flow:** both clients issue one vote-mode create request, never
   call `setSelection`, and navigate to the existing lobby with the returned
   room ID.

--- a/docs/superpowers/specs/2026-07-27-watch-together-user-menu-entry-design.md
+++ b/docs/superpowers/specs/2026-07-27-watch-together-user-menu-entry-design.md
@@ -1,0 +1,172 @@
+# Watch Together User-Menu Entry — Design
+
+**Date:** 2026-07-27
+
+**Status:** Approved design, awaiting written-spec review
+
+**Clients:** Android phone and Android TV
+
+## Goal
+
+Expose Watch Together from each client's user/profile menu without requiring a
+title first. The new entry is a lightweight launch surface for hosting an empty
+vote room, joining by code, or resuming the room already owned by the current
+app session. The existing title-detail entry remains available and continues to
+host with that title preselected.
+
+This product decision supersedes the older “hidden from user menus” direction
+for Watch Together only. It does not expose rich administration or change any
+other menu policy.
+
+## User experience
+
+Both profile menus add a **Watch Together** row in their content/action group,
+before **Requests** when Requests is present and before the divider that
+precedes settings and account actions.
+
+Selecting the row closes the profile menu and opens a transient, dedicated
+Watch Together entry surface:
+
+1. **Resume current room** appears first only when the current authenticated
+   app session owns a non-terminal room snapshot.
+2. **Host a room** creates a room in vote mode with no selected content, then
+   opens the existing lobby.
+3. **Join by code** opens the existing code-entry flow. A successful join uses
+   the existing room destination decision: a room with playable selected
+   content goes to the synchronized player; an unselected room goes to the
+   lobby. The existing host-alone rule may keep a host in the lobby to share
+   the invite.
+
+On phone, the dedicated surface follows the existing modal-sheet idiom. On TV,
+it follows the existing focused popup/dialog idiom. It is not a new persistent
+Watch Together home or a replacement for the lobby. When Resume is available,
+it receives initial TV focus; otherwise Host receives initial focus. Back,
+dismissal, and busy-state input blocking match the existing entry surfaces.
+
+Resuming uses the same destination decision as joining. It does not create,
+join, or reconnect through a second path; the selected destination adopts the
+existing room through `RoomSession`.
+
+## Existing title-detail behavior
+
+Movie, episode, and existing playable-series detail affordances remain intact.
+Their **Watch Together** action continues to open the title-bound entry surface:
+
+- **Host a room** creates the room and sets the current title/file selection.
+- **Host a vote room** and **Join by code** retain their current behavior.
+- Existing feature-policy and media-type gates remain unchanged.
+
+The new menu entry never invents a content ID, opens a title picker, or changes
+the meaning of the detail action.
+
+## Architecture and state ownership
+
+This is an additional presentation entry point over the existing Watch
+Together system:
+
+- `WatchTogetherRepository` remains the only owner of REST room operations,
+  room credentials, auth-scope validation, room snapshots, websocket state,
+  voting, suggestions, and server errors.
+- `RoomSession` remains the process-scoped connection owner and the only path
+  for adopting, replacing, leaving, or closing a room connection.
+- The existing phone and TV lobby, player, websocket, voting, and routing
+  surfaces remain authoritative.
+- The entry controllers reuse the existing create/join state machines. The
+  title-free host action is explicitly
+  `CreateRoomRequest(selectionMode = RoomSelectionMode.Vote.wire)` and must not
+  call `setSelection`.
+- Phone and TV may keep platform-specific composables and navigation types, but
+  they must derive equivalent entry actions and destination decisions from the
+  same room snapshot semantics. No second repository, room cache, websocket
+  client, or parallel “menu room” state is introduced.
+
+“Current room” means the valid, non-terminal room represented by the existing
+process-scoped repository/session state for the current server and profile.
+Identity transitions and room termination already clear that state. This
+feature does not persist room credentials, discover rooms after process death,
+or add a server-side “my active room” lookup. A successful create or join may
+replace the current room through the existing generation/lease and
+`RoomSession` replacement rules.
+
+## Routing and lifecycle
+
+- Empty vote-room creation always routes to the existing lobby with its
+  `roomId`; the lobby establishes the existing session adoption and websocket
+  flow.
+- Join and Resume route to the existing player only when the shared destination
+  rules say the snapshot is ready for playback; otherwise they route to the
+  existing lobby.
+- Repeated taps while an operation is busy are ignored. The entry surface
+  cannot be dismissed while its create/join operation is in flight, matching
+  current behavior.
+- Opening or dismissing the entry surface does not reset a current room.
+- TV closes the profile dropdown before showing the popup so the dropdown and
+  popup never compete for D-pad focus. Dismissing the popup returns through the
+  shell's established focus-restoration path.
+- Phone and TV consume one-shot navigation results before navigating, preventing
+  recomposition from launching the lobby or player twice.
+
+## Authentication, transport, and errors
+
+The menu action is available only in the authenticated profile shell and uses
+the current server/profile scope. All calls continue through the repository and
+existing network clients, preserving auth-scope transition barriers, cleartext
+consent, room-token handling, reconnect behavior, and credential redaction.
+Room credentials must not be copied into UI state, logs, or new route
+parameters.
+
+Create and join failures remain on the entry surface using the existing
+user-facing error mapping. A failed operation does not navigate or discard a
+previously active room. Lobby/player websocket and terminal-room errors remain
+owned by those existing surfaces. No new fallback transport or retry policy is
+added.
+
+## Test strategy
+
+Focused automated coverage must establish:
+
+- **Phone menu visibility:** Watch Together is present in the authenticated
+  profile menu, invokes the entry surface, and does not disturb Requests or
+  account actions.
+- **TV menu visibility and focus:** the row is present in the profile dropdown;
+  opening it closes the dropdown; Resume is initially focused when present,
+  otherwise Host is; Back restores focus without leaking focus behind the
+  popup.
+- **Empty host flow:** both clients issue one vote-mode create request, never
+  call `setSelection`, and navigate to the existing lobby with the returned
+  room ID.
+- **Join routing:** code normalization/validation and errors remain intact;
+  selected rooms route to the synchronized player and unselected rooms route to
+  the lobby on both clients.
+- **Resume routing:** Resume appears only for valid current-session state,
+  routes through existing snapshot rules without a create/join call, and
+  disappears after room termination or an identity change.
+- **Parity:** the phone and TV entry surfaces expose the same action set and
+  state-dependent behavior, with platform-appropriate presentation.
+- **Regression:** title-detail Watch Together remains visible under its current
+  policy/media gates and still hosts with the selected content/file rather than
+  creating an empty room.
+
+Existing repository, `RoomSession`, lobby, websocket, voting, player, auth,
+cleartext-consent, and replacement-race tests remain part of the verification
+gate. Device checks should cover phone touch interaction and TV D-pad
+focus/back behavior; they do not replace the automated routing tests.
+
+## Out of scope
+
+- A title picker before room creation.
+- A new full Watch Together home, room browser, or room history.
+- Cross-process room restoration or a new server endpoint.
+- Changes to room protocol, websocket ownership, voting rules, player sync,
+  cleartext policy, or authentication.
+- Removal or redesign of the title-detail Watch Together action.
+- Changes to non-Android clients.
+
+## Acceptance criteria
+
+The feature is complete when an authenticated phone or TV user can open Watch
+Together from the profile menu, host an empty vote room into the existing
+lobby, join through the existing code flow, and resume current in-process room
+state when available; both clients behave equivalently, TV focus is
+deterministic, title-detail hosting still preselects its title, and no parallel
+room/session architecture or credential exposure is introduced.

--- a/docs/superpowers/specs/2026-07-27-watch-together-user-menu-entry-design.md
+++ b/docs/superpowers/specs/2026-07-27-watch-together-user-menu-entry-design.md
@@ -37,6 +37,13 @@ Watch Together entry surface:
    lobby. The existing host-alone rule may keep a host in the lobby to share
    the invite.
 
+The owner of a top-level empty vote room is a full room participant. The owner
+may suggest titles, vote, apply the existing host override to any suggestion in
+the room (that is, any room-owned suggestion), and close the room for everyone.
+These are the existing voting and host-authority capabilities exposed by the
+current lobby and repository; the menu entry adds no new role, permission,
+protocol message, or server behavior.
+
 On phone, the dedicated surface follows the existing modal-sheet idiom. On TV,
 it follows the existing focused popup/dialog idiom. It is not a new persistent
 Watch Together home or a replacement for the lobby. When Resume is available,
@@ -135,6 +142,10 @@ Focused automated coverage must establish:
 - **Empty host flow:** both clients issue one vote-mode create request, never
   call `setSelection`, and navigate to the existing lobby with the returned
   room ID.
+- **Owner authority regression:** in that lobby, the owner remains able to
+  suggest, vote, exercise the existing host override on any room-owned
+  suggestion, and close the room for everyone, without a new protocol or
+  permission path.
 - **Join routing:** code normalization/validation and errors remain intact;
   selected rooms route to the synchronized player and unselected rooms route to
   the lobby on both clients.

--- a/docs/superpowers/specs/2026-07-27-watch-together-user-menu-entry-design.md
+++ b/docs/superpowers/specs/2026-07-27-watch-together-user-menu-entry-design.md
@@ -95,6 +95,28 @@ or add a server-side “my active room” lookup. A successful create or join ma
 replace the current room through the existing generation/lease and
 `RoomSession` replacement rules.
 
+## Host ownership and continuity
+
+Current server host semantics remain authoritative. The room creator remains
+the host; the clients do not automatically transfer ownership or elect a new
+host.
+
+Normal navigation and backgrounding preserve the process-scoped room while the
+app process and authenticated profile remain alive. A temporary transport loss
+uses the existing server grace period and repository reconnect behavior; a
+successful reconnect within that behavior resumes the same room and host
+authority.
+
+Logout, profile or server switch, and process death clear the client's local,
+profile-scoped room state. After the host disconnects, the server may close the
+room when its existing host-disconnect timeout expires. The clients do not
+extend that timeout, transfer the host role, or reclaim a room after the server
+has closed it.
+
+Accordingly, **Resume current room** is intentionally limited to the same
+running app process, server, and authenticated profile. It is not account-level
+room recovery.
+
 ## Routing and lifecycle
 
 - Empty vote-room creation always routes to the existing lobby with its
@@ -152,6 +174,10 @@ Focused automated coverage must establish:
 - **Resume routing:** Resume appears only for valid current-session state,
   routes through existing snapshot rules without a create/join call, and
   disappears after room termination or an identity change.
+- **Host continuity:** navigation/backgrounding retains the same process-scoped
+  room; a temporary disconnect follows existing grace/reconnect behavior; and
+  logout, profile/server switch, or process death removes Resume and
+  local room state without transferring host ownership.
 - **Parity:** the phone and TV entry surfaces expose the same action set and
   state-dependent behavior, with platform-appropriate presentation.
 - **Regression:** title-detail Watch Together remains visible under its current
@@ -167,6 +193,7 @@ focus/back behavior; they do not replace the automated routing tests.
 
 - A title picker before room creation.
 - A new full Watch Together home, room browser, or room history.
+- Automatic host transfer, ownership election, or original-host reclaim.
 - Cross-process room restoration or a new server endpoint.
 - Changes to room protocol, websocket ownership, voting rules, player sync,
   cleartext policy, or authentication.

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
@@ -26,6 +26,7 @@ import org.siloserver.silo.repository.SettingsRepository
 import org.siloserver.silo.repository.WatchTogetherRepository
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.watchtogether.RoomSession
+import org.siloserver.silo.watchtogether.WatchTogetherEntryGateway
 import org.koin.dsl.module
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -111,6 +112,7 @@ val repositoryModule = module {
             },
         )
     }
+    single<WatchTogetherEntryGateway> { get<WatchTogetherRepository>() }
     // Eager so the identity-transition privacy gate is installed before any
     // profile/server/token mutation can occur. This process-lifetime scope,
     // rather than a screen scope, owns connection replacement and teardown.

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/WatchTogetherRepository.kt
@@ -19,6 +19,7 @@ import org.siloserver.silo.network.WatchTogetherRealtimeClient
 import org.siloserver.silo.network.api.WatchTogetherApi
 import org.siloserver.silo.util.parseRfc3339ToEpochMillis
 import org.siloserver.silo.watchtogether.RoomDeliveryLatch
+import org.siloserver.silo.watchtogether.WatchTogetherEntryGateway
 import org.siloserver.silo.watchtogether.RoomSessionRepository
 import org.siloserver.silo.watchtogether.RoomTransportIntent
 import org.siloserver.silo.watchtogether.roomTransportAuthorized
@@ -97,7 +98,7 @@ class WatchTogetherRepository(
     private val realtimeFactory: () -> WatchTogetherRealtimeClient? = { null },
     private val monotonicNowMs: () -> Long = { MONOTONIC_ORIGIN.elapsedNow().inWholeMilliseconds },
     private val authScopeProvider: suspend () -> AuthScopeSnapshot? = { null },
-) : RoomSessionRepository {
+) : RoomSessionRepository, WatchTogetherEntryGateway {
     /** Successful delivery state follows the process connection, not a UI controller. */
     val roomDeliveryLatch = RoomDeliveryLatch()
 
@@ -192,7 +193,7 @@ class WatchTogetherRepository(
 
     // ---- REST: create / join (store the room token) ---------------------------
 
-    suspend fun createRoom(request: CreateRoomRequest): ApiResult<RoomResponse> {
+    override suspend fun createRoom(request: CreateRoomRequest): ApiResult<RoomResponse> {
         val scope = authScopeProvider() ?: return missingAuthScope()
         val requestGeneration = beginRoomRequest()
         val r = api.createRoom(request, scope)
@@ -200,7 +201,7 @@ class WatchTogetherRepository(
         return if (r is ApiResult.Success) installRoomResponse(r.data, scope, requestGeneration) else r
     }
 
-    suspend fun joinRoom(request: JoinRoomRequest): ApiResult<RoomResponse> {
+    override suspend fun joinRoom(request: JoinRoomRequest): ApiResult<RoomResponse> {
         val scope = authScopeProvider() ?: return missingAuthScope()
         val requestGeneration = beginRoomRequest()
         val r = api.joinRoom(request, scope)
@@ -265,7 +266,7 @@ class WatchTogetherRepository(
 
     // ---- REST: host management ------------------------------------------------
 
-    suspend fun setSelection(request: SetSelectionRequest): ApiResult<RoomResponse> {
+    override suspend fun setSelection(request: SetSelectionRequest): ApiResult<RoomResponse> {
         val lease = activeBinding() ?: return missingRoom()
         val r = api.setSelection(lease.roomId, lease.roomToken, request, lease.authScope)
         return publishRoomResponse(lease, r)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryGateway.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryGateway.kt
@@ -1,0 +1,16 @@
+package org.siloserver.silo.watchtogether
+
+import org.siloserver.silo.model.watchtogether.CreateRoomRequest
+import org.siloserver.silo.model.watchtogether.JoinRoomRequest
+import org.siloserver.silo.model.watchtogether.RoomResponse
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import org.siloserver.silo.model.watchtogether.SetSelectionRequest
+import org.siloserver.silo.network.ApiResult
+import kotlinx.coroutines.flow.StateFlow
+
+interface WatchTogetherEntryGateway {
+    val roomSnapshot: StateFlow<RoomSnapshot?>
+    suspend fun createRoom(request: CreateRoomRequest): ApiResult<RoomResponse>
+    suspend fun joinRoom(request: JoinRoomRequest): ApiResult<RoomResponse>
+    suspend fun setSelection(request: SetSelectionRequest): ApiResult<RoomResponse>
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryPolicy.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryPolicy.kt
@@ -1,0 +1,23 @@
+package org.siloserver.silo.watchtogether
+
+import org.siloserver.silo.model.watchtogether.MemberRole
+import org.siloserver.silo.model.watchtogether.RoomPhase
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+
+enum class WatchTogetherEntryTarget {
+    Lobby,
+    Player,
+}
+
+fun watchTogetherEntryTarget(room: RoomSnapshot): WatchTogetherEntryTarget =
+    if (
+        !room.selectedContentId.isNullOrBlank() &&
+        !(room.selfRole == MemberRole.Host && room.memberCount <= 1)
+    ) {
+        WatchTogetherEntryTarget.Player
+    } else {
+        WatchTogetherEntryTarget.Lobby
+    }
+
+fun resumableWatchTogetherRoom(room: RoomSnapshot?): RoomSnapshot? =
+    room?.takeIf { it.roomId.isNotBlank() && it.phase != RoomPhase.Ended }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/WatchTogetherRepositoryTest.kt
@@ -3,8 +3,10 @@ package org.siloserver.silo.repository
 import org.siloserver.silo.model.watchtogether.AddSuggestionRequest
 import org.siloserver.silo.model.watchtogether.CreateRoomRequest
 import org.siloserver.silo.model.watchtogether.JoinRoomRequest
+import org.siloserver.silo.model.watchtogether.MemberRole
 import org.siloserver.silo.model.watchtogether.PromoteSuggestionRequest
 import org.siloserver.silo.model.watchtogether.RoomResponse
+import org.siloserver.silo.model.watchtogether.RoomSelectionMode
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.model.watchtogether.SetSelectionRequest
 import org.siloserver.silo.model.watchtogether.Suggestion
@@ -58,6 +60,11 @@ class WatchTogetherRepositoryTest {
             RoomResponse(RoomSnapshot(roomId = "room-1", code = "ABCD1234"), "jwt-room"),
         ),
     ) : WatchTogetherApi {
+        var createCalls = 0
+        var addSuggestionCalls = 0
+        var voteCalls = 0
+        var promoteCalls = 0
+        var closeCalls = 0
         var lastRoomToken: String? = null
         var lastRoomId: String? = null
         var lastSelection: SetSelectionRequest? = null
@@ -69,6 +76,7 @@ class WatchTogetherRepositoryTest {
         var listSuggestionsResult: CompletableDeferred<ApiResult<SuggestionsResponse>>? = null
         var listSuggestionsCalls = 0
         override suspend fun createRoom(request: CreateRoomRequest, scope: AuthScopeSnapshot): ApiResult<RoomResponse> {
+            createCalls++
             lastAuthScope = scope
             return createResult?.await() ?: createResponse
         }
@@ -99,6 +107,7 @@ class WatchTogetherRepositoryTest {
             roomToken: String,
             scope: AuthScopeSnapshot,
         ): ApiResult<Unit> {
+            closeCalls++
             lastRoomToken = roomToken
             lastAuthScope = scope
             return ApiResult.Success(Unit)
@@ -114,7 +123,12 @@ class WatchTogetherRepositoryTest {
             roomToken: String,
             request: AddSuggestionRequest,
             scope: AuthScopeSnapshot,
-        ) = ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
+        ): ApiResult<SuggestionsResponse> {
+            addSuggestionCalls++
+            lastRoomToken = roomToken
+            lastAuthScope = scope
+            return ApiResult.Success(SuggestionsResponse())
+        }
         override suspend fun deleteSuggestion(
             roomId: String,
             roomToken: String,
@@ -126,7 +140,12 @@ class WatchTogetherRepositoryTest {
             roomToken: String,
             suggestionId: String,
             scope: AuthScopeSnapshot,
-        ) = ApiResult.Success(SuggestionsResponse()).also { lastRoomToken = roomToken; lastAuthScope = scope }
+        ): ApiResult<SuggestionsResponse> {
+            voteCalls++
+            lastRoomToken = roomToken
+            lastAuthScope = scope
+            return ApiResult.Success(SuggestionsResponse())
+        }
         override suspend fun unvote(
             roomId: String,
             roomToken: String,
@@ -138,7 +157,12 @@ class WatchTogetherRepositoryTest {
             roomToken: String,
             request: PromoteSuggestionRequest,
             scope: AuthScopeSnapshot,
-        ) = createResponse.also { lastRoomToken = roomToken; lastAuthScope = scope }
+        ): ApiResult<RoomResponse> {
+            promoteCalls++
+            lastRoomToken = roomToken
+            lastAuthScope = scope
+            return createResponse
+        }
     }
 
     private class FakeRealtime(
@@ -245,6 +269,46 @@ class WatchTogetherRepositoryTest {
         r.setSelection(SetSelectionRequest(contentId = "tt-9"))
         assertEquals("jwt-room", api.lastRoomToken)
         assertEquals("tt-9", api.lastSelection?.contentId)
+    }
+
+    @Test
+    fun `empty vote room owner keeps existing suggestion vote override and close authority`() = runTest {
+        val api = FakeApi(
+            createResponse = ApiResult.Success(
+                RoomResponse(
+                    room = RoomSnapshot(
+                        roomId = "room-1",
+                        selectionMode = RoomSelectionMode.Vote,
+                        selfRole = MemberRole.Host,
+                        selfCanManageRoom = true,
+                    ),
+                    roomAccessToken = "room-token",
+                ),
+            ),
+        )
+        val repository = WatchTogetherRepository(
+            api = api,
+            authScopeProvider = { scopeA },
+        )
+
+        repository.createRoom(CreateRoomRequest(selectionMode = RoomSelectionMode.Vote.wire))
+        repository.addSuggestion(
+            AddSuggestionRequest(
+                contentId = "movie-1",
+                contentType = "movie",
+                title = "Movie One",
+            ),
+        )
+        repository.vote("suggestion-1")
+        repository.promoteSuggestion(PromoteSuggestionRequest("suggestion-1"))
+        repository.closeRoom()
+
+        assertEquals(1, api.createCalls)
+        assertEquals(1, api.addSuggestionCalls)
+        assertEquals(1, api.voteCalls)
+        assertEquals(1, api.promoteCalls)
+        assertEquals(1, api.closeCalls)
+        assertEquals("room-token", api.lastRoomToken)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomSessionTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/RoomSessionTest.kt
@@ -163,6 +163,37 @@ class RoomSessionTest {
     }
 
     @Test
+    fun `room remains adopted until explicit leave or identity transition`() = runTest {
+        val repository = FakeRoomSessionRepository()
+        val barrier = DefaultIdentityTransitionBarrier()
+        val session = RoomSession(repository, backgroundScope, barrier)
+
+        session.adopt("room-a").join()
+        runCurrent()
+        assertTrue(session.isActive())
+        assertEquals(0, repository.resetCount)
+
+        barrier.changing(IdentityTransitionKind.PROFILE_SWITCH) {
+            assertTrue(!session.isActive())
+            assertEquals(1, repository.resetCount)
+        }
+    }
+
+    @Test
+    fun `sign out clears the adopted room before identity mutation`() = runTest {
+        val repository = FakeRoomSessionRepository()
+        val barrier = DefaultIdentityTransitionBarrier()
+        val session = RoomSession(repository, backgroundScope, barrier)
+        session.adopt("room-a").join()
+        runCurrent()
+
+        barrier.changing(IdentityTransitionKind.SIGN_OUT) {
+            assertTrue(!session.isActive())
+            assertEquals(1, repository.resetCount)
+        }
+    }
+
+    @Test
     fun `every identity transition kind resets the room before mutation`() = runTest {
         IdentityTransitionKind.entries.forEach { kind ->
             val repository = FakeRoomSessionRepository()

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/watchtogether/WatchTogetherEntryPolicyTest.kt
@@ -1,0 +1,57 @@
+package org.siloserver.silo.watchtogether
+
+import org.siloserver.silo.model.watchtogether.MemberRole
+import org.siloserver.silo.model.watchtogether.RoomPhase
+import org.siloserver.silo.model.watchtogether.RoomSnapshot
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class WatchTogetherEntryPolicyTest {
+    @Test
+    fun selectedGuestRoutesToPlayer() {
+        val room = RoomSnapshot(
+            roomId = "room-1",
+            selectedContentId = "movie-1",
+            selfRole = MemberRole.Guest,
+            memberCount = 2,
+        )
+        assertEquals(WatchTogetherEntryTarget.Player, watchTogetherEntryTarget(room))
+    }
+
+    @Test
+    fun emptyRoomAndSoloHostRouteToLobby() {
+        assertEquals(
+            WatchTogetherEntryTarget.Lobby,
+            watchTogetherEntryTarget(RoomSnapshot(roomId = "room-1")),
+        )
+        assertEquals(
+            WatchTogetherEntryTarget.Lobby,
+            watchTogetherEntryTarget(
+                RoomSnapshot(
+                    roomId = "room-1",
+                    selectedContentId = "movie-1",
+                    selfRole = MemberRole.Host,
+                    memberCount = 1,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun onlyNonTerminalNonBlankRoomIsResumable() {
+        assertNull(resumableWatchTogetherRoom(null))
+        assertNull(resumableWatchTogetherRoom(RoomSnapshot(roomId = "")))
+        assertNull(
+            resumableWatchTogetherRoom(
+                RoomSnapshot(roomId = "room-1", phase = RoomPhase.Ended),
+            ),
+        )
+        assertEquals(
+            "room-1",
+            resumableWatchTogetherRoom(
+                RoomSnapshot(roomId = "room-1", phase = RoomPhase.Lobby),
+            )?.roomId,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a top-level Watch Together entry to authenticated phone and TV profile menus, immediately after Requests when enabled
- reuse the existing repository, RoomSession, lobby/player routing, voting, authentication, cleartext, and error boundaries
- support empty Vote-room hosting, join by code, and same-process/same-profile Resume without new protocol or server behavior
- preserve title-detail hosting and separate ordinary Browse/Back from explicit Leave

## Verification completed

- Tasks 1–8 implemented test-first and independently approved for spec compliance and code quality
- focused shared, phone, and TV Watch Together suites pass
- phone and TV debug assemblies pass
- phone and TV minified release assemblies pass
- dedicated phone/TV emulator install, launch, online menu ordering, entry focus/Back, empty-room hosting, phone Browse/Back continuity, and Resume surface verified
- no server, protocol, websocket-frame, proxy, or production configuration changes

## Pending before ready for merge

- finish the remaining Task 9 live two-client checks: TV join/participant propagation, owner suggest/vote/override/close, explicit Leave, and safe teardown
- complete scoped Task 9 follow-up review and most-capable whole-branch review
- update this draft with final evidence and any verified blockers

## Known baseline limitation

The repository-wide Gradle `test` gate reaches 968 release tests and fails only the existing Room migration test because release-unit-test assets do not include the committed schema fixture. Focused debug migration coverage passes; direct isolated `origin/main` evidence and source-set parity classify this separately from the feature. No baseline asset workaround is included here.

## Scope

Android phone and Android TV only. No automatic host transfer, ownership election, cross-process room restoration, server endpoint, protocol, production proxy, or physical-device deployment changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Watch Together” option to Android phone and TV profile menus.
  * Added flows to resume a current room, host a room, or join using an invite code.
  * Added room-aware navigation to the lobby or synchronized player.
  * Improved lobby navigation with explicit “Browse titles” and “Leave room” actions.

* **Tests**
  * Added coverage for hosting, joining, resuming rooms, navigation, menu behavior, focus handling, and session continuity.

* **Documentation**
  * Added Watch Together design and implementation specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->