### PR TITLE
fix(tv): keep option dialogs inside the viewport

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvOptionDialog.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvOptionDialog.kt
@@ -36,10 +36,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.window.PopupPositionProvider
 import androidx.tv.material3.Border
 import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
@@ -73,6 +78,7 @@ fun TvOptionDialog(
         ?: options.firstOrNull { it.enabled }?.key
     val focusedIndex = options.indexOfFirst { it.key == focusedKey }
     val listState: LazyListState = rememberLazyListState()
+    val popupPositionProvider = remember { TvOptionDialogWindowPositionProvider() }
 
     // Re-target focus when the dialog is reused for a new menu (title) or the
     // selected option changes; the shared helper below covers the initial grab.
@@ -86,13 +92,13 @@ fun TvOptionDialog(
     }
 
     Popup(
-        alignment = Alignment.Center,
+        popupPositionProvider = popupPositionProvider,
         onDismissRequest = onDismiss,
         properties = PopupProperties(
             focusable = true,
             dismissOnBackPress = true,
             dismissOnClickOutside = true,
-            clippingEnabled = false,
+            clippingEnabled = true,
         ),
     ) {
         Box(
@@ -155,6 +161,18 @@ fun TvOptionDialog(
             }
         }
     }
+}
+
+internal class TvOptionDialogWindowPositionProvider : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset = IntOffset(
+        x = ((windowSize.width - popupContentSize.width) / 2).coerceAtLeast(0),
+        y = ((windowSize.height - popupContentSize.height) / 2).coerceAtLeast(0),
+    )
 }
 
 @OptIn(ExperimentalTvMaterial3Api::class)

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvOptionDialogPositionProviderTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvOptionDialogPositionProviderTest.kt
@@ -1,0 +1,48 @@
+package org.siloserver.silo.tv.ui.components
+
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TvOptionDialogPositionProviderTest {
+
+    @Test
+    fun `centers tall episode actions in the window regardless of trigger position`() {
+        val provider = TvOptionDialogWindowPositionProvider()
+        val window = IntSize(width = 1920, height = 1080)
+        val popup = IntSize(width = 600, height = 680)
+
+        val nearTop = provider.calculatePosition(
+            anchorBounds = IntRect(left = 80, top = 100, right = 240, bottom = 180),
+            windowSize = window,
+            layoutDirection = LayoutDirection.Ltr,
+            popupContentSize = popup,
+        )
+        val nearBottom = provider.calculatePosition(
+            anchorBounds = IntRect(left = 900, top = 850, right = 1100, bottom = 950),
+            windowSize = window,
+            layoutDirection = LayoutDirection.Ltr,
+            popupContentSize = popup,
+        )
+
+        assertEquals(IntOffset(x = 660, y = 200), nearTop)
+        assertEquals(nearTop, nearBottom)
+    }
+
+    @Test
+    fun `keeps oversized dialog origin inside the viewport`() {
+        val provider = TvOptionDialogWindowPositionProvider()
+
+        val position = provider.calculatePosition(
+            anchorBounds = IntRect(left = 400, top = 700, right = 700, bottom = 800),
+            windowSize = IntSize(width = 1280, height = 720),
+            layoutDirection = LayoutDirection.Rtl,
+            popupContentSize = IntSize(width = 1400, height = 800),
+        )
+
+        assertEquals(IntOffset.Zero, position)
+    }
+}


### PR DESCRIPTION
## Summary
- position shared TV option dialogs relative to the full window instead of their trigger
- clamp popup origin to the viewport and restore clipping
- cover the tall episode More Actions menu that adds Go to Season and Go to Series

## Verification
- new geometry regression was observed RED before implementation and GREEN afterward
- deliberate anchor-relative mutation made both geometry tests fail
- complete Android TV debug unit suite passed
- Android TV debug assembly passed
- repository-wide test reaches the pre-existing SiloDatabaseMigrationTest FileNotFoundException; the identical failure was reproduced on untouched origin/main

## Scope
Shared Android TV option-dialog positioning only. No device installation or ADB changes.