### PR TITLE
fix(home): show metadata runtime in hero when playback duration is absent

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/FeaturedHeroMetadata.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/FeaturedHeroMetadata.kt
@@ -27,7 +27,7 @@ internal fun featuredHeroMetadata(item: SectionItem): List<FeaturedHeroMetadataC
         result += FeaturedHeroMetadataChip(item.year.toString())
     }
 
-    formatFeaturedRuntime(item.durationSeconds)?.let {
+    formatFeaturedRuntime(item.runtime, item.durationSeconds)?.let {
         result += FeaturedHeroMetadataChip(it)
     }
     validImdbRating(item.ratingImdb)
@@ -64,11 +64,18 @@ private fun episodeToken(season: Int?, episode: Int?): String? = when {
     else -> null
 }
 
-private fun formatFeaturedRuntime(durationSeconds: Double?): String? {
+/** Episode/movie length: the metadata runtime when present, else derived
+ *  from the file duration the payload already carries. */
+private fun formatFeaturedRuntime(runtimeMinutes: Int?, durationSeconds: Double?): String? {
+    runtimeMinutes?.takeIf { it > 0 }?.let { return formatRuntimeMinutes(it) }
     val duration = durationSeconds?.takeIf { it.isFinite() && it > 0.0 }
         ?: return null
     val minutes = (duration / 60.0).roundToInt().takeIf { it > 0 }
         ?: return null
+    return formatRuntimeMinutes(minutes)
+}
+
+private fun formatRuntimeMinutes(minutes: Int): String {
     if (minutes < 60) return "$minutes min"
     val hours = minutes / 60
     val remainder = minutes % 60

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarqueeModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarqueeModel.kt
@@ -85,11 +85,11 @@ data class TvMarqueeContent(
             if (isEpisode) {
                 episodeToken(item.seasonNumber, item.episodeNumber)?.let(meta::add)
                 if (item.title.isNotBlank()) meta.add(item.title)
-                lengthText(item.durationSeconds)?.let(meta::add)
+                lengthText(item.runtime, item.durationSeconds)?.let(meta::add)
                 ratingToken(item.ratingImdb)?.let(meta::add)
             } else {
                 if (item.year > 0) meta.add(item.year.toString())
-                lengthText(item.durationSeconds)?.let(meta::add)
+                lengthText(item.runtime, item.durationSeconds)?.let(meta::add)
                 ratingToken(item.ratingImdb)?.let(meta::add)
                 item.genres.firstOrNull { it.isNotBlank() }?.let(meta::add)
             }
@@ -140,11 +140,17 @@ data class TvMarqueeContent(
             return "${remaining}m left"
         }
 
-        private fun lengthText(durationSeconds: Double?): String? {
+        /** Episode/movie length: the metadata runtime when present, else
+         *  derived from the file duration the payload already carries. */
+        private fun lengthText(runtimeMinutes: Int?, durationSeconds: Double?): String? {
+            runtimeText(runtimeMinutes)?.let { return it }
             val duration = durationSeconds?.takeIf { it.isFinite() && it > 0.0 }
                 ?: return null
-            val minutes = (duration / 60.0).roundToInt()
-            if (minutes <= 0) return null
+            return runtimeText((duration / 60.0).roundToInt())
+        }
+
+        private fun runtimeText(minutes: Int?): String? {
+            if (minutes == null || minutes <= 0) return null
             return if (minutes >= 60) {
                 val hours = minutes / 60
                 val rest = minutes % 60


### PR DESCRIPTION
## Problem

Movies were missing their runtime in the home hero. The TV Skyline marquee (`TvFocusMarqueeModel.lengthText`) and the phone featured-hero chips (`FeaturedHeroMetadata.formatFeaturedRuntime`) built their length token from `duration_seconds` only. The server populates that field solely from watch-progress rows, so movies in editorial rows (featured, New Streaming Movies, …) never showed a runtime while episode rows — whose items carry progress — looked fine.

## Fix

Port the tvOS `TVFocusMarquee.lengthText(runtimeMinutes:durationSeconds:)` behavior to both Android hero surfaces: prefer the metadata `runtime` minutes the section payload already carries, fall back to the file/progress duration. Formatting is unchanged and identical to tvOS ("47 min" / "2h" / "2h 15m").

## Testing

- `:androidTvApp:testDebugUnitTest` (TvFocusMarqueeModel) and `:androidApp:testDebugUnitTest` (FeaturedHeroMetadata) pass.
- `:androidTvApp:assembleDebug` and `:androidApp:assembleDebug` build clean.

AI-use disclosure: implemented with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)