### PR TITLE
fix(subtitles): recenter cues after aspect mode changes

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
@@ -606,6 +606,16 @@ private class SubtitleVideoRectSync(
     View.OnAttachStateChangeListener,
     Player.Listener {
 
+    private data class LayoutSnapshot(
+        val resizeMode: Int,
+        val playerWidth: Int,
+        val playerHeight: Int,
+        val frameLeft: Int,
+        val frameTop: Int,
+        val frameWidth: Int,
+        val frameHeight: Int,
+    )
+
     private val playerViewRef = WeakReference(playerView)
     private val contentFrameRef = WeakReference(
         playerView.findViewById<AspectRatioFrameLayout>(
@@ -613,6 +623,9 @@ private class SubtitleVideoRectSync(
         )
     )
     private var observedPlayer: Player? = null
+    private var reconciliationGeneration = 0L
+    private var pendingVerification: Runnable? = null
+    private var appliedPasses = 0
 
     var letterbox: LetterboxInsets = LetterboxInsets.NONE
         set(value) {
@@ -632,11 +645,23 @@ private class SubtitleVideoRectSync(
         private set
 
     private var pendingPreDrawObserver: ViewTreeObserver? = null
+    private var pendingPreDrawGeneration = 0L
     private val postLayoutUpdate = ViewTreeObserver.OnPreDrawListener {
+        val generation = pendingPreDrawGeneration
         clearPendingPostLayoutUpdate()
-        if (!isDisposed) {
+        if (!isDisposed && generation == reconciliationGeneration) {
             update()
+            val currentPlayerView = playerViewRef.get()
+            val appliedSnapshot = currentPlayerView?.let(::currentSnapshot)
+            appliedPasses++
             onPostLayoutReconciled()
+            if (currentPlayerView != null && appliedSnapshot != null && appliedPasses < 2) {
+                postSnapshotVerification(
+                    playerView = currentPlayerView,
+                    generation = generation,
+                    appliedSnapshot = appliedSnapshot,
+                )
+            }
         }
         true
     }
@@ -672,14 +697,65 @@ private class SubtitleVideoRectSync(
         update()
         val playerView = playerViewRef.get() ?: return
         if (isDisposed) return
+        reconciliationGeneration++
+        appliedPasses = 0
+        clearPendingVerification(playerView)
+        schedulePreDrawFor(reconciliationGeneration)
+    }
+
+    private fun schedulePreDrawFor(generation: Long) {
+        val playerView = playerViewRef.get() ?: return dispose(null)
+        if (isDisposed || generation != reconciliationGeneration) return
         pendingPreDrawObserver?.let { observer ->
-            if (observer.isAlive) return
+            if (observer.isAlive) {
+                pendingPreDrawGeneration = generation
+                return
+            }
             pendingPreDrawObserver = null
         }
         val observer = playerView.viewTreeObserver
         if (!observer.isAlive) return
+        pendingPreDrawGeneration = generation
         pendingPreDrawObserver = observer
         observer.addOnPreDrawListener(postLayoutUpdate)
+    }
+
+    private fun postSnapshotVerification(
+        playerView: PlayerView,
+        generation: Long,
+        appliedSnapshot: LayoutSnapshot,
+    ) {
+        lateinit var verification: Runnable
+        verification = Runnable {
+            if (pendingVerification === verification) {
+                pendingVerification = null
+            }
+            val currentPlayerView = playerViewRef.get()
+            if (
+                !isDisposed &&
+                generation == reconciliationGeneration &&
+                appliedPasses < 2 &&
+                currentPlayerView != null &&
+                currentSnapshot(currentPlayerView) != appliedSnapshot
+            ) {
+                schedulePreDrawFor(generation)
+            }
+        }
+        pendingVerification = verification
+        playerView.post(verification)
+    }
+
+    private fun currentSnapshot(playerView: PlayerView): LayoutSnapshot {
+        val contentFrame = contentFrameRef.get()
+        return LayoutSnapshot(
+            resizeMode = playerView.resizeMode,
+            playerWidth = playerView.width,
+            playerHeight = playerView.height,
+            frameLeft = contentFrame?.left ?: 0,
+            frameTop = contentFrame?.top ?: 0,
+            frameWidth = contentFrame?.width ?: 0,
+            frameHeight = contentFrame?.height ?: 0,
+        )
     }
 
     override fun onVideoSizeChanged(videoSize: VideoSize) {
@@ -765,13 +841,15 @@ private class SubtitleVideoRectSync(
     private fun dispose(view: View?) {
         if (isDisposed) return
         val playerView = (view as? PlayerView) ?: playerViewRef.get()
+        isDisposed = true
+        reconciliationGeneration++
         clearPendingPostLayoutUpdate()
+        clearPendingVerification(playerView)
         observedPlayer?.removeListener(this)
         observedPlayer = null
         playerView?.removeOnLayoutChangeListener(this)
         playerView?.removeOnAttachStateChangeListener(this)
         contentFrameRef.get()?.removeOnLayoutChangeListener(this)
-        isDisposed = true
     }
 
     private fun clearPendingPostLayoutUpdate() {
@@ -781,6 +859,13 @@ private class SubtitleVideoRectSync(
             }
         }
         pendingPreDrawObserver = null
+    }
+
+    private fun clearPendingVerification(playerView: PlayerView?) {
+        pendingVerification?.let { verification ->
+            playerView?.removeCallbacks(verification)
+        }
+        pendingVerification = null
     }
 }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
@@ -41,8 +41,16 @@ import kotlin.math.roundToInt
  * This manager builds subtitle configurations and applies track selection.
  */
 @UnstableApi
+enum class AndroidSubtitlePresentation {
+    Phone,
+    Television,
+}
+
+@UnstableApi
 class SubtitleManager(
     private val libassBridge: LibassBridge? = null,
+    private val presentation: AndroidSubtitlePresentation =
+        AndroidSubtitlePresentation.Television,
 ) {
 
     private val videoRectSyncs = WeakHashMap<PlayerView, SubtitleVideoRectSync>()
@@ -332,13 +340,23 @@ class SubtitleManager(
     }
 
     private fun fractionalSizeFor(preset: SubtitleFontSizePreset): Float {
-        return when (preset) {
-            SubtitleFontSizePreset.Small -> 20f / 720f
-            SubtitleFontSizePreset.Medium -> 26f / 720f
-            SubtitleFontSizePreset.Large -> 32f / 720f
-            SubtitleFontSizePreset.XLarge -> 40f / 720f
-            SubtitleFontSizePreset.XXLarge -> 48f / 720f
+        val numerator = when (presentation) {
+            AndroidSubtitlePresentation.Phone -> when (preset) {
+                SubtitleFontSizePreset.Small -> 25f
+                SubtitleFontSizePreset.Medium -> 32.5f
+                SubtitleFontSizePreset.Large -> 40f
+                SubtitleFontSizePreset.XLarge -> 50f
+                SubtitleFontSizePreset.XXLarge -> 60f
+            }
+            AndroidSubtitlePresentation.Television -> when (preset) {
+                SubtitleFontSizePreset.Small -> 20f
+                SubtitleFontSizePreset.Medium -> 26f
+                SubtitleFontSizePreset.Large -> 32f
+                SubtitleFontSizePreset.XLarge -> 40f
+                SubtitleFontSizePreset.XXLarge -> 48f
+            }
         }
+        return numerator / 720f
     }
 
     private fun bottomPaddingFor(position: SubtitlePositionPreset): Float {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
@@ -493,6 +493,17 @@ internal fun displayedSubtitleVideoRect(
     )
 }
 
+internal fun selectSubtitleCanvasRect(
+    resizeMode: Int,
+    contentFrameRect: SubtitleVideoRect?,
+    displayedVideoRect: SubtitleVideoRect,
+): SubtitleVideoRect = when (resizeMode) {
+    AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+    AspectRatioFrameLayout.RESIZE_MODE_FILL,
+    -> displayedVideoRect
+    else -> contentFrameRect ?: displayedVideoRect
+}
+
 internal fun displayedSubtitleContentFrameRect(
     viewWidth: Int,
     viewHeight: Int,
@@ -662,15 +673,20 @@ private class SubtitleVideoRectSync(playerView: PlayerView) :
     private fun applyRect(playerView: PlayerView) {
         val subtitleView = playerView.subtitleView ?: return
         val videoSize = playerView.player?.videoSize ?: VideoSize.UNKNOWN
-        val rect = (playerView.contentFrameSubtitleRect()
-            ?: displayedSubtitleVideoRect(
-                viewWidth = playerView.width,
-                viewHeight = playerView.height,
-                videoWidth = videoSize.width,
-                videoHeight = videoSize.height,
-                videoPixelWidthHeightRatio = videoSize.pixelWidthHeightRatio,
-                resizeMode = playerView.resizeMode,
-            )).insetByLetterbox(letterbox).insetByTitleSafe(titleSafeFraction)
+        val resizeMode = playerView.resizeMode
+        val displayedVideoRect = displayedSubtitleVideoRect(
+            viewWidth = playerView.width,
+            viewHeight = playerView.height,
+            videoWidth = videoSize.width,
+            videoHeight = videoSize.height,
+            videoPixelWidthHeightRatio = videoSize.pixelWidthHeightRatio,
+            resizeMode = resizeMode,
+        )
+        val rect = selectSubtitleCanvasRect(
+            resizeMode = resizeMode,
+            contentFrameRect = playerView.contentFrameSubtitleRect(),
+            displayedVideoRect = displayedVideoRect,
+        ).insetByLetterbox(letterbox).insetByTitleSafe(titleSafeFraction)
         val current = subtitleView.layoutParams as? FrameLayout.LayoutParams
         val params = current ?: FrameLayout.LayoutParams(rect.width, rect.height)
         val gravity = Gravity.TOP or Gravity.START

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
@@ -284,6 +284,7 @@ class SubtitleManager(
         val sync = if (existing?.isDisposed == true || existing == null) {
             SubtitleVideoRectSync(
                 playerView = playerView,
+                presentation = presentation,
                 onPostLayoutReconciled = { postLayoutReconciliationObserver?.invoke() },
             ).also {
                 it.letterbox = letterbox
@@ -342,11 +343,11 @@ class SubtitleManager(
     private fun fractionalSizeFor(preset: SubtitleFontSizePreset): Float {
         val numerator = when (presentation) {
             AndroidSubtitlePresentation.Phone -> when (preset) {
-                SubtitleFontSizePreset.Small -> 25f
-                SubtitleFontSizePreset.Medium -> 32.5f
-                SubtitleFontSizePreset.Large -> 40f
-                SubtitleFontSizePreset.XLarge -> 50f
-                SubtitleFontSizePreset.XXLarge -> 60f
+                SubtitleFontSizePreset.Small -> 22.5f
+                SubtitleFontSizePreset.Medium -> 29.25f
+                SubtitleFontSizePreset.Large -> 36f
+                SubtitleFontSizePreset.XLarge -> 45f
+                SubtitleFontSizePreset.XXLarge -> 54f
             }
             AndroidSubtitlePresentation.Television -> when (preset) {
                 SubtitleFontSizePreset.Small -> 20f
@@ -600,6 +601,7 @@ internal fun neutralizeFullWidthCueSizes(cueGroup: CueGroup): CueGroup {
 @UnstableApi
 private class SubtitleVideoRectSync(
     playerView: PlayerView,
+    private val presentation: AndroidSubtitlePresentation,
     private val onPostLayoutReconciled: () -> Unit,
 ) :
     View.OnLayoutChangeListener,
@@ -802,8 +804,29 @@ private class SubtitleVideoRectSync(
 
     private fun applyRect(playerView: PlayerView) {
         val subtitleView = playerView.subtitleView ?: return
-        val videoSize = playerView.player?.videoSize ?: VideoSize.UNKNOWN
         val resizeMode = playerView.resizeMode
+        val gravity = Gravity.TOP or Gravity.START
+        if (
+            presentation == AndroidSubtitlePresentation.Phone &&
+            (
+                resizeMode == AspectRatioFrameLayout.RESIZE_MODE_FIT ||
+                    resizeMode == AspectRatioFrameLayout.RESIZE_MODE_FILL
+            ) &&
+            !letterbox.isDetected &&
+            titleSafeFraction <= 0f
+        ) {
+            applyLayoutParams(
+                subtitleView = subtitleView,
+                width = FrameLayout.LayoutParams.MATCH_PARENT,
+                height = FrameLayout.LayoutParams.MATCH_PARENT,
+                leftMargin = 0,
+                topMargin = 0,
+                gravity = gravity,
+            )
+            return
+        }
+
+        val videoSize = playerView.player?.videoSize ?: VideoSize.UNKNOWN
         val displayedVideoRect = displayedSubtitleVideoRect(
             viewWidth = playerView.width,
             viewHeight = playerView.height,
@@ -819,7 +842,6 @@ private class SubtitleVideoRectSync(
         ).insetByLetterbox(letterbox).insetByTitleSafe(titleSafeFraction)
         val current = subtitleView.layoutParams as? FrameLayout.LayoutParams
         val params = current ?: FrameLayout.LayoutParams(rect.width, rect.height)
-        val gravity = Gravity.TOP or Gravity.START
         if (
             current == null ||
             params.width != rect.width ||
@@ -832,6 +854,34 @@ private class SubtitleVideoRectSync(
             params.height = rect.height
             params.leftMargin = rect.left
             params.topMargin = rect.top
+            params.gravity = gravity
+            subtitleView.layoutParams = params
+            subtitleView.requestLayout()
+        }
+    }
+
+    private fun applyLayoutParams(
+        subtitleView: View,
+        width: Int,
+        height: Int,
+        leftMargin: Int,
+        topMargin: Int,
+        gravity: Int,
+    ) {
+        val current = subtitleView.layoutParams as? FrameLayout.LayoutParams
+        val params = current ?: FrameLayout.LayoutParams(width, height)
+        if (
+            current == null ||
+            params.width != width ||
+            params.height != height ||
+            params.leftMargin != leftMargin ||
+            params.topMargin != topMargin ||
+            params.gravity != gravity
+        ) {
+            params.width = width
+            params.height = height
+            params.leftMargin = leftMargin
+            params.topMargin = topMargin
             params.gravity = gravity
             subtitleView.layoutParams = params
             subtitleView.requestLayout()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.util.Log
 import android.view.Gravity
 import android.view.View
+import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import androidx.media3.common.C
 import androidx.media3.common.Format
@@ -500,7 +501,10 @@ internal fun selectSubtitleCanvasRect(
 ): SubtitleVideoRect = when (resizeMode) {
     AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
     AspectRatioFrameLayout.RESIZE_MODE_FILL,
-    -> displayedVideoRect
+    -> contentFrameRect?.takeIf {
+        it.width == displayedVideoRect.width &&
+            it.height == displayedVideoRect.height
+    } ?: displayedVideoRect
     else -> contentFrameRect ?: displayedVideoRect
 }
 
@@ -601,10 +605,11 @@ private class SubtitleVideoRectSync(playerView: PlayerView) :
     var isDisposed: Boolean = false
         private set
 
-    private var postLayoutPending = false
-    private val postLayoutUpdate = Runnable {
-        postLayoutPending = false
+    private var pendingPreDrawObserver: ViewTreeObserver? = null
+    private val postLayoutUpdate = ViewTreeObserver.OnPreDrawListener {
+        clearPendingPostLayoutUpdate()
         if (!isDisposed) update()
+        true
     }
 
     init {
@@ -637,9 +642,15 @@ private class SubtitleVideoRectSync(playerView: PlayerView) :
     fun updateAndReconcileAfterLayout() {
         update()
         val playerView = playerViewRef.get() ?: return
-        if (isDisposed || postLayoutPending) return
-        postLayoutPending = true
-        playerView.postOnAnimation(postLayoutUpdate)
+        if (isDisposed) return
+        pendingPreDrawObserver?.let { observer ->
+            if (observer.isAlive) return
+            pendingPreDrawObserver = null
+        }
+        val observer = playerView.viewTreeObserver
+        if (!observer.isAlive) return
+        pendingPreDrawObserver = observer
+        observer.addOnPreDrawListener(postLayoutUpdate)
     }
 
     override fun onVideoSizeChanged(videoSize: VideoSize) {
@@ -725,14 +736,22 @@ private class SubtitleVideoRectSync(playerView: PlayerView) :
     private fun dispose(view: View?) {
         if (isDisposed) return
         val playerView = (view as? PlayerView) ?: playerViewRef.get()
-        playerView?.removeCallbacks(postLayoutUpdate)
-        postLayoutPending = false
+        clearPendingPostLayoutUpdate()
         observedPlayer?.removeListener(this)
         observedPlayer = null
         playerView?.removeOnLayoutChangeListener(this)
         playerView?.removeOnAttachStateChangeListener(this)
         contentFrameRef.get()?.removeOnLayoutChangeListener(this)
         isDisposed = true
+    }
+
+    private fun clearPendingPostLayoutUpdate() {
+        pendingPreDrawObserver?.let { observer ->
+            if (observer.isAlive) {
+                observer.removeOnPreDrawListener(postLayoutUpdate)
+            }
+        }
+        pendingPreDrawObserver = null
     }
 }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
@@ -46,6 +46,8 @@ class SubtitleManager(
 ) {
 
     private val videoRectSyncs = WeakHashMap<PlayerView, SubtitleVideoRectSync>()
+    /** Test-only execution observer; null in production. */
+    internal var postLayoutReconciliationObserver: (() -> Unit)? = null
 
     var letterbox: LetterboxInsets = LetterboxInsets.NONE
         set(value) {
@@ -272,7 +274,10 @@ class SubtitleManager(
         playerView.subtitleView?.let { libassBridge?.attachTo(it) }
         val existing = videoRectSyncs[playerView]
         val sync = if (existing?.isDisposed == true || existing == null) {
-            SubtitleVideoRectSync(playerView).also {
+            SubtitleVideoRectSync(
+                playerView = playerView,
+                onPostLayoutReconciled = { postLayoutReconciliationObserver?.invoke() },
+            ).also {
                 it.letterbox = letterbox
                 it.titleSafeFraction = titleSafeFraction
                 videoRectSyncs[playerView] = it
@@ -575,7 +580,10 @@ internal fun neutralizeFullWidthCueSizes(cueGroup: CueGroup): CueGroup {
 }
 
 @UnstableApi
-private class SubtitleVideoRectSync(playerView: PlayerView) :
+private class SubtitleVideoRectSync(
+    playerView: PlayerView,
+    private val onPostLayoutReconciled: () -> Unit,
+) :
     View.OnLayoutChangeListener,
     View.OnAttachStateChangeListener,
     Player.Listener {
@@ -608,7 +616,10 @@ private class SubtitleVideoRectSync(playerView: PlayerView) :
     private var pendingPreDrawObserver: ViewTreeObserver? = null
     private val postLayoutUpdate = ViewTreeObserver.OnPreDrawListener {
         clearPendingPostLayoutUpdate()
-        if (!isDisposed) update()
+        if (!isDisposed) {
+            update()
+            onPostLayoutReconciled()
+        }
         true
     }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
@@ -279,7 +279,7 @@ class SubtitleManager(
         } else {
             existing
         }
-        sync.update()
+        sync.updateAndReconcileAfterLayout()
     }
 
     private fun buildCaptionStyle(appearance: SubtitleAppearance): CaptionStyleCompat {
@@ -601,6 +601,12 @@ private class SubtitleVideoRectSync(playerView: PlayerView) :
     var isDisposed: Boolean = false
         private set
 
+    private var postLayoutPending = false
+    private val postLayoutUpdate = Runnable {
+        postLayoutPending = false
+        if (!isDisposed) update()
+    }
+
     init {
         playerView.addOnLayoutChangeListener(this)
         playerView.addOnAttachStateChangeListener(this)
@@ -626,6 +632,14 @@ private class SubtitleVideoRectSync(playerView: PlayerView) :
             currentPlayer?.let { forwardNeutralizedCues(playerView, it.currentCues) }
         }
         applyRect(playerView)
+    }
+
+    fun updateAndReconcileAfterLayout() {
+        update()
+        val playerView = playerViewRef.get() ?: return
+        if (isDisposed || postLayoutPending) return
+        postLayoutPending = true
+        playerView.postOnAnimation(postLayoutUpdate)
     }
 
     override fun onVideoSizeChanged(videoSize: VideoSize) {
@@ -710,9 +724,11 @@ private class SubtitleVideoRectSync(playerView: PlayerView) :
 
     private fun dispose(view: View?) {
         if (isDisposed) return
+        val playerView = (view as? PlayerView) ?: playerViewRef.get()
+        playerView?.removeCallbacks(postLayoutUpdate)
+        postLayoutPending = false
         observedPlayer?.removeListener(this)
         observedPlayer = null
-        val playerView = (view as? PlayerView) ?: playerViewRef.get()
         playerView?.removeOnLayoutChangeListener(this)
         playerView?.removeOnAttachStateChangeListener(this)
         contentFrameRef.get()?.removeOnLayoutChangeListener(this)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
@@ -38,16 +38,16 @@ class SubtitleManagerAppearanceTest {
     }
 
     @Test
-    fun phoneSubtitleTextFractionsAreOneQuarterLarger() {
+    fun phoneSubtitleTextFractionsAreOneEighthLarger() {
         val manager = SubtitleManager(
             presentation = AndroidSubtitlePresentation.Phone,
         )
 
-        assertEquals(25f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Small))
-        assertEquals(32.5f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Medium))
-        assertEquals(40f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Large))
-        assertEquals(50f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XLarge))
-        assertEquals(60f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XXLarge))
+        assertEquals(22.5f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Small))
+        assertEquals(29.25f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Medium))
+        assertEquals(36f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Large))
+        assertEquals(45f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XLarge))
+        assertEquals(54f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XXLarge))
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
@@ -2,6 +2,7 @@ package org.siloserver.silo.common.player
 
 import android.app.Activity
 import android.os.Looper
+import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
@@ -16,13 +17,13 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
+import org.robolectric.annotation.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @OptIn(UnstableApi::class)
 @RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w1920dp-h1080dp-mdpi")
 class SubtitleManagerAppearanceTest {
 
     @Test
@@ -224,6 +225,30 @@ class SubtitleManagerAppearanceTest {
     }
 
     @Test
+    fun zoomUsesVisibleViewportInNegativeContentFrameParentCoordinates() {
+        val visibleCanvas = requireNotNull(
+            displayedSubtitleContentFrameRect(
+                viewWidth = 1920,
+                viewHeight = 1080,
+                frameLeft = -120,
+                frameTop = -64,
+                frameWidth = 2160,
+                frameHeight = 1208,
+            ),
+        )
+        val fullViewport = SubtitleVideoRect(left = 0, top = 0, width = 1920, height = 1080)
+
+        assertEquals(
+            SubtitleVideoRect(left = 120, top = 64, width = 1920, height = 1080),
+            selectSubtitleCanvasRect(
+                resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+                contentFrameRect = visibleCanvas,
+                displayedVideoRect = fullViewport,
+            ),
+        )
+    }
+
+    @Test
     fun stretchIgnoresStaleFittedContentFrameAndUsesFullViewport() {
         val staleFit = SubtitleVideoRect(left = 240, top = 0, width = 1920, height = 1080)
         val fullViewport = SubtitleVideoRect(left = 0, top = 0, width = 2400, height = 1080)
@@ -336,38 +361,80 @@ class SubtitleManagerAppearanceTest {
     }
 
     @Test
-    fun explicitSyncQueuesOnlyOnePostLayoutReconciliation() {
-        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
-        val playerView = PlayerView(activity)
-        activity.setContentView(playerView)
-        playerView.layout(0, 0, 2400, 1080)
-        val manager = SubtitleManager()
+    fun mountedCanvasReconcilesFitToZoomAfterContentFrameLayout() {
+        val canvas = MountedSubtitleCanvas()
 
-        manager.syncSubtitleVideoBounds(playerView)
-        manager.syncSubtitleVideoBounds(playerView)
+        assertEquals(SubtitleVideoRect(0, 0, 1440, 1016), canvas.subtitleRect())
 
-        val sync = manager.subtitleRectSyncForTest(playerView)
-        assertTrue(sync.postLayoutPendingForTest())
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
-        assertFalse(sync.postLayoutPendingForTest())
+        canvas.transition(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+            frame = FrameBounds(-120, -64, 2040, 1080),
+        )
+
+        assertEquals(SubtitleVideoRect(120, 64, 1920, 1016), canvas.subtitleRect())
     }
 
     @Test
-    fun detachCancelsPendingPostLayoutReconciliation() {
-        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
-        val playerView = PlayerView(activity)
-        activity.setContentView(playerView)
-        playerView.layout(0, 0, 2400, 1080)
-        val manager = SubtitleManager()
+    fun mountedCanvasReconcilesFitToFillAfterContentFrameLayout() {
+        val canvas = MountedSubtitleCanvas()
 
-        manager.syncSubtitleVideoBounds(playerView)
-        val sync = manager.subtitleRectSyncForTest(playerView)
-        activity.setContentView(FrameLayout(activity))
+        canvas.transition(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL,
+            frame = FrameBounds(0, 0, 1920, 1016),
+        )
 
-        assertTrue(sync.isDisposedForTest())
-        assertFalse(sync.postLayoutPendingForTest())
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
-        assertTrue(sync.isDisposedForTest())
+        assertEquals(SubtitleVideoRect(0, 0, 1920, 1016), canvas.subtitleRect())
+    }
+
+    @Test
+    fun mountedCanvasDoesNotRetainOffsetsAcrossRepeatedZoomAndFillSwitches() {
+        val canvas = MountedSubtitleCanvas()
+
+        canvas.transition(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+            frame = FrameBounds(-120, -64, 2040, 1080),
+        )
+        assertEquals(SubtitleVideoRect(120, 64, 1920, 1016), canvas.subtitleRect())
+
+        canvas.transition(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL,
+            frame = FrameBounds(0, 0, 1920, 1016),
+        )
+        assertEquals(SubtitleVideoRect(0, 0, 1920, 1016), canvas.subtitleRect())
+
+        canvas.transition(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+            frame = FrameBounds(-120, -64, 2040, 1080),
+        )
+        assertEquals(SubtitleVideoRect(120, 64, 1920, 1016), canvas.subtitleRect())
+    }
+
+    @Test
+    fun mountedCanvasReconcilesZoomBackToFitAfterContentFrameLayout() {
+        val canvas = MountedSubtitleCanvas()
+        canvas.transition(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+            frame = FrameBounds(-120, -64, 2040, 1080),
+        )
+
+        canvas.transition(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT,
+            frame = FrameBounds(240, 0, 1680, 1016),
+        )
+
+        assertEquals(SubtitleVideoRect(0, 0, 1440, 1016), canvas.subtitleRect())
+    }
+
+    @Test
+    fun detachedPendingReconciliationLeavesSubtitleLayoutSentinelUnchanged() {
+        val canvas = MountedSubtitleCanvas()
+
+        canvas.schedule(AspectRatioFrameLayout.RESIZE_MODE_ZOOM)
+        val sentinel = SubtitleVideoRect(33, 44, 777, 555)
+        canvas.setSubtitleRect(sentinel)
+        canvas.detachAndDrain(FrameBounds(-120, -64, 2040, 1080))
+
+        assertEquals(sentinel, canvas.subtitleRect())
     }
 
     private fun captionStyleFor(appearance: SubtitleAppearance): CaptionStyleCompat {
@@ -387,14 +454,83 @@ private fun SubtitleManager.subtitleRectSyncForTest(playerView: PlayerView): Any
     return requireNotNull(syncs[playerView])
 }
 
-private fun Any.postLayoutPendingForTest(): Boolean {
-    val field = javaClass.getDeclaredField("postLayoutPending")
-    field.isAccessible = true
-    return field.getBoolean(this)
-}
+private data class FrameBounds(
+    val left: Int,
+    val top: Int,
+    val right: Int,
+    val bottom: Int,
+)
 
-private fun Any.isDisposedForTest(): Boolean {
-    val field = javaClass.getDeclaredField("isDisposed")
-    field.isAccessible = true
-    return field.getBoolean(this)
+private class MountedSubtitleCanvas {
+    private val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    private val playerView = PlayerView(activity)
+    private val contentFrame = requireNotNull(
+        playerView.findViewById<AspectRatioFrameLayout>(
+            androidx.media3.ui.R.id.exo_content_frame,
+        ),
+    )
+    private val subtitleView = requireNotNull(playerView.subtitleView)
+    private val manager = SubtitleManager()
+
+    init {
+        activity.setContentView(playerView)
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        check(playerView.width == 1920 && playerView.height == 1016)
+        playerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+        manager.syncSubtitleVideoBounds(playerView)
+        drainScheduledWork()
+
+        // Isolate the explicit post-layout reconciliation from the permanent
+        // frame listener: production has both, but this harness proves the
+        // bounded fallback still works when an early callback runs before the
+        // content-frame traversal that supplies the final geometry.
+        contentFrame.removeOnLayoutChangeListener(
+            manager.subtitleRectSyncForTest(playerView) as View.OnLayoutChangeListener,
+        )
+        contentFrame.layout(240, 0, 1680, 1016)
+        manager.syncSubtitleVideoBounds(playerView)
+    }
+
+    fun schedule(resizeMode: Int) {
+        playerView.resizeMode = resizeMode
+        manager.syncSubtitleVideoBounds(playerView)
+    }
+
+    fun transition(resizeMode: Int, frame: FrameBounds) {
+        schedule(resizeMode)
+        contentFrame.layout(frame.left, frame.top, frame.right, frame.bottom)
+        playerView.viewTreeObserver.dispatchOnPreDraw()
+    }
+
+    fun detachAndDrain(frame: FrameBounds) {
+        activity.setContentView(FrameLayout(activity))
+        contentFrame.layout(frame.left, frame.top, frame.right, frame.bottom)
+        drainScheduledWork()
+    }
+
+    fun subtitleRect(): SubtitleVideoRect {
+        val params = subtitleView.layoutParams as FrameLayout.LayoutParams
+        return SubtitleVideoRect(
+            left = params.leftMargin,
+            top = params.topMargin,
+            width = params.width,
+            height = params.height,
+        )
+    }
+
+    fun setSubtitleRect(rect: SubtitleVideoRect) {
+        val params = subtitleView.layoutParams as FrameLayout.LayoutParams
+        params.leftMargin = rect.left
+        params.topMargin = rect.top
+        params.width = rect.width
+        params.height = rect.height
+        subtitleView.layoutParams = params
+    }
+
+    private fun drainScheduledWork() {
+        if (playerView.viewTreeObserver.isAlive) {
+            playerView.viewTreeObserver.dispatchOnPreDraw()
+        }
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+    }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
@@ -38,18 +38,41 @@ class SubtitleManagerAppearanceTest {
     }
 
     @Test
-    fun subtitleTextFractionsMatchTheWebScale() {
+    fun phoneSubtitleTextFractionsAreOneQuarterLarger() {
+        val manager = SubtitleManager(
+            presentation = AndroidSubtitlePresentation.Phone,
+        )
+
+        assertEquals(25f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Small))
+        assertEquals(32.5f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Medium))
+        assertEquals(40f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Large))
+        assertEquals(50f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XLarge))
+        assertEquals(60f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XXLarge))
+    }
+
+    @Test
+    fun televisionSubtitleTextFractionsPreserveExistingScale() {
+        val manager = SubtitleManager(
+            presentation = AndroidSubtitlePresentation.Television,
+        )
+
+        assertEquals(20f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Small))
+        assertEquals(26f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Medium))
+        assertEquals(32f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Large))
+        assertEquals(40f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XLarge))
+        assertEquals(48f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XXLarge))
+    }
+
+    private fun fractionalSize(
+        manager: SubtitleManager,
+        preset: SubtitleFontSizePreset,
+    ): Float {
         val method = SubtitleManager::class.java.getDeclaredMethod(
             "fractionalSizeFor",
             SubtitleFontSizePreset::class.java,
         )
         method.isAccessible = true
-
-        assertEquals(20f / 720f, method.invoke(SubtitleManager(), SubtitleFontSizePreset.Small) as Float)
-        assertEquals(26f / 720f, method.invoke(SubtitleManager(), SubtitleFontSizePreset.Medium) as Float)
-        assertEquals(32f / 720f, method.invoke(SubtitleManager(), SubtitleFontSizePreset.Large) as Float)
-        assertEquals(40f / 720f, method.invoke(SubtitleManager(), SubtitleFontSizePreset.XLarge) as Float)
-        assertEquals(48f / 720f, method.invoke(SubtitleManager(), SubtitleFontSizePreset.XXLarge) as Float)
+        return method.invoke(manager, preset) as Float
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
@@ -1,17 +1,25 @@
 package org.siloserver.silo.common.player
 
+import android.app.Activity
+import android.os.Looper
+import android.widget.FrameLayout
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.CaptionStyleCompat
+import androidx.media3.ui.PlayerView
 import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.model.settings.SubtitleBackgroundStylePreset
 import org.siloserver.silo.model.settings.SubtitleFontSizePreset
 import org.siloserver.silo.model.settings.SubtitlePositionPreset
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @OptIn(UnstableApi::class)
 @RunWith(RobolectricTestRunner::class)
@@ -327,6 +335,41 @@ class SubtitleManagerAppearanceTest {
         )
     }
 
+    @Test
+    fun explicitSyncQueuesOnlyOnePostLayoutReconciliation() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val playerView = PlayerView(activity)
+        activity.setContentView(playerView)
+        playerView.layout(0, 0, 2400, 1080)
+        val manager = SubtitleManager()
+
+        manager.syncSubtitleVideoBounds(playerView)
+        manager.syncSubtitleVideoBounds(playerView)
+
+        val sync = manager.subtitleRectSyncForTest(playerView)
+        assertTrue(sync.postLayoutPendingForTest())
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        assertFalse(sync.postLayoutPendingForTest())
+    }
+
+    @Test
+    fun detachCancelsPendingPostLayoutReconciliation() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val playerView = PlayerView(activity)
+        activity.setContentView(playerView)
+        playerView.layout(0, 0, 2400, 1080)
+        val manager = SubtitleManager()
+
+        manager.syncSubtitleVideoBounds(playerView)
+        val sync = manager.subtitleRectSyncForTest(playerView)
+        activity.setContentView(FrameLayout(activity))
+
+        assertTrue(sync.isDisposedForTest())
+        assertFalse(sync.postLayoutPendingForTest())
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        assertTrue(sync.isDisposedForTest())
+    }
+
     private fun captionStyleFor(appearance: SubtitleAppearance): CaptionStyleCompat {
         val method = SubtitleManager::class.java.getDeclaredMethod(
             "buildCaptionStyle",
@@ -335,4 +378,23 @@ class SubtitleManagerAppearanceTest {
         method.isAccessible = true
         return method.invoke(SubtitleManager(), appearance) as CaptionStyleCompat
     }
+}
+
+private fun SubtitleManager.subtitleRectSyncForTest(playerView: PlayerView): Any {
+    val field = SubtitleManager::class.java.getDeclaredField("videoRectSyncs")
+    field.isAccessible = true
+    val syncs = field.get(this) as Map<*, *>
+    return requireNotNull(syncs[playerView])
+}
+
+private fun Any.postLayoutPendingForTest(): Boolean {
+    val field = javaClass.getDeclaredField("postLayoutPending")
+    field.isAccessible = true
+    return field.getBoolean(this)
+}
+
+private fun Any.isDisposedForTest(): Boolean {
+    val field = javaClass.getDeclaredField("isDisposed")
+    field.isAccessible = true
+    return field.getBoolean(this)
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
@@ -201,6 +201,77 @@ class SubtitleManagerAppearanceTest {
     }
 
     @Test
+    fun zoomIgnoresStaleFittedContentFrameAndUsesFullViewport() {
+        val staleFit = SubtitleVideoRect(left = 0, top = 236, width = 2404, height = 1352)
+        val fullViewport = SubtitleVideoRect(left = 0, top = 0, width = 2404, height = 1080)
+
+        assertEquals(
+            fullViewport,
+            selectSubtitleCanvasRect(
+                resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+                contentFrameRect = staleFit,
+                displayedVideoRect = fullViewport,
+            ),
+        )
+    }
+
+    @Test
+    fun stretchIgnoresStaleFittedContentFrameAndUsesFullViewport() {
+        val staleFit = SubtitleVideoRect(left = 240, top = 0, width = 1920, height = 1080)
+        val fullViewport = SubtitleVideoRect(left = 0, top = 0, width = 2400, height = 1080)
+
+        assertEquals(
+            fullViewport,
+            selectSubtitleCanvasRect(
+                resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL,
+                contentFrameRect = staleFit,
+                displayedVideoRect = fullViewport,
+            ),
+        )
+    }
+
+    @Test
+    fun fitContinuesToUsePostLayoutContentFrame() {
+        val fittedFrame = SubtitleVideoRect(left = 0, top = 0, width = 1920, height = 1080)
+        val computedFallback = SubtitleVideoRect(left = 240, top = 0, width = 1920, height = 1080)
+
+        assertEquals(
+            fittedFrame,
+            selectSubtitleCanvasRect(
+                resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT,
+                contentFrameRect = fittedFrame,
+                displayedVideoRect = computedFallback,
+            ),
+        )
+    }
+
+    @Test
+    fun repeatedModeSelectionDoesNotRetainPreviousCanvas() {
+        val fit = SubtitleVideoRect(left = 240, top = 0, width = 1920, height = 1080)
+        val full = SubtitleVideoRect(left = 0, top = 0, width = 2400, height = 1080)
+
+        val fill = selectSubtitleCanvasRect(
+            AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+            fit,
+            full,
+        )
+        val stretch = selectSubtitleCanvasRect(
+            AspectRatioFrameLayout.RESIZE_MODE_FILL,
+            fit,
+            full,
+        )
+        val restoredFit = selectSubtitleCanvasRect(
+            AspectRatioFrameLayout.RESIZE_MODE_FIT,
+            fit,
+            fit,
+        )
+
+        assertEquals(full, fill)
+        assertEquals(full, stretch)
+        assertEquals(fit, restoredFit)
+    }
+
+    @Test
     fun invalidVideoSizeUsesFullViewRect() {
         val rect = displayedSubtitleVideoRect(
             viewWidth = 1080,

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
@@ -449,6 +449,45 @@ class SubtitleManagerAppearanceTest {
     }
 
     @Test
+    fun mountedCanvasCorrectsFillToFitWhenFirstPreDrawSeesCroppedFrame() {
+        val canvas = MountedSubtitleCanvas()
+        canvas.transition(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+            frame = FrameBounds(-120, -64, 2040, 1080),
+        )
+
+        canvas.transitionAfterEarlyPreDraw(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT,
+            finalFrame = FrameBounds(240, 0, 1680, 1016),
+        )
+
+        assertEquals(SubtitleVideoRect(0, 0, 1440, 1016), canvas.subtitleRect())
+    }
+
+    @Test
+    fun rapidEarlyTransitionsApplyOnlyLatestMode() {
+        val canvas = MountedSubtitleCanvas()
+        canvas.schedule(AspectRatioFrameLayout.RESIZE_MODE_ZOOM)
+        canvas.schedule(AspectRatioFrameLayout.RESIZE_MODE_FILL)
+        canvas.schedule(AspectRatioFrameLayout.RESIZE_MODE_FIT)
+        canvas.dispatchEarlyPreDrawThenMount(FrameBounds(240, 0, 1680, 1016))
+
+        assertEquals(SubtitleVideoRect(0, 0, 1440, 1016), canvas.subtitleRect())
+        assertEquals(2, canvas.reconciliationCount)
+    }
+
+    @Test
+    fun detachCancelsPostedSnapshotVerification() {
+        val canvas = MountedSubtitleCanvas()
+        canvas.schedule(AspectRatioFrameLayout.RESIZE_MODE_ZOOM)
+        canvas.dispatchPreDraw()
+        canvas.detach()
+        canvas.mountFrameAndDrain(FrameBounds(-120, -64, 2040, 1080))
+
+        assertEquals(1, canvas.reconciliationCount)
+    }
+
+    @Test
     fun detachedPendingReconciliationLeavesSubtitleLayoutSentinelUnchanged() {
         val canvas = MountedSubtitleCanvas()
 
@@ -517,6 +556,8 @@ private class MountedSubtitleCanvas {
     )
     private val subtitleView = requireNotNull(playerView.subtitleView)
     private val manager = SubtitleManager()
+    var reconciliationCount = 0
+        private set
 
     init {
         activity.setContentView(playerView)
@@ -527,14 +568,16 @@ private class MountedSubtitleCanvas {
         drainScheduledWork()
 
         // Isolate the explicit post-layout reconciliation from the permanent
-        // frame listener: production has both, but this harness proves the
+        // layout listeners: production has both, but this harness proves the
         // bounded fallback still works when an early callback runs before the
         // content-frame traversal that supplies the final geometry.
-        contentFrame.removeOnLayoutChangeListener(
-            manager.subtitleRectSyncForTest(playerView) as View.OnLayoutChangeListener,
-        )
+        val syncListener =
+            manager.subtitleRectSyncForTest(playerView) as View.OnLayoutChangeListener
+        playerView.removeOnLayoutChangeListener(syncListener)
+        contentFrame.removeOnLayoutChangeListener(syncListener)
         contentFrame.layout(240, 0, 1680, 1016)
         manager.syncSubtitleVideoBounds(playerView)
+        manager.postLayoutReconciliationObserver = { reconciliationCount++ }
     }
 
     fun schedule(resizeMode: Int) {
@@ -548,10 +591,67 @@ private class MountedSubtitleCanvas {
         playerView.viewTreeObserver.dispatchOnPreDraw()
     }
 
-    fun detachAndDrain(frame: FrameBounds) {
+    fun transitionAfterEarlyPreDraw(resizeMode: Int, finalFrame: FrameBounds) {
+        schedule(resizeMode)
+        playerView.viewTreeObserver.dispatchOnPreDraw()
+        contentFrame.layout(
+            finalFrame.left,
+            finalFrame.top,
+            finalFrame.right,
+            finalFrame.bottom,
+        )
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        // Robolectric's parent traversal has no renderer-backed aspect ratio,
+        // so re-mount the observed Media3 frame before the corrective pre-draw.
+        contentFrame.layout(
+            finalFrame.left,
+            finalFrame.top,
+            finalFrame.right,
+            finalFrame.bottom,
+        )
+        playerView.viewTreeObserver.dispatchOnPreDraw()
+    }
+
+    fun dispatchEarlyPreDrawThenMount(finalFrame: FrameBounds) {
+        contentFrame.layout(-120, -64, 2040, 1080)
+        playerView.viewTreeObserver.dispatchOnPreDraw()
+        contentFrame.layout(
+            finalFrame.left,
+            finalFrame.top,
+            finalFrame.right,
+            finalFrame.bottom,
+        )
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        // Keep the synthetic final frame mounted after Robolectric drains the
+        // posted verifier and its unrelated full-width parent traversal.
+        contentFrame.layout(
+            finalFrame.left,
+            finalFrame.top,
+            finalFrame.right,
+            finalFrame.bottom,
+        )
+        playerView.viewTreeObserver.dispatchOnPreDraw()
+    }
+
+    fun dispatchPreDraw() {
+        playerView.viewTreeObserver.dispatchOnPreDraw()
+    }
+
+    fun detach() {
         activity.setContentView(FrameLayout(activity))
+    }
+
+    fun mountFrameAndDrain(frame: FrameBounds) {
         contentFrame.layout(frame.left, frame.top, frame.right, frame.bottom)
-        drainScheduledWork()
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        if (playerView.viewTreeObserver.isAlive) {
+            playerView.viewTreeObserver.dispatchOnPreDraw()
+        }
+    }
+
+    fun detachAndDrain(frame: FrameBounds) {
+        detach()
+        mountFrameAndDrain(frame)
     }
 
     fun subtitleRect(): SubtitleVideoRect {

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
@@ -437,6 +437,29 @@ class SubtitleManagerAppearanceTest {
         assertEquals(sentinel, canvas.subtitleRect())
     }
 
+    @Test
+    fun repeatedExplicitSyncsRunOnePostLayoutReconciliation() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val playerView = PlayerView(activity)
+        val manager = SubtitleManager()
+        activity.setContentView(playerView)
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        manager.syncSubtitleVideoBounds(playerView)
+        playerView.viewTreeObserver.dispatchOnPreDraw()
+
+        var reconciliations = 0
+        manager.postLayoutReconciliationObserver = { reconciliations++ }
+        repeat(3) {
+            manager.syncSubtitleVideoBounds(playerView)
+        }
+
+        playerView.viewTreeObserver.dispatchOnPreDraw()
+        playerView.viewTreeObserver.dispatchOnPreDraw()
+
+        assertEquals(1, reconciliations)
+    }
+
     private fun captionStyleFor(appearance: SubtitleAppearance): CaptionStyleCompat {
         val method = SubtitleManager::class.java.getDeclaredMethod(
             "buildCaptionStyle",

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -20,6 +20,7 @@ import org.siloserver.silo.common.pairing.RepositoryCompanionDeviceLoginApprover
 import org.siloserver.silo.common.pairing.TlsPskPairingClientTransport
 import org.siloserver.silo.common.player.AudioCapabilityManager
 import org.siloserver.silo.common.player.AudioTrackManager
+import org.siloserver.silo.common.player.AndroidSubtitlePresentation
 import org.siloserver.silo.common.player.SiloPlayerFactory
 import org.siloserver.silo.common.player.PlaybackCapabilityDetector
 import org.siloserver.silo.common.player.PlaybackSessionManager
@@ -217,7 +218,12 @@ val androidModule = module {
     single { PushMessageHandler(presenter = get()) }
 
     // Player infrastructure
-    single { SubtitleManager(get()) }
+    single {
+        SubtitleManager(
+            libassBridge = get(),
+            presentation = AndroidSubtitlePresentation.Phone,
+        )
+    }
     single { AudioTrackManager() }
     single {
         VideoPlaybackBackendFactory(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapter.kt
@@ -202,6 +202,7 @@ internal class MobileSubtitleTransactionAdapter(
     private var pendingLocalRestore: PendingLocalRestore? = null
     private var localMountGeneration = 0L
     private var localMountTimeout: Job? = null
+    private var lastSettledLocalMountMissSnapshotKey: String? = null
     private val queuedMutations = mutableListOf<SubtitleTransitionEvent>()
     private var commitInFlight = false
     private var resetDuringCommit = false
@@ -477,7 +478,7 @@ internal class MobileSubtitleTransactionAdapter(
                     publish()
                     persist(transition.committed, pendingSelection.context)
                 }
-            } else if (settled && !snapshotKey.isNullOrBlank()) {
+            } else if (isStableLocalMountMiss(snapshotKey, settled)) {
                 failLocalMount(pendingSelection.generation)
             }
             return
@@ -490,9 +491,16 @@ internal class MobileSubtitleTransactionAdapter(
             failureMessage = null
             publish()
             persistence?.let { persist(it.committed, it.context) }
-        } else if (settled && !snapshotKey.isNullOrBlank()) {
+        } else if (isStableLocalMountMiss(snapshotKey, settled)) {
             failLocalMount(pendingRestore.generation)
         }
+    }
+
+    private fun isStableLocalMountMiss(snapshotKey: String?, settled: Boolean): Boolean {
+        if (!settled || snapshotKey.isNullOrBlank()) return false
+        val stable = snapshotKey == lastSettledLocalMountMissSnapshotKey
+        lastSettledLocalMountMissSnapshotKey = snapshotKey
+        return stable
     }
 
     private fun mutate(event: SubtitleTransitionEvent, explicit: Boolean) {
@@ -995,6 +1003,7 @@ internal class MobileSubtitleTransactionAdapter(
         localMountGeneration += 1
         pendingLocalSelection = null
         pendingLocalRestore = null
+        lastSettledLocalMountMissSnapshotKey = null
         localMountTimeout?.cancel()
         localMountTimeout = null
     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt
@@ -2,8 +2,6 @@ package org.siloserver.silo.android.ui.screens.player
 
 import android.content.Context
 import android.media.AudioManager
-import android.view.Window
-import android.view.WindowManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -56,7 +54,7 @@ import kotlin.math.hypot
  * - Hold: temporary 2x playback while held
  * - Two-finger pinch: step video gravity — pinch-out steps Fit -> Fill ->
  *   Stretch, pinch-in steps back, clamped at both ends (iOS parity)
- * - Vertical swipe in the left edge zone: brightness adjustment
+ * - Vertical swipe in the left edge zone: reserved; system brightness remains authoritative
  * - Vertical swipe in the right edge zone: volume adjustment
  * - Vertical swipe down in the center: dismiss the player (iOS
  *   MobilePlayerGestureLayer parity — evaluated on release, mostly-vertical
@@ -81,8 +79,8 @@ fun PlayerGestureHandler(
     onPinchVideoGravity: (Boolean) -> Unit = {},
     onDismiss: () -> Unit = {},
     // Swipe-down-to-dismiss is suppressed until playback is actually established.
-    // During the initial open the media is still loading, and a downward volume/
-    // brightness swipe that drifts inward would otherwise be read as "close the
+    // During the initial open the media is still loading, and a downward edge
+    // swipe that drifts inward would otherwise be read as "close the
     // player" — which then strands the user (Jim, Fold).
     dismissEnabled: Boolean = true,
     modifier: Modifier = Modifier,
@@ -204,20 +202,21 @@ fun PlayerGestureHandler(
                 )
             }
             .pointerInput(Unit) {
-                // iOS edgeAndDismissDrag: the start x picks the mode once —
-                // left 88dp edge = brightness, right 88dp edge = volume, and a
-                // center drag becomes a dismiss candidate judged on release.
+                // The start x picks the mode once: the left 88dp edge is
+                // reserved so Android brightness stays authoritative, the
+                // right edge controls volume, and the center is a dismiss
+                // candidate judged on release.
                 var mode = VerticalDragMode.None
                 var totalDrag = Offset.Zero
                 val edgeZonePx = EdgeZoneWidthDp.dp.toPx()
                 detectVerticalDragGestures(
                     onDragStart = { start ->
                         totalDrag = Offset.Zero
-                        mode = when {
-                            start.x < edgeZonePx -> VerticalDragMode.Brightness
-                            start.x > size.width - edgeZonePx -> VerticalDragMode.Volume
-                            else -> VerticalDragMode.DismissCandidate
-                        }
+                        mode = verticalDragMode(
+                            startX = start.x,
+                            width = size.width.toFloat(),
+                            edgeZonePx = edgeZonePx,
+                        )
                     },
                     onDragEnd = {
                         if (currentDismissEnabled && mode == VerticalDragMode.DismissCandidate) {
@@ -236,8 +235,6 @@ fun PlayerGestureHandler(
                         totalDrag += change.position - change.previousPosition
                         val sensitivity = 0.01f
                         when (mode) {
-                            VerticalDragMode.Brightness ->
-                                adjustBrightness(context, -dragAmount * sensitivity)
                             VerticalDragMode.Volume ->
                                 adjustVolume(audioManager, -dragAmount * sensitivity)
                             else -> Unit
@@ -305,30 +302,26 @@ private const val SkipFlashHoldMs = 700L
 
 private data class SkipFlash(val forward: Boolean, val nonce: Long)
 
-private enum class VerticalDragMode { None, Brightness, Volume, DismissCandidate }
+internal enum class VerticalDragMode { None, Volume, DismissCandidate }
 
-/** iOS edge-zone width (88pt) for brightness/volume vertical drags. */
+/** Edge-zone width for the reserved left edge and right-edge volume drag. */
 private const val EdgeZoneWidthDp = 88
+
+internal fun verticalDragMode(
+    startX: Float,
+    width: Float,
+    edgeZonePx: Float,
+): VerticalDragMode = when {
+    startX < edgeZonePx -> VerticalDragMode.None
+    startX > width - edgeZonePx -> VerticalDragMode.Volume
+    else -> VerticalDragMode.DismissCandidate
+}
 
 /** iOS dismiss threshold: a mostly-vertical downward drag over 140pt. */
 private const val DismissDragThresholdDp = 140
 
 private fun pointerDistance(first: Offset, second: Offset): Float =
     hypot(first.x - second.x, first.y - second.y)
-
-/**
- * Adjusts the screen brightness. Values are clamped to [0.01, 1.0].
- * Uses the window's layout params for per-activity brightness control.
- */
-private fun adjustBrightness(context: Context, delta: Float) {
-    val activity = context as? android.app.Activity ?: return
-    val window: Window = activity.window
-    val layoutParams = window.attributes
-    val currentBrightness = if (layoutParams.screenBrightness < 0) 0.5f else layoutParams.screenBrightness
-    val newBrightness = (currentBrightness + delta).coerceIn(0.01f, 1.0f)
-    layoutParams.screenBrightness = newBrightness
-    window.attributes = layoutParams
-}
 
 /**
  * Adjusts the media volume. Delta is normalized, so we scale to the max volume.

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -997,7 +997,11 @@ fun PlayerScreen(
                     identity = pendingIdentity,
                     selected = selected,
                     snapshotKey = media3TextTrackSnapshotKey(backend.player.currentTracks),
-                    settled = backend.player.playbackState == Player.STATE_READY,
+                    // This composition-side attempt can race Media3's first
+                    // text-track publication. Only onTracksChanged callbacks
+                    // provide settlement evidence; the adapter then requires
+                    // the same non-empty snapshot twice before failing.
+                    settled = false,
                 )
             }
         } else {

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
@@ -604,6 +604,16 @@ class MobileSubtitleTransactionAdapterTest {
         )
         runCurrent()
         assertEquals(local, harness.adapter.snapshot.committedIdentity)
+        assertEquals(local, harness.adapter.snapshot.localMountIdentity)
+        assertNull(harness.adapter.snapshot.failureMessage)
+
+        harness.adapter.reportMountedSelection(
+            identity = local,
+            selected = false,
+            snapshotKey = "ready-local-restore-miss",
+            settled = true,
+        )
+        runCurrent()
         assertNull(harness.adapter.snapshot.localMountIdentity)
         assertTrue(harness.adapter.snapshot.failureMessage?.contains("mount", ignoreCase = true) == true)
     }
@@ -782,7 +792,7 @@ class MobileSubtitleTransactionAdapterTest {
     }
 
     @Test
-    fun `settled local mount miss rolls back immediately without persistence`() = runTest {
+    fun `first settled local mount snapshot remains provisional`() = runTest {
         val harness = harness(backgroundScope)
         val local = SubtitleIdentity.LocalMedia3(
             media(label = "English", language = "en", codec = "webvtt"),
@@ -798,8 +808,61 @@ class MobileSubtitleTransactionAdapterTest {
         runCurrent()
 
         assertEquals(sidecar(3), harness.adapter.snapshot.committedIdentity)
+        assertEquals(local, harness.adapter.snapshot.pendingIdentity)
+        assertEquals(local, harness.adapter.snapshot.localMountIdentity)
+        assertTrue(harness.persistence.persisted.isEmpty())
+        assertNull(harness.adapter.snapshot.failureMessage)
+
+        harness.adapter.reportMountedSelection(
+            identity = local,
+            selected = false,
+            snapshotKey = "ready-track-catalog",
+            settled = true,
+        )
+        runCurrent()
+
+        assertEquals(sidecar(3), harness.adapter.snapshot.committedIdentity)
         assertNull(harness.adapter.snapshot.pendingIdentity)
         assertTrue(harness.persistence.persisted.isEmpty())
+        assertTrue(harness.adapter.snapshot.failureMessage?.contains("mount", ignoreCase = true) == true)
+    }
+
+    @Test
+    fun `changed local mount snapshot must stabilize again before failure`() = runTest {
+        val harness = harness(backgroundScope)
+        val local = SubtitleIdentity.LocalMedia3(
+            media(label = "English", language = "en", codec = "webvtt"),
+        )
+
+        harness.adapter.select(local)
+        harness.adapter.reportMountedSelection(
+            identity = local,
+            selected = false,
+            snapshotKey = "initial-track-catalog",
+            settled = true,
+        )
+        harness.adapter.reportMountedSelection(
+            identity = local,
+            selected = false,
+            snapshotKey = "changed-track-catalog",
+            settled = true,
+        )
+        runCurrent()
+
+        assertEquals(local, harness.adapter.snapshot.pendingIdentity)
+        assertEquals(local, harness.adapter.snapshot.localMountIdentity)
+        assertNull(harness.adapter.snapshot.failureMessage)
+
+        harness.adapter.reportMountedSelection(
+            identity = local,
+            selected = false,
+            snapshotKey = "changed-track-catalog",
+            settled = true,
+        )
+        runCurrent()
+
+        assertEquals(sidecar(3), harness.adapter.snapshot.committedIdentity)
+        assertNull(harness.adapter.snapshot.pendingIdentity)
         assertTrue(harness.adapter.snapshot.failureMessage?.contains("mount", ignoreCase = true) == true)
     }
 

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerVerticalDragModeTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerVerticalDragModeTest.kt
@@ -1,0 +1,30 @@
+package org.siloserver.silo.android.ui.screens.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlayerVerticalDragModeTest {
+    @Test
+    fun `left edge leaves system brightness authoritative`() {
+        assertEquals(
+            VerticalDragMode.None,
+            verticalDragMode(startX = 40f, width = 1_000f, edgeZonePx = 88f),
+        )
+    }
+
+    @Test
+    fun `right edge retains volume routing`() {
+        assertEquals(
+            VerticalDragMode.Volume,
+            verticalDragMode(startX = 950f, width = 1_000f, edgeZonePx = 88f),
+        )
+    }
+
+    @Test
+    fun `center retains dismiss routing`() {
+        assertEquals(
+            VerticalDragMode.DismissCandidate,
+            verticalDragMode(startX = 500f, width = 1_000f, edgeZonePx = 88f),
+        )
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/SubtitleAspectModeWiringSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/SubtitleAspectModeWiringSourceTest.kt
@@ -11,13 +11,27 @@ class SubtitleAspectModeWiringSourceTest {
         return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
     }
 
+    private fun playerViewUpdateBlock(source: String): String {
+        val factoryAnchor = "PlayerView(ctx).apply {"
+        val updateAnchor = "update = { view ->"
+        val endAnchor = "modifier = Modifier"
+        val factoryIndex = source.indexOf(factoryAnchor)
+        require(factoryIndex >= 0) { "PlayerView factory anchor is missing" }
+        val androidViewIndex = source.lastIndexOf("AndroidView(", factoryIndex)
+        require(androidViewIndex >= 0) { "Enclosing AndroidView is missing" }
+        val updateIndex = source.indexOf(updateAnchor, factoryIndex)
+        require(updateIndex > factoryIndex) { "PlayerView update lambda is missing or misordered" }
+        val endIndex = source.indexOf(endAnchor, updateIndex)
+        require(endIndex > updateIndex) { "PlayerView update lambda terminator is missing or misordered" }
+        return source.substring(updateIndex, endIndex)
+    }
+
     @Test
     fun playerViewReconcilesSubtitlesAfterResizeModeUpdate() {
         val source = source(
             "org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt"
         )
-        val update = source.substringAfter("update = { view ->")
-            .substringBefore("modifier = Modifier")
+        val update = playerViewUpdateBlock(source)
 
         assertTrue(update.contains("view.resizeMode = resizeMode"))
         assertTrue(update.contains("subtitleManager.syncSubtitleVideoBounds(view)"))

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/SubtitleAspectModeWiringSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/SubtitleAspectModeWiringSourceTest.kt
@@ -1,0 +1,29 @@
+package org.siloserver.silo.android.ui.screens.player
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SubtitleAspectModeWiringSourceTest {
+    private fun source(path: String): String {
+        val moduleRelative = File("src/androidMain/kotlin/$path")
+        val projectRelative = File("androidApp/src/androidMain/kotlin/$path")
+        return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
+    }
+
+    @Test
+    fun playerViewReconcilesSubtitlesAfterResizeModeUpdate() {
+        val source = source(
+            "org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt"
+        )
+        val update = source.substringAfter("update = { view ->")
+            .substringBefore("modifier = Modifier")
+
+        assertTrue(update.contains("view.resizeMode = resizeMode"))
+        assertTrue(update.contains("subtitleManager.syncSubtitleVideoBounds(view)"))
+        assertTrue(
+            update.indexOf("view.resizeMode = resizeMode") <
+                update.indexOf("subtitleManager.syncSubtitleVideoBounds(view)")
+        )
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/SubtitleAspectSyncWiringTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/SubtitleAspectSyncWiringTest.kt
@@ -1,0 +1,20 @@
+package org.siloserver.silo.android.ui.screens.player
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SubtitleAspectSyncWiringTest {
+    @Test
+    fun phoneSubtitleManagerUsesPhonePresentation() {
+        val source = source("org/siloserver/silo/android/di/AndroidModule.kt")
+
+        assertTrue(source.contains("SubtitleManager(\n            libassBridge = get(),\n            presentation = AndroidSubtitlePresentation.Phone,"))
+    }
+
+    private fun source(path: String): String {
+        val moduleRelative = File("src/androidMain/kotlin/$path")
+        val projectRelative = File("androidApp/src/androidMain/kotlin/$path")
+        return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -19,6 +19,7 @@ import org.siloserver.silo.network.createSecureSharedPrefs
 import org.siloserver.silo.tv.ui.screens.servers.TvServerListViewModel
 import org.siloserver.silo.common.player.AudioCapabilityManager
 import org.siloserver.silo.common.player.AudioTrackManager
+import org.siloserver.silo.common.player.AndroidSubtitlePresentation
 import org.siloserver.silo.common.player.PlaybackCapabilityDetector
 import org.siloserver.silo.common.player.backend.VideoPlaybackBackendFactory
 import org.siloserver.silo.tv.ui.screens.settings.TvSettingsViewModel
@@ -141,7 +142,12 @@ val androidTvModule = module {
         AndroidDeviceMetadataProvider(androidContext(), platform = "android-tv")
     }
     // Player infrastructure (duplicate-for-now; extract to :android-player later).
-    single { SubtitleManager(get()) }
+    single {
+        SubtitleManager(
+            libassBridge = get(),
+            presentation = AndroidSubtitlePresentation.Television,
+        )
+    }
     single { AudioTrackManager() }
     single {
         VideoPlaybackBackendFactory(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleAspectModeWiringSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleAspectModeWiringSourceTest.kt
@@ -11,13 +11,27 @@ class TvSubtitleAspectModeWiringSourceTest {
         return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
     }
 
+    private fun playerViewUpdateBlock(source: String): String {
+        val factoryAnchor = ") as PlayerView).apply {"
+        val updateAnchor = "update = { view ->"
+        val endAnchor = "if (!isInPictureInPictureMode"
+        val factoryIndex = source.indexOf(factoryAnchor)
+        require(factoryIndex >= 0) { "PlayerView factory anchor is missing" }
+        val androidViewIndex = source.lastIndexOf("AndroidView(", factoryIndex)
+        require(androidViewIndex >= 0) { "Enclosing AndroidView is missing" }
+        val updateIndex = source.indexOf(updateAnchor, factoryIndex)
+        require(updateIndex > factoryIndex) { "PlayerView update lambda is missing or misordered" }
+        val endIndex = source.indexOf(endAnchor, updateIndex)
+        require(endIndex > updateIndex) { "PlayerView update lambda terminator is missing or misordered" }
+        return source.substring(updateIndex, endIndex)
+    }
+
     @Test
     fun playerViewReconcilesSubtitlesAfterFillModeUpdate() {
         val source = source(
             "org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
         )
-        val update = source.substringAfter("update = { view ->")
-            .substringBefore("if (!isInPictureInPictureMode")
+        val update = playerViewUpdateBlock(source)
 
         val aspectCall = "applyPlayerViewVideoFillMode(view, state.videoFillMode)"
         val subtitleCall = "subtitleManager.syncSubtitleVideoBounds(view)"

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleAspectModeWiringSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleAspectModeWiringSourceTest.kt
@@ -1,0 +1,28 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class TvSubtitleAspectModeWiringSourceTest {
+    private fun source(path: String): String {
+        val moduleRelative = File("src/androidMain/kotlin/$path")
+        val projectRelative = File("androidTvApp/src/androidMain/kotlin/$path")
+        return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
+    }
+
+    @Test
+    fun playerViewReconcilesSubtitlesAfterFillModeUpdate() {
+        val source = source(
+            "org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+        )
+        val update = source.substringAfter("update = { view ->")
+            .substringBefore("if (!isInPictureInPictureMode")
+
+        val aspectCall = "applyPlayerViewVideoFillMode(view, state.videoFillMode)"
+        val subtitleCall = "subtitleManager.syncSubtitleVideoBounds(view)"
+        assertTrue(update.contains(aspectCall))
+        assertTrue(update.contains(subtitleCall))
+        assertTrue(update.indexOf(aspectCall) < update.indexOf(subtitleCall))
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleAspectSyncWiringTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleAspectSyncWiringTest.kt
@@ -1,0 +1,20 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class TvSubtitleAspectSyncWiringTest {
+    @Test
+    fun televisionSubtitleManagerUsesTelevisionPresentation() {
+        val source = source("org/siloserver/silo/tv/di/AndroidTvModule.kt")
+
+        assertTrue(source.contains("SubtitleManager(\n            libassBridge = get(),\n            presentation = AndroidSubtitlePresentation.Television,"))
+    }
+
+    private fun source(path: String): String {
+        val moduleRelative = File("src/androidMain/kotlin/$path")
+        val projectRelative = File("androidTvApp/src/androidMain/kotlin/$path")
+        return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
+    }
+}

--- a/docs/superpowers/plans/2026-07-28-android-player-system-brightness.md
+++ b/docs/superpowers/plans/2026-07-28-android-player-system-brightness.md
@@ -1,0 +1,188 @@
+# Android Player System Brightness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the Android phone player's window-brightness override while preserving every other player gesture and keep-screen-awake behavior.
+
+**Architecture:** Extract the vertical-drag start-zone decision into a small pure classifier used by `PlayerGestureHandler`. The classifier maps the left edge to no action, the right edge to volume, and the center to dismissal; the obsolete brightness mode and window mutation are then removed.
+
+**Tech Stack:** Kotlin, Jetpack Compose pointer input, Android `AudioManager`, Kotlin/JUnit unit tests, Gradle.
+
+## Global Constraints
+
+- Android phone only; do not change Android TV.
+- Never write `WindowManager.LayoutParams.screenBrightness`.
+- Preserve right-edge volume, center swipe-down dismissal, double-tap seeking, pinch aspect changes, control toggling, temporary fast-forward, and `FLAG_KEEP_SCREEN_ON`.
+- A left-edge vertical drag is a no-op and must not become a dismiss candidate.
+- Do not add permissions or mutate Android system brightness settings.
+- Do not install or modify the Shield.
+
+---
+
+### Task 1: Remove mobile window-brightness ownership
+
+**Files:**
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt`
+- Create: `androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerVerticalDragModeTest.kt`
+
+**Interfaces:**
+- Produces: `internal enum class VerticalDragMode { None, Volume, DismissCandidate }`.
+- Produces: `internal fun verticalDragMode(startX: Float, width: Float, edgeZonePx: Float): VerticalDragMode`.
+- Preserves: `adjustVolume(AudioManager, Float)` and every public `PlayerGestureHandler` parameter.
+
+- [ ] **Step 1: Write the failing classifier tests**
+
+```kotlin
+class PlayerVerticalDragModeTest {
+    @Test
+    fun `left edge leaves system brightness authoritative`() {
+        assertEquals(
+            VerticalDragMode.None,
+            verticalDragMode(startX = 40f, width = 1_000f, edgeZonePx = 88f),
+        )
+    }
+
+    @Test
+    fun `right edge retains volume routing`() {
+        assertEquals(
+            VerticalDragMode.Volume,
+            verticalDragMode(startX = 950f, width = 1_000f, edgeZonePx = 88f),
+        )
+    }
+
+    @Test
+    fun `center retains dismiss routing`() {
+        assertEquals(
+            VerticalDragMode.DismissCandidate,
+            verticalDragMode(startX = 500f, width = 1_000f, edgeZonePx = 88f),
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+./gradlew :androidApp:testDebugUnitTest \
+  --tests '*PlayerVerticalDragModeTest*' \
+  --rerun-tasks --max-workers=2 --no-daemon
+```
+
+Expected: test compilation fails because the production classifier and visible
+mode contract do not exist yet.
+
+- [ ] **Step 3: Implement the minimal routing change**
+
+In `PlayerGestureHandler.kt`, add:
+
+```kotlin
+internal enum class VerticalDragMode { None, Volume, DismissCandidate }
+
+internal fun verticalDragMode(
+    startX: Float,
+    width: Float,
+    edgeZonePx: Float,
+): VerticalDragMode = when {
+    startX < edgeZonePx -> VerticalDragMode.None
+    startX > width - edgeZonePx -> VerticalDragMode.Volume
+    else -> VerticalDragMode.DismissCandidate
+}
+```
+
+Use this function from `onDragStart`. Remove `VerticalDragMode.Brightness`,
+`adjustBrightness`, and the unused `Window`/`WindowManager` imports. Keep
+`LocalContext` because `AudioManager` still needs it. Update the gesture
+documentation to say the left edge is reserved and does not alter brightness.
+
+- [ ] **Step 4: Run GREEN**
+
+```bash
+./gradlew :androidApp:testDebugUnitTest \
+  --tests '*PlayerVerticalDragModeTest*' \
+  --rerun-tasks --max-workers=2 --no-daemon
+```
+
+Expected: all three routing tests pass.
+
+- [ ] **Step 5: Run focused player regressions**
+
+```bash
+./gradlew :androidApp:testDebugUnitTest \
+  --tests '*Player*Gesture*' \
+  --tests '*PlayerPinchGravity*' \
+  --tests '*MobilePlayerLifecycle*' \
+  --rerun-tasks --max-workers=2 --no-daemon
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Build the phone release**
+
+```bash
+./gradlew :androidApp:assembleRelease \
+  -PallowDebugReleaseSigning=true \
+  --max-workers=2 --no-daemon
+```
+
+Expected: `BUILD SUCCESSFUL` and release APK outputs exist.
+
+- [ ] **Step 7: Verify the final diff and commit**
+
+```bash
+git diff --check
+git diff --stat
+git status --short
+```
+
+Confirm that no Android TV or system-settings code changed, then commit:
+
+```bash
+git add \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt \
+  androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerVerticalDragModeTest.kt
+git commit -m "fix(player): leave phone brightness system-managed"
+```
+
+### Task 2: Pixel validation and PR update
+
+**Files:**
+- Modify only if a confirmed regression requires a test-first correction: Task 1 files.
+- Update: PR #127 description/check evidence without merging.
+
+**Interfaces:**
+- Consumes: the Task 1 release APK.
+- Produces: Pixel evidence that system brightness remains authoritative and preserved gestures still operate.
+
+- [ ] **Step 1: Verify safe Pixel upgrade compatibility**
+
+On serial `58211FDCQ000CU`, compare candidate and installed package, version,
+and signing certificate. Abort without uninstall, clear-data, or downgrade if
+they differ incompatibly.
+
+- [ ] **Step 2: Install and launch on the Pixel**
+
+```bash
+adb -s 58211FDCQ000CU install -r \
+  androidApp/build/outputs/apk/release/androidApp-arm64-v8a-release.apk
+adb -s 58211FDCQ000CU shell am start \
+  -n org.siloserver.silo/.android.MainActivity
+```
+
+- [ ] **Step 3: Validate behavior**
+
+During video playback, verify:
+
+1. Android's brightness slider changes display brightness before and after a
+   left-edge vertical drag.
+2. A left-edge drag does not dismiss playback.
+3. A right-edge drag still changes media volume.
+4. A center downward drag still dismisses after playback is established.
+5. Double-tap seek and pinch aspect-mode changes still work.
+6. Playback still prevents the display from sleeping while playing/buffering.
+7. Fresh app logs contain no fatal exception, crash, or ANR.
+
+- [ ] **Step 4: Push and update PR #127**
+
+Push `fix/subtitle-aspect-recenter`, record focused test/release/Pixel evidence
+on PR #127, and wait for hosted Unit tests and CodeRabbit. Do not merge without
+fresh user authorization.

--- a/docs/superpowers/plans/2026-07-28-android-subtitle-aspect-reconciliation-and-phone-sizing.md
+++ b/docs/superpowers/plans/2026-07-28-android-subtitle-aspect-reconciliation-and-phone-sizing.md
@@ -1,0 +1,440 @@
+# Android Subtitle Aspect Reconciliation and Phone Sizing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate stale/clipped subtitle geometry after Android aspect changes and make all phone subtitle presets 1.25× larger without changing TV sizing.
+
+**Architecture:** `SubtitleManager` remains the shared owner of Media3 and libass subtitle presentation. A fixed phone/television presentation class selects the font fraction, while `SubtitleVideoRectSync` uses generation-bound post-layout snapshot verification to request at most one corrective pre-draw pass when an aspect change exposes stale `exo_content_frame` bounds.
+
+**Tech Stack:** Kotlin Multiplatform, Android Media3 `PlayerView`/`SubtitleView`, Compose `AndroidView`, Koin, Robolectric, Gradle.
+
+## Global Constraints
+
+- Preserve subtitle selection, cue styling, authored positioning, libass/ASS, bitmap subtitle, letterbox, and title-safe behavior.
+- Do not change subtitle tracks, server subtitle processing, playback protocols, preset names, or persisted subtitle appearance schema.
+- Phone fractions are exactly Small `25 / 720`, Medium `32.5 / 720`, Large `40 / 720`, XLarge `50 / 720`, and XXLarge `60 / 720`.
+- Television fractions remain Small `20 / 720`, Medium `26 / 720`, Large `32 / 720`, XLarge `40 / 720`, and XXLarge `48 / 720`.
+- Reconciliation is bounded to two post-layout applications per explicit sync generation, coalesces repeated requests, and cancels all pending work on detach/dispose.
+- Use Media3's measured `exo_content_frame`; do not duplicate Media3's aspect-ratio algorithm.
+- Do not install or modify the Shield. Physical validation is limited to Pixel serial `58211FDCQ000CU`.
+
+---
+
+### Task 1: Phone-only subtitle preset scaling
+
+**Files:**
+- Modify: `android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt:40-46,334-342`
+- Modify: `android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt:35-55`
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt:219-222`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt:142-146`
+- Test: `androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/SubtitleAspectSyncWiringTest.kt`
+- Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleAspectSyncWiringTest.kt`
+
+**Interfaces:**
+- Produces: `enum class AndroidSubtitlePresentation { Phone, Television }`.
+- Produces: `SubtitleManager(libassBridge: LibassBridge? = null, presentation: AndroidSubtitlePresentation = AndroidSubtitlePresentation.Television)`.
+- Preserves: all existing `SubtitleManager()` test and utility construction as television-scale compatibility.
+
+- [ ] **Step 1: Write failing fraction tests**
+
+Replace the single reflected web-scale test with explicit phone and television assertions:
+
+```kotlin
+@Test
+fun phoneSubtitleTextFractionsAreOneQuarterLarger() {
+    val manager = SubtitleManager(
+        presentation = AndroidSubtitlePresentation.Phone,
+    )
+    assertEquals(25f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Small))
+    assertEquals(32.5f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Medium))
+    assertEquals(40f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Large))
+    assertEquals(50f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XLarge))
+    assertEquals(60f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XXLarge))
+}
+
+@Test
+fun televisionSubtitleTextFractionsPreserveExistingScale() {
+    val manager = SubtitleManager(
+        presentation = AndroidSubtitlePresentation.Television,
+    )
+    assertEquals(20f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Small))
+    assertEquals(26f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Medium))
+    assertEquals(32f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Large))
+    assertEquals(40f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XLarge))
+    assertEquals(48f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XXLarge))
+}
+```
+
+Update the existing phone/TV source-wiring contract tests to require the named
+`presentation` argument with `Phone` and `Television`, respectively. The
+production change that makes these tests pass is explicit DI selection plus
+the presentation-aware conversion.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+./gradlew \
+  :android-shared:testDebugUnitTest \
+  :androidApp:testDebugUnitTest \
+  :androidTvApp:testDebugUnitTest \
+  --tests '*SubtitleManagerAppearanceTest*' \
+  --tests '*SubtitleAspectSyncWiringTest*' \
+  --tests '*TvSubtitleAspectSyncWiringTest*' \
+  --max-workers=2 --no-daemon
+```
+
+Expected: compilation/assertion failures because
+`AndroidSubtitlePresentation` and the explicit DI arguments do not exist and
+phone fractions still equal television fractions.
+
+- [ ] **Step 3: Implement the presentation-aware conversion**
+
+Add the enum next to `SubtitleManager`, retain television as the default for
+existing shared call sites, and select the numerator table without changing
+the persisted `SubtitleFontSizePreset`:
+
+```kotlin
+enum class AndroidSubtitlePresentation {
+    Phone,
+    Television,
+}
+
+class SubtitleManager(
+    private val libassBridge: LibassBridge? = null,
+    private val presentation: AndroidSubtitlePresentation =
+        AndroidSubtitlePresentation.Television,
+) {
+    private fun fractionalSizeFor(preset: SubtitleFontSizePreset): Float {
+        val numerator = when (presentation) {
+            AndroidSubtitlePresentation.Phone -> when (preset) {
+                SubtitleFontSizePreset.Small -> 25f
+                SubtitleFontSizePreset.Medium -> 32.5f
+                SubtitleFontSizePreset.Large -> 40f
+                SubtitleFontSizePreset.XLarge -> 50f
+                SubtitleFontSizePreset.XXLarge -> 60f
+            }
+            AndroidSubtitlePresentation.Television -> when (preset) {
+                SubtitleFontSizePreset.Small -> 20f
+                SubtitleFontSizePreset.Medium -> 26f
+                SubtitleFontSizePreset.Large -> 32f
+                SubtitleFontSizePreset.XLarge -> 40f
+                SubtitleFontSizePreset.XXLarge -> 48f
+            }
+        }
+        return numerator / 720f
+    }
+}
+```
+
+Construct the phone singleton with
+`presentation = AndroidSubtitlePresentation.Phone` and TV with
+`presentation = AndroidSubtitlePresentation.Television`; use named arguments
+for both constructor parameters.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run the Step 2 command. Expected: all selected tests pass with no compilation
+or assertion failure.
+
+- [ ] **Step 5: Commit the sizing change**
+
+```bash
+git add \
+  android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt \
+  android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt \
+  androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/SubtitleAspectSyncWiringTest.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleAspectSyncWiringTest.kt
+git commit -m "fix(subtitles): scale phone caption presets"
+```
+
+### Task 2: Bounded stale-frame convergence
+
+**Files:**
+- Modify: `android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt:583-768`
+- Modify: `android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt:360-560`
+
+**Interfaces:**
+- Consumes: existing `SubtitleVideoRectSync.updateAndReconcileAfterLayout()`.
+- Produces: an internal immutable content-frame/resize snapshot used only to decide whether one corrective pre-draw is required.
+- Preserves: `syncSubtitleVideoBounds(PlayerView)`, layout-listener behavior, and all public subtitle APIs.
+
+- [ ] **Step 1: Add a production-shaped RED transition test**
+
+Extend `MountedSubtitleCanvas` with a method that deliberately dispatches the
+first pre-draw while the old content-frame bounds are still mounted, changes
+the frame, drains the posted snapshot verification, then dispatches the
+corrective pre-draw:
+
+```kotlin
+fun transitionAfterEarlyPreDraw(resizeMode: Int, finalFrame: FrameBounds) {
+    schedule(resizeMode)
+    playerView.viewTreeObserver.dispatchOnPreDraw()
+    contentFrame.layout(
+        finalFrame.left,
+        finalFrame.top,
+        finalFrame.right,
+        finalFrame.bottom,
+    )
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    playerView.viewTreeObserver.dispatchOnPreDraw()
+}
+```
+
+Add:
+
+```kotlin
+@Test
+fun mountedCanvasCorrectsFillToFitWhenFirstPreDrawSeesCroppedFrame() {
+    val canvas = MountedSubtitleCanvas()
+    canvas.transition(
+        resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+        frame = FrameBounds(-120, -64, 2040, 1080),
+    )
+
+    canvas.transitionAfterEarlyPreDraw(
+        resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT,
+        finalFrame = FrameBounds(240, 0, 1680, 1016),
+    )
+
+    assertEquals(SubtitleVideoRect(0, 0, 1440, 1016), canvas.subtitleRect())
+}
+```
+
+The production change that makes this test pass is retaining the explicit-sync
+generation long enough to notice that the frame snapshot changed after the
+first pre-draw and scheduling exactly one corrective pass.
+
+- [ ] **Step 2: Run the single test and verify RED**
+
+Run:
+
+```bash
+./gradlew :android-shared:testDebugUnitTest \
+  --tests '*SubtitleManagerAppearanceTest.mountedCanvasCorrectsFillToFitWhenFirstPreDrawSeesCroppedFrame' \
+  --rerun-tasks --max-workers=2 --no-daemon
+```
+
+Expected: FAIL because the existing one-shot pre-draw listener is removed
+before the final Fit frame is mounted, leaving the Zoom-derived top/left
+offset.
+
+- [ ] **Step 3: Add latest-generation and detach RED tests**
+
+Add tests that:
+
+```kotlin
+@Test
+fun rapidEarlyTransitionsApplyOnlyLatestMode() {
+    val canvas = MountedSubtitleCanvas()
+    canvas.schedule(AspectRatioFrameLayout.RESIZE_MODE_ZOOM)
+    canvas.schedule(AspectRatioFrameLayout.RESIZE_MODE_FILL)
+    canvas.schedule(AspectRatioFrameLayout.RESIZE_MODE_FIT)
+    canvas.dispatchEarlyPreDrawThenMount(FrameBounds(240, 0, 1680, 1016))
+    assertEquals(SubtitleVideoRect(0, 0, 1440, 1016), canvas.subtitleRect())
+    assertEquals(2, canvas.reconciliationCount)
+}
+
+@Test
+fun detachCancelsPostedSnapshotVerification() {
+    val canvas = MountedSubtitleCanvas()
+    canvas.schedule(AspectRatioFrameLayout.RESIZE_MODE_ZOOM)
+    canvas.dispatchPreDraw()
+    canvas.detach()
+    canvas.mountFrameAndDrain(FrameBounds(-120, -64, 2040, 1080))
+    assertEquals(1, canvas.reconciliationCount)
+}
+```
+
+Expose `reconciliationCount` through the existing
+`postLayoutReconciliationObserver`; keep all harness helpers test-only.
+
+- [ ] **Step 4: Run the three tests and verify RED**
+
+Run:
+
+```bash
+./gradlew :android-shared:testDebugUnitTest \
+  --tests '*SubtitleManagerAppearanceTest.mountedCanvasCorrectsFillToFitWhenFirstPreDrawSeesCroppedFrame' \
+  --tests '*SubtitleManagerAppearanceTest.rapidEarlyTransitionsApplyOnlyLatestMode' \
+  --tests '*SubtitleManagerAppearanceTest.detachCancelsPostedSnapshotVerification' \
+  --rerun-tasks --max-workers=2 --no-daemon
+```
+
+Expected: the Fill-to-Fit test remains red and the new lifecycle/count
+assertions fail because no generation-bound snapshot verification exists.
+
+- [ ] **Step 5: Implement bounded snapshot verification**
+
+Inside `SubtitleVideoRectSync`, add:
+
+```kotlin
+private data class LayoutSnapshot(
+    val resizeMode: Int,
+    val playerWidth: Int,
+    val playerHeight: Int,
+    val frameLeft: Int,
+    val frameTop: Int,
+    val frameWidth: Int,
+    val frameHeight: Int,
+)
+
+private var reconciliationGeneration = 0L
+private var pendingVerification: Runnable? = null
+private var appliedPasses = 0
+```
+
+`updateAndReconcileAfterLayout()` increments the generation only when creating
+a new explicit reconciliation request, resets `appliedPasses`, coalesces the
+single pending pre-draw, and captures no mutable view geometry.
+
+After the pre-draw calls `update()`, capture the snapshot actually applied,
+increment `appliedPasses`, and post one main-thread verification runnable. The
+runnable must:
+
+```kotlin
+if (
+    !isDisposed &&
+    generation == reconciliationGeneration &&
+    appliedPasses < 2 &&
+    currentSnapshot(playerView) != appliedSnapshot
+) {
+    schedulePreDrawFor(generation)
+}
+```
+
+The second application does not post another correction. `dispose()` removes
+the pre-draw listener, removes the posted runnable with
+`playerView.removeCallbacks`, increments/invalidates the generation, and keeps
+the existing listener cleanup. The permanent content-frame layout listener
+continues to handle genuine later layouts.
+
+- [ ] **Step 6: Run focused reconciliation tests and verify GREEN**
+
+Run:
+
+```bash
+./gradlew :android-shared:testDebugUnitTest \
+  --tests '*SubtitleManagerAppearanceTest*' \
+  --rerun-tasks --max-workers=2 --no-daemon
+```
+
+Expected: all appearance, geometry, coalescing, rapid-transition, and detach
+tests pass. `repeatedExplicitSyncsRunOnePostLayoutReconciliation` must remain
+green for stable geometry.
+
+- [ ] **Step 7: Commit the reconciliation fix**
+
+```bash
+git add \
+  android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt \
+  android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+git commit -m "fix(subtitles): converge aspect bounds after layout"
+```
+
+### Task 3: Regression, release, and Pixel validation
+
+**Files:**
+- Modify only if evidence requires a test correction: files from Tasks 1-2.
+- Record verification in the PR description; do not add generated artifacts to git.
+
+**Interfaces:**
+- Consumes: phone presentation scaling and bounded reconciliation from Tasks 1-2.
+- Produces: verified phone/TV release artifacts and physical Pixel evidence.
+
+- [ ] **Step 1: Run focused shared/phone/TV tests uncached**
+
+```bash
+./gradlew \
+  :android-shared:testDebugUnitTest \
+  :androidApp:testDebugUnitTest \
+  :androidTvApp:testDebugUnitTest \
+  --tests '*Subtitle*' \
+  --rerun-tasks --max-workers=2 --no-daemon
+```
+
+Expected: all selected subtitle tests pass.
+
+- [ ] **Step 2: Run supply-chain verification**
+
+```bash
+./scripts/test-check-build-supply-chain.sh
+./scripts/check-build-supply-chain.sh
+```
+
+Expected: both scripts exit zero without changing tracked files.
+
+- [ ] **Step 3: Run the full unit and release gates**
+
+```bash
+./gradlew \
+  testDebugUnitTest \
+  :androidApp:assembleRelease \
+  :androidTvApp:assembleRelease \
+  -PallowDebugReleaseSigning=true \
+  --max-workers=2 --no-daemon
+```
+
+Expected: `BUILD SUCCESSFUL`; both release APK outputs exist. Do not install the
+TV artifact.
+
+- [ ] **Step 4: Safely install the phone release on the Pixel**
+
+Verify serial, package, version, and signer compatibility first. Then use only:
+
+```bash
+adb -s 58211FDCQ000CU install -r \
+  androidApp/build/outputs/apk/release/androidApp-universal-release.apk
+```
+
+Abort without uninstalling, clearing data, downgrading, or changing settings if
+the signer or version is incompatible.
+
+- [ ] **Step 5: Validate the reproduced matrix on Pixel**
+
+Using the already configured subtitle track:
+
+1. Play through at least three consecutive text cues in Fit.
+2. Change Fit → Fill → Stretch → Fit, closing the sheet after each selection.
+3. Repeat Fill → Fit rapidly three times.
+4. Confirm each cue is horizontally centered, fully above the display bottom,
+   and visible on the first cue after each transition.
+5. Confirm multi-line cues are not clipped.
+6. Confirm the default Large phone size is visibly larger than the pre-fix
+   `32 / 720` build and that Small through XXLarge remain ordered.
+7. Capture serial-scoped screenshots and fresh app-process logs; confirm no
+   fatal exception, ANR, subtitle parser error, or playback regression.
+
+- [ ] **Step 6: Request independent review**
+
+Provide the reviewer with the approved spec, this plan, commits from Tasks 1-2,
+the focused/full gate outputs, and Pixel screenshots. Require explicit verdicts
+on:
+
+- generation/coalescing correctness,
+- detach and callback ownership,
+- parent-local Media3 geometry,
+- phone-only sizing and TV preservation,
+- absence of server/protocol/persistence changes.
+
+Fix only evidenced findings test-first and rerun the smallest affected gate.
+
+- [ ] **Step 7: Final diff and branch verification**
+
+```bash
+git diff --check origin/main...HEAD
+git status --short
+git log --oneline --decorate origin/main..HEAD
+```
+
+Expected: no whitespace errors, a clean worktree, and only the approved PR #127
+subtitle work plus its spec/plan/fix commits.
+
+- [ ] **Step 8: Push and update PR #127 without merging**
+
+Push `fix/subtitle-aspect-recenter`, update PR #127 with the new Pixel
+reproduction and verification evidence, and wait for hosted checks and
+CodeRabbit. Do not merge without fresh user authorization.

--- a/docs/superpowers/plans/2026-07-28-android-subtitle-aspect-reconciliation-and-phone-sizing.md
+++ b/docs/superpowers/plans/2026-07-28-android-subtitle-aspect-reconciliation-and-phone-sizing.md
@@ -335,10 +335,102 @@ git add \
 git commit -m "fix(subtitles): converge aspect bounds after layout"
 ```
 
-### Task 3: Regression, release, and Pixel validation
+### Task 3: Stabilize initial phone subtitle restore
 
 **Files:**
-- Modify only if evidence requires a test correction: files from Tasks 1-2.
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapter.kt`
+- Modify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt`
+- Test: `androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt`
+- Verify unchanged: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleRemountReselection.kt`
+- Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/SubtitleRemountReselectionTest.kt`
+
+**Interfaces:**
+- Consumes: `MobileSubtitleTransactionAdapter.reportMountedSelection(...)` and
+  the existing five-second mobile mount deadline.
+- Produces: stable-snapshot evidence owned by the pending mobile mount
+  generation; the first non-empty miss remains pending, a changed snapshot
+  restarts settlement, and a repeated identical miss may fail.
+
+- [ ] **Step 1: Write the failing mobile transaction tests**
+
+Change the immediate-miss test so it reports one ready, non-empty catalog and
+asserts that the pending local restore remains active with no failure. Add a
+second test that reports the same key twice and asserts the existing failure,
+plus a changed-key test that requires the changed key to repeat before failure.
+
+```kotlin
+harness.adapter.reportMountedSelection(
+    identity = local,
+    selected = false,
+    snapshotKey = "intermediate",
+    settled = true,
+)
+assertEquals(local, harness.adapter.snapshot.localMountIdentity)
+assertNull(harness.adapter.snapshot.failureMessage)
+
+harness.adapter.reportMountedSelection(
+    identity = local,
+    selected = false,
+    snapshotKey = "intermediate",
+    settled = true,
+)
+assertNull(harness.adapter.snapshot.localMountIdentity)
+assertTrue(harness.adapter.snapshot.failureMessage?.contains("mount", true) == true)
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+./gradlew :androidApp:testDebugUnitTest \
+  --tests '*MobileSubtitleTransactionAdapterTest*' \
+  --rerun-tasks --max-workers=2 --no-daemon
+```
+
+Expected: the first-snapshot assertion fails because the adapter currently
+calls `failLocalMount` immediately.
+
+- [ ] **Step 3: Implement generation-owned snapshot stabilization**
+
+Add one nullable last-miss snapshot key to
+`MobileSubtitleTransactionAdapter`. For a non-selected result with
+`settled=true`, record the first non-blank key; fail only when the same key is
+reported again. A changed key replaces the candidate and remains provisional.
+Clear the candidate from `invalidateLocalMount()` so content, identity, and
+generation changes cannot inherit old evidence.
+
+In `PlayerScreen` keep the immediate `LaunchedEffect` mount attempt
+provisional (`settled = false`). Track callbacks remain the source of settled
+catalog evidence. Do not change the five-second timeout, successful-selection
+path, persisted identity, or error copy.
+
+- [ ] **Step 4: Run GREEN and focused TV parity**
+
+```bash
+./gradlew \
+  :androidApp:testDebugUnitTest \
+  :androidTvApp:testDebugUnitTest \
+  --tests '*MobileSubtitleTransactionAdapterTest*' \
+  --tests '*SubtitleRemountReselectionTest*' \
+  --rerun-tasks --max-workers=2 --no-daemon
+```
+
+Expected: mobile first/changed/repeated snapshot tests pass, and TV's existing
+first-snapshot stabilization tests remain green without TV production edits.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapter.kt \
+  androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt \
+  androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
+git commit -m "fix(subtitles): await stable tracks on playback restore"
+```
+
+### Task 4: Regression, release, and Pixel validation
+
+**Files:**
+- Modify only if evidence requires a test correction: files from Tasks 1-3.
 - Record verification in the PR description; do not add generated artifacts to git.
 
 **Interfaces:**

--- a/docs/superpowers/plans/2026-07-28-android-subtitle-aspect-reconciliation-and-phone-sizing.md
+++ b/docs/superpowers/plans/2026-07-28-android-subtitle-aspect-reconciliation-and-phone-sizing.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Eliminate stale/clipped subtitle geometry after Android aspect changes and make all phone subtitle presets 1.25× larger without changing TV sizing.
+**Goal:** Eliminate stale/clipped subtitle geometry after Android aspect changes and make all phone subtitle presets 1.125× larger without changing TV sizing.
 
 **Architecture:** `SubtitleManager` remains the shared owner of Media3 and libass subtitle presentation. A fixed phone/television presentation class selects the font fraction, while `SubtitleVideoRectSync` uses generation-bound post-layout snapshot verification to request at most one corrective pre-draw pass when an aspect change exposes stale `exo_content_frame` bounds.
 
@@ -12,7 +12,7 @@
 
 - Preserve subtitle selection, cue styling, authored positioning, libass/ASS, bitmap subtitle, letterbox, and title-safe behavior.
 - Do not change subtitle tracks, server subtitle processing, playback protocols, preset names, or persisted subtitle appearance schema.
-- Phone fractions are exactly Small `25 / 720`, Medium `32.5 / 720`, Large `40 / 720`, XLarge `50 / 720`, and XXLarge `60 / 720`.
+- Phone fractions are exactly Small `22.5 / 720`, Medium `29.25 / 720`, Large `36 / 720`, XLarge `45 / 720`, and XXLarge `54 / 720`.
 - Television fractions remain Small `20 / 720`, Medium `26 / 720`, Large `32 / 720`, XLarge `40 / 720`, and XXLarge `48 / 720`.
 - Reconciliation is bounded to two post-layout applications per explicit sync generation, coalesces repeated requests, and cancels all pending work on detach/dispose.
 - Use Media3's measured `exo_content_frame`; do not duplicate Media3's aspect-ratio algorithm.
@@ -41,15 +41,15 @@ Replace the single reflected web-scale test with explicit phone and television a
 
 ```kotlin
 @Test
-fun phoneSubtitleTextFractionsAreOneQuarterLarger() {
+fun phoneSubtitleTextFractionsUseApprovedPhoneScale() {
     val manager = SubtitleManager(
         presentation = AndroidSubtitlePresentation.Phone,
     )
-    assertEquals(25f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Small))
-    assertEquals(32.5f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Medium))
-    assertEquals(40f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Large))
-    assertEquals(50f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XLarge))
-    assertEquals(60f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XXLarge))
+    assertEquals(22.5f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Small))
+    assertEquals(29.25f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Medium))
+    assertEquals(36f / 720f, fractionalSize(manager, SubtitleFontSizePreset.Large))
+    assertEquals(45f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XLarge))
+    assertEquals(54f / 720f, fractionalSize(manager, SubtitleFontSizePreset.XXLarge))
 }
 
 @Test
@@ -109,11 +109,11 @@ class SubtitleManager(
     private fun fractionalSizeFor(preset: SubtitleFontSizePreset): Float {
         val numerator = when (presentation) {
             AndroidSubtitlePresentation.Phone -> when (preset) {
-                SubtitleFontSizePreset.Small -> 25f
-                SubtitleFontSizePreset.Medium -> 32.5f
-                SubtitleFontSizePreset.Large -> 40f
-                SubtitleFontSizePreset.XLarge -> 50f
-                SubtitleFontSizePreset.XXLarge -> 60f
+                SubtitleFontSizePreset.Small -> 22.5f
+                SubtitleFontSizePreset.Medium -> 29.25f
+                SubtitleFontSizePreset.Large -> 36f
+                SubtitleFontSizePreset.XLarge -> 45f
+                SubtitleFontSizePreset.XXLarge -> 54f
             }
             AndroidSubtitlePresentation.Television -> when (preset) {
                 SubtitleFontSizePreset.Small -> 20f

--- a/docs/superpowers/plans/2026-07-28-subtitle-aspect-recenter.md
+++ b/docs/superpowers/plans/2026-07-28-subtitle-aspect-recenter.md
@@ -1,0 +1,528 @@
+# Subtitle Aspect-Mode Recentring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the Android phone and TV subtitle canvas aligned with the final visible video viewport when switching among Fit, Fill/Zoom, and Stretch.
+
+**Architecture:** `SubtitleManager` remains the only subtitle-geometry owner. A pure mode-aware selector will reject stale fitted content-frame geometry for modes whose video fills the viewport, and the existing per-`PlayerView` synchronizer will perform one lifecycle-owned post-layout reconciliation after each explicit sync request.
+
+**Tech Stack:** Kotlin 2.1, Android Views, Media3 `PlayerView`/`AspectRatioFrameLayout`, Robolectric/JUnit, Gradle 8.12.
+
+## Global Constraints
+
+- Apply the shared correction to Android phone and Android TV; phone is the confirmed reproduction.
+- Fit aligns the subtitle canvas with the fitted video rectangle.
+- Phone Fill/Media3 Zoom and phone Stretch/Media3 Fill align the canvas with the full visible player viewport.
+- Preserve authored ASS/SSA and PGS positions relative to the canvas; do not rewrite individual cue coordinates.
+- Preserve existing letterbox detection, title-safe insets, subtitle appearance, timing, track selection, playback state, networking, and persisted settings.
+- Do not add polling, arbitrary delays, a second renderer, server changes, protocol changes, or transcoding changes.
+- A delayed reconciliation must not mutate a detached or replaced `PlayerView`.
+- Do not install on the Shield without a separate explicit request.
+
+---
+
+### Task 1: Make subtitle canvas selection resize-mode aware
+
+**Files:**
+- Modify: `android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt:445-492,662-673`
+- Test: `android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt:143-251`
+
+**Interfaces:**
+- Consumes: `SubtitleVideoRect`, Media3 resize-mode constants, `displayedSubtitleVideoRect(...)`, and the current content-frame rectangle.
+- Produces: `internal fun selectSubtitleCanvasRect(resizeMode: Int, contentFrameRect: SubtitleVideoRect?, displayedVideoRect: SubtitleVideoRect): SubtitleVideoRect`.
+
+- [ ] **Step 1: Add failing stale-frame regression tests**
+
+Add these tests to `SubtitleManagerAppearanceTest`:
+
+```kotlin
+@Test
+fun zoomIgnoresStaleFittedContentFrameAndUsesFullViewport() {
+    val staleFit = SubtitleVideoRect(left = 0, top = 236, width = 2404, height = 1352)
+    val fullViewport = SubtitleVideoRect(left = 0, top = 0, width = 2404, height = 1080)
+
+    assertEquals(
+        fullViewport,
+        selectSubtitleCanvasRect(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+            contentFrameRect = staleFit,
+            displayedVideoRect = fullViewport,
+        ),
+    )
+}
+
+@Test
+fun stretchIgnoresStaleFittedContentFrameAndUsesFullViewport() {
+    val staleFit = SubtitleVideoRect(left = 240, top = 0, width = 1920, height = 1080)
+    val fullViewport = SubtitleVideoRect(left = 0, top = 0, width = 2400, height = 1080)
+
+    assertEquals(
+        fullViewport,
+        selectSubtitleCanvasRect(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL,
+            contentFrameRect = staleFit,
+            displayedVideoRect = fullViewport,
+        ),
+    )
+}
+
+@Test
+fun fitContinuesToUsePostLayoutContentFrame() {
+    val fittedFrame = SubtitleVideoRect(left = 0, top = 0, width = 1920, height = 1080)
+    val computedFallback = SubtitleVideoRect(left = 240, top = 0, width = 1920, height = 1080)
+
+    assertEquals(
+        fittedFrame,
+        selectSubtitleCanvasRect(
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT,
+            contentFrameRect = fittedFrame,
+            displayedVideoRect = computedFallback,
+        ),
+    )
+}
+
+@Test
+fun repeatedModeSelectionDoesNotRetainPreviousCanvas() {
+    val fit = SubtitleVideoRect(left = 240, top = 0, width = 1920, height = 1080)
+    val full = SubtitleVideoRect(left = 0, top = 0, width = 2400, height = 1080)
+
+    val fill = selectSubtitleCanvasRect(
+        AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+        fit,
+        full,
+    )
+    val stretch = selectSubtitleCanvasRect(
+        AspectRatioFrameLayout.RESIZE_MODE_FILL,
+        fit,
+        full,
+    )
+    val restoredFit = selectSubtitleCanvasRect(
+        AspectRatioFrameLayout.RESIZE_MODE_FIT,
+        fit,
+        fit,
+    )
+
+    assertEquals(full, fill)
+    assertEquals(full, stretch)
+    assertEquals(fit, restoredFit)
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+./gradlew :android-shared:testDebugUnitTest \
+  --tests org.siloserver.silo.common.player.SubtitleManagerAppearanceTest \
+  --max-workers=2 --no-daemon
+```
+
+Expected: compilation fails because `selectSubtitleCanvasRect` does not exist.
+
+- [ ] **Step 3: Implement the minimal mode-aware selector**
+
+Add beside `displayedSubtitleVideoRect`:
+
+```kotlin
+internal fun selectSubtitleCanvasRect(
+    resizeMode: Int,
+    contentFrameRect: SubtitleVideoRect?,
+    displayedVideoRect: SubtitleVideoRect,
+): SubtitleVideoRect = when (resizeMode) {
+    AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+    AspectRatioFrameLayout.RESIZE_MODE_FILL,
+    -> displayedVideoRect
+    else -> contentFrameRect ?: displayedVideoRect
+}
+```
+
+Change `SubtitleVideoRectSync.applyRect` to compute both inputs before applying
+letterbox and title-safe insets:
+
+```kotlin
+val resizeMode = playerView.resizeMode
+val displayedVideoRect = displayedSubtitleVideoRect(
+    viewWidth = playerView.width,
+    viewHeight = playerView.height,
+    videoWidth = videoSize.width,
+    videoHeight = videoSize.height,
+    videoPixelWidthHeightRatio = videoSize.pixelWidthHeightRatio,
+    resizeMode = resizeMode,
+)
+val rect = selectSubtitleCanvasRect(
+    resizeMode = resizeMode,
+    contentFrameRect = playerView.contentFrameSubtitleRect(),
+    displayedVideoRect = displayedVideoRect,
+).insetByLetterbox(letterbox).insetByTitleSafe(titleSafeFraction)
+```
+
+This deliberately selects the already-full `displayedVideoRect` for Zoom and
+Fill even when the content frame has not completed its next layout.
+
+- [ ] **Step 4: Run the focused class and verify GREEN**
+
+Run the Step 2 command.
+
+Expected: `SubtitleManagerAppearanceTest` passes with zero failures.
+
+- [ ] **Step 5: Commit the independently testable geometry correction**
+
+```bash
+git add \
+  android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt \
+  android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+git commit -m "fix(subtitles): recenter canvas for fill modes"
+```
+
+---
+
+### Task 2: Reconcile once after layout and cancel stale callbacks
+
+**Files:**
+- Modify: `android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt:270-282,563-704`
+- Test: `android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1's `selectSubtitleCanvasRect(...)`.
+- Produces: `SubtitleVideoRectSync.updateAndReconcileAfterLayout()`; at most one posted callback per `PlayerView`, removed during disposal.
+
+- [ ] **Step 1: Add failing lifecycle regression tests**
+
+Add Robolectric tests that mount a real `PlayerView` in an `Activity`, invoke
+`SubtitleManager.syncSubtitleVideoBounds`, and inspect the private synchronizer
+through the manager's `videoRectSyncs` field:
+
+```kotlin
+@Test
+fun explicitSyncQueuesOnlyOnePostLayoutReconciliation() {
+    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    val playerView = PlayerView(activity)
+    activity.setContentView(playerView)
+    playerView.layout(0, 0, 2400, 1080)
+    val manager = SubtitleManager()
+
+    manager.syncSubtitleVideoBounds(playerView)
+    manager.syncSubtitleVideoBounds(playerView)
+
+    val sync = manager.subtitleRectSyncForTest(playerView)
+    assertTrue(sync.postLayoutPendingForTest())
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    assertFalse(sync.postLayoutPendingForTest())
+}
+
+@Test
+fun detachCancelsPendingPostLayoutReconciliation() {
+    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    val playerView = PlayerView(activity)
+    activity.setContentView(playerView)
+    playerView.layout(0, 0, 2400, 1080)
+    val manager = SubtitleManager()
+
+    manager.syncSubtitleVideoBounds(playerView)
+    val sync = manager.subtitleRectSyncForTest(playerView)
+    activity.setContentView(FrameLayout(activity))
+
+    assertTrue(sync.isDisposedForTest())
+    assertFalse(sync.postLayoutPendingForTest())
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    assertTrue(sync.isDisposedForTest())
+}
+```
+
+Keep reflection helpers private to the test file. They must expose existing
+objects only; do not add production `ForTest` methods:
+
+```kotlin
+private fun SubtitleManager.subtitleRectSyncForTest(playerView: PlayerView): Any {
+    val field = SubtitleManager::class.java.getDeclaredField("videoRectSyncs")
+    field.isAccessible = true
+    val syncs = field.get(this) as Map<*, *>
+    return requireNotNull(syncs[playerView])
+}
+
+private fun Any.postLayoutPendingForTest(): Boolean {
+    val field = javaClass.getDeclaredField("postLayoutPending")
+    field.isAccessible = true
+    return field.getBoolean(this)
+}
+
+private fun Any.isDisposedForTest(): Boolean {
+    val field = javaClass.getDeclaredField("isDisposed")
+    field.isAccessible = true
+    return field.getBoolean(this)
+}
+```
+
+The test file imports `android.app.Activity`, `android.os.Looper`,
+`android.widget.FrameLayout`, `androidx.media3.ui.PlayerView`,
+`org.robolectric.Robolectric`, `org.robolectric.Shadows`,
+`kotlin.test.assertFalse`, and `kotlin.test.assertTrue`.
+
+- [ ] **Step 2: Run the focused class and verify RED**
+
+Run:
+
+```bash
+./gradlew :android-shared:testDebugUnitTest \
+  --tests org.siloserver.silo.common.player.SubtitleManagerAppearanceTest \
+  --max-workers=2 --no-daemon
+```
+
+Expected: the test cannot find `postLayoutPending`, proving the bounded
+reconciliation is absent.
+
+- [ ] **Step 3: Implement one lifecycle-owned post-layout callback**
+
+In `SubtitleVideoRectSync`, add:
+
+```kotlin
+private var postLayoutPending = false
+private val postLayoutUpdate = Runnable {
+    postLayoutPending = false
+    if (!isDisposed) update()
+}
+
+fun updateAndReconcileAfterLayout() {
+    update()
+    val playerView = playerViewRef.get() ?: return
+    if (isDisposed || postLayoutPending) return
+    postLayoutPending = true
+    playerView.postOnAnimation(postLayoutUpdate)
+}
+```
+
+Change `SubtitleManager.syncSubtitleVideoBounds` to call:
+
+```kotlin
+sync.updateAndReconcileAfterLayout()
+```
+
+In `dispose`, remove the callback before clearing listeners:
+
+```kotlin
+playerView?.removeCallbacks(postLayoutUpdate)
+postLayoutPending = false
+```
+
+Do not post from ordinary layout/video-size callbacks; those continue calling
+`update()` directly. This keeps the extra reconciliation bounded to explicit
+screen sync requests.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run the Step 2 command.
+
+Expected: all `SubtitleManagerAppearanceTest` tests pass.
+
+- [ ] **Step 5: Run neighboring subtitle geometry tests**
+
+```bash
+./gradlew :android-shared:testDebugUnitTest \
+  --tests org.siloserver.silo.common.player.SubtitleManagerAppearanceTest \
+  --tests org.siloserver.silo.common.player.LetterboxInsetTest \
+  --tests org.siloserver.silo.common.player.TitleSafeInsetTest \
+  --max-workers=2 --no-daemon
+```
+
+Expected: zero failures.
+
+- [ ] **Step 6: Commit the lifecycle correction**
+
+```bash
+git add \
+  android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt \
+  android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerAppearanceTest.kt
+git commit -m "fix(subtitles): reconcile canvas after aspect layout"
+```
+
+---
+
+### Task 3: Lock phone/TV wiring and verify release behaviour
+
+**Files:**
+- Create: `androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/SubtitleAspectModeWiringSourceTest.kt`
+- Create: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleAspectModeWiringSourceTest.kt`
+- Verify: `androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt:1085-1123`
+- Verify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt:1775-1793,3088-3113`
+
+**Interfaces:**
+- Consumes: existing `SubtitleManager.syncSubtitleVideoBounds(PlayerView)`, phone resize-mode mapping, and TV `applyPlayerViewVideoFillMode`.
+- Produces: platform source-contract tests ensuring each resize update is immediately followed by shared subtitle reconciliation.
+
+- [ ] **Step 1: Add phone and TV source-contract tests**
+
+Phone:
+
+```kotlin
+class SubtitleAspectModeWiringSourceTest {
+    private fun source(path: String): String {
+        val moduleRelative = File("src/androidMain/kotlin/$path")
+        val projectRelative = File("androidApp/src/androidMain/kotlin/$path")
+        return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
+    }
+
+    @Test
+    fun playerViewReconcilesSubtitlesAfterResizeModeUpdate() {
+        val source = source(
+            "org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt"
+        )
+        val update = source.substringAfter("update = { view ->")
+            .substringBefore("modifier = Modifier")
+
+        assertTrue(update.contains("view.resizeMode = resizeMode"))
+        assertTrue(update.contains("subtitleManager.syncSubtitleVideoBounds(view)"))
+        assertTrue(
+            update.indexOf("view.resizeMode = resizeMode") <
+                update.indexOf("subtitleManager.syncSubtitleVideoBounds(view)")
+        )
+    }
+}
+```
+
+TV:
+
+```kotlin
+class TvSubtitleAspectModeWiringSourceTest {
+    private fun source(path: String): String {
+        val moduleRelative = File("src/androidMain/kotlin/$path")
+        val projectRelative = File("androidTvApp/src/androidMain/kotlin/$path")
+        return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
+    }
+
+    @Test
+    fun playerViewReconcilesSubtitlesAfterFillModeUpdate() {
+        val source = source(
+            "org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+        )
+        val update = source.substringAfter("update = { view ->")
+            .substringBefore("if (!isInPictureInPictureMode")
+
+        val aspectCall = "applyPlayerViewVideoFillMode(view, state.videoFillMode)"
+        val subtitleCall = "subtitleManager.syncSubtitleVideoBounds(view)"
+        assertTrue(update.contains(aspectCall))
+        assertTrue(update.contains(subtitleCall))
+        assertTrue(update.indexOf(aspectCall) < update.indexOf(subtitleCall))
+    }
+}
+```
+
+Both files import `java.io.File`, `kotlin.test.Test`, and
+`kotlin.test.assertTrue`.
+
+- [ ] **Step 2: Prove the source tests detect reversed ordering**
+
+Temporarily reverse each extracted ordering assertion (`<` to `>`) and run:
+
+```bash
+./gradlew \
+  :androidApp:testDebugUnitTest \
+  :androidTvApp:testDebugUnitTest \
+  --tests '*SubtitleAspectModeWiringSourceTest' \
+  --max-workers=2 --no-daemon
+```
+
+Expected: both tests fail on their ordering assertion. Restore `<` before
+continuing.
+
+- [ ] **Step 3: Run the source tests GREEN**
+
+Run the Step 2 command after restoring the intended assertions.
+
+Expected: both tests pass.
+
+- [ ] **Step 4: Run the complete relevant feature gate**
+
+```bash
+./gradlew \
+  :android-shared:testDebugUnitTest \
+  :androidApp:testDebugUnitTest \
+  :androidTvApp:testDebugUnitTest \
+  --tests '*SubtitleManagerAppearanceTest' \
+  --tests '*LetterboxInsetTest' \
+  --tests '*TitleSafeInsetTest' \
+  --tests '*SubtitleAspectModeWiringSourceTest' \
+  --max-workers=2 --no-daemon
+```
+
+Expected: zero failures.
+
+- [ ] **Step 5: Run full debug unit tests**
+
+```bash
+./gradlew testDebugUnitTest --max-workers=2 --no-daemon
+```
+
+Expected: build succeeds with zero test failures.
+
+- [ ] **Step 6: Run supply-chain and release compilation gates**
+
+```bash
+./scripts/test-check-build-supply-chain.sh
+./scripts/check-build-supply-chain.sh
+./gradlew \
+  :androidApp:assembleRelease \
+  :androidTvApp:assembleRelease \
+  -PallowDebugReleaseSigning=true \
+  --max-workers=2 --no-daemon
+```
+
+Expected: policy scripts exit zero and both minified release assemblies succeed.
+
+- [ ] **Step 7: Verify on the physical Pixel only**
+
+First confirm serial `58211FDCQ000CU`, compare the candidate and installed
+package/version/signing certificate, and stop if the signer differs. Then use
+only:
+
+```bash
+adb -s 58211FDCQ000CU install -r \
+  androidApp/build/outputs/apk/release/androidApp-universal-release.apk
+adb -s 58211FDCQ000CU shell am start -W \
+  -n org.siloserver.silo/org.siloserver.silo.android.MainActivity
+```
+
+With Bluetooth earbuds disconnected, play a title containing centred text
+subtitles and switch Fit → Fill → Stretch → Fit. Capture screenshots after
+layout settles and verify:
+
+- Fill and Stretch centre the subtitle canvas in the full visible viewport.
+- Returning to Fit restores the fitted-video canvas.
+- repeated switching does not retain an earlier offset;
+- subtitle timing and vertical position remain stable;
+- no immediate fatal exception, ANR, or player error appears in Pixel logcat.
+
+Do not issue any ADB command to the Shield or an emulator.
+
+- [ ] **Step 8: Request independent focused review**
+
+Review only the branch diff against:
+
+- mode-aware stale-frame rejection;
+- authored cue preservation;
+- bounded callback ownership and detach cancellation;
+- phone/TV wiring;
+- absence of unrelated playback changes.
+
+Address every substantive finding test-first and rerun Tasks 1-3's focused
+gates.
+
+- [ ] **Step 9: Commit verification contracts**
+
+```bash
+git add \
+  androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/SubtitleAspectModeWiringSourceTest.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleAspectModeWiringSourceTest.kt
+git commit -m "test(subtitles): lock aspect recenter wiring"
+```
+
+- [ ] **Step 10: Final diff and branch verification**
+
+```bash
+git diff --check origin/main...HEAD
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: no whitespace errors, clean worktree, and only the approved spec,
+plan, shared geometry fix, lifecycle reconciliation, and platform tests.

--- a/docs/superpowers/plans/2026-07-28-subtitle-aspect-recenter.md
+++ b/docs/superpowers/plans/2026-07-28-subtitle-aspect-recenter.md
@@ -4,7 +4,12 @@
 
 **Goal:** Keep the Android phone and TV subtitle canvas aligned with the final visible video viewport when switching among Fit, Fill/Zoom, and Stretch.
 
-**Architecture:** `SubtitleManager` remains the only subtitle-geometry owner. A pure mode-aware selector will reject stale fitted content-frame geometry for modes whose video fills the viewport, and the existing per-`PlayerView` synchronizer will perform one lifecycle-owned post-layout reconciliation after each explicit sync request.
+**Architecture:** `SubtitleManager` remains the only subtitle-geometry owner. A
+pure mode-aware selector rejects stale fitted content-frame geometry while
+preserving a matching post-layout content-frame rectangle so Zoom retains the
+visible viewport's parent-local offset. The existing per-`PlayerView`
+synchronizer performs one lifecycle-owned pre-draw reconciliation after each
+explicit sync request and removes that observer on completion or disposal.
 
 **Tech Stack:** Kotlin 2.1, Android Views, Media3 `PlayerView`/`AspectRatioFrameLayout`, Robolectric/JUnit, Gradle 8.12.
 
@@ -31,7 +36,7 @@
 - Consumes: `SubtitleVideoRect`, Media3 resize-mode constants, `displayedSubtitleVideoRect(...)`, and the current content-frame rectangle.
 - Produces: `internal fun selectSubtitleCanvasRect(resizeMode: Int, contentFrameRect: SubtitleVideoRect?, displayedVideoRect: SubtitleVideoRect): SubtitleVideoRect`.
 
-- [ ] **Step 1: Add failing stale-frame regression tests**
+- [x] **Step 1: Add failing stale-frame regression tests**
 
 Add these tests to `SubtitleManagerAppearanceTest`:
 
@@ -108,7 +113,7 @@ fun repeatedModeSelectionDoesNotRetainPreviousCanvas() {
 }
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run:
 
@@ -120,7 +125,7 @@ Run:
 
 Expected: compilation fails because `selectSubtitleCanvasRect` does not exist.
 
-- [ ] **Step 3: Implement the minimal mode-aware selector**
+- [x] **Step 3: Implement the minimal mode-aware selector**
 
 Add beside `displayedSubtitleVideoRect`:
 
@@ -132,7 +137,10 @@ internal fun selectSubtitleCanvasRect(
 ): SubtitleVideoRect = when (resizeMode) {
     AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
     AspectRatioFrameLayout.RESIZE_MODE_FILL,
-    -> displayedVideoRect
+    -> contentFrameRect?.takeIf {
+        it.width == displayedVideoRect.width &&
+            it.height == displayedVideoRect.height
+    } ?: displayedVideoRect
     else -> contentFrameRect ?: displayedVideoRect
 }
 ```
@@ -157,16 +165,18 @@ val rect = selectSubtitleCanvasRect(
 ).insetByLetterbox(letterbox).insetByTitleSafe(titleSafeFraction)
 ```
 
-This deliberately selects the already-full `displayedVideoRect` for Zoom and
-Fill even when the content frame has not completed its next layout.
+For Zoom and Fill, a content-frame rectangle is used only when its dimensions
+match the visible viewport. This preserves the post-layout parent-local offset
+of an oversized, negatively positioned Zoom frame. A stale fitted rectangle
+does not match, so selection falls back to `displayedVideoRect`.
 
-- [ ] **Step 4: Run the focused class and verify GREEN**
+- [x] **Step 4: Run the focused class and verify GREEN**
 
 Run the Step 2 command.
 
 Expected: `SubtitleManagerAppearanceTest` passes with zero failures.
 
-- [ ] **Step 5: Commit the independently testable geometry correction**
+- [x] **Step 5: Commit the independently testable geometry correction**
 
 ```bash
 git add \
@@ -185,81 +195,50 @@ git commit -m "fix(subtitles): recenter canvas for fill modes"
 
 **Interfaces:**
 - Consumes: Task 1's `selectSubtitleCanvasRect(...)`.
-- Produces: `SubtitleVideoRectSync.updateAndReconcileAfterLayout()`; at most one posted callback per `PlayerView`, removed during disposal.
+- Produces: `SubtitleVideoRectSync.updateAndReconcileAfterLayout()`; at most one
+  pre-draw observer per `PlayerView`, removed after execution or during disposal.
 
-- [ ] **Step 1: Add failing lifecycle regression tests**
+- [x] **Step 1: Add failing lifecycle regression tests**
 
 Add Robolectric tests that mount a real `PlayerView` in an `Activity`, invoke
-`SubtitleManager.syncSubtitleVideoBounds`, and inspect the private synchronizer
-through the manager's `videoRectSyncs` field:
+`SubtitleManager.syncSubtitleVideoBounds`, drive layout and pre-draw, and assert
+the actual `SubtitleView` layout parameters for Fit → Zoom, Fit → Fill,
+repeated switching, and Zoom → Fit. Count completed reconciliations so deleting
+the coalescing guard fails the suite, and use sentinel layout parameters to
+prove a detached view cannot be mutated by a pending observer:
 
 ```kotlin
 @Test
-fun explicitSyncQueuesOnlyOnePostLayoutReconciliation() {
-    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
-    val playerView = PlayerView(activity)
-    activity.setContentView(playerView)
-    playerView.layout(0, 0, 2400, 1080)
-    val manager = SubtitleManager()
+fun repeatedExplicitSyncsRunOnePostLayoutReconciliation() {
+    val mounted = MountedSubtitleCanvas()
+    var reconciliations = 0
+    mounted.manager.postLayoutReconciliationObserver = { reconciliations++ }
 
-    manager.syncSubtitleVideoBounds(playerView)
-    manager.syncSubtitleVideoBounds(playerView)
+    repeat(5) {
+        mounted.manager.syncSubtitleVideoBounds(mounted.playerView)
+    }
+    mounted.dispatchPreDraw()
 
-    val sync = manager.subtitleRectSyncForTest(playerView)
-    assertTrue(sync.postLayoutPendingForTest())
-    Shadows.shadowOf(Looper.getMainLooper()).idle()
-    assertFalse(sync.postLayoutPendingForTest())
+    assertEquals(1, reconciliations)
 }
 
 @Test
-fun detachCancelsPendingPostLayoutReconciliation() {
-    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
-    val playerView = PlayerView(activity)
-    activity.setContentView(playerView)
-    playerView.layout(0, 0, 2400, 1080)
-    val manager = SubtitleManager()
+fun detachCancelsPendingPostLayoutReconciliationWithoutMutatingLayout() {
+    val mounted = MountedSubtitleCanvas()
+    val sentinel = FrameLayout.LayoutParams(17, 19)
+    mounted.subtitleView.layoutParams = sentinel
 
-    manager.syncSubtitleVideoBounds(playerView)
-    val sync = manager.subtitleRectSyncForTest(playerView)
-    activity.setContentView(FrameLayout(activity))
+    mounted.detach()
+    mounted.dispatchPreDraw()
 
-    assertTrue(sync.isDisposedForTest())
-    assertFalse(sync.postLayoutPendingForTest())
-    Shadows.shadowOf(Looper.getMainLooper()).idle()
-    assertTrue(sync.isDisposedForTest())
+    assertSame(sentinel, mounted.subtitleView.layoutParams)
 }
 ```
 
-Keep reflection helpers private to the test file. They must expose existing
-objects only; do not add production `ForTest` methods:
+The execution observer is instance-local, internal, and null by default. It
+adds only a null check in production and does not retain a `PlayerView`.
 
-```kotlin
-private fun SubtitleManager.subtitleRectSyncForTest(playerView: PlayerView): Any {
-    val field = SubtitleManager::class.java.getDeclaredField("videoRectSyncs")
-    field.isAccessible = true
-    val syncs = field.get(this) as Map<*, *>
-    return requireNotNull(syncs[playerView])
-}
-
-private fun Any.postLayoutPendingForTest(): Boolean {
-    val field = javaClass.getDeclaredField("postLayoutPending")
-    field.isAccessible = true
-    return field.getBoolean(this)
-}
-
-private fun Any.isDisposedForTest(): Boolean {
-    val field = javaClass.getDeclaredField("isDisposed")
-    field.isAccessible = true
-    return field.getBoolean(this)
-}
-```
-
-The test file imports `android.app.Activity`, `android.os.Looper`,
-`android.widget.FrameLayout`, `androidx.media3.ui.PlayerView`,
-`org.robolectric.Robolectric`, `org.robolectric.Shadows`,
-`kotlin.test.assertFalse`, and `kotlin.test.assertTrue`.
-
-- [ ] **Step 2: Run the focused class and verify RED**
+- [x] **Step 2: Run the focused class and verify RED**
 
 Run:
 
@@ -269,26 +248,36 @@ Run:
   --max-workers=2 --no-daemon
 ```
 
-Expected: the test cannot find `postLayoutPending`, proving the bounded
-reconciliation is absent.
+Expected: mounted transition assertions fail before the content-frame offset
+and lifecycle-owned post-layout reconciliation are implemented.
 
-- [ ] **Step 3: Implement one lifecycle-owned post-layout callback**
+- [x] **Step 3: Implement one lifecycle-owned post-layout callback**
 
-In `SubtitleVideoRectSync`, add:
+In `SubtitleVideoRectSync`, register one removable pre-draw observer:
 
 ```kotlin
-private var postLayoutPending = false
-private val postLayoutUpdate = Runnable {
-    postLayoutPending = false
-    if (!isDisposed) update()
+private var pendingPreDrawObserver: ViewTreeObserver? = null
+private val postLayoutUpdate = ViewTreeObserver.OnPreDrawListener {
+    clearPendingPostLayoutUpdate()
+    if (!isDisposed) {
+        update()
+        onPostLayoutReconciled()
+    }
+    true
 }
 
 fun updateAndReconcileAfterLayout() {
     update()
     val playerView = playerViewRef.get() ?: return
-    if (isDisposed || postLayoutPending) return
-    postLayoutPending = true
-    playerView.postOnAnimation(postLayoutUpdate)
+    if (isDisposed) return
+    pendingPreDrawObserver?.let { observer ->
+        if (observer.isAlive) return
+        pendingPreDrawObserver = null
+    }
+    val observer = playerView.viewTreeObserver
+    if (!observer.isAlive) return
+    pendingPreDrawObserver = observer
+    observer.addOnPreDrawListener(postLayoutUpdate)
 }
 ```
 
@@ -298,24 +287,24 @@ Change `SubtitleManager.syncSubtitleVideoBounds` to call:
 sync.updateAndReconcileAfterLayout()
 ```
 
-In `dispose`, remove the callback before clearing listeners:
+In `dispose`, remove the observer before clearing listeners:
 
 ```kotlin
-playerView?.removeCallbacks(postLayoutUpdate)
-postLayoutPending = false
+clearPendingPostLayoutUpdate()
 ```
 
-Do not post from ordinary layout/video-size callbacks; those continue calling
-`update()` directly. This keeps the extra reconciliation bounded to explicit
-screen sync requests.
+`clearPendingPostLayoutUpdate()` removes the listener from the exact
+`ViewTreeObserver` used for registration and clears the reference. Ordinary
+layout/video-size callbacks continue calling `update()` directly, keeping the
+extra reconciliation bounded to explicit screen sync requests.
 
-- [ ] **Step 4: Run focused tests and verify GREEN**
+- [x] **Step 4: Run focused tests and verify GREEN**
 
 Run the Step 2 command.
 
 Expected: all `SubtitleManagerAppearanceTest` tests pass.
 
-- [ ] **Step 5: Run neighboring subtitle geometry tests**
+- [x] **Step 5: Run neighboring subtitle geometry tests**
 
 ```bash
 ./gradlew :android-shared:testDebugUnitTest \
@@ -327,7 +316,7 @@ Expected: all `SubtitleManagerAppearanceTest` tests pass.
 
 Expected: zero failures.
 
-- [ ] **Step 6: Commit the lifecycle correction**
+- [x] **Step 6: Commit the lifecycle correction**
 
 ```bash
 git add \
@@ -350,7 +339,7 @@ git commit -m "fix(subtitles): reconcile canvas after aspect layout"
 - Consumes: existing `SubtitleManager.syncSubtitleVideoBounds(PlayerView)`, phone resize-mode mapping, and TV `applyPlayerViewVideoFillMode`.
 - Produces: platform source-contract tests ensuring each resize update is immediately followed by shared subtitle reconciliation.
 
-- [ ] **Step 1: Add phone and TV source-contract tests**
+- [x] **Step 1: Add phone and TV source-contract tests**
 
 Phone:
 
@@ -362,13 +351,28 @@ class SubtitleAspectModeWiringSourceTest {
         return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
     }
 
+    private fun playerViewUpdateBlock(source: String): String {
+        val factoryIndex = source.indexOf("PlayerView(ctx).apply {")
+        require(factoryIndex >= 0) { "PlayerView factory anchor is missing" }
+        val androidViewIndex = source.lastIndexOf("AndroidView(", factoryIndex)
+        require(androidViewIndex >= 0) { "Enclosing AndroidView is missing" }
+        val updateIndex = source.indexOf("update = { view ->", factoryIndex)
+        require(updateIndex > factoryIndex) {
+            "PlayerView update lambda is missing or misordered"
+        }
+        val endIndex = source.indexOf("modifier = Modifier", updateIndex)
+        require(endIndex > updateIndex) {
+            "PlayerView update lambda terminator is missing or misordered"
+        }
+        return source.substring(updateIndex, endIndex)
+    }
+
     @Test
     fun playerViewReconcilesSubtitlesAfterResizeModeUpdate() {
         val source = source(
             "org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt"
         )
-        val update = source.substringAfter("update = { view ->")
-            .substringBefore("modifier = Modifier")
+        val update = playerViewUpdateBlock(source)
 
         assertTrue(update.contains("view.resizeMode = resizeMode"))
         assertTrue(update.contains("subtitleManager.syncSubtitleVideoBounds(view)"))
@@ -390,13 +394,31 @@ class TvSubtitleAspectModeWiringSourceTest {
         return (moduleRelative.takeIf(File::exists) ?: projectRelative).readText()
     }
 
+    private fun playerViewUpdateBlock(source: String): String {
+        val factoryIndex = source.indexOf(") as PlayerView).apply {")
+        require(factoryIndex >= 0) { "PlayerView factory anchor is missing" }
+        val androidViewIndex = source.lastIndexOf("AndroidView(", factoryIndex)
+        require(androidViewIndex >= 0) { "Enclosing AndroidView is missing" }
+        val updateIndex = source.indexOf("update = { view ->", factoryIndex)
+        require(updateIndex > factoryIndex) {
+            "PlayerView update lambda is missing or misordered"
+        }
+        val endIndex = source.indexOf(
+            "if (!isInPictureInPictureMode",
+            updateIndex,
+        )
+        require(endIndex > updateIndex) {
+            "PlayerView update lambda terminator is missing or misordered"
+        }
+        return source.substring(updateIndex, endIndex)
+    }
+
     @Test
     fun playerViewReconcilesSubtitlesAfterFillModeUpdate() {
         val source = source(
             "org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
         )
-        val update = source.substringAfter("update = { view ->")
-            .substringBefore("if (!isInPictureInPictureMode")
+        val update = playerViewUpdateBlock(source)
 
         val aspectCall = "applyPlayerViewVideoFillMode(view, state.videoFillMode)"
         val subtitleCall = "subtitleManager.syncSubtitleVideoBounds(view)"
@@ -410,7 +432,7 @@ class TvSubtitleAspectModeWiringSourceTest {
 Both files import `java.io.File`, `kotlin.test.Test`, and
 `kotlin.test.assertTrue`.
 
-- [ ] **Step 2: Prove the source tests detect reversed ordering**
+- [x] **Step 2: Prove the source tests detect reversed ordering**
 
 Temporarily reverse each extracted ordering assertion (`<` to `>`) and run:
 
@@ -425,13 +447,13 @@ Temporarily reverse each extracted ordering assertion (`<` to `>`) and run:
 Expected: both tests fail on their ordering assertion. Restore `<` before
 continuing.
 
-- [ ] **Step 3: Run the source tests GREEN**
+- [x] **Step 3: Run the source tests GREEN**
 
 Run the Step 2 command after restoring the intended assertions.
 
 Expected: both tests pass.
 
-- [ ] **Step 4: Run the complete relevant feature gate**
+- [x] **Step 4: Run the complete relevant feature gate**
 
 ```bash
 ./gradlew \
@@ -447,7 +469,7 @@ Expected: both tests pass.
 
 Expected: zero failures.
 
-- [ ] **Step 5: Run full debug unit tests**
+- [x] **Step 5: Run full debug unit tests**
 
 ```bash
 ./gradlew testDebugUnitTest --max-workers=2 --no-daemon
@@ -455,7 +477,7 @@ Expected: zero failures.
 
 Expected: build succeeds with zero test failures.
 
-- [ ] **Step 6: Run supply-chain and release compilation gates**
+- [x] **Step 6: Run supply-chain and release compilation gates**
 
 ```bash
 ./scripts/test-check-build-supply-chain.sh
@@ -469,7 +491,7 @@ Expected: build succeeds with zero test failures.
 
 Expected: policy scripts exit zero and both minified release assemblies succeed.
 
-- [ ] **Step 7: Verify on the physical Pixel only**
+- [ ] **Step 7: Verify on the physical Pixel only — blocked: device disconnected**
 
 First confirm serial `58211FDCQ000CU`, compare the candidate and installed
 package/version/signing certificate, and stop if the signer differs. Then use
@@ -494,7 +516,7 @@ layout settles and verify:
 
 Do not issue any ADB command to the Shield or an emulator.
 
-- [ ] **Step 8: Request independent focused review**
+- [x] **Step 8: Request independent focused review**
 
 Review only the branch diff against:
 
@@ -507,7 +529,7 @@ Review only the branch diff against:
 Address every substantive finding test-first and rerun Tasks 1-3's focused
 gates.
 
-- [ ] **Step 9: Commit verification contracts**
+- [x] **Step 9: Commit verification contracts**
 
 ```bash
 git add \
@@ -516,7 +538,7 @@ git add \
 git commit -m "test(subtitles): lock aspect recenter wiring"
 ```
 
-- [ ] **Step 10: Final diff and branch verification**
+- [x] **Step 10: Final diff and branch verification**
 
 ```bash
 git diff --check origin/main...HEAD

--- a/docs/superpowers/specs/2026-07-28-android-player-system-brightness-design.md
+++ b/docs/superpowers/specs/2026-07-28-android-player-system-brightness-design.md
@@ -1,0 +1,53 @@
+# Android Player System Brightness Design
+
+## Decision
+
+The Android phone video player will stop overriding window brightness. Android
+system and adaptive brightness remain authoritative while playback is open.
+
+## Current problem
+
+`PlayerGestureHandler` assigns a vertical drag beginning in the left 88 dp edge
+to brightness control. The first drag converts the system-managed window value
+into a fixed per-window brightness and later drags continue changing that
+override. While the player is visible, Android's normal brightness control
+appears ineffective because the window override wins.
+
+## Behavior
+
+- Remove the left-edge brightness drag mode and all writes to
+  `WindowManager.LayoutParams.screenBrightness`.
+- A vertical drag beginning in the left edge performs no brightness action.
+- Preserve the right-edge volume gesture.
+- Preserve center swipe-down dismissal, double-tap seeking, pinch aspect-mode
+  changes, control toggling, and temporary fast-forward.
+- Preserve `FLAG_KEEP_SCREEN_ON` while playing or buffering; it prevents sleep
+  and is independent of brightness.
+- Do not change Android TV behavior, system settings, permissions, or adaptive
+  brightness.
+
+## Implementation
+
+Remove the `Brightness` member from `VerticalDragMode`, the
+`adjustBrightness` helper, and their now-unused Android window imports. Retain
+the left/right edge boundary only for routing the right edge to volume and the
+center region to dismissal. The left edge resolves to `None`, so it cannot
+accidentally dismiss playback.
+
+## Verification
+
+Automated coverage will prove that the mobile gesture implementation contains
+no window-brightness mutation while retaining volume and dismissal routing.
+Focused mobile player tests and the phone release assembly must pass. A Pixel
+smoke check will confirm that Android's brightness control remains effective
+during playback and that right-edge volume and center dismissal still work.
+The Shield will not be installed or modified.
+
+## Success criteria
+
+- Opening and using the phone player never creates a per-window brightness
+  override.
+- Android system/adaptive brightness continues controlling the display during
+  playback.
+- Existing non-brightness player gestures and keep-screen-awake behavior do not
+  regress.

--- a/docs/superpowers/specs/2026-07-28-android-subtitle-aspect-reconciliation-and-phone-sizing-design.md
+++ b/docs/superpowers/specs/2026-07-28-android-subtitle-aspect-reconciliation-and-phone-sizing-design.md
@@ -1,0 +1,122 @@
+# Android Subtitle Aspect Reconciliation and Phone Sizing Design
+
+## Context
+
+PR #127 makes the shared Android subtitle canvas follow the displayed video
+area in Fit, Fill, and Stretch modes. On a physical Pixel running the PR head,
+changing Fill to Fit reproduced a remaining defect: subtitle cues stayed
+vertically displaced and were clipped below the display. Depending on the cue
+and dialogue gap, subtitles appeared enabled but absent. Playback, subtitle
+selection, cue delivery, and video decoding remained healthy, and subsequent
+captures showed the same track rendering normally in Fill mode.
+
+The same device validation also showed that the Android default subtitle size
+is too small on a phone. The shared default is `Large`, but Android maps it to
+`32 / 720` of the subtitle canvas, below Media3's default fractional size and
+smaller than the shared model's nominal 56-point Large value.
+
+## Goals
+
+- Keep subtitle cues fully visible and correctly centered after every supported
+  aspect-mode transition.
+- Make every phone subtitle-size preset legible at normal handheld viewing
+  distance while preserving the relative steps between presets.
+- Preserve existing Android TV subtitle sizing.
+- Preserve subtitle selection, cue styling, authored positioning, libass/ASS,
+  bitmap subtitle, letterbox, and title-safe behavior.
+
+## Non-goals
+
+- Changing subtitle tracks, server subtitle processing, or playback protocols.
+- Changing the shared preset names or persisted subtitle appearance schema.
+- Changing Android TV's existing font-size scale.
+- Reimplementing Media3's aspect-ratio measurement algorithm.
+- Adding unbounded frame callbacks, polling, delays, or timeout-based layout
+  workarounds.
+
+## Design
+
+### Stable post-layout reconciliation
+
+`SubtitleVideoRectSync` remains the single owner of subtitle-view geometry. An
+aspect change may expose old `exo_content_frame` bounds during the immediate
+Compose `AndroidView.update` callback. The sync will therefore reconcile from
+the actual post-layout content-frame geometry and verify that the rectangle it
+applied still matches the current resize mode and content-frame snapshot.
+
+If the snapshot changes during that traversal, one further pre-draw
+reconciliation is scheduled. The operation is generation-bound and capped at
+two post-layout passes for each explicit sync request. A newer request replaces
+the older generation, repeated requests coalesce, and detach/dispose cancels
+pending work. No callback remains installed after the rectangle is stable or
+the bound is reached. At the bound, the latest measured rectangle remains
+applied; the permanent content-frame layout listener still handles any later
+real layout change without spinning.
+
+The sync continues using Media3's measured `exo_content_frame` instead of
+duplicating its aspect calculations. Geometry remains expressed in the
+subtitle view's parent-local coordinate space.
+
+### Phone-only subtitle scaling
+
+Font-size conversion will accept an explicit Android presentation class:
+`Phone` or `Television`. Phone uses a 1.25 multiplier over the current
+fractions:
+
+| Preset | Phone | Television |
+| --- | ---: | ---: |
+| Small | 25 / 720 | 20 / 720 |
+| Medium | 32.5 / 720 | 26 / 720 |
+| Large | 40 / 720 | 32 / 720 |
+| XLarge | 50 / 720 | 40 / 720 |
+| XXLarge | 60 / 720 | 48 / 720 |
+
+The phone and TV dependency-injection modules construct `SubtitleManager` with
+their fixed presentation class. The persisted preset remains unchanged, so an
+existing `Large` preference becomes more legible on phone without a migration
+and retains its current appearance on TV.
+
+Fractional sizing remains relative to the active subtitle canvas. It therefore
+continues to respond naturally to orientation and displayed-video bounds.
+
+## Correctness and lifecycle constraints
+
+- Immediate synchronization remains available for already-stable layouts.
+- Reconciliation reads the current player, resize mode, video size, and content
+  frame on every pass; it must not apply a rectangle captured for an older
+  mode.
+- At most one pre-draw listener exists per `PlayerView`.
+- Detaching the view removes listeners and prevents late mutation.
+- A replaced player cannot receive or influence later reconciliation.
+- Existing cue forwarding and libass overlay attachment remain unchanged.
+
+## Testing
+
+Unit and mounted Robolectric coverage will prove:
+
+- Fill to Fit and Stretch to Fit settle to the final parent-local rectangle
+  without retaining a cropped top/left margin.
+- Fit to Fill and rapid Fit/Fill/Stretch changes use the latest mode.
+- A changed content-frame snapshot receives the bounded second pass.
+- Stable geometry uses no extra pass, repeated explicit syncs coalesce, and
+  detach cancels pending work.
+- Every phone preset is exactly 1.25 times its TV fraction.
+- The default `Large` preset resolves to `40 / 720` on phone and `32 / 720` on
+  TV.
+- Phone and TV construction paths select their intended presentation class.
+
+Focused shared, phone, and TV subtitle tests will run first, followed by the
+full unit suite and phone/TV release assemblies. Physical validation will use
+the Pixel only and exercise Fit, Fill, Stretch, rapid transitions, multi-line
+cues, and cue gaps. The Shield will not be installed or modified without
+separate authorization.
+
+## Success criteria
+
+- The reproduced Fill-to-Fit cue is fully visible immediately after the sheet
+  closes and remains visible across subsequent cues.
+- No supported aspect transition leaves stale subtitle margins or dimensions.
+- Default phone subtitles are visibly larger while all phone presets remain
+  ordered and selectable.
+- TV output, persistence, selection, styling, and subtitle formats show no
+  regression in automated verification.

--- a/docs/superpowers/specs/2026-07-28-android-subtitle-aspect-reconciliation-and-phone-sizing-design.md
+++ b/docs/superpowers/specs/2026-07-28-android-subtitle-aspect-reconciliation-and-phone-sizing-design.md
@@ -33,6 +33,7 @@ smaller than the shared model's nominal 56-point Large value.
 - Reimplementing Media3's aspect-ratio measurement algorithm.
 - Adding unbounded frame callbacks, polling, delays, or timeout-based layout
   workarounds.
+- Reworking Android TV's existing subtitle remount transaction architecture.
 
 ## Design
 
@@ -40,9 +41,14 @@ smaller than the shared model's nominal 56-point Large value.
 
 `SubtitleVideoRectSync` remains the single owner of subtitle-view geometry. An
 aspect change may expose old `exo_content_frame` bounds during the immediate
-Compose `AndroidView.update` callback. The sync will therefore reconcile from
-the actual post-layout content-frame geometry and verify that the rectangle it
-applied still matches the current resize mode and content-frame snapshot.
+Compose `AndroidView.update` callback. Mobile Fit and Stretch must not convert
+those transitional bounds into fixed pixel dimensions: they set the subtitle
+child to `MATCH_PARENT` with zero margins, allowing the Media3 content frame to
+remeasure the subtitle child automatically.
+
+Mobile Fill maps to Media3 Zoom and still needs a parent-local visible crop
+rectangle because its content frame extends beyond the viewport. That mode
+continues to reconcile from the measured `exo_content_frame`.
 
 If the snapshot changes during that traversal, one further pre-draw
 reconciliation is scheduled. The operation is generation-bound and capped at
@@ -54,22 +60,24 @@ applied; the permanent content-frame layout listener still handles any later
 real layout change without spinning.
 
 The sync continues using Media3's measured `exo_content_frame` instead of
-duplicating its aspect calculations. Geometry remains expressed in the
-subtitle view's parent-local coordinate space.
+duplicating its aspect calculations. Fixed geometry remains expressed in the
+subtitle view's parent-local coordinate space. Television title-safe and
+letterbox insets retain their existing fixed-rectangle behavior; the
+`MATCH_PARENT` shortcut applies only when both insets are absent.
 
 ### Phone-only subtitle scaling
 
 Font-size conversion will accept an explicit Android presentation class:
-`Phone` or `Television`. Phone uses a 1.25 multiplier over the current
+`Phone` or `Television`. Phone uses a 1.125 multiplier over the current
 fractions:
 
 | Preset | Phone | Television |
 | --- | ---: | ---: |
-| Small | 25 / 720 | 20 / 720 |
-| Medium | 32.5 / 720 | 26 / 720 |
-| Large | 40 / 720 | 32 / 720 |
-| XLarge | 50 / 720 | 40 / 720 |
-| XXLarge | 60 / 720 | 48 / 720 |
+| Small | 22.5 / 720 | 20 / 720 |
+| Medium | 29.25 / 720 | 26 / 720 |
+| Large | 36 / 720 | 32 / 720 |
+| XLarge | 45 / 720 | 40 / 720 |
+| XXLarge | 54 / 720 | 48 / 720 |
 
 The phone and TV dependency-injection modules construct `SubtitleManager` with
 their fixed presentation class. The persisted preset remains unchanged, so an
@@ -78,6 +86,25 @@ and retains its current appearance on TV.
 
 Fractional sizing remains relative to the active subtitle canvas. It therefore
 continues to respond naturally to orientation and displayed-video bounds.
+
+### Initial subtitle restore settlement
+
+On phone, restoring a persisted mounted subtitle must not treat Media3
+`Player.STATE_READY` as proof that its text-track catalog has settled. Media3
+can report ready while publishing an intermediate non-empty text-track
+snapshot; failing the restore against that first snapshot produces a transient
+error even though the requested track appears moments later.
+
+The phone player will follow the existing TV settlement rule: the first
+non-empty text-track snapshot is provisional, a changed snapshot restarts
+settlement, and only a repeated identical non-empty snapshot may prove that a
+requested track is missing. A successful identity match still commits
+immediately. The existing bounded mobile mount timeout remains the terminal
+fallback when no stable success arrives.
+
+Android TV already implements this rule through
+`TvSubtitleSnapshotSettlementTracker` and `SubtitleRemountReselection`; its
+production path remains unchanged and receives focused regression coverage.
 
 ## Correctness and lifecycle constraints
 
@@ -100,10 +127,20 @@ Unit and mounted Robolectric coverage will prove:
 - A changed content-frame snapshot receives the bounded second pass.
 - Stable geometry uses no extra pass, repeated explicit syncs coalesce, and
   detach cancels pending work.
-- Every phone preset is exactly 1.25 times its TV fraction.
-- The default `Large` preset resolves to `40 / 720` on phone and `32 / 720` on
+- Every phone preset is exactly 1.125 times its TV fraction.
+- The default `Large` preset resolves to `36 / 720` on phone and `32 / 720` on
   TV.
 - Phone and TV construction paths select their intended presentation class.
+- Mobile Fit and Stretch apply `MATCH_PARENT` dimensions and zero margins when
+  no title-safe or letterbox inset is configured.
+- A stale Zoom crop followed immediately by Fit cannot retain its top/left
+  offsets, even before the Media3 parent completes its new layout.
+- A restored phone subtitle cannot fail on the first non-empty Media3
+  text-track snapshot, and a changed snapshot must stabilize again before it is
+  terminal.
+- A matching restored phone subtitle commits as soon as it appears; a track
+  that never appears still fails through the existing bounded timeout.
+- TV's first-snapshot and changed-snapshot settlement regressions remain green.
 
 Focused shared, phone, and TV subtitle tests will run first, followed by the
 full unit suite and phone/TV release assemblies. Physical validation will use
@@ -116,7 +153,9 @@ separate authorization.
 - The reproduced Fill-to-Fit cue is fully visible immediately after the sheet
   closes and remains visible across subsequent cues.
 - No supported aspect transition leaves stale subtitle margins or dimensions.
-- Default phone subtitles are visibly larger while all phone presets remain
-  ordered and selectable.
+- Default phone subtitles sit between the original undersized build and the
+  rejected 1.25× build while all phone presets remain ordered and selectable.
+- Restarting playback with a persisted subtitle does not show a transient mount
+  error while Media3 is still publishing text tracks.
 - TV output, persistence, selection, styling, and subtitle formats show no
   regression in automated verification.

--- a/docs/superpowers/specs/2026-07-28-subtitle-aspect-recenter-design.md
+++ b/docs/superpowers/specs/2026-07-28-subtitle-aspect-recenter-design.md
@@ -1,0 +1,81 @@
+# Subtitle Aspect-Mode Recentring Design
+
+## Problem
+
+On Android phone, changing video gravity from Fit to Fill or Stretch can leave
+the subtitle layer using the previous fitted-video geometry. The visible video
+then fills the player while subtitles remain positioned against stale bounds,
+so ordinary centred subtitles appear off-centre.
+
+The phone and TV players both use `SubtitleManager` to align Media3, libass, and
+bitmap subtitle rendering with the visible video viewport. Phone is the
+confirmed reproduction. TV must receive the same shared correction because it
+uses the same geometry owner, while its existing player wiring must be verified
+independently.
+
+## Intended Behaviour
+
+- The subtitle canvas follows the final visible video viewport after every
+  aspect-mode change.
+- Fit aligns the canvas with the fitted video rectangle.
+- Fill and Stretch align the canvas with the full visible player viewport.
+- Switching modes repeatedly cannot retain geometry from an earlier mode.
+- Ordinary centred SRT/WebVTT cues remain centred in the new canvas.
+- Authored ASS/SSA and PGS positions remain relative to the canvas. The client
+  does not rewrite individual cue positions or force every cue to centre.
+- Existing letterbox detection, title-safe insets, subtitle appearance, and
+  transactional subtitle selection remain unchanged.
+
+## Design
+
+`SubtitleManager` remains the single geometry owner. Aspect-mode consumers
+continue setting `PlayerView.resizeMode` and requesting a subtitle-bound sync.
+The synchronizer must resolve bounds from the current resize mode and the
+post-layout content frame, and it must schedule one bounded post-layout
+reconciliation when a resize request can still expose the previous frame.
+
+The reconciliation is idempotent: it computes the desired rectangle, compares
+it with the current subtitle layout parameters, and writes only when dimensions
+or offsets differ. It does not introduce polling, arbitrary delays, or a second
+subtitle renderer.
+
+The shared correction applies to both phone and TV. Platform screens retain
+their existing aspect-mode mappings:
+
+- Phone Fill maps to Media3 Zoom; Stretch maps to Media3 Fill.
+- TV Zoom and Stretch retain their existing mappings.
+
+## Lifecycle and Safety
+
+Any posted reconciliation is owned by the existing `PlayerView` synchronizer.
+It is cancelled or made inert when the view detaches or the synchronizer is
+disposed. A stale callback must not update a detached or replacement player
+view.
+
+The change must not alter playback state, track selection, subtitle timing,
+network requests, or persisted settings.
+
+## Verification
+
+Automated regression coverage will prove:
+
+- Fit computes fitted-video bounds.
+- Fit to Fill and Fit to Stretch settle on full-viewport bounds.
+- repeated mode switching does not retain stale offsets or dimensions;
+- authored cue coordinates are not rewritten;
+- phone and TV aspect-mode update paths both request shared subtitle
+  reconciliation;
+- disposal prevents a delayed reconciliation from mutating a detached view.
+
+Focused shared, phone, and TV unit tests will run before both release variants
+are assembled. On-device phone verification will switch among Fit, Fill, and
+Stretch with a centred text subtitle and confirm visual recentring. TV will be
+verified through focused tests and compilation; no Shield installation is
+required unless separately requested.
+
+## Out of Scope
+
+- Changing subtitle appearance, size, vertical presets, or delay.
+- Repositioning authored ASS/SSA or bitmap cues.
+- Server, protocol, transcoding, or subtitle-format changes.
+- Replacing Media3 or libass subtitle rendering.


### PR DESCRIPTION
## Summary

- recenter the shared subtitle canvas when phone or TV switches between Fit, Zoom, and Fill/Stretch
- preserve authored ASS/SSA/PGS cue positioning while translating the visible player viewport into the subtitle parent coordinate space
- reconcile geometry after layout with lifecycle-owned, coalesced pre-draw handling
- stabilize subtitle-track restoration when resuming playback
- use a smaller phone subtitle presentation without changing TV sizing
- leave phone playback brightness under Android system/adaptive control; the former left-edge brightness drag is now reserved while volume and dismiss gestures are preserved

## Verification

- `./gradlew testDebugUnitTest --max-workers=2 --no-daemon`
- uncached shared/phone/TV subtitle gate: 118 tasks executed, BUILD SUCCESSFUL
- `SubtitleManagerAppearanceTest`: 26/26 green
- mutation check: disabling coalescing fails with expected 1 reconciliation vs 5 observed
- focused player gesture, pinch-gravity, lifecycle, subtitle startup, and aspect-routing tests: green
- `./scripts/test-check-build-supply-chain.sh`
- `./scripts/check-build-supply-chain.sh`
- phone + TV release assemblies completed successfully with repository-supported debug release signing
- independent whole-branch and focused brightness reviews: no remaining actionable findings

## Manual validation

- Physical Pixel `58211FDCQ000CU` upgraded in place with matching signer; package 0.3.11/code 14 launched resumed with a live process and no immediate crash/ANR
- subtitle aspect/sizing and startup restoration were validated interactively on the Pixel
- final system-brightness behavior is ready for interactive confirmation on the Pixel
- Shield was not touched for the phone-only brightness change
