### PR TITLE
test(shared): stabilize profile-switch request fixture

### DIFF
--- a/docs/superpowers/plans/2026-07-29-section-cache-profile-switch-test-race.md
+++ b/docs/superpowers/plans/2026-07-29-section-cache-profile-switch-test-race.md
@@ -1,0 +1,95 @@
+# Section Cache Profile-Switch Test Race Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the deterministic scheduling race in the shared section-cache test helper without changing production behavior.
+
+**Architecture:** Keep the existing gated mock engine and its two synchronization points. Assign the response fixture to the current request before notifying the waiting test coroutine, so later requests cannot change that request's fixture through the shared counter.
+
+**Tech Stack:** Kotlin, kotlinx.coroutines-test, Ktor MockEngine, Kotlin Test/JUnit, Gradle.
+
+## Global Constraints
+
+- Modify only the shared test helper.
+- Make no production-code, timeout, worker-count, or application-binary changes.
+- Preserve all existing profile-isolation assertions.
+- Do not add sleeps, retries, or timeout widening.
+
+---
+
+### Task 1: Order Fixture Capture Before Entry Notification
+
+**Files:**
+- Modify: `shared/src/commonTest/kotlin/org/siloserver/silo/repository/SectionRepositoryCacheTest.kt:56-61`
+
+**Interfaces:**
+- Consumes: `onRequest: () -> Unit`, `body: () -> String`, `requestEntered: CompletableDeferred<Unit>`.
+- Produces: the same `gatedRepository(...)` helper signature and behavior with deterministic per-request fixture capture.
+
+- [x] **Step 1: Preserve RED evidence**
+
+Record the hosted failure from workflow `30453920065`:
+
+```text
+expected:<[Old]> but was:<[New]>
+at SectionRepositoryCacheTest.kt:218
+```
+
+- [x] **Step 2: Apply the minimal ordering fix**
+
+Change the MockEngine body from:
+
+```kotlin
+onRequest()
+requestEntered.complete(Unit)
+val responseBody = body()
+releaseResponse.await()
+```
+
+to:
+
+```kotlin
+onRequest()
+val responseBody = body()
+requestEntered.complete(Unit)
+releaseResponse.await()
+```
+
+- [x] **Step 3: Verify the exact regression repeatedly**
+
+Run the exact test at least five times:
+
+```bash
+for run in 1 2 3 4 5; do
+  ./gradlew :shared:testDebugUnitTest \
+    --tests 'org.siloserver.silo.repository.SectionRepositoryCacheTest.homeRequestStartedBeforeProfileSwitchDoesNotServeOldProfileSectionsToNewProfile' \
+    --max-workers=2 --rerun-tasks --no-daemon
+done
+```
+
+Expected: all five runs pass.
+
+- [x] **Step 4: Verify the containing class and shared suite**
+
+```bash
+./gradlew :shared:testDebugUnitTest \
+  --tests 'org.siloserver.silo.repository.SectionRepositoryCacheTest' \
+  --max-workers=2 --rerun-tasks --no-daemon
+
+./gradlew :shared:testDebugUnitTest \
+  --max-workers=2 --rerun-tasks --no-daemon
+```
+
+Expected: both commands pass.
+
+- [x] **Step 5: Inspect and commit**
+
+```bash
+git diff --check
+git diff -- shared/src/commonTest/kotlin/org/siloserver/silo/repository/SectionRepositoryCacheTest.kt
+git add \
+  docs/superpowers/specs/2026-07-29-section-cache-profile-switch-test-race-design.md \
+  docs/superpowers/plans/2026-07-29-section-cache-profile-switch-test-race.md \
+  shared/src/commonTest/kotlin/org/siloserver/silo/repository/SectionRepositoryCacheTest.kt
+git commit -m "test(shared): stabilize profile-switch request fixture"
+```

--- a/docs/superpowers/specs/2026-07-29-section-cache-profile-switch-test-race-design.md
+++ b/docs/superpowers/specs/2026-07-29-section-cache-profile-switch-test-race-design.md
@@ -1,0 +1,47 @@
+# Section Cache Profile-Switch Test Race Design
+
+**Date:** 2026-07-29
+**Status:** Approved
+
+## Problem
+
+The post-merge `main` workflow failed
+`SectionRepositoryCacheTest.homeRequestStartedBeforeProfileSwitchDoesNotServeOldProfileSectionsToNewProfile`
+with `expected Old, got New`.
+
+The shared `gatedRepository` test helper currently:
+
+1. increments the request counter;
+2. completes `requestEntered`, which can resume the waiting test coroutine;
+3. derives the response body from the mutable counter.
+
+The resumed coroutine can start request two between steps 2 and 3. Request one
+then observes the second request's counter value and receives the wrong fixture.
+This is a test-harness scheduling race; the failed branch and merge commit have
+identical Git trees, and PR #130 did not change shared production or test code.
+
+## Design
+
+Capture each request's response body immediately after `onRequest()` and before
+completing `requestEntered`. Only then expose the request to the waiting test and
+block on `releaseResponse`.
+
+This assigns the fixture deterministically to the request that incremented the
+counter while preserving the helper's existing request-entry and release gates.
+
+## Scope
+
+- Modify only `gatedRepository` in
+  `shared/src/commonTest/kotlin/org/siloserver/silo/repository/SectionRepositoryCacheTest.kt`.
+- Do not change `SectionRepository`, identity-transition behavior, production
+  code, timeouts, worker counts, or application binaries.
+- Do not weaken or remove the profile-isolation assertions.
+
+## Verification
+
+- Use the hosted failure as the RED evidence: request one received `New`.
+- Run the exact failed test repeatedly under `--max-workers=2 --rerun-tasks
+  --no-daemon`.
+- Run the complete `SectionRepositoryCacheTest` class.
+- Run the complete shared debug unit suite under the hosted two-worker shape.
+- Confirm the final diff is test-only and whitespace-clean.

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/SectionRepositoryCacheTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/SectionRepositoryCacheTest.kt
@@ -64,8 +64,8 @@ class SectionRepositoryCacheTest {
         val client = HttpClient(
             MockEngine {
                 onRequest()
-                requestEntered.complete(Unit)
                 val responseBody = body()
+                requestEntered.complete(Unit)
                 releaseResponse.await()
                 respond(
                     responseBody,


### PR DESCRIPTION
## Summary
- fix the post-merge Unit tests race in `SectionRepositoryCacheTest`
- snapshot each request fixture before notifying the waiting test coroutine
- keep production code, timeouts, worker settings, and application binaries unchanged

## Root cause
`requestEntered.complete(Unit)` could resume the test and start request two before request one evaluated `body()`. Request one then observed the incremented shared counter and received the `New` fixture instead of `Old`.

## Verification
- hosted RED: workflow `30453920065`, `expected Old, got New` at `SectionRepositoryCacheTest.kt:218`
- exact failed test: 5/5 passes with `--max-workers=2 --rerun-tasks --no-daemon`
- complete `SectionRepositoryCacheTest`: pass
- complete `:shared:testDebugUnitTest`: pass
- independent focused review: approved, no Critical or Important findings
- `git diff --check`: pass

Test-only change. No APK/application builds were run.