### PR TITLE
feat(onboarding): add invite claim and server-driven feature tour

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStore.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStore.kt
@@ -11,6 +11,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
 import org.siloserver.silo.model.settings.EffectiveSetting
 import org.siloserver.silo.model.download.DownloadQuality
+import org.siloserver.silo.model.settings.LanguageOptions
 import org.siloserver.silo.model.settings.PlaybackSettingsKeys
 import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.network.ApiResult
@@ -218,8 +219,16 @@ class AndroidPlayerSettingsStore(
     override val preferredQualityFlow: Flow<String> =
         profileScopedFlow("auto") { p, s -> p.stringFor(s, PlaybackSettingsKeys.PreferredQuality, "auto") }
 
+    // Older builds stored the display name ("English") here rather than a BCP 47
+    // tag. Those values are rejected by the server and never matched a track, so
+    // they are translated on read instead of being handed to ExoPlayer or
+    // re-sent. Anything already a tag passes through untouched.
     override val audioLanguageFlow: Flow<String> =
-        profileScopedFlow("") { p, s -> p.stringFor(s, PlaybackSettingsKeys.AudioLanguage, "") }
+        profileScopedFlow("") { p, s ->
+            LanguageOptions.migrateLegacyValue(
+                p.stringFor(s, PlaybackSettingsKeys.AudioLanguage, ""),
+            )
+        }
 
     override val videoGravityFlow: Flow<String> =
         profileScopedFlow("fit") { p, s -> p.stringFor(s, PlaybackSettingsKeys.VideoGravity, "fit") }

--- a/androidApp/src/androidMain/AndroidManifest.xml
+++ b/androidApp/src/androidMain/AndroidManifest.xml
@@ -54,6 +54,7 @@
 
                 <data android:scheme="silo" />
                 <data android:host="device" />
+                <data android:host="invite" />
                 <data android:host="item" />
                 <data android:host="play" />
                 <data android:host="downloads" />

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MainActivity.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MainActivity.kt
@@ -36,8 +36,10 @@ import org.siloserver.silo.android.ui.navigation.Route
 import org.siloserver.silo.android.ui.navigation.contentDeepLinkRouteOrNull
 import org.siloserver.silo.android.ui.navigation.deviceLoginPairRouteOrNull
 import org.siloserver.silo.android.ui.navigation.hasLocalDownloadsForScope
+import org.siloserver.silo.android.ui.navigation.inviteClaimRouteOrNull
 import org.siloserver.silo.android.ui.navigation.notificationNavigationRouteOrNull
 import org.siloserver.silo.android.ui.navigation.shouldStartOnDownloads
+import org.siloserver.silo.android.ui.screens.onboarding.OnboardingTourLocalCache
 import org.siloserver.silo.android.ui.theme.SiloTheme
 import org.siloserver.silo.common.network.ServerReachabilityMonitor
 import org.siloserver.silo.common.pip.SiloPictureInPictureCoordinator
@@ -164,6 +166,7 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         val route = deviceLoginPairRouteOrNull(intent.dataString)
+            ?: inviteClaimRouteOrNull(intent.dataString)
             ?: notificationRouteOrNull(intent)
             ?: contentDeepLinkRouteOrNull(intent.dataString)
         route?.let { incomingExternalRoutes.tryEmit(it) }
@@ -283,6 +286,16 @@ class MainActivity : ComponentActivity() {
             )
         ) {
             return Route.Downloads.route
+        }
+
+        // A warm start would otherwise bypass the tour gate entirely (e.g.
+        // process death mid-tour). Once completion is confirmed the local
+        // cache short-circuits inside the gate, so this costs nothing on
+        // launches after the first; the gate itself fails open to Home on
+        // any error, so it can't strand an offline start.
+        val tourCache = get<OnboardingTourLocalCache>(OnboardingTourLocalCache::class.java)
+        if (!tourCache.isDone(activeEntry.id, profileId)) {
+            return Route.OnboardingTour.route
         }
 
         return Route.Home.route

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -414,7 +414,7 @@ val androidModule = module {
     viewModel { LoginViewModel(get()) }
     viewModel { SetupViewModel(get()) }
     viewModel { SignupViewModel(get()) }
-    viewModel { InviteClaimViewModel(get()) }
+    viewModel { InviteClaimViewModel(get(), get()) }
     viewModel { OnboardingTourViewModel(get(), get(), get(), get(), get()) }
     viewModel { ProfileSelectionViewModel(get()) }
     viewModel { CreateProfileViewModel(get()) }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -121,6 +121,7 @@ val androidModule = module {
     // when the redefining module is loaded after the original — sharedModules()
     // is registered first in SiloApplication, so this wins.
     single<TokenManager> { EncryptedTokenManagerImpl(get(), get(), get()) }
+    single { org.siloserver.silo.android.ui.screens.onboarding.OnboardingTourLocalCache(androidContext()) }
 
     // Offline-first Room store (Track B). Bound after sharedModules() so the
     // commonMain PersonalDataRepository's `getOrNull<UserItemStatePort>()` picks
@@ -414,7 +415,7 @@ val androidModule = module {
     viewModel { SetupViewModel(get()) }
     viewModel { SignupViewModel(get()) }
     viewModel { InviteClaimViewModel(get()) }
-    viewModel { OnboardingTourViewModel(get(), get()) }
+    viewModel { OnboardingTourViewModel(get(), get(), get(), get(), get()) }
     viewModel { ProfileSelectionViewModel(get()) }
     viewModel { CreateProfileViewModel(get()) }
     viewModel { EditProfileViewModel(get()) }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -61,7 +61,9 @@ import org.siloserver.silo.android.ui.screens.people.PersonDetailViewModel
 import org.siloserver.silo.android.ui.screens.auth.LoginViewModel
 import org.siloserver.silo.android.ui.screens.auth.ServerSetupViewModel
 import org.siloserver.silo.android.ui.screens.auth.SetupViewModel
+import org.siloserver.silo.android.ui.screens.auth.InviteClaimViewModel
 import org.siloserver.silo.android.ui.screens.auth.SignupViewModel
+import org.siloserver.silo.android.ui.screens.onboarding.OnboardingTourViewModel
 import org.siloserver.silo.android.ui.screens.MainHeaderViewModel
 import org.siloserver.silo.viewmodel.DevicePairingViewModel
 import org.siloserver.silo.android.ui.screens.profiles.CreateProfileViewModel
@@ -411,6 +413,8 @@ val androidModule = module {
     viewModel { LoginViewModel(get()) }
     viewModel { SetupViewModel(get()) }
     viewModel { SignupViewModel(get()) }
+    viewModel { InviteClaimViewModel(get()) }
+    viewModel { OnboardingTourViewModel(get(), get()) }
     viewModel { ProfileSelectionViewModel(get()) }
     viewModel { CreateProfileViewModel(get()) }
     viewModel { EditProfileViewModel(get()) }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/aurora/AuroraChrome.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/aurora/AuroraChrome.kt
@@ -131,10 +131,20 @@ fun AuroraErrorLabel(text: String, modifier: Modifier = Modifier) {
  * sheen + soft drop shadow; optional gold halo). Compose has no backdrop blur,
  * so the tint is kept translucent enough for the aurora to glow through.
  */
-fun Modifier.auroraGlass(cornerRadius: Dp = 28.dp, emphasized: Boolean = false): Modifier {
+fun Modifier.auroraGlass(
+    cornerRadius: Dp = 28.dp,
+    emphasized: Boolean = false,
+    /**
+     * The drop shadow reads as depth under a small panel floating on a static
+     * screen. Pass 0.dp for a large or moving panel: the fill is translucent,
+     * so at full size the shadow's own outline shows *through* the glass as a
+     * faint hard-edged box rather than sitting behind it.
+     */
+    elevation: Dp = 60.dp,
+): Modifier {
     val shape = RoundedCornerShape(cornerRadius)
     return this
-        .shadow(elevation = 60.dp, shape = shape, clip = false)
+        .then(if (elevation > 0.dp) Modifier.shadow(elevation, shape, clip = false) else Modifier)
         .clip(shape)
         .background(AuroraGlassTint.copy(alpha = 0.62f))
         .background(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/aurora/AuroraScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/aurora/AuroraScreen.kt
@@ -1,31 +1,54 @@
 package org.siloserver.silo.android.ui.components.aurora
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /**
- * Aurora backdrop + a vertically scrollable, keyboard-friendly column capped to
- * a comfortable reading width and centered over the plum backdrop. Callers
- * supply the wordmark + content. Port of silo-apple's `AuroraScreen`.
+ * Aurora backdrop + a keyboard-friendly column capped to a comfortable reading
+ * width and centered over the plum backdrop. Callers supply the wordmark +
+ * content. Port of silo-apple's `AuroraScreen`.
  */
 @Composable
 fun AuroraScreen(
     variant: AuroraVariant,
     modifier: Modifier = Modifier,
     scrim: AuroraScrim = AuroraScrim.Soft,
-    maxContentWidth: androidx.compose.ui.unit.Dp = 480.dp,
+    maxContentWidth: Dp = 480.dp,
+    /**
+     * Scrolls the content as one block and sizes it to its children — right for
+     * the form screens, which are shorter than the display until the keyboard
+     * opens.
+     *
+     * Screens that lay themselves out against the full height (a `weight`ed
+     * body between fixed chrome) must pass `false`. A scrolling parent measures
+     * its children with unbounded height, which leaves nothing for `weight` to
+     * divide, so weighted children collapse to zero and vanish.
+     */
+    scrollable: Boolean = true,
+    /**
+     * Gutter between the content and the display edge. Screens that run a
+     * full-bleed element (a pager whose neighbouring pages should peek past the
+     * gutter rather than be clipped at it) set this to zero and pad their own
+     * rows instead.
+     */
+    horizontalPadding: Dp = 24.dp,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -33,16 +56,21 @@ fun AuroraScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .imePadding(),
+                .then(if (scrollable) Modifier.verticalScroll(rememberScrollState()) else Modifier)
+                // safeDrawing covers the status/navigation bars, the cutout and
+                // the IME — the activity draws edge to edge, so without this the
+                // first and last rows of a full-height screen sit under system
+                // chrome.
+                .windowInsetsPadding(WindowInsets.safeDrawing),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
+            verticalArrangement = Arrangement.Center,
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .widthIn(max = maxContentWidth)
-                    .padding(horizontal = 24.dp, vertical = 32.dp),
+                    .then(if (scrollable) Modifier else Modifier.fillMaxHeight())
+                    .padding(horizontal = horizontalPadding, vertical = 32.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 content = content,
             )

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
@@ -40,7 +40,9 @@ import org.siloserver.silo.android.ui.screens.auth.LoginScreen
 import org.siloserver.silo.android.ui.screens.auth.DevicePairingScreen
 import org.siloserver.silo.android.ui.screens.auth.ServerSetupScreen
 import org.siloserver.silo.android.ui.screens.auth.SetupScreen
+import org.siloserver.silo.android.ui.screens.auth.InviteClaimScreen
 import org.siloserver.silo.android.ui.screens.auth.SignupScreen
+import org.siloserver.silo.android.ui.screens.onboarding.OnboardingTourScreen
 import org.siloserver.silo.android.ui.screens.browse.BrowseScreen
 import org.siloserver.silo.android.ui.screens.browse.BrowseViewModel
 import org.siloserver.silo.android.ui.screens.calendar.CalendarScreen
@@ -252,6 +254,44 @@ fun AppNavigation(
             )
         }
         composable(
+            route = Route.InviteClaim.ROUTE,
+            arguments = listOf(
+                navArgument("server") { type = NavType.StringType },
+                navArgument("token") { type = NavType.StringType },
+            ),
+            deepLinks = listOf(
+                navDeepLink { uriPattern = "silo://invite?server={server}&token={token}" },
+            ),
+        ) { backStackEntry ->
+            val server = backStackEntry.arguments?.getString("server").orEmpty()
+            val claimToken = backStackEntry.arguments?.getString("token").orEmpty()
+            InviteClaimScreen(
+                serverUrl = server,
+                token = claimToken,
+                onNavigateToLogin = {
+                    navController.navigate(Route.Login.route) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                },
+                onClaimComplete = {
+                    navController.navigate(Route.ProfileSelection.route) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                },
+            )
+        }
+
+        composable(Route.OnboardingTour.route) {
+            OnboardingTourScreen(
+                onDone = {
+                    navController.navigate(Route.Home.route) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                },
+            )
+        }
+
+        composable(
             route = Route.PairDevice.ROUTE,
             arguments = listOf(
                 navArgument("token") {
@@ -317,7 +357,10 @@ fun AppNavigation(
         composable(Route.ProfileSelection.route) {
             ProfileSelectionScreen(
                 onNavigateToHome = {
-                    navController.navigate(Route.Home.route) {
+                    // Route through the tour gate: OnboardingTourScreen checks
+                    // server-side state and immediately hands off to Home when
+                    // the profile has already completed or skipped the tour.
+                    navController.navigate(Route.OnboardingTour.route) {
                         popUpTo(0) { inclusive = true }
                     }
                 },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
@@ -146,8 +146,14 @@ fun AppNavigation(
                 Route.CreateProfile.route,
                 Route.EditProfile.ROUTE,
                 Route.PairDevice.ROUTE,
+                Route.InviteClaim.ROUTE,
+                Route.OnboardingTour.route,
             )
-            if (entry.destination.route in authRoutes) return@collect
+            // An invite claim is itself the signed-out flow — holding it
+            // until the authenticated graph shows would queue it forever on
+            // Login, which is exactly where an invitee starts.
+            val isPreAuthTarget = route.startsWith("invite_claim")
+            if (!isPreAuthTarget && entry.destination.route in authRoutes) return@collect
             navController.navigate(route) {
                 launchSingleTop = true
             }
@@ -340,7 +346,10 @@ fun AppNavigation(
                     // already exist (so the user stays signed in), else
                     // ProfileSelection or Login as appropriate.
                     val target = when (destination) {
-                        ServerSwitchDestination.Home -> Route.Home.route
+                        // Through the tour gate, not straight to Home — the
+                        // switched-to server's profile may not have seen the
+                        // tour; the gate short-circuits when it has.
+                        ServerSwitchDestination.Home -> Route.OnboardingTour.route
                         ServerSwitchDestination.ProfileSelection -> Route.ProfileSelection.route
                         ServerSwitchDestination.Login -> Route.Login.route
                     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/DeviceLoginRouteParser.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/DeviceLoginRouteParser.kt
@@ -45,9 +45,11 @@ private fun URI.queryParameters(): Map<String, String> =
         .mapNotNull { pair ->
             val idx = pair.indexOf("=")
             if (idx < 0) return@mapNotNull null
-            val key = pair.substring(0, idx).urlDecode()
-            val value = pair.substring(idx + 1).urlDecode()
-            key to value
+            // Reachable from onNewIntent with URIs other apps craft; bad
+            // percent-encoding must parse to null, not throw.
+            runCatching {
+                pair.substring(0, idx).urlDecode() to pair.substring(idx + 1).urlDecode()
+            }.getOrNull()
         }
         .toMap()
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/InviteClaimRouteParser.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/InviteClaimRouteParser.kt
@@ -22,6 +22,8 @@ internal fun inviteClaimRouteOrNull(rawUri: String?): String? {
     if (!uri.scheme.equals("silo", ignoreCase = true)) return null
     if (!uri.host.equals("invite", ignoreCase = true)) return null
 
+    // Any other app can hand the exported activity a malformed URI via
+    // onNewIntent; bad percent-encoding must parse to null, not throw.
     val params = uri.rawQuery
         .orEmpty()
         .split("&")
@@ -29,9 +31,11 @@ internal fun inviteClaimRouteOrNull(rawUri: String?): String? {
         .mapNotNull { pair ->
             val idx = pair.indexOf("=")
             if (idx < 0) return@mapNotNull null
-            val key = URLDecoder.decode(pair.substring(0, idx), Charsets.UTF_8.name())
-            val value = URLDecoder.decode(pair.substring(idx + 1), Charsets.UTF_8.name())
-            key to value
+            runCatching {
+                val key = URLDecoder.decode(pair.substring(0, idx), Charsets.UTF_8.name())
+                val value = URLDecoder.decode(pair.substring(idx + 1), Charsets.UTF_8.name())
+                key to value
+            }.getOrNull()
         }
         .toMap()
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/InviteClaimRouteParser.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/InviteClaimRouteParser.kt
@@ -1,0 +1,45 @@
+package org.siloserver.silo.android.ui.navigation
+
+import java.net.URI
+import java.net.URLDecoder
+import java.net.URLEncoder
+
+/**
+ * Maps an emailed-invitation link (`silo://invite?server=...&token=...`)
+ * into the in-app claim route.
+ *
+ * Cold starts match through the composable's navDeepLink; this exists for
+ * the warm path — an intent delivered to a live activity via onNewIntent
+ * never reaches navDeepLink matching, and without this the tap would be
+ * silently dropped.
+ */
+internal fun inviteClaimRouteOrNull(rawUri: String?): String? {
+    val uri = rawUri
+        ?.takeIf { it.isNotBlank() }
+        ?.let { runCatching { URI(it) }.getOrNull() }
+        ?: return null
+
+    if (!uri.scheme.equals("silo", ignoreCase = true)) return null
+    if (!uri.host.equals("invite", ignoreCase = true)) return null
+
+    val params = uri.rawQuery
+        .orEmpty()
+        .split("&")
+        .filter { it.isNotBlank() }
+        .mapNotNull { pair ->
+            val idx = pair.indexOf("=")
+            if (idx < 0) return@mapNotNull null
+            val key = URLDecoder.decode(pair.substring(0, idx), Charsets.UTF_8.name())
+            val value = URLDecoder.decode(pair.substring(idx + 1), Charsets.UTF_8.name())
+            key to value
+        }
+        .toMap()
+
+    val server = params["server"]?.takeIf { it.isNotBlank() } ?: return null
+    val token = params["token"]?.takeIf { it.isNotBlank() } ?: return null
+
+    return "invite_claim?server=${server.routeEncode()}&token=${token.routeEncode()}"
+}
+
+private fun String.routeEncode(): String =
+    URLEncoder.encode(this, Charsets.UTF_8.name()).replace("+", "%20")

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/Routes.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/Routes.kt
@@ -19,6 +19,21 @@ sealed class Route(val route: String) {
     data object Setup : Route("setup")
     data object Signup : Route("signup")
 
+    /**
+     * Emailed-invitation claim. The deep link carries the server URL and the
+     * single-use token, so the app skips its "which server?" step entirely.
+     */
+    data class InviteClaim(val server: String, val token: String) : Route(
+        "invite_claim?server=${Uri.encode(server)}&token=${Uri.encode(token)}",
+    ) {
+        companion object {
+            const val ROUTE = "invite_claim?server={server}&token={token}"
+        }
+    }
+
+    /** Server-driven first-run feature tour, shown after profile selection. */
+    data object OnboardingTour : Route("onboarding_tour")
+
     data class PairDevice(
         val token: String? = null,
         val code: String? = null,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimScreen.kt
@@ -62,11 +62,10 @@ fun InviteClaimScreen(
         viewModel.load(serverUrl, token)
     }
 
+    // One-way latch: the success navigation clears the whole back stack, so
+    // there is nothing to consume or reset.
     LaunchedEffect(state.claimSuccess) {
-        if (state.claimSuccess) {
-            viewModel.onClaimSuccessConsumed()
-            onClaimComplete()
-        }
+        if (state.claimSuccess) onClaimComplete()
     }
 
     AuroraScreen(variant = AuroraVariant.SignIn, scrim = AuroraScrim.Soft) {
@@ -82,6 +81,42 @@ fun InviteClaimScreen(
                     Spacer(Modifier.height(60.dp))
                     CircularProgressIndicator(color = Color(0xFFF3EFE9))
                 }
+            }
+
+            state.lookupFailed -> {
+                AuroraEyebrow(text = "Invitation", centered = true)
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = "Couldn't reach the server",
+                    fontSize = 30.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFFF3EFE9),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = "Your invite is probably still fine — we just couldn't check it. " +
+                        "Make sure you're online and try again.",
+                    fontSize = 15.sp,
+                    color = Color.White.copy(alpha = 0.65f),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp),
+                )
+                Spacer(Modifier.height(24.dp))
+                AuroraPrimaryButton(
+                    label = "Try again",
+                    onClick = viewModel::onRetryLookup,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(10.dp))
+                AuroraGhostButton(
+                    label = "Back to sign in",
+                    onClick = onNavigateToLogin,
+                    fillMaxWidth = true,
+                )
             }
 
             state.invitationInvalid -> {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimScreen.kt
@@ -1,0 +1,214 @@
+package org.siloserver.silo.android.ui.screens.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.koin.compose.viewmodel.koinViewModel
+import org.siloserver.silo.android.ui.components.aurora.AuroraErrorLabel
+import org.siloserver.silo.android.ui.components.aurora.AuroraEyebrow
+import org.siloserver.silo.android.ui.components.aurora.AuroraGhostButton
+import org.siloserver.silo.android.ui.components.aurora.AuroraPrimaryButton
+import org.siloserver.silo.android.ui.components.aurora.AuroraScreen
+import org.siloserver.silo.android.ui.components.aurora.AuroraScrim
+import org.siloserver.silo.android.ui.components.aurora.AuroraTextField
+import org.siloserver.silo.android.ui.components.aurora.AuroraVariant
+import org.siloserver.silo.android.ui.components.aurora.auroraGlass
+
+/**
+ * Emailed-invitation claim: the deep link carried the server and token, so
+ * this screen asks for a password and nothing else. Everything visual
+ * mirrors SignupScreen's Aurora treatment.
+ */
+@Composable
+fun InviteClaimScreen(
+    serverUrl: String,
+    token: String,
+    onNavigateToLogin: () -> Unit,
+    onClaimComplete: () -> Unit,
+    viewModel: InviteClaimViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    var showPassword by remember { mutableStateOf(false) }
+
+    LaunchedEffect(serverUrl, token) {
+        viewModel.load(serverUrl, token)
+    }
+
+    LaunchedEffect(state.claimSuccess) {
+        if (state.claimSuccess) {
+            viewModel.onClaimSuccessConsumed()
+            onClaimComplete()
+        }
+    }
+
+    AuroraScreen(variant = AuroraVariant.SignIn, scrim = AuroraScrim.Soft) {
+        SiloLogo()
+        Spacer(Modifier.height(30.dp))
+
+        when {
+            state.isLoadingInvitation -> {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Spacer(Modifier.height(60.dp))
+                    CircularProgressIndicator(color = Color(0xFFF3EFE9))
+                }
+            }
+
+            state.invitationInvalid -> {
+                AuroraEyebrow(text = "Invitation", centered = true)
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = "This invite has expired",
+                    fontSize = 30.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFFF3EFE9),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = "The link may have been used already, revoked, or simply expired. " +
+                        "Ask whoever invited you to send a fresh one.",
+                    fontSize = 15.sp,
+                    color = Color.White.copy(alpha = 0.65f),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp),
+                )
+                Spacer(Modifier.height(24.dp))
+                AuroraGhostButton(
+                    label = "Back to sign in",
+                    onClick = onNavigateToLogin,
+                    fillMaxWidth = true,
+                )
+            }
+
+            else -> {
+                val invitation = state.invitation ?: return@AuroraScreen
+                invitation.inviterName?.let {
+                    AuroraEyebrow(text = "Invited by $it", centered = true)
+                    Spacer(Modifier.height(12.dp))
+                }
+                Text(
+                    text = "Welcome to ${invitation.serverName}",
+                    fontSize = 30.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFFF3EFE9),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "Choose a password and you're in. You'll sign in with your email address.",
+                    fontSize = 15.sp,
+                    color = Color.White.copy(alpha = 0.65f),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp),
+                )
+                Spacer(Modifier.height(24.dp))
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .auroraGlass(cornerRadius = 24.dp, emphasized = true)
+                        .padding(22.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    // The address is fixed by the invitation; show it, don't edit it.
+                    Column {
+                        Text(
+                            text = "EMAIL",
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color.White.copy(alpha = 0.55f),
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = invitation.email,
+                            fontSize = 16.sp,
+                            color = Color.White.copy(alpha = 0.8f),
+                        )
+                    }
+                    AuroraTextField(
+                        label = "Password",
+                        value = state.password,
+                        onValueChange = viewModel::onPasswordChanged,
+                        placeholder = "••••••",
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Next,
+                        visualTransformation = if (showPassword) {
+                            VisualTransformation.None
+                        } else {
+                            PasswordVisualTransformation()
+                        },
+                        trailing = {
+                            IconButton(onClick = { showPassword = !showPassword }) {
+                                Icon(
+                                    imageVector = if (showPassword) {
+                                        Icons.Filled.VisibilityOff
+                                    } else {
+                                        Icons.Filled.Visibility
+                                    },
+                                    contentDescription = if (showPassword) "Hide password" else "Show password",
+                                    tint = Color.White.copy(alpha = 0.62f),
+                                )
+                            }
+                        },
+                    )
+                    AuroraTextField(
+                        label = "Confirm password",
+                        value = state.confirmPassword,
+                        onValueChange = viewModel::onConfirmPasswordChanged,
+                        placeholder = "••••••",
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Go,
+                        onImeAction = viewModel::onClaimClick,
+                        visualTransformation = PasswordVisualTransformation(),
+                    )
+
+                    state.error?.let { AuroraErrorLabel(it) }
+
+                    AuroraPrimaryButton(
+                        label = if (state.isSubmitting) "Creating…" else "Create account",
+                        onClick = viewModel::onClaimClick,
+                        isLoading = state.isSubmitting,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -66,6 +67,34 @@ fun InviteClaimScreen(
     // there is nothing to consume or reset.
     LaunchedEffect(state.claimSuccess) {
         if (state.claimSuccess) onClaimComplete()
+    }
+
+    state.pendingCleartextOrigin?.let { origin ->
+        AlertDialog(
+            onDismissRequest = viewModel::onCancelCleartext,
+            title = { Text("Use unencrypted HTTP?") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text(origin, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        "This connection is not encrypted. Anyone on the network may see or change " +
+                            "traffic, including your new password. Continue only on a network you trust.",
+                    )
+                }
+            },
+            confirmButton = {
+                AuroraPrimaryButton(
+                    label = "Use HTTP",
+                    onClick = viewModel::onConfirmCleartext,
+                )
+            },
+            dismissButton = {
+                AuroraGhostButton(
+                    label = "Cancel",
+                    onClick = viewModel::onCancelCleartext,
+                )
+            },
+        )
     }
 
     AuroraScreen(variant = AuroraVariant.SignIn, scrim = AuroraScrim.Soft) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimViewModel.kt
@@ -1,0 +1,113 @@
+package org.siloserver.silo.android.ui.screens.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.siloserver.silo.model.auth.InvitationLookupResponse
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.repository.AuthRepository
+
+data class InviteClaimUiState(
+    val isLoadingInvitation: Boolean = true,
+    val invitation: InvitationLookupResponse? = null,
+    val invitationInvalid: Boolean = false,
+    val password: String = "",
+    val confirmPassword: String = "",
+    val isSubmitting: Boolean = false,
+    val error: String? = null,
+    val claimSuccess: Boolean = false,
+)
+
+/**
+ * Claim flow for an emailed invitation deep link (silo://invite or an
+ * https app link): server URL and token arrive in the link, the invitee
+ * chooses only a password. On success the account is created, tokens are
+ * stored, and the server is registered so the rest of the app works exactly
+ * as after a normal login.
+ */
+class InviteClaimViewModel(
+    private val authRepository: AuthRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(InviteClaimUiState())
+    val uiState: StateFlow<InviteClaimUiState> = _uiState.asStateFlow()
+
+    private var serverUrl: String = ""
+    private var token: String = ""
+
+    fun load(serverUrl: String, token: String) {
+        if (this.token == token && _uiState.value.invitation != null) return
+        this.serverUrl = serverUrl
+        this.token = token
+        _uiState.update { InviteClaimUiState() }
+        viewModelScope.launch {
+            when (val result = authRepository.lookupInvitation(serverUrl, token)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(isLoadingInvitation = false, invitation = result.data)
+                }
+                is ApiResult.Error -> _uiState.update {
+                    it.copy(isLoadingInvitation = false, invitationInvalid = true)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        isLoadingInvitation = false,
+                        invitationInvalid = true,
+                        error = "Could not reach the server.",
+                    )
+                }
+            }
+        }
+    }
+
+    fun onPasswordChanged(value: String) {
+        _uiState.update { it.copy(password = value, error = null) }
+    }
+
+    fun onConfirmPasswordChanged(value: String) {
+        _uiState.update { it.copy(confirmPassword = value, error = null) }
+    }
+
+    fun onClaimClick() {
+        val current = _uiState.value
+        val validationError = when {
+            current.password.length < 8 -> "Password must be at least 8 characters"
+            current.password != current.confirmPassword -> "Passwords do not match"
+            else -> null
+        }
+        if (validationError != null) {
+            _uiState.update { it.copy(error = validationError) }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmitting = true, error = null) }
+            // Activate the server first so the tokens accept persists land in
+            // that server's scope — the same order the manual setup flow uses.
+            authRepository.setServerUrl(serverUrl)
+            when (val result = authRepository.acceptInvitation(serverUrl, token, current.password)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(isSubmitting = false, claimSuccess = true) }
+                }
+                is ApiResult.Error -> {
+                    val message = when (result.code) {
+                        404 -> "This invitation is invalid or has expired."
+                        409 -> "This invitation has already been used."
+                        else -> result.message.ifBlank { "Could not create your account" }
+                    }
+                    _uiState.update { it.copy(isSubmitting = false, error = message) }
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(isSubmitting = false, error = "Network error. Please check your connection.")
+                }
+            }
+        }
+    }
+
+    fun onClaimSuccessConsumed() {
+        _uiState.update { it.copy(claimSuccess = false) }
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimViewModel.kt
@@ -60,7 +60,16 @@ class InviteClaimViewModel(
     private var lookupGeneration = 0
 
     fun load(serverUrl: String, token: String) {
-        if (this.token == token && _uiState.value.invitation != null) return
+        // An invite is identified by server *and* token: the same token can
+        // exist on another server, and matching on the token alone would keep
+        // the previous server, submitting the password to the wrong one.
+        if (
+            this.serverUrl == serverUrl &&
+            this.token == token &&
+            _uiState.value.invitation != null
+        ) {
+            return
+        }
         this.serverUrl = serverUrl
         this.token = token
         val generation = ++lookupGeneration
@@ -153,11 +162,20 @@ class InviteClaimViewModel(
 
     private suspend fun submitClaim() {
         val current = _uiState.value
+        // Pin the invite this submission is for. A second deep link can replace
+        // the route mid-POST; without this the first response would still drive
+        // the UI — navigating away from the invite now on screen, or reporting
+        // success for an account on a server the user is no longer claiming.
+        val generation = lookupGeneration
+        val claimServerUrl = serverUrl
+        val claimToken = token
         _uiState.update { it.copy(isSubmitting = true, error = null) }
         // acceptInvitation talks to the invite's server directly and only
         // adopts it as the active server after the claim succeeds, so a
         // failed claim leaves any existing session untouched.
-        when (val result = authRepository.acceptInvitation(serverUrl, token, current.password)) {
+        val result = authRepository.acceptInvitation(claimServerUrl, claimToken, current.password)
+        if (generation != lookupGeneration) return
+        when (result) {
             is ApiResult.Success -> {
                 _uiState.update { it.copy(isSubmitting = false, claimSuccess = true) }
             }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimViewModel.kt
@@ -7,18 +7,26 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.siloserver.silo.common.network.CleartextConsentStore
 import org.siloserver.silo.model.auth.InvitationLookupResponse
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.errorMessage
+import org.siloserver.silo.network.requiresApproval
 import org.siloserver.silo.repository.AuthRepository
 
 data class InviteClaimUiState(
     val isLoadingInvitation: Boolean = true,
     val invitation: InvitationLookupResponse? = null,
-    /** The server answered and said no — the invite really is dead. */
+    /** The server said the token itself is dead — the invite really is gone. */
     val invitationInvalid: Boolean = false,
-    /** The server never answered — the invite may be fine; offer retry. */
+    /** The lookup failed for reasons unrelated to the token; offer retry. */
     val lookupFailed: Boolean = false,
+    /**
+     * The invite points at a cleartext HTTP server the user hasn't approved.
+     * The claim POST carries credentials, so it needs the same explicit
+     * consent the manual server-setup flow collects.
+     */
+    val pendingCleartextOrigin: String? = null,
     val password: String = "",
     val confirmPassword: String = "",
     val isSubmitting: Boolean = false,
@@ -35,6 +43,7 @@ data class InviteClaimUiState(
  */
 class InviteClaimViewModel(
     private val authRepository: AuthRepository,
+    private val cleartextConsentStore: CleartextConsentStore,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(InviteClaimUiState())
@@ -43,22 +52,43 @@ class InviteClaimViewModel(
     private var serverUrl: String = ""
     private var token: String = ""
 
+    /**
+     * Bumped whenever the target invite changes; in-flight lookups compare
+     * against it before touching state, so a slow response for a superseded
+     * link can't paint another invite's email over the current one.
+     */
+    private var lookupGeneration = 0
+
     fun load(serverUrl: String, token: String) {
         if (this.token == token && _uiState.value.invitation != null) return
         this.serverUrl = serverUrl
         this.token = token
+        val generation = ++lookupGeneration
         _uiState.update { InviteClaimUiState() }
         viewModelScope.launch {
-            when (val result = authRepository.lookupInvitation(serverUrl, token)) {
+            val result = authRepository.lookupInvitation(serverUrl, token)
+            if (generation != lookupGeneration) return@launch
+            when (result) {
                 is ApiResult.Success -> _uiState.update {
                     it.copy(isLoadingInvitation = false, invitation = result.data)
                 }
-                is ApiResult.Error -> _uiState.update {
-                    it.copy(isLoadingInvitation = false, invitationInvalid = true)
+                is ApiResult.Error -> {
+                    // Only statuses that speak about the token itself are
+                    // terminal. A 429/5xx says nothing about the invite, and
+                    // showing "expired" for it sends the user off to have a
+                    // valid link revoked and reissued.
+                    if (result.code in TERMINAL_LOOKUP_CODES) {
+                        _uiState.update {
+                            it.copy(isLoadingInvitation = false, invitationInvalid = true)
+                        }
+                    } else {
+                        _uiState.update {
+                            it.copy(isLoadingInvitation = false, lookupFailed = true)
+                        }
+                    }
                 }
-                // A failure to reach the server says nothing about the
-                // invite; telling the user it expired sends them off to have
-                // a perfectly valid link revoked and reissued.
+                // A failure to reach the server says nothing about the invite
+                // either.
                 is ApiResult.NetworkError -> _uiState.update {
                     it.copy(isLoadingInvitation = false, lookupFailed = true)
                 }
@@ -95,27 +125,58 @@ class InviteClaimViewModel(
         }
 
         viewModelScope.launch {
-            _uiState.update { it.copy(isSubmitting = true, error = null) }
-            // acceptInvitation talks to the invite's server directly and only
-            // adopts it as the active server after the claim succeeds, so a
-            // failed claim leaves any existing session untouched.
-            when (val result = authRepository.acceptInvitation(serverUrl, token, current.password)) {
-                is ApiResult.Success -> {
-                    _uiState.update { it.copy(isSubmitting = false, claimSuccess = true) }
+            // The read-only lookup may have slipped past the cleartext gate,
+            // but the claim POST carries a password and will be rejected by
+            // the interceptor for an unapproved http:// origin — surfacing as
+            // an opaque network error. Ask for the same consent server setup
+            // does, then proceed.
+            if (cleartextConsentStore.requiresApproval(serverUrl)) {
+                _uiState.update { it.copy(pendingCleartextOrigin = serverUrl) }
+                return@launch
+            }
+            submitClaim()
+        }
+    }
+
+    fun onConfirmCleartext() {
+        val origin = _uiState.value.pendingCleartextOrigin ?: return
+        viewModelScope.launch {
+            cleartextConsentStore.approve(origin)
+            _uiState.update { it.copy(pendingCleartextOrigin = null) }
+            submitClaim()
+        }
+    }
+
+    fun onCancelCleartext() {
+        _uiState.update { it.copy(pendingCleartextOrigin = null) }
+    }
+
+    private suspend fun submitClaim() {
+        val current = _uiState.value
+        _uiState.update { it.copy(isSubmitting = true, error = null) }
+        // acceptInvitation talks to the invite's server directly and only
+        // adopts it as the active server after the claim succeeds, so a
+        // failed claim leaves any existing session untouched.
+        when (val result = authRepository.acceptInvitation(serverUrl, token, current.password)) {
+            is ApiResult.Success -> {
+                _uiState.update { it.copy(isSubmitting = false, claimSuccess = true) }
+            }
+            is ApiResult.Error -> {
+                val message = when (result.code) {
+                    404 -> "This invitation is invalid or has expired."
+                    409 -> "This invitation has already been used."
+                    else -> result.errorMessage("Could not create your account")
                 }
-                is ApiResult.Error -> {
-                    val message = when (result.code) {
-                        404 -> "This invitation is invalid or has expired."
-                        409 -> "This invitation has already been used."
-                        else -> result.errorMessage("Could not create your account")
-                    }
-                    _uiState.update { it.copy(isSubmitting = false, error = message) }
-                }
-                is ApiResult.NetworkError -> _uiState.update {
-                    it.copy(isSubmitting = false, error = result.errorMessage("Could not create your account"))
-                }
+                _uiState.update { it.copy(isSubmitting = false, error = message) }
+            }
+            is ApiResult.NetworkError -> _uiState.update {
+                it.copy(isSubmitting = false, error = result.errorMessage("Could not create your account"))
             }
         }
     }
 
+    private companion object {
+        /** Statuses that mean the token itself is gone, used, or malformed. */
+        private val TERMINAL_LOOKUP_CODES = setOf(400, 404, 409, 410)
+    }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/InviteClaimViewModel.kt
@@ -9,12 +9,16 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.siloserver.silo.model.auth.InvitationLookupResponse
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.errorMessage
 import org.siloserver.silo.repository.AuthRepository
 
 data class InviteClaimUiState(
     val isLoadingInvitation: Boolean = true,
     val invitation: InvitationLookupResponse? = null,
+    /** The server answered and said no — the invite really is dead. */
     val invitationInvalid: Boolean = false,
+    /** The server never answered — the invite may be fine; offer retry. */
+    val lookupFailed: Boolean = false,
     val password: String = "",
     val confirmPassword: String = "",
     val isSubmitting: Boolean = false,
@@ -52,15 +56,22 @@ class InviteClaimViewModel(
                 is ApiResult.Error -> _uiState.update {
                     it.copy(isLoadingInvitation = false, invitationInvalid = true)
                 }
+                // A failure to reach the server says nothing about the
+                // invite; telling the user it expired sends them off to have
+                // a perfectly valid link revoked and reissued.
                 is ApiResult.NetworkError -> _uiState.update {
-                    it.copy(
-                        isLoadingInvitation = false,
-                        invitationInvalid = true,
-                        error = "Could not reach the server.",
-                    )
+                    it.copy(isLoadingInvitation = false, lookupFailed = true)
                 }
             }
         }
+    }
+
+    fun onRetryLookup() {
+        val url = serverUrl
+        val tok = token
+        // Clear the loaded marker so load() runs the lookup again.
+        this.token = ""
+        load(url, tok)
     }
 
     fun onPasswordChanged(value: String) {
@@ -85,9 +96,9 @@ class InviteClaimViewModel(
 
         viewModelScope.launch {
             _uiState.update { it.copy(isSubmitting = true, error = null) }
-            // Activate the server first so the tokens accept persists land in
-            // that server's scope — the same order the manual setup flow uses.
-            authRepository.setServerUrl(serverUrl)
+            // acceptInvitation talks to the invite's server directly and only
+            // adopts it as the active server after the claim succeeds, so a
+            // failed claim leaves any existing session untouched.
             when (val result = authRepository.acceptInvitation(serverUrl, token, current.password)) {
                 is ApiResult.Success -> {
                     _uiState.update { it.copy(isSubmitting = false, claimSuccess = true) }
@@ -96,18 +107,15 @@ class InviteClaimViewModel(
                     val message = when (result.code) {
                         404 -> "This invitation is invalid or has expired."
                         409 -> "This invitation has already been used."
-                        else -> result.message.ifBlank { "Could not create your account" }
+                        else -> result.errorMessage("Could not create your account")
                     }
                     _uiState.update { it.copy(isSubmitting = false, error = message) }
                 }
                 is ApiResult.NetworkError -> _uiState.update {
-                    it.copy(isSubmitting = false, error = "Network error. Please check your connection.")
+                    it.copy(isSubmitting = false, error = result.errorMessage("Could not create your account"))
                 }
             }
         }
     }
 
-    fun onClaimSuccessConsumed() {
-        _uiState.update { it.copy(claimSuccess = false) }
-    }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourLocalCache.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourLocalCache.kt
@@ -1,0 +1,29 @@
+package org.siloserver.silo.android.ui.screens.onboarding
+
+import android.content.Context
+
+/**
+ * Local record of "this profile finished (or skipped) the tour", keyed per
+ * server + profile. The server stays the source of truth — this only lets
+ * the app skip the blocking state fetch on every profile selection once the
+ * answer is known to be "done". It is set on a server-confirmed done state
+ * or a locally initiated complete/skip, never on a failed check, so a
+ * network error can't silence a tour that is still pending.
+ */
+class OnboardingTourLocalCache(context: Context) {
+
+    private val prefs =
+        context.getSharedPreferences("onboarding_tour", Context.MODE_PRIVATE)
+
+    private fun key(serverId: String?, profileId: String?): String? {
+        if (serverId.isNullOrBlank() || profileId.isNullOrBlank()) return null
+        return "done:$serverId:$profileId"
+    }
+
+    fun isDone(serverId: String?, profileId: String?): Boolean =
+        key(serverId, profileId)?.let { prefs.getBoolean(it, false) } ?: false
+
+    fun markDone(serverId: String?, profileId: String?) {
+        key(serverId, profileId)?.let { prefs.edit().putBoolean(it, true).apply() }
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourScreen.kt
@@ -33,9 +33,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -167,27 +164,28 @@ fun OnboardingTourScreen(
 
                 if (step.kind == "setting_choice" && step.setting != null) {
                     Spacer(Modifier.height(22.dp))
-                    SettingChoiceCard(step = step, onChosen = viewModel::onSettingChosen)
+                    SettingChoiceCard(
+                        step = step,
+                        selected = state.pendingChoices[step.id] ?: "",
+                        onChosen = viewModel::onSettingChosen,
+                    )
                 }
             }
 
             Spacer(Modifier.height(20.dp))
 
+            val isTerminal = step.kind == "handoff" || isLast
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 if (state.currentIndex > 0) {
                     AuroraGhostButton(label = "Back", onClick = viewModel::onBack)
                 }
                 AuroraPrimaryButton(
                     label = when {
-                        step.kind == "handoff" || isLast -> "Done"
+                        isTerminal -> "Done"
                         state.currentIndex == 0 -> "Show me"
                         else -> "Next"
                     },
-                    onClick = if (step.kind == "handoff" || isLast) {
-                        viewModel::onFinish
-                    } else {
-                        viewModel::onAdvance
-                    },
+                    onClick = if (isTerminal) viewModel::onFinish else viewModel::onAdvance,
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -195,14 +193,18 @@ fun OnboardingTourScreen(
     }
 }
 
-/** Renders the manifest's options as a tappable list, saving immediately. */
+/**
+ * Renders the manifest's options as a tappable list. Selection lives in the
+ * ViewModel (persisted when the user advances past the step), so the
+ * highlight can never disagree with what gets saved.
+ */
 @Composable
 private fun SettingChoiceCard(
     step: OnboardingStep,
+    selected: String,
     onChosen: (OnboardingStep, String) -> Unit,
 ) {
     val spec = step.setting ?: return
-    var selected by remember(step.id) { mutableStateOf(spec.default ?: "") }
 
     Column(
         modifier = Modifier
@@ -221,10 +223,7 @@ private fun SettingChoiceCard(
                         color = if (isSelected) Color.White.copy(alpha = 0.12f) else Color.Transparent,
                         shape = RoundedCornerShape(12.dp),
                     )
-                    .clickable {
-                        selected = option.value
-                        onChosen(step, option.value)
-                    }
+                    .clickable { onChosen(step, option.value) }
                     .padding(horizontal = 14.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,6 +16,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -33,21 +36,32 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.util.lerp
+import kotlin.math.abs
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.koin.compose.viewmodel.koinViewModel
+import org.siloserver.silo.android.ui.components.aurora.AuroraAccent
 import org.siloserver.silo.android.ui.components.aurora.AuroraGhostButton
+import org.siloserver.silo.android.ui.components.aurora.AuroraInk
+import org.siloserver.silo.android.ui.components.aurora.AuroraInkSecondary
 import org.siloserver.silo.android.ui.components.aurora.AuroraPrimaryButton
 import org.siloserver.silo.android.ui.components.aurora.AuroraScreen
 import org.siloserver.silo.android.ui.components.aurora.AuroraScrim
 import org.siloserver.silo.android.ui.components.aurora.AuroraVariant
 import org.siloserver.silo.android.ui.components.aurora.auroraGlass
 import org.siloserver.silo.model.onboarding.OnboardingStep
+
+/** Gutter the fixed rows and the pager's peek share. */
+private val TourGutter = 20.dp
 
 /** Client-side illustration keys — the server only ever names them. */
 private fun illustrationFor(key: String?): ImageVector = when (key) {
@@ -77,7 +91,17 @@ fun OnboardingTourScreen(
         if (state.finished) onDone()
     }
 
-    AuroraScreen(variant = AuroraVariant.SignIn, scrim = AuroraScrim.Soft) {
+    // scrollable = false: this screen sizes itself against the display — pips
+    // and buttons pinned, the cards taking the space between them. Inside a
+    // scrolling parent that weighted body would collapse to nothing.
+    // horizontalPadding = 0: the pager runs full-bleed so the next card peeks
+    // in from the edge; the fixed rows re-apply the gutter themselves.
+    AuroraScreen(
+        variant = AuroraVariant.SignIn,
+        scrim = AuroraScrim.Soft,
+        scrollable = false,
+        horizontalPadding = 0.dp,
+    ) {
         if (state.isLoading || state.steps.isEmpty()) {
             // Skip stays reachable while the manifest loads: this gate sits
             // between profile selection and Home with the back stack already
@@ -85,7 +109,9 @@ fun OnboardingTourScreen(
             // the full request timeout.
             Column(Modifier.fillMaxSize()) {
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = TourGutter),
                     horizontalArrangement = Arrangement.End,
                 ) {
                     AuroraGhostButton(label = "Skip", onClick = viewModel::onSkip)
@@ -100,14 +126,35 @@ fun OnboardingTourScreen(
         val step = state.steps[state.currentIndex]
         val isLast = state.currentIndex == state.steps.lastIndex
 
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 4.dp),
-        ) {
+        val pagerState = rememberPagerState(
+            // The tour can resume mid-way, so the pager has to open on the
+            // step the ViewModel restored rather than snapping to zero.
+            initialPage = state.currentIndex,
+            pageCount = { state.steps.size },
+        )
+
+        // Pager -> ViewModel: only once a swipe has settled, so a drag the user
+        // releases halfway doesn't record a step they never actually saw.
+        LaunchedEffect(pagerState) {
+            snapshotFlow { pagerState.settledPage }
+                .collect { viewModel.onPageSettled(it) }
+        }
+        // ViewModel -> pager: Back/Next (and the resume index) drive the pager
+        // so buttons and swipes stay one shared position. Guarded on the
+        // pager's target, not its settled page — mid-fling the two disagree and
+        // an unguarded call here would cancel the user's own swipe.
+        LaunchedEffect(state.currentIndex) {
+            if (pagerState.targetPage != state.currentIndex) {
+                pagerState.animateScrollToPage(state.currentIndex)
+            }
+        }
+
+        Column(modifier = Modifier.fillMaxSize()) {
             // Progress pips + skip
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = TourGutter),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Row(
@@ -135,59 +182,46 @@ fun OnboardingTourScreen(
 
             Spacer(Modifier.height(24.dp))
 
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(56.dp)
-                        .background(Color.White.copy(alpha = 0.08f), RoundedCornerShape(16.dp)),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        imageVector = illustrationFor(step.illustration),
-                        contentDescription = null,
-                        tint = Color(0xFFF3EFE9),
-                        modifier = Modifier.size(28.dp),
-                    )
-                }
-                Spacer(Modifier.height(20.dp))
-                step.title?.let {
-                    Text(
-                        text = it,
-                        fontSize = 27.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        color = Color(0xFFF3EFE9),
-                        lineHeight = 34.sp,
-                    )
-                }
-                step.body?.let {
-                    Spacer(Modifier.height(12.dp))
-                    Text(
-                        text = it,
-                        fontSize = 15.sp,
-                        color = Color.White.copy(alpha = 0.68f),
-                        lineHeight = 23.sp,
-                    )
-                }
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.weight(1f),
+                // Inset the pages rather than the pager: the pager itself keeps
+                // the full width, so the neighbouring card slides in from the
+                // display edge instead of being clipped at a gutter.
+                contentPadding = PaddingValues(horizontal = TourGutter),
+                pageSpacing = 12.dp,
+                verticalAlignment = Alignment.CenterVertically,
+            ) { page ->
+                // Distance of this page from the settled position: 0 while it
+                // is the current card, ±1 once fully a neighbour. Driven by the
+                // live scroll offset so the card tracks the finger.
+                val offset = (
+                    (pagerState.currentPage - page) + pagerState.currentPageOffsetFraction
+                    ).coerceIn(-1f, 1f)
+                val distance = abs(offset)
 
-                if (step.kind == "setting_choice" && step.setting != null) {
-                    Spacer(Modifier.height(22.dp))
-                    SettingChoiceCard(
-                        step = step,
-                        selected = state.pendingChoices[step.id] ?: "",
-                        onChosen = viewModel::onSettingChosen,
-                    )
-                }
+                TourStepPage(
+                    step = state.steps[page],
+                    selected = state.pendingChoices[state.steps[page].id] ?: "",
+                    onChosen = viewModel::onSettingChosen,
+                    modifier = Modifier.graphicsLayer {
+                        // Neighbours sit slightly back and dimmed, so the stack
+                        // reads as depth rather than a filmstrip.
+                        val scale = lerp(0.92f, 1f, 1f - distance)
+                        scaleX = scale
+                        scaleY = scale
+                        alpha = lerp(0.5f, 1f, 1f - distance)
+                    },
+                )
             }
 
             Spacer(Modifier.height(20.dp))
 
             val isTerminal = step.kind == "handoff" || isLast
-            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            Row(
+                modifier = Modifier.padding(horizontal = TourGutter),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
                 if (state.currentIndex > 0) {
                     AuroraGhostButton(label = "Back", onClick = viewModel::onBack)
                 }
@@ -201,6 +235,74 @@ fun OnboardingTourScreen(
                     modifier = Modifier.weight(1f),
                 )
             }
+        }
+    }
+}
+
+/**
+ * One tour card. Rendered per pager page rather than for the current step
+ * alone, so the neighbouring pages are already drawn as a swipe reveals them.
+ */
+@Composable
+private fun TourStepPage(
+    step: OnboardingStep,
+    selected: String,
+    onChosen: (OnboardingStep, String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            // No drop shadow: a full-height translucent card lets the shadow's
+            // own edge show through as a faint box, and it tracks the card
+            // across a swipe.
+            .auroraGlass(cornerRadius = 28.dp, elevation = 0.dp)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 32.dp),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(64.dp)
+                .background(
+                    Brush.linearGradient(
+                        listOf(AuroraAccent.copy(alpha = 0.28f), AuroraAccent.copy(alpha = 0.06f)),
+                    ),
+                    RoundedCornerShape(20.dp),
+                )
+                .border(1.dp, AuroraAccent.copy(alpha = 0.30f), RoundedCornerShape(20.dp)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = illustrationFor(step.illustration),
+                contentDescription = null,
+                tint = AuroraAccent,
+                modifier = Modifier.size(30.dp),
+            )
+        }
+        Spacer(Modifier.height(24.dp))
+        step.title?.let {
+            Text(
+                text = it,
+                fontSize = 27.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = AuroraInk,
+                lineHeight = 34.sp,
+            )
+        }
+        step.body?.let {
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = it,
+                fontSize = 15.sp,
+                color = AuroraInkSecondary,
+                lineHeight = 23.sp,
+            )
+        }
+
+        if (step.kind == "setting_choice" && step.setting != null) {
+            Spacer(Modifier.height(22.dp))
+            SettingChoiceCard(step = step, selected = selected, onChosen = onChosen)
         }
     }
 }
@@ -221,7 +323,10 @@ private fun SettingChoiceCard(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .auroraGlass(cornerRadius = 20.dp)
+            // A hairline well rather than another glass panel: this now sits
+            // inside the card's glass, and stacking the two muddies both.
+            .background(Color.White.copy(alpha = 0.04f), RoundedCornerShape(20.dp))
+            .border(1.dp, Color.White.copy(alpha = 0.08f), RoundedCornerShape(20.dp))
             .padding(10.dp)
             .animateContentSize(),
         verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourScreen.kt
@@ -1,0 +1,254 @@
+package org.siloserver.silo.android.ui.screens.onboarding
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.PlayCircle
+import androidx.compose.material.icons.filled.Subtitles
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.koin.compose.viewmodel.koinViewModel
+import org.siloserver.silo.android.ui.components.aurora.AuroraGhostButton
+import org.siloserver.silo.android.ui.components.aurora.AuroraPrimaryButton
+import org.siloserver.silo.android.ui.components.aurora.AuroraScreen
+import org.siloserver.silo.android.ui.components.aurora.AuroraScrim
+import org.siloserver.silo.android.ui.components.aurora.AuroraVariant
+import org.siloserver.silo.android.ui.components.aurora.auroraGlass
+import org.siloserver.silo.model.onboarding.OnboardingStep
+
+/** Client-side illustration keys — the server only ever names them. */
+private fun illustrationFor(key: String?): ImageVector = when (key) {
+    "watchlist" -> Icons.Filled.Favorite
+    "watch-together" -> Icons.Filled.Groups
+    "calendar" -> Icons.Filled.CalendarMonth
+    "playback" -> Icons.Filled.PlayCircle
+    "subtitles" -> Icons.Filled.Subtitles
+    else -> Icons.Filled.AutoAwesome
+}
+
+/**
+ * Server-driven first-run tour: one step per page, skip always reachable.
+ * Kind filtering happened in the ViewModel; by the time a step renders here
+ * it is one of the known kinds.
+ */
+@Composable
+fun OnboardingTourScreen(
+    onDone: () -> Unit,
+    viewModel: OnboardingTourViewModel = koinViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.load() }
+
+    LaunchedEffect(state.finished) {
+        if (state.finished) onDone()
+    }
+
+    AuroraScreen(variant = AuroraVariant.SignIn, scrim = AuroraScrim.Soft) {
+        if (state.isLoading || state.steps.isEmpty()) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = Color(0xFFF3EFE9))
+            }
+            return@AuroraScreen
+        }
+
+        val step = state.steps[state.currentIndex]
+        val isLast = state.currentIndex == state.steps.lastIndex
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 4.dp),
+        ) {
+            // Progress pips + skip
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    state.steps.forEachIndexed { index, _ ->
+                        Box(
+                            modifier = Modifier
+                                .height(6.dp)
+                                .width(if (index == state.currentIndex) 18.dp else 6.dp)
+                                .background(
+                                    color = if (index == state.currentIndex) {
+                                        Color(0xFFF3EFE9)
+                                    } else {
+                                        Color.White.copy(alpha = 0.25f)
+                                    },
+                                    shape = CircleShape,
+                                ),
+                        )
+                    }
+                }
+                AuroraGhostButton(label = "Skip", onClick = viewModel::onSkip)
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(56.dp)
+                        .background(Color.White.copy(alpha = 0.08f), RoundedCornerShape(16.dp)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = illustrationFor(step.illustration),
+                        contentDescription = null,
+                        tint = Color(0xFFF3EFE9),
+                        modifier = Modifier.size(28.dp),
+                    )
+                }
+                Spacer(Modifier.height(20.dp))
+                step.title?.let {
+                    Text(
+                        text = it,
+                        fontSize = 27.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color(0xFFF3EFE9),
+                        lineHeight = 34.sp,
+                    )
+                }
+                step.body?.let {
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = it,
+                        fontSize = 15.sp,
+                        color = Color.White.copy(alpha = 0.68f),
+                        lineHeight = 23.sp,
+                    )
+                }
+
+                if (step.kind == "setting_choice" && step.setting != null) {
+                    Spacer(Modifier.height(22.dp))
+                    SettingChoiceCard(step = step, onChosen = viewModel::onSettingChosen)
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                if (state.currentIndex > 0) {
+                    AuroraGhostButton(label = "Back", onClick = viewModel::onBack)
+                }
+                AuroraPrimaryButton(
+                    label = when {
+                        step.kind == "handoff" || isLast -> "Done"
+                        state.currentIndex == 0 -> "Show me"
+                        else -> "Next"
+                    },
+                    onClick = if (step.kind == "handoff" || isLast) {
+                        viewModel::onFinish
+                    } else {
+                        viewModel::onAdvance
+                    },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+/** Renders the manifest's options as a tappable list, saving immediately. */
+@Composable
+private fun SettingChoiceCard(
+    step: OnboardingStep,
+    onChosen: (OnboardingStep, String) -> Unit,
+) {
+    val spec = step.setting ?: return
+    var selected by remember(step.id) { mutableStateOf(spec.default ?: "") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .auroraGlass(cornerRadius = 20.dp)
+            .padding(10.dp)
+            .animateContentSize(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        spec.options.forEach { option ->
+            val isSelected = option.value == selected
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = if (isSelected) Color.White.copy(alpha = 0.12f) else Color.Transparent,
+                        shape = RoundedCornerShape(12.dp),
+                    )
+                    .clickable {
+                        selected = option.value
+                        onChosen(step, option.value)
+                    }
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .background(
+                            color = if (isSelected) Color(0xFFF3EFE9) else Color.Transparent,
+                            shape = CircleShape,
+                        )
+                        .border(
+                            width = 1.5.dp,
+                            color = if (isSelected) Color(0xFFF3EFE9) else Color.White.copy(alpha = 0.4f),
+                            shape = CircleShape,
+                        ),
+                )
+                Spacer(Modifier.width(12.dp))
+                Text(
+                    text = option.label,
+                    fontSize = 15.sp,
+                    fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                    color = Color(0xFFF3EFE9),
+                )
+            }
+        }
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourScreen.kt
@@ -79,8 +79,20 @@ fun OnboardingTourScreen(
 
     AuroraScreen(variant = AuroraVariant.SignIn, scrim = AuroraScrim.Soft) {
         if (state.isLoading || state.steps.isEmpty()) {
-            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator(color = Color(0xFFF3EFE9))
+            // Skip stays reachable while the manifest loads: this gate sits
+            // between profile selection and Home with the back stack already
+            // cleared, so a slow server must never hold the app hostage for
+            // the full request timeout.
+            Column(Modifier.fillMaxSize()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    AuroraGhostButton(label = "Skip", onClick = viewModel::onSkip)
+                }
+                Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = Color(0xFFF3EFE9))
+                }
             }
             return@AuroraScreen
         }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourViewModel.kt
@@ -1,0 +1,134 @@
+package org.siloserver.silo.android.ui.screens.onboarding
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.siloserver.silo.model.onboarding.OnboardingFlow
+import org.siloserver.silo.model.onboarding.OnboardingStep
+import org.siloserver.silo.model.profile.UpdateProfileRequest
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.repository.OnboardingRepository
+import org.siloserver.silo.repository.ProfileRepository
+
+/** Step kinds this client can render; anything else is dropped at load. */
+private val KNOWN_KINDS = setOf("welcome", "feature_card", "setting_choice", "handoff")
+
+data class OnboardingTourUiState(
+    val isLoading: Boolean = true,
+    /** null after load = nothing to show (done already, feature off, or error). */
+    val steps: List<OnboardingStep> = emptyList(),
+    val tourId: String = "",
+    val currentIndex: Int = 0,
+    val finished: Boolean = false,
+)
+
+/**
+ * Drives the server-driven first-run tour. Progress and completion post to
+ * the server per profile, so finishing here silences the web and TV too.
+ * setting_choice steps write through the existing profile-update path.
+ */
+class OnboardingTourViewModel(
+    private val onboardingRepository: OnboardingRepository,
+    private val profileRepository: ProfileRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(OnboardingTourUiState())
+    val uiState: StateFlow<OnboardingTourUiState> = _uiState.asStateFlow()
+
+    fun load() {
+        viewModelScope.launch {
+            when (val state = onboardingRepository.getState()) {
+                is ApiResult.Success -> {
+                    if (state.data.done) {
+                        _uiState.update { it.copy(isLoading = false, finished = true) }
+                        return@launch
+                    }
+                }
+                // On any error, skip the tour rather than block first run.
+                is ApiResult.Error, is ApiResult.NetworkError -> {
+                    _uiState.update { it.copy(isLoading = false, finished = true) }
+                    return@launch
+                }
+            }
+            when (val flow = onboardingRepository.getFlow(surface = "phone")) {
+                is ApiResult.Success -> applyFlow(flow.data)
+                is ApiResult.Error, is ApiResult.NetworkError -> {
+                    _uiState.update { it.copy(isLoading = false, finished = true) }
+                }
+            }
+        }
+    }
+
+    private fun applyFlow(flow: OnboardingFlow) {
+        val steps = flow.steps.filter { it.kind in KNOWN_KINDS }
+        if (steps.isEmpty()) {
+            // Nothing renderable: mark complete so we never loop.
+            viewModelScope.launch { onboardingRepository.complete(flow.tourId, null) }
+            _uiState.update { it.copy(isLoading = false, finished = true) }
+            return
+        }
+        _uiState.update {
+            it.copy(isLoading = false, steps = steps, tourId = flow.tourId, currentIndex = 0)
+        }
+    }
+
+    fun onAdvance() {
+        val current = _uiState.value
+        val next = current.currentIndex + 1
+        if (next >= current.steps.size) {
+            finish(skipped = false)
+            return
+        }
+        viewModelScope.launch {
+            onboardingRepository.recordStep(current.tourId, current.steps[next].id)
+        }
+        _uiState.update { it.copy(currentIndex = next) }
+    }
+
+    fun onBack() {
+        _uiState.update { it.copy(currentIndex = (it.currentIndex - 1).coerceAtLeast(0)) }
+    }
+
+    fun onSkip() = finish(skipped = true)
+
+    fun onFinish() = finish(skipped = false)
+
+    private fun finish(skipped: Boolean) {
+        val current = _uiState.value
+        viewModelScope.launch {
+            val lastStep = current.steps.getOrNull(current.currentIndex)?.id
+            if (skipped) {
+                onboardingRepository.skip(current.tourId, lastStep)
+            } else {
+                onboardingRepository.complete(current.tourId, lastStep)
+            }
+        }
+        _uiState.update { it.copy(finished = true) }
+    }
+
+    /**
+     * Writes one setting_choice value. UpdateProfileRequest is typed per
+     * field, so the manifest's string key maps onto the matching field;
+     * unknown keys (a newer server) are ignored rather than failing the
+     * tour. Only profile_field targets exist for phones today.
+     */
+    fun onSettingChosen(step: OnboardingStep, value: String) {
+        val spec = step.setting ?: return
+        if (spec.target != "profile_field") return
+        val request = when (spec.key) {
+            "quality_preference" -> UpdateProfileRequest(qualityPreference = value)
+            "subtitle_language" -> UpdateProfileRequest(subtitleLanguage = value)
+            "subtitle_mode" -> UpdateProfileRequest(subtitleMode = value)
+            "auto_skip_intro" -> UpdateProfileRequest(autoSkipIntro = value.toBoolean())
+            "auto_skip_credits" -> UpdateProfileRequest(autoSkipCredits = value.toBoolean())
+            else -> return
+        }
+        viewModelScope.launch {
+            profileRepository.updateActiveProfile(request)
+        }
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourViewModel.kt
@@ -143,20 +143,47 @@ class OnboardingTourViewModel(
 
     fun onAdvance() {
         val current = _uiState.value
-        persistChoiceIfAny(current.steps.getOrNull(current.currentIndex))
         val next = current.currentIndex + 1
         if (next >= current.steps.size) {
-            finish(skipped = false, persistCurrentChoice = false)
+            finish(skipped = false, persistCurrentChoice = true)
             return
         }
-        viewModelScope.launch {
-            onboardingRepository.recordStep(current.tourId, current.steps[next].id)
-        }
-        _uiState.update { it.copy(currentIndex = next) }
+        moveTo(next)
     }
 
     fun onBack() {
-        _uiState.update { it.copy(currentIndex = (it.currentIndex - 1).coerceAtLeast(0)) }
+        moveTo(_uiState.value.currentIndex - 1)
+    }
+
+    /**
+     * Settle handler for swipe navigation. The pager is the one that moved, so
+     * this only reconciles state; the screen must not echo it back as a scroll
+     * or the two chase each other.
+     */
+    fun onPageSettled(index: Int) {
+        if (index == _uiState.value.currentIndex) return
+        moveTo(index)
+    }
+
+    /**
+     * Single path for every index change — button or swipe — so a step reached
+     * by swiping records and persists exactly like one reached by tapping.
+     */
+    private fun moveTo(target: Int) {
+        val current = _uiState.value
+        val index = target.coerceIn(0, current.steps.lastIndex.coerceAtLeast(0))
+        if (index == current.currentIndex) return
+        // Advancing past a setting_choice commits it; going back doesn't, so a
+        // user who swipes backwards to reconsider isn't saving on the way out.
+        if (index > current.currentIndex) {
+            persistChoiceIfAny(current.steps.getOrNull(current.currentIndex))
+            viewModelScope.launch {
+                current.steps.getOrNull(index)?.let {
+                    onboardingRepository.recordStep(current.tourId, it.id)
+                }
+            }
+        }
+        _uiState.update { it.copy(currentIndex = index) }
     }
 
     fun onSkip() = finish(skipped = true, persistCurrentChoice = false)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourViewModel.kt
@@ -74,16 +74,20 @@ class OnboardingTourViewModel(
             // two round trips in front of first render.
             val stateDeferred = async { onboardingRepository.getState() }
             val flowDeferred = async { onboardingRepository.getFlow(surface = "phone") }
+            val resumeStep: String?
             when (val state = stateDeferred.await()) {
                 is ApiResult.Success -> {
                     if (state.data.done) {
+                        // Server-confirmed done — safe to cache locally.
                         markDoneLocally()
                         flowDeferred.cancel()
                         _uiState.update { it.copy(isLoading = false, finished = true) }
                         return@launch
                     }
+                    resumeStep = state.data.lastStep
                 }
-                // On any error, skip the tour rather than block first run.
+                // On any error, skip the tour rather than block first run —
+                // but don't cache done: the server was never consulted.
                 is ApiResult.Error, is ApiResult.NetworkError -> {
                     flowDeferred.cancel()
                     _uiState.update { it.copy(isLoading = false, finished = true) }
@@ -91,7 +95,7 @@ class OnboardingTourViewModel(
                 }
             }
             when (val flow = flowDeferred.await()) {
-                is ApiResult.Success -> applyFlow(flow.data)
+                is ApiResult.Success -> applyFlow(flow.data, resumeStep)
                 is ApiResult.Error, is ApiResult.NetworkError -> {
                     _uiState.update { it.copy(isLoading = false, finished = true) }
                 }
@@ -99,14 +103,17 @@ class OnboardingTourViewModel(
         }
     }
 
-    private suspend fun applyFlow(flow: OnboardingFlow) {
+    private suspend fun applyFlow(flow: OnboardingFlow, resumeStep: String?) {
         val steps = flow.steps.filter { it.kind in KNOWN_KINDS }
         if (steps.isEmpty()) {
-            // Nothing renderable: mark complete so we never loop.
-            markDoneLocally()
+            // Nothing renderable: mark complete so we never loop — locally
+            // only once the server acknowledged, so an offline auto-complete
+            // is retried next launch instead of silently diverging.
             _uiState.update { it.copy(isLoading = false, finished = true) }
             withContext(NonCancellable) {
-                onboardingRepository.complete(flow.tourId, null)
+                if (onboardingRepository.complete(flow.tourId, null) is ApiResult.Success) {
+                    localCache.markDone(tokenManager.getCurrentServerId(), tokenManager.getProfileId())
+                }
             }
             return
         }
@@ -117,12 +124,18 @@ class OnboardingTourViewModel(
             .filter { it.kind == "setting_choice" }
             .mapNotNull { step -> step.setting?.default?.let { step.id to it } }
             .toMap()
+        // Progress recorded from another device or before a process death:
+        // resume at the server's last-seen step instead of step one.
+        val startIndex = resumeStep
+            ?.let { last -> steps.indexOfFirst { it.id == last } }
+            ?.takeIf { it >= 0 }
+            ?: 0
         _uiState.update {
             it.copy(
                 isLoading = false,
                 steps = steps,
                 tourId = flow.tourId,
-                currentIndex = 0,
+                currentIndex = startIndex,
                 pendingChoices = defaults,
             )
         }
@@ -155,17 +168,30 @@ class OnboardingTourViewModel(
         if (persistCurrentChoice) {
             persistChoiceIfAny(current.steps.getOrNull(current.currentIndex))
         }
-        markDoneLocally()
+        // Skip tapped while the manifest is still loading: there is no tour
+        // id to post against. Let the user through; server state stays
+        // not-done, so the tour is simply offered again another time.
+        if (current.tourId.isBlank()) {
+            _uiState.update { it.copy(finished = true) }
+            return
+        }
         viewModelScope.launch {
             val lastStep = current.steps.getOrNull(current.currentIndex)?.id
             // finished=true (below) navigates away with popUpTo, which clears
             // this ViewModel and cancels its scope — the POST must survive
             // that or the server never learns the tour ended and re-shows it.
+            // The local done-cache is written only on the server's ack: if
+            // the POST is lost, the next launch re-consults the server and
+            // retries the tour rather than silently diverging from every
+            // other client.
             withContext(NonCancellable) {
-                if (skipped) {
+                val result = if (skipped) {
                     onboardingRepository.skip(current.tourId, lastStep)
                 } else {
                     onboardingRepository.complete(current.tourId, lastStep)
+                }
+                if (result is ApiResult.Success) {
+                    localCache.markDone(tokenManager.getCurrentServerId(), tokenManager.getProfileId())
                 }
             }
         }
@@ -205,13 +231,19 @@ class OnboardingTourViewModel(
         }
         viewModelScope.launch {
             withContext(NonCancellable) {
-                // Android playback and the Settings screen read quality from
-                // the local player settings store, not the profile field —
-                // write both or the choice the tour just showed has no
-                // visible effect anywhere in this app.
-                if (spec.key == "quality_preference") {
-                    playerSettingsStore.setPreferredQuality(value)
+                // Android playback and the Settings screen read quality and
+                // auto-skip from the local player settings store, not the
+                // profile fields — mirror those there too or the choice the
+                // tour just showed has no visible effect in this app.
+                when (spec.key) {
+                    "quality_preference" -> playerSettingsStore.setPreferredQuality(value)
+                    "auto_skip_intro" -> playerSettingsStore.setAutoSkipIntro(value.toBoolean())
+                    "auto_skip_credits" -> playerSettingsStore.setAutoSkipCredits(value.toBoolean())
                 }
+                // Best-effort against the profile: the local store above is
+                // what this device plays back with, and Settings re-syncs
+                // from the server later. A rejected PUT here shouldn't trap
+                // the user in a tour they can't leave.
                 profileRepository.updateActiveProfile(request)
             }
         }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourViewModel.kt
@@ -110,9 +110,13 @@ class OnboardingTourViewModel(
             // only once the server acknowledged, so an offline auto-complete
             // is retried next launch instead of silently diverging.
             _uiState.update { it.copy(isLoading = false, finished = true) }
+            // Snapshot before the POST: finished=true navigates to Home, where
+            // the active profile can change while this is still in flight.
+            val serverId = tokenManager.getCurrentServerId()
+            val profileId = tokenManager.getProfileId()
             withContext(NonCancellable) {
                 if (onboardingRepository.complete(flow.tourId, null) is ApiResult.Success) {
-                    localCache.markDone(tokenManager.getCurrentServerId(), tokenManager.getProfileId())
+                    localCache.markDone(serverId, profileId)
                 }
             }
             return
@@ -204,6 +208,13 @@ class OnboardingTourViewModel(
         }
         viewModelScope.launch {
             val lastStep = current.steps.getOrNull(current.currentIndex)?.id
+            // Snapshot the identity that is finishing the tour. finished=true
+            // navigates to Home, where the user can switch profile or server
+            // while this POST is still in flight — reading the token manager on
+            // acknowledgement would then mark whichever profile is active by
+            // then, letting it skip a tour it never saw.
+            val serverId = tokenManager.getCurrentServerId()
+            val profileId = tokenManager.getProfileId()
             // finished=true (below) navigates away with popUpTo, which clears
             // this ViewModel and cancels its scope — the POST must survive
             // that or the server never learns the tour ended and re-shows it.
@@ -218,7 +229,7 @@ class OnboardingTourViewModel(
                     onboardingRepository.complete(current.tourId, lastStep)
                 }
                 if (result is ApiResult.Success) {
-                    localCache.markDone(tokenManager.getCurrentServerId(), tokenManager.getProfileId())
+                    localCache.markDone(serverId, profileId)
                 }
             }
         }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourViewModel.kt
@@ -2,15 +2,20 @@ package org.siloserver.silo.android.ui.screens.onboarding
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.model.onboarding.OnboardingFlow
 import org.siloserver.silo.model.onboarding.OnboardingStep
 import org.siloserver.silo.model.profile.UpdateProfileRequest
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.repository.OnboardingRepository
 import org.siloserver.silo.repository.ProfileRepository
 
@@ -19,10 +24,16 @@ private val KNOWN_KINDS = setOf("welcome", "feature_card", "setting_choice", "ha
 
 data class OnboardingTourUiState(
     val isLoading: Boolean = true,
-    /** null after load = nothing to show (done already, feature off, or error). */
+    /** Empty after load with [finished] set = nothing to show. */
     val steps: List<OnboardingStep> = emptyList(),
     val tourId: String = "",
     val currentIndex: Int = 0,
+    /**
+     * setting_choice values picked (or defaulted) but not yet persisted.
+     * Written when the user advances past the step, so what the card shows
+     * as selected is exactly what gets saved.
+     */
+    val pendingChoices: Map<String, String> = emptyMap(),
     val finished: Boolean = false,
 )
 
@@ -34,27 +45,52 @@ data class OnboardingTourUiState(
 class OnboardingTourViewModel(
     private val onboardingRepository: OnboardingRepository,
     private val profileRepository: ProfileRepository,
+    private val playerSettingsStore: PlayerSettingsStore,
+    private val tokenManager: TokenManager,
+    private val localCache: OnboardingTourLocalCache,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(OnboardingTourUiState())
     val uiState: StateFlow<OnboardingTourUiState> = _uiState.asStateFlow()
 
+    private var loadStarted = false
+
     fun load() {
+        // The screen calls this from a LaunchedEffect that re-runs on every
+        // composition restart (rotation, theme change); without the guard a
+        // mid-tour user would be re-fetched back to step 1.
+        if (loadStarted) return
+        loadStarted = true
         viewModelScope.launch {
-            when (val state = onboardingRepository.getState()) {
+            // Known-done locally: skip the network entirely. The flag is only
+            // ever set from a server-confirmed done state or our own
+            // complete/skip, so trusting it can't hide a pending tour.
+            if (localCache.isDone(tokenManager.getCurrentServerId(), tokenManager.getProfileId())) {
+                _uiState.update { it.copy(isLoading = false, finished = true) }
+                return@launch
+            }
+            // Fetch state and manifest together — the manifest is discarded
+            // when state says done, but that waste is cheaper than serializing
+            // two round trips in front of first render.
+            val stateDeferred = async { onboardingRepository.getState() }
+            val flowDeferred = async { onboardingRepository.getFlow(surface = "phone") }
+            when (val state = stateDeferred.await()) {
                 is ApiResult.Success -> {
                     if (state.data.done) {
+                        markDoneLocally()
+                        flowDeferred.cancel()
                         _uiState.update { it.copy(isLoading = false, finished = true) }
                         return@launch
                     }
                 }
                 // On any error, skip the tour rather than block first run.
                 is ApiResult.Error, is ApiResult.NetworkError -> {
+                    flowDeferred.cancel()
                     _uiState.update { it.copy(isLoading = false, finished = true) }
                     return@launch
                 }
             }
-            when (val flow = onboardingRepository.getFlow(surface = "phone")) {
+            when (val flow = flowDeferred.await()) {
                 is ApiResult.Success -> applyFlow(flow.data)
                 is ApiResult.Error, is ApiResult.NetworkError -> {
                     _uiState.update { it.copy(isLoading = false, finished = true) }
@@ -63,24 +99,41 @@ class OnboardingTourViewModel(
         }
     }
 
-    private fun applyFlow(flow: OnboardingFlow) {
+    private suspend fun applyFlow(flow: OnboardingFlow) {
         val steps = flow.steps.filter { it.kind in KNOWN_KINDS }
         if (steps.isEmpty()) {
             // Nothing renderable: mark complete so we never loop.
-            viewModelScope.launch { onboardingRepository.complete(flow.tourId, null) }
+            markDoneLocally()
             _uiState.update { it.copy(isLoading = false, finished = true) }
+            withContext(NonCancellable) {
+                onboardingRepository.complete(flow.tourId, null)
+            }
             return
         }
+        // Seed each setting_choice with its manifest default so a user who
+        // accepts what the card already shows still has it persisted on
+        // advance.
+        val defaults = steps
+            .filter { it.kind == "setting_choice" }
+            .mapNotNull { step -> step.setting?.default?.let { step.id to it } }
+            .toMap()
         _uiState.update {
-            it.copy(isLoading = false, steps = steps, tourId = flow.tourId, currentIndex = 0)
+            it.copy(
+                isLoading = false,
+                steps = steps,
+                tourId = flow.tourId,
+                currentIndex = 0,
+                pendingChoices = defaults,
+            )
         }
     }
 
     fun onAdvance() {
         val current = _uiState.value
+        persistChoiceIfAny(current.steps.getOrNull(current.currentIndex))
         val next = current.currentIndex + 1
         if (next >= current.steps.size) {
-            finish(skipped = false)
+            finish(skipped = false, persistCurrentChoice = false)
             return
         }
         viewModelScope.launch {
@@ -93,21 +146,43 @@ class OnboardingTourViewModel(
         _uiState.update { it.copy(currentIndex = (it.currentIndex - 1).coerceAtLeast(0)) }
     }
 
-    fun onSkip() = finish(skipped = true)
+    fun onSkip() = finish(skipped = true, persistCurrentChoice = false)
 
-    fun onFinish() = finish(skipped = false)
+    fun onFinish() = finish(skipped = false, persistCurrentChoice = true)
 
-    private fun finish(skipped: Boolean) {
+    private fun finish(skipped: Boolean, persistCurrentChoice: Boolean) {
         val current = _uiState.value
+        if (persistCurrentChoice) {
+            persistChoiceIfAny(current.steps.getOrNull(current.currentIndex))
+        }
+        markDoneLocally()
         viewModelScope.launch {
             val lastStep = current.steps.getOrNull(current.currentIndex)?.id
-            if (skipped) {
-                onboardingRepository.skip(current.tourId, lastStep)
-            } else {
-                onboardingRepository.complete(current.tourId, lastStep)
+            // finished=true (below) navigates away with popUpTo, which clears
+            // this ViewModel and cancels its scope — the POST must survive
+            // that or the server never learns the tour ended and re-shows it.
+            withContext(NonCancellable) {
+                if (skipped) {
+                    onboardingRepository.skip(current.tourId, lastStep)
+                } else {
+                    onboardingRepository.complete(current.tourId, lastStep)
+                }
             }
         }
         _uiState.update { it.copy(finished = true) }
+    }
+
+    private fun markDoneLocally() {
+        viewModelScope.launch {
+            withContext(NonCancellable) {
+                localCache.markDone(tokenManager.getCurrentServerId(), tokenManager.getProfileId())
+            }
+        }
+    }
+
+    /** Records a tapped option locally; nothing is written until advance. */
+    fun onSettingChosen(step: OnboardingStep, value: String) {
+        _uiState.update { it.copy(pendingChoices = it.pendingChoices + (step.id to value)) }
     }
 
     /**
@@ -116,9 +191,10 @@ class OnboardingTourViewModel(
      * unknown keys (a newer server) are ignored rather than failing the
      * tour. Only profile_field targets exist for phones today.
      */
-    fun onSettingChosen(step: OnboardingStep, value: String) {
-        val spec = step.setting ?: return
+    private fun persistChoiceIfAny(step: OnboardingStep?) {
+        val spec = step?.setting ?: return
         if (spec.target != "profile_field") return
+        val value = _uiState.value.pendingChoices[step.id] ?: return
         val request = when (spec.key) {
             "quality_preference" -> UpdateProfileRequest(qualityPreference = value)
             "subtitle_language" -> UpdateProfileRequest(subtitleLanguage = value)
@@ -128,7 +204,16 @@ class OnboardingTourViewModel(
             else -> return
         }
         viewModelScope.launch {
-            profileRepository.updateActiveProfile(request)
+            withContext(NonCancellable) {
+                // Android playback and the Settings screen read quality from
+                // the local player settings store, not the profile field —
+                // write both or the choice the tour just showed has no
+                // visible effect anywhere in this app.
+                if (spec.key == "quality_preference") {
+                    playerSettingsStore.setPreferredQuality(value)
+                }
+                profileRepository.updateActiveProfile(request)
+            }
         }
     }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/PlaybackSettings.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/PlaybackSettings.kt
@@ -23,6 +23,7 @@ private val qualityOptions = listOf("Auto", "Original", "4K", "1080p", "720p", "
 // persist codes, as the server's settings contract requires. Shared with the TV
 // UI and with subtitles so the four surfaces cannot drift apart again.
 private val audioLanguageOptions = LanguageOptions.options(unsetLabel = "Default")
+private val audioLanguageLabels = audioLanguageOptions.map { it.second }
 
 // Discrete choices for the two behavior settings (0 = off). Dropdown idiom
 // matches the rest of this section; the label↔value maps below convert.
@@ -83,7 +84,7 @@ fun PlaybackSettings(
         SettingsDropdownRow(
             label = "Audio Language",
             value = LanguageOptions.label(audioLanguage, unsetLabel = "Default"),
-            options = audioLanguageOptions.map { it.second },
+            options = audioLanguageLabels,
             onOptionSelected = { label ->
                 onAudioLanguageChanged(LanguageOptions.wireValue(label))
             },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/PlaybackSettings.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/PlaybackSettings.kt
@@ -15,9 +15,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import org.siloserver.silo.model.settings.LanguageOptions
 
 private val qualityOptions = listOf("Auto", "Original", "4K", "1080p", "720p", "480p")
-private val languageOptions = listOf("Default", "English", "Spanish", "French", "German", "Japanese", "Korean", "Chinese", "Portuguese", "Italian", "Russian")
+
+// Audio language stores BCP 47 tags ("" = no preference) — display labels,
+// persist codes, as the server's settings contract requires. Shared with the TV
+// UI and with subtitles so the four surfaces cannot drift apart again.
+private val audioLanguageOptions = LanguageOptions.options(unsetLabel = "Default")
 
 // Discrete choices for the two behavior settings (0 = off). Dropdown idiom
 // matches the rest of this section; the label↔value maps below convert.
@@ -77,9 +82,11 @@ fun PlaybackSettings(
 
         SettingsDropdownRow(
             label = "Audio Language",
-            value = audioLanguage,
-            options = languageOptions,
-            onOptionSelected = onAudioLanguageChanged,
+            value = LanguageOptions.label(audioLanguage, unsetLabel = "Default"),
+            options = audioLanguageOptions.map { it.second },
+            onOptionSelected = { label ->
+                onAudioLanguageChanged(LanguageOptions.wireValue(label))
+            },
         )
 
         SettingsSwitchRow(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
@@ -48,7 +48,8 @@ data class SettingsUiState(
 
     // Playback
     val defaultQuality: String = "Auto",
-    val audioLanguage: String = "Default",
+    // BCP 47 tag, "" = no preference. The picker converts to and from labels.
+    val audioLanguage: String = "",
     val autoSkipIntro: Boolean = false,
     val autoSkipCredits: Boolean = false,
     val pictureInPictureEnabled: Boolean = true,
@@ -73,7 +74,8 @@ data class SettingsUiState(
     val defaultDownloadQuality: String = DownloadQuality.Original.label,
 
     // Subtitles
-    val subtitleLanguage: String = "Off",
+    // BCP 47 tag, "" = off. The picker converts to and from labels.
+    val subtitleLanguage: String = "",
     // Metadata AI: preferred description/metadata language.
     // ISO 639-1 code; "" = inherit library metadata language.
     val metadataLanguage: String = "",
@@ -131,7 +133,7 @@ class SettingsViewModel(
                     val profile = profileResult.data
                     _uiState.update {
                         it.copy(
-                            subtitleLanguage = profile.subtitleLanguage?.ifBlank { "Off" } ?: "Off",
+                            subtitleLanguage = profile.subtitleLanguage.orEmpty(),
                             metadataLanguage = profile.preferredMetadataLanguage.orEmpty(),
                             subtitleMode = subtitleModeFromServer(profile.subtitleMode),
                             showForcedSubtitles = profile.showForcedSubtitles ?: true,
@@ -168,7 +170,7 @@ class SettingsViewModel(
             _uiState.update {
                 it.copy(
                     defaultQuality = qualityLabel(snap.quality),
-                    audioLanguage = audioLanguageLabel(snap.audioLanguage),
+                    audioLanguage = snap.audioLanguage,
                     autoSkipIntro = snap.autoSkipIntro,
                     autoSkipCredits = snap.autoSkipCredits,
                 )
@@ -373,9 +375,10 @@ class SettingsViewModel(
         }
     }
 
+    /** [language] is a BCP 47 tag, or "" for no preference. */
     fun setAudioLanguage(language: String) {
         viewModelScope.launch {
-            playerSettingsStore.setAudioLanguage(audioLanguageWireValue(language))
+            playerSettingsStore.setAudioLanguage(language)
         }
     }
 
@@ -433,6 +436,7 @@ class SettingsViewModel(
         }
     }
 
+    /** [language] is a BCP 47 tag, or "" for off. */
     fun setSubtitleLanguage(language: String) {
         _uiState.update { it.copy(subtitleLanguage = language) }
         persistProfileSubtitleSettings()
@@ -453,7 +457,7 @@ class SettingsViewModel(
         viewModelScope.launch {
             profileRepository.updateActiveProfile(
                 UpdateProfileRequest(
-                    subtitleLanguage = state.subtitleLanguage.takeUnless { it == "Off" },
+                    subtitleLanguage = state.subtitleLanguage.ifBlank { null },
                     subtitleMode = state.subtitleMode.toServerValue(),
                     showForcedSubtitles = state.showForcedSubtitles,
                 )
@@ -482,12 +486,6 @@ class SettingsViewModel(
 
     private fun downloadQualityWireValue(value: String): String =
         DownloadQuality.entries.firstOrNull { it.label == value }?.wire ?: DownloadQuality.Original.wire
-
-    private fun audioLanguageLabel(value: String): String =
-        value.ifBlank { "Default" }
-
-    private fun audioLanguageWireValue(value: String): String =
-        value.takeUnless { it == "Default" }.orEmpty()
 
     private fun subtitleModeFromServer(value: String?): SubtitleMode =
         when (value?.lowercase()) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import org.siloserver.silo.model.auth.isActingAdmin
 import org.siloserver.silo.model.download.DownloadQuality
 import org.siloserver.silo.model.notifications.NotificationPreferencesUpdate
 import org.siloserver.silo.model.profile.UpdateProfileRequest
+import org.siloserver.silo.model.settings.LanguageOptions
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.AuthRepository
 import org.siloserver.silo.repository.NotificationsRepository
@@ -133,8 +134,11 @@ class SettingsViewModel(
                     val profile = profileResult.data
                     _uiState.update {
                         it.copy(
-                            subtitleLanguage = profile.subtitleLanguage.orEmpty(),
-                            metadataLanguage = profile.preferredMetadataLanguage.orEmpty(),
+                            // Old phone builds stored display labels here; the
+                            // server now rejects them, so translate at load or
+                            // every later profile PUT re-sends the bad value.
+                            subtitleLanguage = LanguageOptions.migrateLegacyValue(profile.subtitleLanguage),
+                            metadataLanguage = LanguageOptions.migrateLegacyValue(profile.preferredMetadataLanguage),
                             subtitleMode = subtitleModeFromServer(profile.subtitleMode),
                             showForcedSubtitles = profile.showForcedSubtitles ?: true,
                             isAdminVisible = shouldShowClientAdminSurface(isActingAdmin(it.user, profile)),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SubtitleSettings.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SubtitleSettings.kt
@@ -6,10 +6,11 @@ import androidx.compose.material.icons.filled.ClosedCaption
 import androidx.compose.ui.Modifier
 import org.siloserver.silo.model.settings.LanguageOptions
 
-// Both of these store language codes, not the labels shown in the picker: the
+// Both language rows store codes, not the labels shown in the picker: the
 // profile's subtitle_language and the metadata language are BCP 47 on the wire.
-private val subtitleLanguageOptions = LanguageOptions.options(unsetLabel = "Off")
-private val metadataLanguageOptions = LanguageOptions.options(unsetLabel = "Off")
+// Hoisted so recomposition doesn't rebuild the label list per frame.
+private val languageOptionLabels =
+    LanguageOptions.options(unsetLabel = "Off").map { it.second }
 
 /**
  * Subtitle settings section with language, display mode, and forced subtitles toggle.
@@ -37,7 +38,7 @@ fun SubtitleSettings(
         SettingsDropdownRow(
             label = "Subtitle Language",
             value = LanguageOptions.label(subtitleLanguage, unsetLabel = "Off"),
-            options = subtitleLanguageOptions.map { it.second },
+            options = languageOptionLabels,
             onOptionSelected = { label ->
                 onLanguageChanged(LanguageOptions.wireValue(label))
             },
@@ -78,7 +79,7 @@ fun SubtitleSettings(
             SettingsDropdownRow(
                 label = "Metadata Language",
                 value = LanguageOptions.label(metadataLanguage, unsetLabel = "Off"),
-                options = metadataLanguageOptions.map { it.second },
+                options = languageOptionLabels,
                 onOptionSelected = { label ->
                     onMetadataLanguageChanged(LanguageOptions.wireValue(label))
                 },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SubtitleSettings.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SubtitleSettings.kt
@@ -4,24 +4,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ClosedCaption
 import androidx.compose.ui.Modifier
+import org.siloserver.silo.model.settings.LanguageOptions
 
-private val subtitleLanguageOptions = listOf("Off", "English", "Spanish", "French", "German", "Japanese", "Korean", "Chinese", "Portuguese", "Italian", "Russian")
-
-// Metadata language stores ISO 639-1 codes (server contract; "" = inherit) —
-// display labels, persist codes. Kept in lockstep with the TV list.
-private val metadataLanguageOptions = listOf(
-    "" to "Off",
-    "en" to "English",
-    "es" to "Spanish",
-    "fr" to "French",
-    "de" to "German",
-    "ja" to "Japanese",
-    "ko" to "Korean",
-    "zh" to "Chinese",
-    "pt" to "Portuguese",
-    "it" to "Italian",
-    "ru" to "Russian",
-)
+// Both of these store language codes, not the labels shown in the picker: the
+// profile's subtitle_language and the metadata language are BCP 47 on the wire.
+private val subtitleLanguageOptions = LanguageOptions.options(unsetLabel = "Off")
+private val metadataLanguageOptions = LanguageOptions.options(unsetLabel = "Off")
 
 /**
  * Subtitle settings section with language, display mode, and forced subtitles toggle.
@@ -40,7 +28,7 @@ fun SubtitleSettings(
     modifier: Modifier = Modifier,
     // Metadata AI description translation (server-gated; row hidden when off).
     metadataLanguageEnabled: Boolean = false,
-    metadataLanguage: String = "Off",
+    metadataLanguage: String = "",
     onMetadataLanguageChanged: (String) -> Unit = {},
 ) {
     SettingsSectionCard(modifier = modifier) {
@@ -48,9 +36,11 @@ fun SubtitleSettings(
 
         SettingsDropdownRow(
             label = "Subtitle Language",
-            value = subtitleLanguage,
-            options = subtitleLanguageOptions,
-            onOptionSelected = onLanguageChanged,
+            value = LanguageOptions.label(subtitleLanguage, unsetLabel = "Off"),
+            options = subtitleLanguageOptions.map { it.second },
+            onOptionSelected = { label ->
+                onLanguageChanged(LanguageOptions.wireValue(label))
+            },
         )
 
         SettingsDropdownRow(
@@ -85,15 +75,12 @@ fun SubtitleSettings(
         }
 
         if (metadataLanguageEnabled) {
-            val selectedLabel = metadataLanguageOptions.firstOrNull { it.first == metadataLanguage }?.second ?: "Off"
             SettingsDropdownRow(
                 label = "Metadata Language",
-                value = selectedLabel,
+                value = LanguageOptions.label(metadataLanguage, unsetLabel = "Off"),
                 options = metadataLanguageOptions.map { it.second },
                 onOptionSelected = { label ->
-                    metadataLanguageOptions.firstOrNull { it.second == label }?.let {
-                        onMetadataLanguageChanged(it.first)
-                    }
+                    onMetadataLanguageChanged(LanguageOptions.wireValue(label))
                 },
             )
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
@@ -897,7 +897,7 @@ private fun TvPlaybackSettingsPane(
         )
         PlaybackPicker.AudioLanguage -> TvSettingsPickerSheet(
             title = "Audio Language",
-            options = AudioLanguages.map { PickerOption(it.first, it.second) },
+            options = audioLanguages.map { PickerOption(it.first, it.second) },
             selectedId = state.audioLanguage,
             onSelect = { onAudioLanguageChanged(it); activePicker = null },
             onDismiss = { activePicker = null },
@@ -1101,14 +1101,14 @@ private fun TvSubtitleSettingsPane(
         )
         SubtitlePicker.Language -> TvSettingsPickerSheet(
             title = "Language",
-            options = SubtitleLanguages.map { PickerOption(it.first, it.second) },
+            options = subtitleLanguages.map { PickerOption(it.first, it.second) },
             selectedId = state.subtitleLanguage,
             onSelect = { onSubtitleLanguageChanged(it); activePicker = null },
             onDismiss = { activePicker = null },
         )
         SubtitlePicker.MetadataLanguage -> TvSettingsPickerSheet(
             title = "Metadata Language",
-            options = SubtitleLanguages.map { PickerOption(it.first, it.second) },
+            options = subtitleLanguages.map { PickerOption(it.first, it.second) },
             selectedId = state.metadataLanguage,
             onSelect = { onMetadataLanguageChanged(it); activePicker = null },
             onDismiss = { activePicker = null },
@@ -2031,9 +2031,9 @@ private val NextUpPromptOptions = listOf(0, 10, 30, 60, 120)
 // for playback.audio_language and the profile's subtitle_language. Audio used
 // to store the display name here, which the server now rejects — and which
 // never matched a track anyway, since ExoPlayer compares against `eng`.
-private val AudioLanguages = LanguageOptions.options(unsetLabel = "Default")
+private val audioLanguages = LanguageOptions.options(unsetLabel = "Default")
 
-private val SubtitleLanguages = LanguageOptions.options(unsetLabel = "Off")
+private val subtitleLanguages = LanguageOptions.options(unsetLabel = "Off")
 
 private fun audioLanguageLabel(wire: String): String =
     LanguageOptions.label(wire, unsetLabel = "Default")

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
@@ -76,6 +76,7 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
+import org.siloserver.silo.model.settings.LanguageOptions
 import org.siloserver.silo.model.settings.SubtitleBackgroundStylePreset
 import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.model.settings.SubtitleFontSizePreset
@@ -2026,41 +2027,19 @@ private val PassOutThresholdOptions = listOf(0, 2, 3, 4, 5)
 // Up-Next prompt timing (seconds before end; 0 = at end). Mirrors tvOS.
 private val NextUpPromptOptions = listOf(0, 10, 30, 60, 120)
 
-// Audio-language options mirror the phone: the stored value IS the display
-// name (Default => "" locally), persisted to playerSettingsStore.audioLanguage.
-private val AudioLanguages = listOf(
-    "" to "Default",
-    "English" to "English",
-    "Spanish" to "Spanish",
-    "French" to "French",
-    "German" to "German",
-    "Japanese" to "Japanese",
-    "Korean" to "Korean",
-    "Chinese" to "Chinese",
-    "Portuguese" to "Portuguese",
-    "Italian" to "Italian",
-    "Russian" to "Russian",
-)
+// Both store BCP 47 tags, which is what the server's settings contract declares
+// for playback.audio_language and the profile's subtitle_language. Audio used
+// to store the display name here, which the server now rejects — and which
+// never matched a track anyway, since ExoPlayer compares against `eng`.
+private val AudioLanguages = LanguageOptions.options(unsetLabel = "Default")
 
-private val SubtitleLanguages = listOf(
-    "" to "Off",
-    "en" to "English",
-    "es" to "Spanish",
-    "fr" to "French",
-    "de" to "German",
-    "ja" to "Japanese",
-    "ko" to "Korean",
-    "zh" to "Chinese",
-    "pt" to "Portuguese",
-    "it" to "Italian",
-    "ru" to "Russian",
-)
+private val SubtitleLanguages = LanguageOptions.options(unsetLabel = "Off")
 
 private fun audioLanguageLabel(wire: String): String =
-    AudioLanguages.firstOrNull { it.first == wire }?.second ?: "Default"
+    LanguageOptions.label(wire, unsetLabel = "Default")
 
 private fun subtitleLanguageLabel(wire: String): String =
-    SubtitleLanguages.firstOrNull { it.first == wire }?.second ?: "Off"
+    LanguageOptions.label(wire, unsetLabel = "Off")
 
 private fun resumeRewindLabel(seconds: Int): String =
     if (seconds <= 0) "Off" else "${seconds}s"

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
@@ -10,6 +10,7 @@ import org.siloserver.silo.model.admin.shouldShowClientAdminSurface
 import org.siloserver.silo.model.auth.User
 import org.siloserver.silo.model.auth.isActingAdmin
 import org.siloserver.silo.model.profile.UpdateProfileRequest
+import org.siloserver.silo.model.settings.LanguageOptions
 import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.model.settings.SubtitleBackgroundStylePreset
 import org.siloserver.silo.model.settings.SubtitleFontSizePreset
@@ -185,8 +186,12 @@ class TvSettingsViewModel(
                     _uiState.update {
                         it.copy(
                             subtitleMode = SubtitleMode.fromWire(profile.subtitleMode),
-                            subtitleLanguage = profile.subtitleLanguage.orEmpty(),
-                            metadataLanguage = profile.preferredMetadataLanguage.orEmpty(),
+                            // Old phone builds stored display labels in the
+                            // shared profile; the server now rejects them, so
+                            // translate at load or every later profile PUT
+                            // (which the error path reverts) re-sends them.
+                            subtitleLanguage = LanguageOptions.migrateLegacyValue(profile.subtitleLanguage),
+                            metadataLanguage = LanguageOptions.migrateLegacyValue(profile.preferredMetadataLanguage),
                             showForcedSubtitles = profile.showForcedSubtitles ?: true,
                         )
                     }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/NetworkModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/NetworkModule.kt
@@ -13,6 +13,7 @@ val networkModule = module {
     single<TokenManager> { TokenManagerImpl(get()) }
     single { createSiloClient(get(), getOrNull(), getOrNull(), getOrNull()) }
     single { AuthApi(get()) }
+    single { OnboardingApi(get()) }
     single<DeviceLoginApi> { DefaultDeviceLoginApi(get()) }
     single { CatalogApi(get()) }
     single { PlaybackApi(get()) }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
@@ -6,6 +6,7 @@ import org.siloserver.silo.domain.MediaActionsCoordinator
 import org.siloserver.silo.model.feature.RequestsFeatureStore
 import org.siloserver.silo.repository.AdminRepository
 import org.siloserver.silo.repository.AuthRepository
+import org.siloserver.silo.repository.OnboardingRepository
 import org.siloserver.silo.repository.CalendarRepository
 import org.siloserver.silo.repository.DeviceLoginRepository
 import org.siloserver.silo.repository.CatalogRepository
@@ -47,6 +48,7 @@ val repositoryModule = module {
     // (commonMain tests, hypothetical iOS reuse). Both repos no-op the
     // multi-server side effects when the registry is null.
     single { AuthRepository(get(), get(), getOrNull(), getOrNull()) }
+    single { OnboardingRepository(get()) }
     single { DeviceLoginRepository(get()) }
     single { CatalogRepository(get(), getOrNull<org.siloserver.silo.repository.port.CatalogCachePort>() ?: org.siloserver.silo.repository.port.NoOpCatalogCachePort) }
     single { CalendarRepository(get()) }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/auth/InvitationModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/auth/InvitationModels.kt
@@ -1,0 +1,22 @@
+package org.siloserver.silo.model.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emailed-invitation claim flow. The invitee's email address is their
+ * username; the claim screen asks for a password and nothing else.
+ */
+@Serializable
+data class InvitationLookupResponse(
+    val email: String,
+    @SerialName("inviter_name") val inviterName: String? = null,
+    @SerialName("server_name") val serverName: String,
+    @SerialName("expires_at") val expiresAt: String,
+    @SerialName("show_tour") val showTour: Boolean = true,
+)
+
+@Serializable
+data class AcceptInvitationRequest(
+    val password: String,
+)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/auth/InvitationModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/auth/InvitationModels.kt
@@ -13,7 +13,6 @@ data class InvitationLookupResponse(
     @SerialName("inviter_name") val inviterName: String? = null,
     @SerialName("server_name") val serverName: String,
     @SerialName("expires_at") val expiresAt: String,
-    @SerialName("show_tour") val showTour: Boolean = true,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/onboarding/OnboardingModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/onboarding/OnboardingModels.kt
@@ -26,8 +26,6 @@ data class OnboardingStep(
     /** Client-side asset key; the server never sends image URLs. */
     val illustration: String? = null,
     val setting: OnboardingSettingSpec? = null,
-    val route: String? = null,
-    @SerialName("action_label") val actionLabel: String? = null,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/onboarding/OnboardingModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/onboarding/OnboardingModels.kt
@@ -1,0 +1,65 @@
+package org.siloserver.silo.model.onboarding
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Server-driven onboarding tour manifest. The server has already filtered
+ * out steps for disabled features and for the requested surface; the client
+ * renders the step kinds it knows and silently skips the rest — that skip is
+ * the forward-compatibility contract.
+ */
+@Serializable
+data class OnboardingFlow(
+    val version: Int,
+    @SerialName("tour_id") val tourId: String,
+    val steps: List<OnboardingStep> = emptyList(),
+)
+
+@Serializable
+data class OnboardingStep(
+    val id: String,
+    /** Open string on purpose: unknown kinds must be skipped, not fail decode. */
+    val kind: String,
+    val title: String? = null,
+    val body: String? = null,
+    /** Client-side asset key; the server never sends image URLs. */
+    val illustration: String? = null,
+    val setting: OnboardingSettingSpec? = null,
+    val route: String? = null,
+    @SerialName("action_label") val actionLabel: String? = null,
+)
+
+@Serializable
+data class OnboardingSettingSpec(
+    /** "profile_field" | "setting" | "device_setting" — selects the write API. */
+    val target: String,
+    val key: String,
+    val control: String,
+    val options: List<OnboardingSettingOption> = emptyList(),
+    val default: String? = null,
+    val label: String? = null,
+)
+
+@Serializable
+data class OnboardingSettingOption(
+    val value: String,
+    val label: String,
+)
+
+@Serializable
+data class OnboardingState(
+    @SerialName("tour_id") val tourId: String,
+    @SerialName("last_step") val lastStep: String? = null,
+    @SerialName("completed_at") val completedAt: String? = null,
+    @SerialName("skipped_at") val skippedAt: String? = null,
+    val done: Boolean = false,
+)
+
+@Serializable
+data class OnboardingProgressRequest(
+    @SerialName("tour_id") val tourId: String,
+    @SerialName("last_step") val lastStep: String? = null,
+    val completed: Boolean = false,
+    val skipped: Boolean = false,
+)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
@@ -1,5 +1,7 @@
 package org.siloserver.silo.model.settings
 
+import org.siloserver.silo.playback.canonicalSubtitleLanguage
+
 /**
  * The language choices the settings UI offers, and the wire values they map to.
  *
@@ -64,12 +66,32 @@ object LanguageOptions {
      * Those rows are already on devices in the field. They are not tags, so the
      * server rejects them and track matching never hit on them — but left alone
      * they would keep being read and re-sent. A value that is already a known
-     * tag, or already unset, is returned unchanged; anything else that matches a
-     * label becomes its tag, and an unrecognized value becomes [UNSET].
+     * tag, or already unset, is returned unchanged; a known label becomes its
+     * tag. Anything else that is tag-shaped ("pt-BR", "nl", an alias like
+     * "eng") passes through untouched — the table lists only the languages the
+     * pickers offer, and a valid tag synced from another surface must not be
+     * erased just because it is outside that list. Only values that are neither
+     * a plausible tag nor a known label (i.e. legacy display names we no longer
+     * recognize) become [UNSET].
      */
     fun migrateLegacyValue(stored: String?): String = when {
         stored.isNullOrBlank() -> UNSET
+        // The old pickers' unset labels; "Off" is 3 letters and would
+        // otherwise slip through the tag-shape check below.
+        stored.equals("Off", ignoreCase = true) ||
+            stored.equals("Default", ignoreCase = true) -> UNSET
         TAGS.any { it.first == stored } -> stored
-        else -> wireValue(stored)
+        TAGS.any { it.second == stored } -> wireValue(stored)
+        isTagShaped(stored) -> stored
+        else -> UNSET
     }
+
+    /**
+     * Loose BCP 47 shape check: 2-3 letter primary subtag, optional script /
+     * region subtags. Deliberately permissive — the server is the validator;
+     * this only has to separate tags from display names like "English".
+     */
+    private fun isTagShaped(value: String): Boolean =
+        Regex("^[a-zA-Z]{2,3}([-_][a-zA-Z0-9]{2,8})*$").matches(value) &&
+            canonicalSubtitleLanguage(value) != null
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
@@ -46,12 +46,17 @@ object LanguageOptions {
     /**
      * The label for a stored wire value.
      *
-     * Anything unrecognized reads as unset rather than being echoed back: a
-     * value stored by an older build is a display label the picker has no entry
-     * for, and showing it would suggest a choice the server does not hold.
+     * A tag outside the picker table ("nl", "pt-BR" synced from another
+     * surface) is echoed back as itself: it is a real, active preference, and
+     * labeling it as unset would tell the user a preference playback still
+     * applies is off. Only values that aren't tags at all — legacy display
+     * labels — read as unset, since the server does not hold them.
      */
-    fun label(wire: String?, unsetLabel: String): String =
-        TAGS.firstOrNull { it.first == wire }?.second ?: unsetLabel
+    fun label(wire: String?, unsetLabel: String): String {
+        if (wire.isNullOrBlank()) return unsetLabel
+        TAGS.firstOrNull { it.first == wire }?.let { return it.second }
+        return if (isPreservableTag(wire)) wire else unsetLabel
+    }
 
     /**
      * The wire value for a label the user picked. Falls back to [UNSET], which
@@ -76,13 +81,9 @@ object LanguageOptions {
      */
     fun migrateLegacyValue(stored: String?): String = when {
         stored.isNullOrBlank() -> UNSET
-        // The old pickers' unset labels; "Off" is 3 letters and would
-        // otherwise slip through the tag-shape check below.
-        stored.equals("Off", ignoreCase = true) ||
-            stored.equals("Default", ignoreCase = true) -> UNSET
         TAGS.any { it.first == stored } -> stored
         TAGS.any { it.second == stored } -> wireValue(stored)
-        isTagShaped(stored) -> stored
+        isPreservableTag(stored) -> stored
         else -> UNSET
     }
 
@@ -90,8 +91,12 @@ object LanguageOptions {
      * Loose BCP 47 shape check: 2-3 letter primary subtag, optional script /
      * region subtags. Deliberately permissive — the server is the validator;
      * this only has to separate tags from display names like "English".
+     * The old pickers' unset labels are excluded by name: "Off" is 3 letters
+     * and would otherwise pass as a tag.
      */
-    private fun isTagShaped(value: String): Boolean =
-        Regex("^[a-zA-Z]{2,3}([-_][a-zA-Z0-9]{2,8})*$").matches(value) &&
+    private fun isPreservableTag(value: String): Boolean =
+        !value.equals("Off", ignoreCase = true) &&
+            !value.equals("Default", ignoreCase = true) &&
+            Regex("^[a-zA-Z]{2,3}([-_][a-zA-Z0-9]{2,8})*$").matches(value) &&
             canonicalSubtitleLanguage(value) != null
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
@@ -1,0 +1,75 @@
+package org.siloserver.silo.model.settings
+
+/**
+ * The language choices the settings UI offers, and the wire values they map to.
+ *
+ * The server's settings contract declares `playback.audio_language` and the
+ * profile's `subtitle_language` as BCP 47 language tags, and validates them as
+ * such. Sending a display label ("English") is rejected outright — and was
+ * never useful even when the server accepted it, because
+ * `setPreferredAudioLanguage("English")` never matches a track tagged `eng`.
+ *
+ * One table rather than a list per screen: the phone and TV UIs, audio and
+ * subtitle, previously carried four copies that had already drifted apart —
+ * subtitles on TV stored codes while the phone stored labels, and audio stored
+ * labels on both. A single source means adding a language cannot leave one
+ * surface behind.
+ */
+object LanguageOptions {
+    /** Wire value meaning "no preference"; the server stores this as null. */
+    const val UNSET = ""
+
+    /**
+     * (wire tag, display label), in the order the pickers show them. The first
+     * entry is the unset choice, whose label differs by context — "Default" for
+     * audio, "Off" for subtitles — so callers supply it.
+     */
+    val TAGS: List<Pair<String, String>> = listOf(
+        "en" to "English",
+        "es" to "Spanish",
+        "fr" to "French",
+        "de" to "German",
+        "ja" to "Japanese",
+        "ko" to "Korean",
+        "zh" to "Chinese",
+        "pt" to "Portuguese",
+        "it" to "Italian",
+        "ru" to "Russian",
+    )
+
+    /** The full option list for a picker, led by [unsetLabel]. */
+    fun options(unsetLabel: String): List<Pair<String, String>> =
+        listOf(UNSET to unsetLabel) + TAGS
+
+    /**
+     * The label for a stored wire value.
+     *
+     * Anything unrecognized reads as unset rather than being echoed back: a
+     * value stored by an older build is a display label the picker has no entry
+     * for, and showing it would suggest a choice the server does not hold.
+     */
+    fun label(wire: String?, unsetLabel: String): String =
+        TAGS.firstOrNull { it.first == wire }?.second ?: unsetLabel
+
+    /**
+     * The wire value for a label the user picked. Falls back to [UNSET], which
+     * is the one value the server always accepts.
+     */
+    fun wireValue(label: String?): String =
+        TAGS.firstOrNull { it.second == label }?.first ?: UNSET
+
+    /**
+     * Translates a value stored by a build that persisted display names.
+     *
+     * Those rows are already on devices in the field. They are not tags, so the
+     * server rejects them and track matching never hit on them — but left alone
+     * they would keep being read and re-sent. A value that is already a known
+     * tag, or already unset, is returned unchanged; anything else that matches a
+     * label becomes its tag, and an unrecognized value becomes [UNSET].
+     */
+    fun migrateLegacyValue(stored: String?): String = when {
+        stored.isNullOrBlank() -> UNSET
+        TAGS.any { it.first == stored } -> stored
+        else -> wireValue(stored)
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
@@ -26,7 +26,7 @@ object LanguageOptions {
      * entry is the unset choice, whose label differs by context — "Default" for
      * audio, "Off" for subtitles — so callers supply it.
      */
-    val TAGS: List<Pair<String, String>> = listOf(
+    val tags: List<Pair<String, String>> = listOf(
         "en" to "English",
         "es" to "Spanish",
         "fr" to "French",
@@ -41,7 +41,7 @@ object LanguageOptions {
 
     /** The full option list for a picker, led by [unsetLabel]. */
     fun options(unsetLabel: String): List<Pair<String, String>> =
-        listOf(UNSET to unsetLabel) + TAGS
+        listOf(UNSET to unsetLabel) + tags
 
     /**
      * The label for a stored wire value.
@@ -54,7 +54,7 @@ object LanguageOptions {
      */
     fun label(wire: String?, unsetLabel: String): String {
         if (wire.isNullOrBlank()) return unsetLabel
-        TAGS.firstOrNull { it.first == wire }?.let { return it.second }
+        tags.firstOrNull { it.first == wire }?.let { return it.second }
         return if (isPreservableTag(wire)) wire else unsetLabel
     }
 
@@ -63,7 +63,7 @@ object LanguageOptions {
      * is the one value the server always accepts.
      */
     fun wireValue(label: String?): String =
-        TAGS.firstOrNull { it.second == label }?.first ?: UNSET
+        tags.firstOrNull { it.second == label }?.first ?: UNSET
 
     /**
      * Translates a value stored by a build that persisted display names.
@@ -81,8 +81,8 @@ object LanguageOptions {
      */
     fun migrateLegacyValue(stored: String?): String = when {
         stored.isNullOrBlank() -> UNSET
-        TAGS.any { it.first == stored } -> stored
-        TAGS.any { it.second == stored } -> wireValue(stored)
+        tags.any { it.first == stored } -> stored
+        tags.any { it.second == stored } -> wireValue(stored)
         isPreservableTag(stored) -> stored
         else -> UNSET
     }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/AuthApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/AuthApi.kt
@@ -72,7 +72,9 @@ class AuthApi(private val client: HttpClient) {
         serverUrl: String,
         token: String,
     ): ApiResult<InvitationLookupResponse> = safeApiCall {
-        client.get("${serverUrl.trimEnd('/')}/api/v1/invitations/$token") {
+        // The token arrives from an emailed link and is not ours to trust as
+        // path-safe: a '/' or '?' in it would otherwise re-shape the request.
+        client.get("${serverUrl.trimEnd('/')}/api/v1/invitations/${token.encodeURLPathPart()}") {
             skipSiloAuth()
         }
     }
@@ -86,7 +88,7 @@ class AuthApi(private val client: HttpClient) {
         token: String,
         password: String,
     ): ApiResult<LoginResponse> = safeApiCall {
-        client.post("${serverUrl.trimEnd('/')}/api/v1/invitations/$token/accept") {
+        client.post("${serverUrl.trimEnd('/')}/api/v1/invitations/${token.encodeURLPathPart()}/accept") {
             skipSiloAuth()
             contentType(ContentType.Application.Json)
             setBody(AcceptInvitationRequest(password = password))

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/AuthApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/AuthApi.kt
@@ -64,6 +64,35 @@ class AuthApi(private val client: HttpClient) {
         }
     }
 
+    /**
+     * Resolves an emailed-invitation claim token against the given server.
+     * Unauthenticated: this runs before any account exists.
+     */
+    suspend fun lookupInvitation(
+        serverUrl: String,
+        token: String,
+    ): ApiResult<InvitationLookupResponse> = safeApiCall {
+        client.get("${serverUrl.trimEnd('/')}/api/v1/invitations/$token") {
+            skipSiloAuth()
+        }
+    }
+
+    /**
+     * Accepts an invitation: creates the account (username = the invitation's
+     * email) and returns a normal login response.
+     */
+    suspend fun acceptInvitation(
+        serverUrl: String,
+        token: String,
+        password: String,
+    ): ApiResult<LoginResponse> = safeApiCall {
+        client.post("${serverUrl.trimEnd('/')}/api/v1/invitations/$token/accept") {
+            skipSiloAuth()
+            contentType(ContentType.Application.Json)
+            setBody(AcceptInvitationRequest(password = password))
+        }
+    }
+
     suspend fun getMe(): ApiResult<User> = safeApiCall {
         client.get("/api/v1/auth/me")
     }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/OnboardingApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/OnboardingApi.kt
@@ -2,6 +2,7 @@ package org.siloserver.silo.network.api
 
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
+import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -20,7 +21,9 @@ class OnboardingApi(private val client: HttpClient) {
 
     /** surface is "phone" or "tv"; the server filters unsuitable steps. */
     suspend fun getFlow(surface: String): ApiResult<OnboardingFlow> = safeApiCall {
-        client.get("/api/v1/onboarding/flow?surface=$surface")
+        client.get("/api/v1/onboarding/flow") {
+            parameter("surface", surface)
+        }
     }
 
     suspend fun getState(): ApiResult<OnboardingState> = safeApiCall {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/OnboardingApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/OnboardingApi.kt
@@ -1,0 +1,36 @@
+package org.siloserver.silo.network.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import org.siloserver.silo.model.onboarding.OnboardingFlow
+import org.siloserver.silo.model.onboarding.OnboardingProgressRequest
+import org.siloserver.silo.model.onboarding.OnboardingState
+import org.siloserver.silo.network.ApiResult
+
+/**
+ * Server-driven onboarding tour. All endpoints are profile-scoped — the auth
+ * interceptor attaches X-Profile-Id, so these are only callable once a
+ * profile is active.
+ */
+class OnboardingApi(private val client: HttpClient) {
+
+    /** surface is "phone" or "tv"; the server filters unsuitable steps. */
+    suspend fun getFlow(surface: String): ApiResult<OnboardingFlow> = safeApiCall {
+        client.get("/api/v1/onboarding/flow?surface=$surface")
+    }
+
+    suspend fun getState(): ApiResult<OnboardingState> = safeApiCall {
+        client.get("/api/v1/onboarding/state")
+    }
+
+    suspend fun postProgress(request: OnboardingProgressRequest): ApiResult<Unit> = safeApiCall {
+        client.post("/api/v1/onboarding/progress") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -22,12 +22,12 @@ class AuthRepository(
     private val healthApi: HealthApi? = null,
 ) {
     /**
-     * Logs in with username and password.
-     * On success, persists tokens via [TokenManager] and returns the [User].
+     * Persists a successful auth response's tokens into the active server's
+     * scope and unwraps the [User] — the shared tail of every path that ends
+     * a signed-out state (login, signup, setup, invitation claim).
      */
-    suspend fun login(username: String, password: String): ApiResult<User> {
-        val result = authApi.login(LoginRequest(username = username, password = password))
-        return when (result) {
+    private suspend fun persistSession(result: ApiResult<LoginResponse>): ApiResult<User> =
+        when (result) {
             is ApiResult.Success -> {
                 val data = result.data
                 tokenManager.saveTokens(
@@ -40,7 +40,13 @@ class AuthRepository(
             is ApiResult.Error -> result
             is ApiResult.NetworkError -> result
         }
-    }
+
+    /**
+     * Logs in with username and password.
+     * On success, persists tokens via [TokenManager] and returns the [User].
+     */
+    suspend fun login(username: String, password: String): ApiResult<User> =
+        persistSession(authApi.login(LoginRequest(username = username, password = password)))
 
     /**
      * Credential login without persistence. TV keeps QR and password sign-in
@@ -60,27 +66,16 @@ class AuthRepository(
         password: String,
         inviteCode: String,
     ): ApiResult<User> {
-        val result = authApi.signup(
-            SignupRequest(
-                username = username,
-                email = email,
-                password = password,
-                inviteCode = inviteCode,
+        return persistSession(
+            authApi.signup(
+                SignupRequest(
+                    username = username,
+                    email = email,
+                    password = password,
+                    inviteCode = inviteCode,
+                ),
             ),
         )
-        return when (result) {
-            is ApiResult.Success -> {
-                val data = result.data
-                tokenManager.saveTokens(
-                    accessToken = data.accessToken,
-                    refreshToken = data.refreshToken,
-                    expiresIn = data.expiresIn,
-                )
-                ApiResult.Success(data.user)
-            }
-            is ApiResult.Error -> result
-            is ApiResult.NetworkError -> result
-        }
     }
 
     /**
@@ -91,22 +86,7 @@ class AuthRepository(
         username: String,
         email: String,
         password: String,
-    ): ApiResult<User> {
-        val result = authApi.setup(username, email, password)
-        return when (result) {
-            is ApiResult.Success -> {
-                val data = result.data
-                tokenManager.saveTokens(
-                    accessToken = data.accessToken,
-                    refreshToken = data.refreshToken,
-                    expiresIn = data.expiresIn,
-                )
-                ApiResult.Success(data.user)
-            }
-            is ApiResult.Error -> result
-            is ApiResult.NetworkError -> result
-        }
-    }
+    ): ApiResult<User> = persistSession(authApi.setup(username, email, password))
 
     /** Checks whether the server requires initial setup. */
     suspend fun getSetupStatus(): ApiResult<SetupStatusResponse> =
@@ -128,6 +108,12 @@ class AuthRepository(
      * Accepts an emailed invitation: the account is created with the
      * invitation's email as username, tokens are persisted, and the new
      * [User] is returned — same post-conditions as [signup].
+     *
+     * The claim request goes to [serverUrl] directly (it needs no auth), and
+     * the app only adopts that server as active once the claim has actually
+     * succeeded. Switching first would strand a user whose claim fails —
+     * expired token, already used, network error — on a server they have no
+     * account on, with their previous session no longer active.
      */
     suspend fun acceptInvitation(
         serverUrl: String,
@@ -135,19 +121,10 @@ class AuthRepository(
         password: String,
     ): ApiResult<User> {
         val result = authApi.acceptInvitation(serverUrl, token, password)
-        return when (result) {
-            is ApiResult.Success -> {
-                val data = result.data
-                tokenManager.saveTokens(
-                    accessToken = data.accessToken,
-                    refreshToken = data.refreshToken,
-                    expiresIn = data.expiresIn,
-                )
-                ApiResult.Success(data.user)
-            }
-            is ApiResult.Error -> result
-            is ApiResult.NetworkError -> result
+        if (result is ApiResult.Success) {
+            setServerUrl(serverUrl)
         }
+        return persistSession(result)
     }
 
     /** Checks whether public signups are enabled. */

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -11,6 +11,7 @@ import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.network.api.AuthApi
+import org.siloserver.silo.model.auth.InvitationLookupResponse
 import org.siloserver.silo.network.api.HealthApi
 import org.siloserver.silo.network.map
 
@@ -113,6 +114,41 @@ class AuthRepository(
 
     suspend fun getSetupStatus(serverUrl: String): ApiResult<SetupStatusResponse> =
         authApi.getSetupStatus(serverUrl)
+
+    /**
+     * Resolves an emailed-invitation claim token against a server the app is
+     * not signed into yet.
+     */
+    suspend fun lookupInvitation(
+        serverUrl: String,
+        token: String,
+    ): ApiResult<InvitationLookupResponse> = authApi.lookupInvitation(serverUrl, token)
+
+    /**
+     * Accepts an emailed invitation: the account is created with the
+     * invitation's email as username, tokens are persisted, and the new
+     * [User] is returned — same post-conditions as [signup].
+     */
+    suspend fun acceptInvitation(
+        serverUrl: String,
+        token: String,
+        password: String,
+    ): ApiResult<User> {
+        val result = authApi.acceptInvitation(serverUrl, token, password)
+        return when (result) {
+            is ApiResult.Success -> {
+                val data = result.data
+                tokenManager.saveTokens(
+                    accessToken = data.accessToken,
+                    refreshToken = data.refreshToken,
+                    expiresIn = data.expiresIn,
+                )
+                ApiResult.Success(data.user)
+            }
+            is ApiResult.Error -> result
+            is ApiResult.NetworkError -> result
+        }
+    }
 
     /** Checks whether public signups are enabled. */
     suspend fun getSignupStatus(): ApiResult<SignupStatusResponse> =

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -123,6 +123,14 @@ class AuthRepository(
         val result = authApi.acceptInvitation(serverUrl, token, password)
         if (result is ApiResult.Success) {
             setServerUrl(serverUrl)
+            // The server may already be registered with a previous account's
+            // profile scope, which setServerUrl just restored. The claimed
+            // account is a different identity — drop the stale profile id +
+            // token so its first requests don't carry another user's profile
+            // headers, and so the app lands on profile selection.
+            tokenManager.setProfileId(null)
+            tokenManager.setProfileToken(null)
+            tokenManager.getCurrentServerId()?.let { serverRegistry?.setProfileId(it, null) }
         }
         return persistSession(result)
     }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/OnboardingRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/OnboardingRepository.kt
@@ -1,0 +1,31 @@
+package org.siloserver.silo.repository
+
+import org.siloserver.silo.model.onboarding.OnboardingFlow
+import org.siloserver.silo.model.onboarding.OnboardingProgressRequest
+import org.siloserver.silo.model.onboarding.OnboardingState
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.api.OnboardingApi
+
+/**
+ * First-run tour state and manifest. Completion is per profile and lives on
+ * the server, so finishing on any device silences every other one.
+ */
+class OnboardingRepository(private val api: OnboardingApi) {
+
+    suspend fun getFlow(surface: String): ApiResult<OnboardingFlow> = api.getFlow(surface)
+
+    suspend fun getState(): ApiResult<OnboardingState> = api.getState()
+
+    suspend fun recordStep(tourId: String, stepId: String): ApiResult<Unit> =
+        api.postProgress(OnboardingProgressRequest(tourId = tourId, lastStep = stepId))
+
+    suspend fun complete(tourId: String, lastStep: String?): ApiResult<Unit> =
+        api.postProgress(
+            OnboardingProgressRequest(tourId = tourId, lastStep = lastStep, completed = true),
+        )
+
+    suspend fun skip(tourId: String, lastStep: String?): ApiResult<Unit> =
+        api.postProgress(
+            OnboardingProgressRequest(tourId = tourId, lastStep = lastStep, skipped = true),
+        )
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
@@ -12,7 +12,7 @@ class LanguageOptionsTest {
         // subtitle_language as BCP 47. A display name is rejected outright, and
         // never matched a track even when it was accepted.
         val tagShape = Regex("^[a-z]{2,3}$")
-        for ((wire, label) in LanguageOptions.TAGS) {
+        for ((wire, label) in LanguageOptions.tags) {
             assertTrue(tagShape.matches(wire), "$label persists \"$wire\", which is not a tag")
         }
     }
@@ -24,13 +24,13 @@ class LanguageOptionsTest {
 
         assertEquals(LanguageOptions.UNSET to "Default", audio.first())
         assertEquals(LanguageOptions.UNSET to "Off", subtitles.first())
-        assertEquals(LanguageOptions.TAGS.size + 1, audio.size)
+        assertEquals(LanguageOptions.tags.size + 1, audio.size)
         assertEquals(audio.drop(1), subtitles.drop(1))
     }
 
     @Test
     fun labelsAndWireValuesRoundTrip() {
-        for ((wire, label) in LanguageOptions.TAGS) {
+        for ((wire, label) in LanguageOptions.tags) {
             assertEquals(label, LanguageOptions.label(wire, unsetLabel = "Default"))
             assertEquals(wire, LanguageOptions.wireValue(label))
         }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
@@ -37,13 +37,21 @@ class LanguageOptionsTest {
     }
 
     @Test
-    fun anUnsetOrUnknownValueReadsAsTheUnsetLabel() {
+    fun anUnsetOrLegacyLabelValueReadsAsTheUnsetLabel() {
         assertEquals("Default", LanguageOptions.label("", unsetLabel = "Default"))
         assertEquals("Default", LanguageOptions.label(null, unsetLabel = "Default"))
-        assertEquals("Off", LanguageOptions.label("kl", unsetLabel = "Off"))
         // A value stored by a build that persisted labels must not be echoed
         // back as if it were a choice the server holds.
         assertEquals("Off", LanguageOptions.label("English", unsetLabel = "Off"))
+    }
+
+    @Test
+    fun aPreservedTagOutsideTheTableReadsAsItselfNotAsUnset() {
+        // migrateLegacyValue passes these through, so playback still applies
+        // them; showing "Off"/"Default" would claim an active preference is
+        // disabled.
+        assertEquals("nl", LanguageOptions.label("nl", unsetLabel = "Off"))
+        assertEquals("pt-BR", LanguageOptions.label("pt-BR", unsetLabel = "Default"))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
@@ -60,4 +60,24 @@ class LanguageOptionsTest {
         assertEquals(LanguageOptions.UNSET, LanguageOptions.migrateLegacyValue(null))
         assertEquals(LanguageOptions.UNSET, LanguageOptions.migrateLegacyValue("Klingon"))
     }
+
+    @Test
+    fun validTagsOutsideThePickerTableSurviveMigration() {
+        // The table lists only the languages the pickers offer. A tag synced
+        // from another surface (web offers 37 languages) is server-valid and
+        // must pass through, not be erased to "no preference".
+        assertEquals("nl", LanguageOptions.migrateLegacyValue("nl"))
+        assertEquals("hi", LanguageOptions.migrateLegacyValue("hi"))
+        assertEquals("pt-BR", LanguageOptions.migrateLegacyValue("pt-BR"))
+        assertEquals("zh-Hant", LanguageOptions.migrateLegacyValue("zh-Hant"))
+        assertEquals("eng", LanguageOptions.migrateLegacyValue("eng"))
+    }
+
+    @Test
+    fun legacyUnsetLabelsMigrateToUnset() {
+        // "Off"/"Default" were the old pickers' unset rows; "Off" is short
+        // enough to look tag-shaped and must still clear.
+        assertEquals(LanguageOptions.UNSET, LanguageOptions.migrateLegacyValue("Off"))
+        assertEquals(LanguageOptions.UNSET, LanguageOptions.migrateLegacyValue("Default"))
+    }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
@@ -1,0 +1,63 @@
+package org.siloserver.silo.model.settings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LanguageOptionsTest {
+
+    @Test
+    fun everyOptionPersistsALanguageTagRatherThanItsLabel() {
+        // The server validates playback.audio_language and the profile's
+        // subtitle_language as BCP 47. A display name is rejected outright, and
+        // never matched a track even when it was accepted.
+        val tagShape = Regex("^[a-z]{2,3}$")
+        for ((wire, label) in LanguageOptions.TAGS) {
+            assertTrue(tagShape.matches(wire), "$label persists \"$wire\", which is not a tag")
+        }
+    }
+
+    @Test
+    fun optionsLeadWithTheUnsetChoiceUnderTheCallersLabel() {
+        val audio = LanguageOptions.options(unsetLabel = "Default")
+        val subtitles = LanguageOptions.options(unsetLabel = "Off")
+
+        assertEquals(LanguageOptions.UNSET to "Default", audio.first())
+        assertEquals(LanguageOptions.UNSET to "Off", subtitles.first())
+        assertEquals(LanguageOptions.TAGS.size + 1, audio.size)
+        assertEquals(audio.drop(1), subtitles.drop(1))
+    }
+
+    @Test
+    fun labelsAndWireValuesRoundTrip() {
+        for ((wire, label) in LanguageOptions.TAGS) {
+            assertEquals(label, LanguageOptions.label(wire, unsetLabel = "Default"))
+            assertEquals(wire, LanguageOptions.wireValue(label))
+        }
+    }
+
+    @Test
+    fun anUnsetOrUnknownValueReadsAsTheUnsetLabel() {
+        assertEquals("Default", LanguageOptions.label("", unsetLabel = "Default"))
+        assertEquals("Default", LanguageOptions.label(null, unsetLabel = "Default"))
+        assertEquals("Off", LanguageOptions.label("kl", unsetLabel = "Off"))
+        // A value stored by a build that persisted labels must not be echoed
+        // back as if it were a choice the server holds.
+        assertEquals("Off", LanguageOptions.label("English", unsetLabel = "Off"))
+    }
+
+    @Test
+    fun legacyLabelValuesMigrateToTheirTags() {
+        // What older builds actually wrote to DataStore and PUT to the server.
+        assertEquals("en", LanguageOptions.migrateLegacyValue("English"))
+        assertEquals("ja", LanguageOptions.migrateLegacyValue("Japanese"))
+        // Already-correct values survive untouched.
+        assertEquals("en", LanguageOptions.migrateLegacyValue("en"))
+        assertEquals("pt", LanguageOptions.migrateLegacyValue("pt"))
+        // Unset stays unset, and anything unrecognized clears rather than
+        // continuing to fail validation on every flush.
+        assertEquals(LanguageOptions.UNSET, LanguageOptions.migrateLegacyValue(""))
+        assertEquals(LanguageOptions.UNSET, LanguageOptions.migrateLegacyValue(null))
+        assertEquals(LanguageOptions.UNSET, LanguageOptions.migrateLegacyValue("Klingon"))
+    }
+}


### PR DESCRIPTION
## Summary

Android companion to Silo-Server/silo-server#501 (emailed invitations + server-driven onboarding).

- **Invite deep link** — `silo://invite?server=…&token=…` (host registered in the manifest) opens `InviteClaimScreen` with the server URL and single-use token already bound, skipping the "which server?" step entirely. The invitee sets only a password; their email address becomes their username. On success the server is registered through the existing `AuthRepository.setServerUrl` path and tokens persist — identical post-conditions to a manual login. Expired/used/revoked links render an explanatory card, not an error toast.
- **Server-driven feature tour** — `OnboardingTourScreen` renders `GET /onboarding/flow?surface=phone`: one step per page (Aurora treatment), skip always reachable, unknown step kinds dropped at load per the forward-compat contract. Progress and completion post per profile, so finishing on the phone silences web and TV. `setting_choice` steps write through the existing profile-update path (`quality_preference`, `subtitle_mode`, …).
- **Gate** — profile selection now routes Home entry through the tour screen, which checks `/onboarding/state` and immediately hands off to Home when the profile has already completed or skipped. Any state/flow error also skips rather than blocking first run.

Shared additions: `InvitationModels`, `OnboardingModels`, `OnboardingApi`, `OnboardingRepository`, invitation lookup/accept on `AuthApi`/`AuthRepository`, Koin wiring.

Out of scope (follow-up): androidTvApp `surface=tv` renderer; https App Links (need the server to host `assetlinks.json` — custom scheme works today).

## Verification

```
$ ./gradlew :shared:compileDebugKotlinAndroid :androidApp:compileDebugKotlinAndroid
BUILD SUCCESSFUL
$ ./gradlew :shared:testDebugUnitTest :androidApp:testDebugUnitTest
BUILD SUCCESSFUL
```

Not yet exercised against a device/emulator — the server endpoints themselves were verified end-to-end in the server PR (browser + curl). Flagging that a manual emulator pass of the deep link (`adb shell am start -a android.intent.action.VIEW -d "silo://invite?server=…&token=…"`) is the right pre-merge check.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-fable-5
- Involvement: fully AI-generated
- Adversarial review: reviewed the diff before commit. Found and fixed: (1) the claim VM originally took a ServerRegistry directly and called a method that doesn't exist on it — replaced with the established `AuthRepository.setServerUrl` path which upserts + switches + restores token scope; (2) the tour screen initially used invented modifier helpers (`clickableOption`, `border16`) — replaced with real `clickable`/`border`; (3) `UpdateProfileRequest` is typed per field, so the manifest's string key maps through an explicit whitelist and unknown keys no-op instead of failing the tour. Known gap: no emulator run yet (stated above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added emailed-invitation claim flow with `silo://invite` deep links (password setup + completion routing).
  * Added server-driven onboarding tour with step persistence, skip, and “done” handling (including onboarding settings).
* **Improvements**
  * Standardized audio/subtitle/metadata language pickers using shared language-tag mappings, with legacy migration.
  * Added cleartext HTTP consent prompt during invitation claims.
  * Improved deep-link and start-route handling for invite-claim and onboarding completion.
* **Bug Fixes**
  * Prevented onboarding from being bypassed after warm starts or server/profile switching.
* **Tests**
  * Added language-tag mapping and migration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->