### PR TITLE
feat(settings): offer every language the web does, and make them match

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -407,7 +407,7 @@ val androidModule = module {
             tmdbId = args.second,
         )
     }
-    viewModel { SettingsViewModel(get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { SettingsViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { DiagnosticsViewModel(get()) }
     viewModel { AdminEntryViewModel(get(), get()) }
     viewModel { AdminStatsViewModel(get()) }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/PlaybackSettings.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/PlaybackSettings.kt
@@ -26,8 +26,6 @@ import org.siloserver.silo.model.settings.QualityPresets
 // Audio language stores BCP 47 tags ("" = no preference) — display labels,
 // persist codes, as the server's settings contract requires. Shared with the TV
 // UI and with subtitles so the four surfaces cannot drift apart again.
-private val audioLanguageOptions = LanguageOptions.options(unsetLabel = "Default")
-private val audioLanguageLabels = audioLanguageOptions.map { it.second }
 
 // Discrete choices for the two behavior settings (0 = off). Dropdown idiom
 // matches the rest of this section; the label↔value maps below convert.
@@ -53,6 +51,8 @@ fun PlaybackSettings(
     qualityResolution: String,
     maxBitrateKbps: Int?,
     audioLanguage: String,
+    /** Codes the catalog holds; floats the viewer's own languages to the top. */
+    libraryLanguages: List<String> = emptyList(),
     autoSkipIntro: Boolean,
     autoSkipCredits: Boolean,
     pictureInPictureEnabled: Boolean,
@@ -77,6 +77,14 @@ fun PlaybackSettings(
     onResetPlaybackOverrides: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val audioLanguageLabels = remember(libraryLanguages, audioLanguage) {
+        LanguageOptions.optionsPrioritising(
+            unsetLabel = "Default",
+            libraryLanguages = libraryLanguages,
+            current = audioLanguage,
+        ).map { it.second }
+    }
+
     SettingsSectionCard(modifier = modifier) {
         SettingsSectionHeader("Playback")
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsScreen.kt
@@ -196,6 +196,7 @@ fun SettingsScreen(
             item {
                 PlaybackSettings(
                     qualityResolution = state.qualityResolution,
+                    libraryLanguages = state.libraryLanguages,
                     maxBitrateKbps = state.maxBitrateKbps,
                     audioLanguage = state.audioLanguage,
                     autoSkipIntro = state.autoSkipIntro,
@@ -227,6 +228,7 @@ fun SettingsScreen(
                 val metadataAiStatus by metadataAiStore.status.collectAsState()
                 SubtitleSettings(
                     subtitleLanguage = state.subtitleLanguage,
+                    libraryLanguages = state.libraryLanguages,
                     subtitleMode = state.subtitleMode,
                     showForcedSubtitles = state.showForcedSubtitles,
                     onLanguageChanged = viewModel::setSubtitleLanguage,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
@@ -15,6 +15,7 @@ import org.siloserver.silo.model.notifications.NotificationPreferencesUpdate
 import org.siloserver.silo.model.settings.QualityPresets
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.AuthRepository
+import org.siloserver.silo.repository.CatalogRepository
 import org.siloserver.silo.repository.NotificationsRepository
 import org.siloserver.silo.repository.ProfileRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -70,6 +71,12 @@ data class SettingsUiState(
     val qualityConstrained: Boolean = false,
     // BCP 47 tag, "" = no preference. The picker converts to and from labels.
     val audioLanguage: String = "",
+    /**
+     * Language codes the catalog actually holds, used to float the
+     * viewer's own languages to the top of a 37-entry picker. Empty is
+     * fine — the pickers fall back to alphabetical.
+     */
+    val libraryLanguages: List<String> = emptyList(),
     val autoSkipIntro: Boolean = false,
     val autoSkipCredits: Boolean = false,
     val pictureInPictureEnabled: Boolean = true,
@@ -120,16 +127,38 @@ class SettingsViewModel(
     private val overlayPrefsStore: OverlayPrefsStore,
     private val notificationsRepository: NotificationsRepository,
     private val profileSettings: ProfileSettingsController,
+    private val catalogRepository: CatalogRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
     init {
+        loadLibraryLanguages()
         loadUserInfo()
         observePlayerSettings()
         observePlaybackBehaviorSettings()
         observeNotifications()
+    }
+
+    /**
+     * Best-effort: the picker is fully usable without it, so a failure here is
+     * silent rather than an error the viewer has to dismiss on a settings
+     * screen they opened to do something else.
+     */
+    private fun loadLibraryLanguages() {
+        viewModelScope.launch {
+            val result = catalogRepository.getFilters(includeTechnical = true)
+            if (result is ApiResult.Success) {
+                val languages = buildList {
+                    addAll(result.data.subtitleLanguages.orEmpty())
+                    addAll(result.data.audioLanguages.orEmpty())
+                }
+                if (languages.isNotEmpty()) {
+                    _uiState.update { it.copy(libraryLanguages = languages) }
+                }
+            }
+        }
     }
 
     private fun loadUserInfo() {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SubtitleSettings.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SubtitleSettings.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.android.ui.screens.settings
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ClosedCaption
 import androidx.compose.ui.Modifier
@@ -8,9 +9,6 @@ import org.siloserver.silo.model.settings.LanguageOptions
 
 // Both language rows store codes, not the labels shown in the picker: the
 // profile's subtitle_language and the metadata language are BCP 47 on the wire.
-// Hoisted so recomposition doesn't rebuild the label list per frame.
-private val languageOptionLabels =
-    LanguageOptions.options(unsetLabel = SUBTITLE_UNSET_LABEL).map { it.second }
 
 // "Off" is right for subtitles — no language means no subtitles — but wrong for
 // metadata, where unset inherits the library's language rather than disabling
@@ -18,8 +16,6 @@ private val languageOptionLabels =
 private const val SUBTITLE_UNSET_LABEL = "Off"
 private const val METADATA_UNSET_LABEL = "Default"
 
-private val metadataLanguageOptionLabels =
-    LanguageOptions.options(unsetLabel = METADATA_UNSET_LABEL).map { it.second }
 
 /**
  * Subtitle settings section with language, display mode, and forced subtitles toggle.
@@ -27,6 +23,8 @@ private val metadataLanguageOptionLabels =
 @Composable
 fun SubtitleSettings(
     subtitleLanguage: String,
+    /** Codes the catalog holds; floats the viewer's own languages to the top. */
+    libraryLanguages: List<String> = emptyList(),
     subtitleMode: SubtitleMode,
     showForcedSubtitles: Boolean,
     onLanguageChanged: (String) -> Unit,
@@ -41,6 +39,23 @@ fun SubtitleSettings(
     metadataLanguage: String = "",
     onMetadataLanguageChanged: (String) -> Unit = {},
 ) {
+    // Recomputed only when the catalog languages or the current choice change,
+    // not per frame.
+    val languageOptionLabels = remember(libraryLanguages, subtitleLanguage) {
+        LanguageOptions.optionsPrioritising(
+            unsetLabel = SUBTITLE_UNSET_LABEL,
+            libraryLanguages = libraryLanguages,
+            current = subtitleLanguage,
+        ).map { it.second }
+    }
+    val metadataLanguageOptionLabels = remember(libraryLanguages, metadataLanguage) {
+        LanguageOptions.optionsPrioritising(
+            unsetLabel = METADATA_UNSET_LABEL,
+            libraryLanguages = libraryLanguages,
+            current = metadataLanguage,
+        ).map { it.second }
+    }
+
     SettingsSectionCard(modifier = modifier) {
         SettingsSectionHeader("Subtitles")
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -492,6 +492,7 @@ val androidTvModule = module {
             overlayPrefsStore = get(),
             legacyTvPrefsMigration = get(),
             profileSettings = get(),
+            catalogRepository = get(),
             tvLibraryScopeStore = getOrNull(),
         )
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryBrowseFacets.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryBrowseFacets.kt
@@ -4,6 +4,7 @@ import org.siloserver.silo.model.catalog.CatalogFiltersResponse
 import org.siloserver.silo.model.catalog.CatalogQueryGroup
 import org.siloserver.silo.model.catalog.CatalogQueryRule
 import org.siloserver.silo.model.navigation.isAudiobookLikeLibraryType
+import org.siloserver.silo.model.settings.LanguageOptions
 
 /**
  * Personalized watch-status facet, mirroring tvOS `WatchStatusFilter`. Each
@@ -71,9 +72,9 @@ enum class TvCatalogFacet(val title: String) {
         Studio -> options?.studios.orEmpty().map { it to it }
         Network -> options?.networks.orEmpty().map { it to it }
         Country -> options?.countries.orEmpty().map { it to it }
-        AudioLanguage -> options?.audioLanguages.orEmpty().map { it to it }
-        SubtitleLanguage -> options?.subtitleLanguages.orEmpty().map { it to it }
-        OriginalLanguage -> options?.originalLanguages.orEmpty().map { it to it }
+        AudioLanguage -> options?.audioLanguages.orEmpty().map { it to LanguageOptions.displayLanguage(it) }
+        SubtitleLanguage -> options?.subtitleLanguages.orEmpty().map { it to LanguageOptions.displayLanguage(it) }
+        OriginalLanguage -> options?.originalLanguages.orEmpty().map { it to LanguageOptions.displayLanguage(it) }
         Author -> options?.authors.orEmpty().map { it to it }
         Narrator -> options?.narrators.orEmpty().map { it to it }
         SeriesName -> options?.series.orEmpty().map { it to it }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
@@ -905,7 +905,11 @@ private fun TvPlaybackSettingsPane(
         )
         PlaybackPicker.AudioLanguage -> TvSettingsPickerSheet(
             title = "Audio Language",
-            options = audioLanguages.map { PickerOption(it.first, it.second) },
+            options = LanguageOptions.optionsPrioritising(
+                unsetLabel = "Default",
+                libraryLanguages = state.libraryLanguages,
+                current = state.audioLanguage,
+            ).map { PickerOption(it.first, it.second) },
             selectedId = state.audioLanguage,
             onSelect = { onAudioLanguageChanged(it); activePicker = null },
             onDismiss = { activePicker = null },
@@ -1114,14 +1118,22 @@ private fun TvSubtitleSettingsPane(
         )
         SubtitlePicker.Language -> TvSettingsPickerSheet(
             title = "Language",
-            options = subtitleLanguages.map { PickerOption(it.first, it.second) },
+            options = LanguageOptions.optionsPrioritising(
+                unsetLabel = "Off",
+                libraryLanguages = state.libraryLanguages,
+                current = state.subtitleLanguage,
+            ).map { PickerOption(it.first, it.second) },
             selectedId = state.subtitleLanguage,
             onSelect = { onSubtitleLanguageChanged(it); activePicker = null },
             onDismiss = { activePicker = null },
         )
         SubtitlePicker.MetadataLanguage -> TvSettingsPickerSheet(
             title = "Metadata Language",
-            options = metadataLanguages.map { PickerOption(it.first, it.second) },
+            options = LanguageOptions.optionsPrioritising(
+                unsetLabel = "Default",
+                libraryLanguages = state.libraryLanguages,
+                current = state.metadataLanguage,
+            ).map { PickerOption(it.first, it.second) },
             selectedId = state.metadataLanguage,
             onSelect = { onMetadataLanguageChanged(it); activePicker = null },
             onDismiss = { activePicker = null },
@@ -2063,15 +2075,12 @@ private val NextUpPromptOptions = listOf(0, 10, 30, 60, 120)
 // for playback.audio_language and the profile's subtitle_language. Audio used
 // to store the display name here, which the server now rejects — and which
 // never matched a track anyway, since ExoPlayer compares against `eng`.
-private val audioLanguages = LanguageOptions.options(unsetLabel = "Default")
 
-private val subtitleLanguages = LanguageOptions.options(unsetLabel = "Off")
 
 // "Off" is right for subtitles — no language means no subtitles — but wrong for
 // metadata, where unset inherits the library's language rather than disabling
 // anything (catalog.metadata_language: "Language Silo prefers for titles,
 // descriptions, and artwork").
-private val metadataLanguages = LanguageOptions.options(unsetLabel = "Default")
 
 private fun audioLanguageLabel(wire: String): String =
     LanguageOptions.label(wire, unsetLabel = "Default")

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
@@ -19,6 +19,7 @@ import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.repository.AuthRepository
+import org.siloserver.silo.repository.CatalogRepository
 import org.siloserver.silo.repository.ProfileRepository
 import org.siloserver.silo.tv.data.preferences.LegacyTvPrefsMigration
 import org.siloserver.silo.tv.data.preferences.SubtitleMode
@@ -55,6 +56,7 @@ class TvSettingsViewModel(
     private val overlayPrefsStore: OverlayPrefsStore,
     private val legacyTvPrefsMigration: LegacyTvPrefsMigration,
     private val profileSettings: ProfileSettingsController,
+    private val catalogRepository: CatalogRepository,
     private val tvLibraryScopeStore: org.siloserver.silo.tv.data.preferences.TvLibraryScopeStore? = null,
 ) : ViewModel() {
 
@@ -62,6 +64,13 @@ class TvSettingsViewModel(
 
     data class UiState(
         val user: User? = null,
+        /**
+         * Language codes the catalog holds, used to lift the viewer's own
+         * languages above a 37-entry list. Matters most here: a D-pad has no
+         * way to jump, and the device locale is no help (the Shield ships with
+         * persist.sys.locale unset and ro.product.locale at the factory en-US).
+         */
+        val libraryLanguages: List<String> = emptyList(),
         val userLoading: Boolean = true,
         val userError: String? = null,
         // Active profile identity for the tappable account header row.
@@ -116,9 +125,26 @@ class TvSettingsViewModel(
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
     init {
+        loadLibraryLanguages()
         loadUser()
         loadSettings()
         observePlayerSettings()
+    }
+
+    /** Best-effort; the pickers stay fully usable without it. */
+    private fun loadLibraryLanguages() {
+        viewModelScope.launch {
+            val result = catalogRepository.getFilters(includeTechnical = true)
+            if (result is ApiResult.Success) {
+                val languages = buildList {
+                    addAll(result.data.subtitleLanguages.orEmpty())
+                    addAll(result.data.audioLanguages.orEmpty())
+                }
+                if (languages.isNotEmpty()) {
+                    _uiState.update { it.copy(libraryLanguages = languages) }
+                }
+            }
+        }
     }
 
     /**

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/catalog/filter/CatalogFilterState.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/catalog/filter/CatalogFilterState.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 import org.siloserver.silo.model.catalog.CatalogFiltersResponse
 import org.siloserver.silo.model.catalog.CatalogQueryGroup
 import org.siloserver.silo.model.catalog.CatalogQueryRule
+import org.siloserver.silo.model.settings.LanguageOptions
 
 /**
  * The mobile browse facet system, mirroring silo-apple's
@@ -84,9 +85,11 @@ fun facetOptionPairs(
     CatalogFacet.Studio -> vocabulary?.studios.orEmpty().map { it to it }
     CatalogFacet.Network -> vocabulary?.networks.orEmpty().map { it to it }
     CatalogFacet.Country -> vocabulary?.countries.orEmpty().map { it to it }
-    CatalogFacet.AudioLanguage -> vocabulary?.audioLanguages.orEmpty().map { it to it }
-    CatalogFacet.SubtitleLanguage -> vocabulary?.subtitleLanguages.orEmpty().map { it to it }
-    CatalogFacet.OriginalLanguage -> vocabulary?.originalLanguages.orEmpty().map { it to it }
+    // Labelled, not raw: the vocabulary carries codes ('nl', 'dut'), and a
+    // filter row reading 'dut' tells the viewer nothing.
+    CatalogFacet.AudioLanguage -> vocabulary?.audioLanguages.orEmpty().map { it to LanguageOptions.displayLanguage(it) }
+    CatalogFacet.SubtitleLanguage -> vocabulary?.subtitleLanguages.orEmpty().map { it to LanguageOptions.displayLanguage(it) }
+    CatalogFacet.OriginalLanguage -> vocabulary?.originalLanguages.orEmpty().map { it to LanguageOptions.displayLanguage(it) }
     CatalogFacet.Author -> vocabulary?.authors.orEmpty().map { it to it }
     CatalogFacet.Narrator -> vocabulary?.narrators.orEmpty().map { it to it }
     CatalogFacet.SeriesName -> vocabulary?.series.orEmpty().map { it to it }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
@@ -95,6 +95,21 @@ object LanguageOptions {
     }
 
     /**
+     * A human-readable name for a language code that came from server data
+     * rather than from a picker — catalog filter facets, for instance.
+     *
+     * Unlike [label] this canonicalises first, because catalog values are
+     * whatever the ingest wrote before the server's own canonicalisation ran,
+     * and a facet list should read "Dutch" whether the file said `nl`, `nld`
+     * or `dut`. An unrecognised code is returned as-is: showing the raw tag is
+     * honest, and better than hiding a filter the user can still apply.
+     */
+    fun displayLanguage(code: String): String {
+        val canonical = canonicalSubtitleLanguage(code) ?: return code
+        return tags.firstOrNull { it.first == canonical }?.second ?: code
+    }
+
+    /**
      * The wire value for a label the user picked. Falls back to [UNSET], which
      * is the one value the server always accepts.
      */

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.model.settings
 
 import org.siloserver.silo.playback.canonicalSubtitleLanguage
+import org.siloserver.silo.playback.orNullIfBlank
 
 /**
  * The language choices the settings UI offers, and the wire values they map to.
@@ -92,6 +93,43 @@ object LanguageOptions {
         if (wire.isNullOrBlank()) return unsetLabel
         tags.firstOrNull { it.first == wire }?.let { return it.second }
         return if (isPreservableTag(wire)) wire else unsetLabel
+    }
+
+    /**
+     * The picker list with the languages the viewer's own library carries
+     * lifted to the top, and everything else alphabetical beneath them.
+     *
+     * Thirty-seven entries is a long way to travel on a D-pad, and the obvious
+     * shortcut — the device locale — is worthless on a TV: the Shield ships
+     * `persist.sys.locale` empty and `ro.product.locale` at the factory
+     * `en-US`, so it would suggest English to everyone. What the catalog holds
+     * is a real signal: a viewer whose library has Dutch subtitles is far more
+     * likely to want Dutch than Bengali.
+     *
+     * [current] is pinned first so the language already in force stays at the
+     * top even when the catalog lookup fails or returns nothing. The tail is
+     * alphabetical rather than the web's prominence order, which stops being
+     * meaningful once a list is this long — with no signal, predictable
+     * beats editorial.
+     */
+    fun optionsPrioritising(
+        unsetLabel: String,
+        libraryLanguages: Collection<String>,
+        current: String? = null,
+    ): List<Pair<String, String>> {
+        val offered = tags.associateBy { it.first }
+        val priority = LinkedHashSet<String>()
+        current.orNullIfBlank()
+            ?.let { canonicalSubtitleLanguage(it) }
+            ?.takeIf { offered.containsKey(it) }
+            ?.let(priority::add)
+        for (code in libraryLanguages) {
+            val canonical = canonicalSubtitleLanguage(code) ?: continue
+            if (offered.containsKey(canonical)) priority.add(canonical)
+        }
+        val top = priority.mapNotNull { offered[it] }
+        val rest = tags.filterNot { it.first in priority }.sortedBy { it.second }
+        return listOf(UNSET to unsetLabel) + top + rest
     }
 
     /**

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/LanguageOptions.kt
@@ -25,18 +25,54 @@ object LanguageOptions {
      * (wire tag, display label), in the order the pickers show them. The first
      * entry is the unset choice, whose label differs by context — "Default" for
      * audio, "Off" for subtitles — so callers supply it.
+     *
+     * This mirrors the web client's ISO 639-1 table
+     * (`web/src/player/utils/languageNames.ts` in silo-server), in its order,
+     * because that is the widest first-party list and the server imposes no
+     * enum of its own: the settings contract types
+     * `playback.subtitle_language` as `language_tag`, validated only for BCP 47
+     * shape. A language missing here was never a server limitation — it was
+     * simply a shorter picker, which left users who had set e.g. Dutch on the
+     * web unable to set or re-select it on Android.
      */
     val tags: List<Pair<String, String>> = listOf(
         "en" to "English",
         "es" to "Spanish",
         "fr" to "French",
         "de" to "German",
+        "it" to "Italian",
+        "pt" to "Portuguese",
+        "nl" to "Dutch",
+        "pl" to "Polish",
+        "ru" to "Russian",
+        "zh" to "Chinese",
         "ja" to "Japanese",
         "ko" to "Korean",
-        "zh" to "Chinese",
-        "pt" to "Portuguese",
-        "it" to "Italian",
-        "ru" to "Russian",
+        "ar" to "Arabic",
+        "tr" to "Turkish",
+        "sv" to "Swedish",
+        "da" to "Danish",
+        "no" to "Norwegian",
+        "fi" to "Finnish",
+        "hu" to "Hungarian",
+        "cs" to "Czech",
+        "ro" to "Romanian",
+        "he" to "Hebrew",
+        "th" to "Thai",
+        "vi" to "Vietnamese",
+        "el" to "Greek",
+        "bg" to "Bulgarian",
+        "hr" to "Croatian",
+        "sk" to "Slovak",
+        "sl" to "Slovenian",
+        "uk" to "Ukrainian",
+        "id" to "Indonesian",
+        "ms" to "Malay",
+        "hi" to "Hindi",
+        "ta" to "Tamil",
+        "te" to "Telugu",
+        "bn" to "Bengali",
+        "fa" to "Persian",
     )
 
     /** The full option list for a picker, led by [unsetLabel]. */
@@ -46,7 +82,7 @@ object LanguageOptions {
     /**
      * The label for a stored wire value.
      *
-     * A tag outside the picker table ("nl", "pt-BR" synced from another
+     * A tag outside the picker table ("pt-BR", "zh-Hant" synced from another
      * surface) is echoed back as itself: it is a real, active preference, and
      * labeling it as unset would tell the user a preference playback still
      * applies is off. Only values that aren't tags at all — legacy display
@@ -72,8 +108,8 @@ object LanguageOptions {
      * server rejects them and track matching never hit on them — but left alone
      * they would keep being read and re-sent. A value that is already a known
      * tag, or already unset, is returned unchanged; a known label becomes its
-     * tag. Anything else that is tag-shaped ("pt-BR", "nl", an alias like
-     * "eng") passes through untouched — the table lists only the languages the
+     * tag. Anything else that is tag-shaped ("pt-BR", "zh-Hant", an alias
+     * like "eng") passes through untouched — the table lists only the languages the
      * pickers offer, and a valid tag synced from another surface must not be
      * erased just because it is outside that list. Only values that are neither
      * a plausible tag nor a known label (i.e. legacy display names we no longer

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/playback/SubtitleLanguage.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/playback/SubtitleLanguage.kt
@@ -29,14 +29,62 @@ fun canonicalSubtitleLanguage(language: String?): String? {
         ?.replace('_', '-')
         ?.substringBefore('-')
         ?: return null
-    return when (primary) {
-        "eng" -> "en"
-        "spa" -> "es"
-        "fre", "fra" -> "fr"
-        "ger", "deu" -> "de"
-        "dut", "nld" -> "nl"
-        "jpn" -> "ja"
-        "dan" -> "da"
-        else -> primary
-    }
+    return THREE_LETTER_ALIASES[primary] ?: primary
 }
+
+/**
+ * ISO 639-2 (and legacy ISO 639-1) aliases for the languages the pickers offer,
+ * mapped to the 639-1 tag those pickers persist.
+ *
+ * Both sides of every comparison run through [canonicalSubtitleLanguage], so an
+ * alias missing here is not cosmetic: a track tagged `ita` never matches a
+ * stored preference of `it`, and the language silently fails to auto-select.
+ * The table previously covered seven languages while the pickers offered ten,
+ * so Italian, Portuguese, Korean, Chinese and Russian were already affected on
+ * any server exposing bibliographic codes.
+ *
+ * Where 639-2 has both a bibliographic (B) and terminological (T) code, both
+ * appear. `iw`/`in` are the pre-1989 639-1 codes for Hebrew and Indonesian,
+ * still emitted by older tooling. Norwegian folds Bokmål and Nynorsk into
+ * `no`: they are separate codes but one choice in the picker, and a viewer
+ * asking for Norwegian subtitles wants whichever the release carries.
+ */
+private val THREE_LETTER_ALIASES: Map<String, String> = mapOf(
+    "eng" to "en",
+    "spa" to "es",
+    "fre" to "fr", "fra" to "fr",
+    "ger" to "de", "deu" to "de",
+    "ita" to "it",
+    "por" to "pt",
+    "dut" to "nl", "nld" to "nl",
+    "pol" to "pl",
+    "rus" to "ru",
+    "chi" to "zh", "zho" to "zh",
+    "jpn" to "ja",
+    "kor" to "ko",
+    "ara" to "ar",
+    "tur" to "tr",
+    "swe" to "sv",
+    "dan" to "da",
+    "nor" to "no", "nob" to "no", "nno" to "no",
+    "fin" to "fi",
+    "hun" to "hu",
+    "cze" to "cs", "ces" to "cs",
+    "rum" to "ro", "ron" to "ro",
+    "heb" to "he", "iw" to "he",
+    "tha" to "th",
+    "vie" to "vi",
+    "gre" to "el", "ell" to "el",
+    "bul" to "bg",
+    "hrv" to "hr",
+    "slo" to "sk", "slk" to "sk",
+    "slv" to "sl",
+    "ukr" to "uk",
+    "ind" to "id", "in" to "id",
+    "may" to "ms", "msa" to "ms",
+    "hin" to "hi",
+    "tam" to "ta",
+    "tel" to "te",
+    "ben" to "bn",
+    "per" to "fa", "fas" to "fa",
+)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/playback/SubtitleLanguage.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/playback/SubtitleLanguage.kt
@@ -43,48 +43,99 @@ fun canonicalSubtitleLanguage(language: String?): String? {
  * so Italian, Portuguese, Korean, Chinese and Russian were already affected on
  * any server exposing bibliographic codes.
  *
- * Where 639-2 has both a bibliographic (B) and terminological (T) code, both
- * appear. `iw`/`in` are the pre-1989 639-1 codes for Hebrew and Indonesian,
- * still emitted by older tooling. Norwegian folds Bokmål and Nynorsk into
- * `no`: they are separate codes but one choice in the picker, and a viewer
- * asking for Norwegian subtitles wants whichever the release carries.
+ * This is a faithful mirror of the server's `canonical_language_code`
+ * (migrations/sql/121_canonicalize_language_codes.sql, itself mirroring the Go
+ * helper in `internal/lang`), deliberately copied rather than reinvented. The
+ * catalog stores languages already canonicalised by that function, so any
+ * disagreement here shows up as a preference that silently fails to match —
+ * hand-rolling a "close enough" subset is how that happens. It therefore
+ * covers far more languages than the pickers offer, which costs nothing and
+ * means an unlisted language still compares correctly.
+ *
+ * Note Norwegian follows the server in keeping `nob` → `nb` and `nno` → `nn`
+ * distinct from `nor` → `no`, rather than folding all three together.
  */
 private val THREE_LETTER_ALIASES: Map<String, String> = mapOf(
     "eng" to "en",
+    "jpn" to "ja",
+    "fra" to "fr", "fre" to "fr",
+    "deu" to "de", "ger" to "de",
     "spa" to "es",
-    "fre" to "fr", "fra" to "fr",
-    "ger" to "de", "deu" to "de",
     "ita" to "it",
     "por" to "pt",
-    "dut" to "nl", "nld" to "nl",
-    "pol" to "pl",
     "rus" to "ru",
-    "chi" to "zh", "zho" to "zh",
-    "jpn" to "ja",
+    "zho" to "zh", "chi" to "zh",
     "kor" to "ko",
     "ara" to "ar",
-    "tur" to "tr",
+    "nld" to "nl", "dut" to "nl",
+    "pol" to "pl",
     "swe" to "sv",
     "dan" to "da",
-    "nor" to "no", "nob" to "no", "nno" to "no",
     "fin" to "fi",
+    "tur" to "tr",
+    "ces" to "cs", "cze" to "cs",
+    "slk" to "sk", "slo" to "sk",
     "hun" to "hu",
-    "cze" to "cs", "ces" to "cs",
-    "rum" to "ro", "ron" to "ro",
-    "heb" to "he", "iw" to "he",
+    "heb" to "he",
     "tha" to "th",
+    "ind" to "id",
+    "msa" to "ms", "may" to "ms",
     "vie" to "vi",
-    "gre" to "el", "ell" to "el",
+    "ukr" to "uk",
+    "ron" to "ro", "rum" to "ro",
     "bul" to "bg",
     "hrv" to "hr",
-    "slo" to "sk", "slk" to "sk",
+    "srp" to "sr",
     "slv" to "sl",
-    "ukr" to "uk",
-    "ind" to "id", "in" to "id",
-    "may" to "ms", "msa" to "ms",
+    "ell" to "el", "gre" to "el",
     "hin" to "hi",
     "tam" to "ta",
     "tel" to "te",
     "ben" to "bn",
-    "per" to "fa", "fas" to "fa",
+    "fas" to "fa", "per" to "fa",
+    "cat" to "ca",
+    "lit" to "lt",
+    "lav" to "lv",
+    "est" to "et",
+    "isl" to "is", "ice" to "is",
+    "mlt" to "mt",
+    "gle" to "ga",
+    "cym" to "cy", "wel" to "cy",
+    "mya" to "my", "bur" to "my",
+    "khm" to "km",
+    "lao" to "lo",
+    "sin" to "si",
+    "mar" to "mr",
+    "pan" to "pa",
+    "guj" to "gu",
+    "kan" to "kn",
+    "mal" to "ml",
+    "urd" to "ur",
+    "nep" to "ne",
+    "aze" to "az",
+    "kat" to "ka", "geo" to "ka",
+    "hye" to "hy", "arm" to "hy",
+    "kaz" to "kk",
+    "uzb" to "uz",
+    "mon" to "mn",
+    "mlg" to "mg",
+    "swa" to "sw",
+    "zul" to "zu",
+    "afr" to "af",
+    "amh" to "am",
+    "lat" to "la",
+    "epo" to "eo",
+    "baq" to "eu", "eus" to "eu",
+    "glg" to "gl",
+    "nor" to "no",
+    "nob" to "nb",
+    "nno" to "nn",
+    // Pre-1989 ISO 639-1 spellings. Java's Locale still normalises Hebrew to
+    // "iw" and Indonesian to "in", so these reach us from the platform side.
+    // The server's map does not carry them (they are 639-1, not 639-2) and
+    // passes them through unchanged, so a file ingested with one of these
+    // spellings will not agree with a preference stored here — worth adding
+    // server-side too.
+    "iw" to "he",
+    "in" to "id",
 )

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
@@ -115,4 +115,26 @@ class LanguageOptionsTest {
         assertEquals(LanguageOptions.UNSET, LanguageOptions.migrateLegacyValue("Off"))
         assertEquals(LanguageOptions.UNSET, LanguageOptions.migrateLegacyValue("Default"))
     }
+
+    @Test
+    fun facetCodesRenderAsLanguageNamesWhateverSpellingTheCatalogHolds() {
+        // Catalog vocabulary carries whatever ingest wrote. A filter row
+        // reading "dut" tells the viewer nothing.
+        assertEquals("Dutch", LanguageOptions.displayLanguage("nl"))
+        assertEquals("Dutch", LanguageOptions.displayLanguage("dut"))
+        assertEquals("Dutch", LanguageOptions.displayLanguage("nld"))
+        assertEquals("English", LanguageOptions.displayLanguage("eng"))
+        assertEquals("Portuguese", LanguageOptions.displayLanguage("pt-BR"))
+    }
+
+    @Test
+    fun anUnlabelledFacetCodeIsShownRatherThanHidden() {
+        // Outside the offered list: the raw tag is honest, and the filter
+        // still applies. Blanking it would hide a usable filter.
+        assertEquals("tlh", LanguageOptions.displayLanguage("tlh"))
+        // Catalan canonicalises to "ca" but no picker offers it, so the code
+        // the facet actually filters by is what gets shown — display and wire
+        // value stay the same string.
+        assertEquals("cat", LanguageOptions.displayLanguage("cat"))
+    }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
@@ -56,15 +56,33 @@ class LanguageOptionsTest {
     }
 
     @Test
-    fun thePickerOffersEveryLanguageTheWebClientDoes() {
-        // The web (silo-server web/src/player/utils/languageNames.ts) is the
-        // widest first-party list, and the server enforces no enum of its own:
-        // playback.subtitle_language is typed language_tag, BCP 47 shape only.
-        // A user who set Dutch on the web could not previously set or
-        // re-select it here, which is the report this list exists to answer.
+    fun thePickerMirrorsTheWebClientsTableExactly() {
+        // The whole claim of this list is that it mirrors the web's ISO 639-1
+        // table (silo-server web/src/player/utils/languageNames.ts) IN ITS
+        // ORDER. Asserting only a count and one language would let a wrong
+        // label or a silent reordering through, so the table is pinned whole:
+        // if the web list changes, this fails and someone decides deliberately.
+        assertEquals(
+            listOf(
+                "en" to "English", "es" to "Spanish", "fr" to "French",
+                "de" to "German", "it" to "Italian", "pt" to "Portuguese",
+                "nl" to "Dutch", "pl" to "Polish", "ru" to "Russian",
+                "zh" to "Chinese", "ja" to "Japanese", "ko" to "Korean",
+                "ar" to "Arabic", "tr" to "Turkish", "sv" to "Swedish",
+                "da" to "Danish", "no" to "Norwegian", "fi" to "Finnish",
+                "hu" to "Hungarian", "cs" to "Czech", "ro" to "Romanian",
+                "he" to "Hebrew", "th" to "Thai", "vi" to "Vietnamese",
+                "el" to "Greek", "bg" to "Bulgarian", "hr" to "Croatian",
+                "sk" to "Slovak", "sl" to "Slovenian", "uk" to "Ukrainian",
+                "id" to "Indonesian", "ms" to "Malay", "hi" to "Hindi",
+                "ta" to "Tamil", "te" to "Telugu", "bn" to "Bengali",
+                "fa" to "Persian",
+            ),
+            LanguageOptions.tags,
+        )
+        // The reported case, called out by name so a regression names itself.
         assertEquals("Dutch", LanguageOptions.label("nl", unsetLabel = "Off"))
         assertEquals("nl", LanguageOptions.wireValue("Dutch"))
-        assertEquals(37, LanguageOptions.tags.size)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
@@ -137,4 +137,73 @@ class LanguageOptionsTest {
         // value stay the same string.
         assertEquals("cat", LanguageOptions.displayLanguage("cat"))
     }
+
+    @Test
+    fun theLibrarysOwnLanguagesComeFirst() {
+        // The signal the device locale cannot give on a TV: a viewer whose
+        // catalog carries Dutch is far likelier to want Dutch than Bengali.
+        val options = LanguageOptions.optionsPrioritising(
+            unsetLabel = "Off",
+            libraryLanguages = listOf("nld", "en", "de"),
+        )
+
+        assertEquals(LanguageOptions.UNSET to "Off", options.first())
+        assertEquals(listOf("Dutch", "English", "German"), options.drop(1).take(3).map { it.second })
+        // Nothing is lost from the tail.
+        assertEquals(LanguageOptions.tags.size + 1, options.size)
+    }
+
+    @Test
+    fun theLanguageAlreadyInForceIsPinnedAboveTheLibrary() {
+        // If the catalog lookup fails or the library has no Dutch yet, the
+        // choice the viewer already made must not sink into the alphabet.
+        val options = LanguageOptions.optionsPrioritising(
+            unsetLabel = "Off",
+            libraryLanguages = listOf("en"),
+            current = "nl",
+        )
+
+        assertEquals(listOf("Dutch", "English"), options.drop(1).take(2).map { it.second })
+    }
+
+    @Test
+    fun withNoSignalTheListIsAlphabeticalRatherThanEditorial() {
+        // Thirty-seven entries in prominence order is unscannable; with
+        // nothing to prioritise, predictable ordering is the only help left.
+        val options = LanguageOptions.optionsPrioritising(unsetLabel = "Off", libraryLanguages = emptyList())
+        val labels = options.drop(1).map { it.second }
+
+        assertEquals(labels.sorted(), labels)
+        assertEquals(LanguageOptions.tags.size + 1, options.size)
+    }
+
+    @Test
+    fun libraryLanguagesTheUiCannotOfferAreIgnoredNotInvented() {
+        // The catalog holds languages with no picker entry (Catalan, Klingon);
+        // they must not appear as unlabelled rows.
+        val options = LanguageOptions.optionsPrioritising(
+            unsetLabel = "Off",
+            libraryLanguages = listOf("cat", "tlh", "nl"),
+        )
+
+        assertEquals(LanguageOptions.tags.size + 1, options.size)
+        assertEquals("Dutch", options[1].second)
+    }
+
+    @Test
+    fun everyOptionRemainsUniquelyReversibleWhenPrioritised() {
+        // The phone pickers select by label and map back with wireValue, so a
+        // reordering that duplicated or dropped a label would misroute writes.
+        val options = LanguageOptions.optionsPrioritising(
+            unsetLabel = "Off",
+            libraryLanguages = listOf("nl", "en"),
+            current = "de",
+        )
+        val offered = options.drop(1)
+
+        assertEquals(offered.size, offered.map { it.second }.toSet().size)
+        for ((wire, label) in offered) {
+            assertEquals(wire, LanguageOptions.wireValue(label), "label $label")
+        }
+    }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/LanguageOptionsTest.kt
@@ -49,9 +49,36 @@ class LanguageOptionsTest {
     fun aPreservedTagOutsideTheTableReadsAsItselfNotAsUnset() {
         // migrateLegacyValue passes these through, so playback still applies
         // them; showing "Off"/"Default" would claim an active preference is
-        // disabled.
-        assertEquals("nl", LanguageOptions.label("nl", unsetLabel = "Off"))
+        // disabled. Region- and script-qualified tags stay outside the table
+        // even though their primary languages are in it.
         assertEquals("pt-BR", LanguageOptions.label("pt-BR", unsetLabel = "Default"))
+        assertEquals("zh-Hant", LanguageOptions.label("zh-Hant", unsetLabel = "Off"))
+    }
+
+    @Test
+    fun thePickerOffersEveryLanguageTheWebClientDoes() {
+        // The web (silo-server web/src/player/utils/languageNames.ts) is the
+        // widest first-party list, and the server enforces no enum of its own:
+        // playback.subtitle_language is typed language_tag, BCP 47 shape only.
+        // A user who set Dutch on the web could not previously set or
+        // re-select it here, which is the report this list exists to answer.
+        assertEquals("Dutch", LanguageOptions.label("nl", unsetLabel = "Off"))
+        assertEquals("nl", LanguageOptions.wireValue("Dutch"))
+        assertEquals(37, LanguageOptions.tags.size)
+    }
+
+    @Test
+    fun noLanguageIsListedTwice() {
+        assertEquals(
+            LanguageOptions.tags.size,
+            LanguageOptions.tags.map { it.first }.toSet().size,
+            "duplicate wire tag",
+        )
+        assertEquals(
+            LanguageOptions.tags.size,
+            LanguageOptions.tags.map { it.second }.toSet().size,
+            "duplicate display label",
+        )
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/playback/SubtitleLanguageTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/playback/SubtitleLanguageTest.kt
@@ -116,10 +116,26 @@ class SubtitleLanguageTest {
         // Guards the pairing the pickers depend on: if a language is offered,
         // some 639-2 spelling of it must canonicalise back to the offered tag,
         // or a server exposing that spelling can never match the choice.
-        val reachable = LanguageOptions.tags.map { it.first }.filter { tag ->
-            THREE_LETTER_FORMS[tag]?.any { canonicalSubtitleLanguage(it) == tag } ?: true
+        //
+        // Every offered tag must HAVE a spelling listed and every listed
+        // spelling must resolve. An earlier version defaulted a tag with no
+        // entry to "reachable", which meant adding a language and forgetting
+        // its aliases — precisely the drift this guards — passed silently.
+        val offered = LanguageOptions.tags.map { it.first }
+        val unmapped = offered.filterNot(THREE_LETTER_FORMS::containsKey)
+        assertEquals(emptyList(), unmapped, "offered languages with no 639-2 spelling listed")
+
+        val unreachable = offered.flatMap { tag ->
+            THREE_LETTER_FORMS.getValue(tag)
+                .filter { canonicalSubtitleLanguage(it) != tag }
+                .map { "$it should canonicalise to $tag, got ${canonicalSubtitleLanguage(it)}" }
         }
-        assertEquals(LanguageOptions.tags.size, reachable.size)
+        assertEquals(emptyList(), unreachable, "639-2 spellings that do not resolve")
+
+        // And nothing stale: a spelling listed for a language the picker no
+        // longer offers would quietly stop being exercised.
+        val orphaned = THREE_LETTER_FORMS.keys.filterNot(offered::contains)
+        assertEquals(emptyList(), orphaned.toList(), "spellings listed for unoffered languages")
     }
 
     private companion object {

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/playback/SubtitleLanguageTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/playback/SubtitleLanguageTest.kt
@@ -4,7 +4,6 @@ import org.siloserver.silo.model.settings.LanguageOptions
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Auto-selection compares a stored preference against a track's language with
@@ -65,12 +64,14 @@ class SubtitleLanguageTest {
     }
 
     @Test
-    fun norwegianVariantsFoldIntoTheSingleOfferedChoice() {
-        // Bokmal and Nynorsk are distinct codes but one picker entry; a viewer
-        // asking for Norwegian wants whichever the release carries.
-        for (form in listOf("nor", "nob", "nno")) {
-            assertEquals("no", canonicalSubtitleLanguage(form), "form $form")
-        }
+    fun norwegianVariantsStayDistinctExactlyAsTheServerKeepsThem() {
+        // The server's canonical_language_code maps nob to nb and nno to nn,
+        // NOT to no. Folding them here would look friendlier and then fail to
+        // match: the catalog stores what the server canonicalised, so a
+        // Bokmal file is "nb" on both sides or it matches nothing.
+        assertEquals("no", canonicalSubtitleLanguage("nor"))
+        assertEquals("nb", canonicalSubtitleLanguage("nob"))
+        assertEquals("nn", canonicalSubtitleLanguage("nno"))
     }
 
     @Test
@@ -91,27 +92,52 @@ class SubtitleLanguageTest {
 
     @Test
     fun anUnknownTagPassesThroughRatherThanBeingDropped() {
-        // The table covers the offered languages; anything else is still a
-        // real preference and must keep comparing equal to itself.
-        assertEquals("sr", canonicalSubtitleLanguage("sr"))
-        assertEquals("cat", canonicalSubtitleLanguage("cat"))
+        // Outside the table entirely — the server does the same (its ELSE
+        // branch returns lower(trim(code))), so both sides still agree and the
+        // preference keeps comparing equal to itself.
+        assertEquals("tlh", canonicalSubtitleLanguage("tlh"))
+        assertEquals("sme", canonicalSubtitleLanguage("SME"))
     }
 
     @Test
-    fun everyAliasResolvesToALanguageThePickerOffers() {
-        // An alias pointing at a tag no picker lists would be dead weight and
-        // a sign the two tables had drifted.
-        val offered = LanguageOptions.tags.map { it.first }.toSet()
-        val aliases = listOf(
-            "eng", "spa", "fre", "fra", "ger", "deu", "ita", "por", "dut", "nld",
-            "pol", "rus", "chi", "zho", "jpn", "kor", "ara", "tur", "swe", "dan",
-            "nor", "nob", "nno", "fin", "hun", "cze", "ces", "rum", "ron", "heb",
-            "iw", "tha", "vie", "gre", "ell", "bul", "hrv", "slo", "slk", "slv",
-            "ukr", "ind", "in", "may", "msa", "hin", "tam", "tel", "ben", "per", "fas",
-        )
-        for (alias in aliases) {
-            val canonical = canonicalSubtitleLanguage(alias)
-            assertTrue(canonical in offered, "$alias resolves to $canonical, which no picker offers")
+    fun aliasesCoverLanguagesBeyondThePickerToo() {
+        // The table mirrors the server's full map rather than just the offered
+        // list, so an unlisted language still compares correctly against a
+        // preference synced from another surface.
+        assertEquals("ca", canonicalSubtitleLanguage("cat"))
+        assertEquals("sr", canonicalSubtitleLanguage("srp"))
+        assertEquals("is", canonicalSubtitleLanguage("ice"))
+        assertEquals("cy", canonicalSubtitleLanguage("wel"))
+        assertEquals("eu", canonicalSubtitleLanguage("baq"))
+    }
+
+    @Test
+    fun everyOfferedLanguageIsReachableFromItsThreeLetterForm() {
+        // Guards the pairing the pickers depend on: if a language is offered,
+        // some 639-2 spelling of it must canonicalise back to the offered tag,
+        // or a server exposing that spelling can never match the choice.
+        val reachable = LanguageOptions.tags.map { it.first }.filter { tag ->
+            THREE_LETTER_FORMS[tag]?.any { canonicalSubtitleLanguage(it) == tag } ?: true
         }
+        assertEquals(LanguageOptions.tags.size, reachable.size)
+    }
+
+    private companion object {
+        /** A representative 639-2 spelling per offered language, where one exists. */
+        val THREE_LETTER_FORMS = mapOf(
+            "en" to listOf("eng"), "es" to listOf("spa"), "fr" to listOf("fre", "fra"),
+            "de" to listOf("ger", "deu"), "it" to listOf("ita"), "pt" to listOf("por"),
+            "nl" to listOf("dut", "nld"), "pl" to listOf("pol"), "ru" to listOf("rus"),
+            "zh" to listOf("chi", "zho"), "ja" to listOf("jpn"), "ko" to listOf("kor"),
+            "ar" to listOf("ara"), "tr" to listOf("tur"), "sv" to listOf("swe"),
+            "da" to listOf("dan"), "no" to listOf("nor"), "fi" to listOf("fin"),
+            "hu" to listOf("hun"), "cs" to listOf("cze", "ces"), "ro" to listOf("rum", "ron"),
+            "he" to listOf("heb"), "th" to listOf("tha"), "vi" to listOf("vie"),
+            "el" to listOf("gre", "ell"), "bg" to listOf("bul"), "hr" to listOf("hrv"),
+            "sk" to listOf("slo", "slk"), "sl" to listOf("slv"), "uk" to listOf("ukr"),
+            "id" to listOf("ind"), "ms" to listOf("may", "msa"), "hi" to listOf("hin"),
+            "ta" to listOf("tam"), "te" to listOf("tel"), "bn" to listOf("ben"),
+            "fa" to listOf("per", "fas"),
+        )
     }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/playback/SubtitleLanguageTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/playback/SubtitleLanguageTest.kt
@@ -1,0 +1,117 @@
+package org.siloserver.silo.playback
+
+import org.siloserver.silo.model.settings.LanguageOptions
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Auto-selection compares a stored preference against a track's language with
+ * both sides run through [canonicalSubtitleLanguage], so this function is what
+ * decides whether a chosen language actually turns subtitles on.
+ */
+class SubtitleLanguageTest {
+
+    @Test
+    fun everyPickerTagIsAlreadyCanonical() {
+        // A picker option that canonicalises to something else would never
+        // equal the canonical form of a matching track.
+        for ((wire, label) in LanguageOptions.tags) {
+            assertEquals(wire, canonicalSubtitleLanguage(wire), "$label ($wire) is not canonical")
+        }
+    }
+
+    @Test
+    fun everyPickerLanguageMatchesItsThreeLetterTrackTag() {
+        // Servers commonly expose ISO 639-2 while the pickers persist 639-1.
+        // Before this table was completed, only seven languages survived the
+        // round trip; Italian, Portuguese, Korean, Chinese and Russian were
+        // offered in the picker but could not match a bibliographic tag.
+        val cases = mapOf(
+            "ita" to "it",
+            "por" to "pt",
+            "kor" to "ko",
+            "chi" to "zh",
+            "zho" to "zh",
+            "rus" to "ru",
+            "pol" to "pl",
+            "swe" to "sv",
+            "ces" to "cs",
+            "cze" to "cs",
+            "ell" to "el",
+            "gre" to "el",
+            "fas" to "fa",
+            "per" to "fa",
+        )
+        for ((trackTag, expected) in cases) {
+            assertEquals(expected, canonicalSubtitleLanguage(trackTag), "track tag $trackTag")
+        }
+    }
+
+    @Test
+    fun dutchMatchesAcrossEveryFormAServerMightReport() {
+        // The reported case: Dutch chosen as the default subtitle language.
+        for (form in listOf("nl", "nld", "dut", "NL", "nl-NL", "nl_BE")) {
+            assertEquals("nl", canonicalSubtitleLanguage(form), "form $form")
+        }
+    }
+
+    @Test
+    fun legacyIso639CodesStillResolve() {
+        // Pre-1989 codes, still emitted by older muxing tools.
+        assertEquals("he", canonicalSubtitleLanguage("iw"))
+        assertEquals("id", canonicalSubtitleLanguage("in"))
+    }
+
+    @Test
+    fun norwegianVariantsFoldIntoTheSingleOfferedChoice() {
+        // Bokmal and Nynorsk are distinct codes but one picker entry; a viewer
+        // asking for Norwegian wants whichever the release carries.
+        for (form in listOf("nor", "nob", "nno")) {
+            assertEquals("no", canonicalSubtitleLanguage(form), "form $form")
+        }
+    }
+
+    @Test
+    fun regionAndScriptSuffixesDoNotSplitALanguage() {
+        assertEquals("pt", canonicalSubtitleLanguage("pt-BR"))
+        assertEquals("zh", canonicalSubtitleLanguage("zh-Hant"))
+        assertEquals("en", canonicalSubtitleLanguage("en_GB"))
+    }
+
+    @Test
+    fun absentAndUndeterminedLanguagesResolveToNothing() {
+        assertNull(canonicalSubtitleLanguage(null))
+        assertNull(canonicalSubtitleLanguage(""))
+        assertNull(canonicalSubtitleLanguage("   "))
+        assertNull(canonicalSubtitleLanguage("und"))
+        assertNull(canonicalSubtitleLanguage("UND"))
+    }
+
+    @Test
+    fun anUnknownTagPassesThroughRatherThanBeingDropped() {
+        // The table covers the offered languages; anything else is still a
+        // real preference and must keep comparing equal to itself.
+        assertEquals("sr", canonicalSubtitleLanguage("sr"))
+        assertEquals("cat", canonicalSubtitleLanguage("cat"))
+    }
+
+    @Test
+    fun everyAliasResolvesToALanguageThePickerOffers() {
+        // An alias pointing at a tag no picker lists would be dead weight and
+        // a sign the two tables had drifted.
+        val offered = LanguageOptions.tags.map { it.first }.toSet()
+        val aliases = listOf(
+            "eng", "spa", "fre", "fra", "ger", "deu", "ita", "por", "dut", "nld",
+            "pol", "rus", "chi", "zho", "jpn", "kor", "ara", "tur", "swe", "dan",
+            "nor", "nob", "nno", "fin", "hun", "cze", "ces", "rum", "ron", "heb",
+            "iw", "tha", "vie", "gre", "ell", "bul", "hrv", "slo", "slk", "slv",
+            "ukr", "ind", "in", "may", "msa", "hin", "tam", "tel", "ben", "per", "fas",
+        )
+        for (alias in aliases) {
+            val canonical = canonicalSubtitleLanguage(alias)
+            assertTrue(canonical in offered, "$alias resolves to $canonical, which no picker offers")
+        }
+    }
+}


### PR DESCRIPTION
## The report

> On Android I'm running the store version but can't put Dutch as default sub.

Correct, and it is not fixed on `main` either — the picker offers the same ten languages in both, and Dutch is in neither:

`English, Spanish, French, German, Japanese, Korean, Chinese, Portuguese, Italian, Russian`

## It was never a server limitation

The settings contract types `playback.subtitle_language` as:

```json
{ "type": "language_tag", "nullable": true }
```

validated for BCP 47 shape only — there is no enum. The web client already offers **37** languages, Dutch included. Android's picker was simply shorter.

`LanguageOptions.tags` now mirrors the web's ISO 639-1 table (`web/src/player/utils/languageNames.ts` in silo-server) in its order. Ten becomes 37.

Worth noting: the table's own comment already named `"nl"` as a tag that arrives *"synced from another surface"* and must be preserved. So a Dutch preference set on the web was being honoured by playback the whole time — the picker just refused to display or re-select it. The user was looking at a setting that was working and appeared absent.

## Completing the picker exposed an older bug

Auto-selection compares the stored preference against a track's language with **both sides** through `canonicalSubtitleLanguage` (`MobileSubtitleAutoSelection`, `TrackSelectionFingerprint`). That function's ISO 639-2 alias table covered seven languages while the picker offered ten:

```kotlin
"eng" -> "en"   "spa" -> "es"   "fre", "fra" -> "fr"
"ger", "deu" -> "de"   "dut", "nld" -> "nl"   "jpn" -> "ja"   "dan" -> "da"
```

A track tagged `ita` canonicalises to `ita`, which never equals a stored `it`. **Italian, Portuguese, Korean, Chinese and Russian were already offered in the picker but could not auto-select on any server exposing bibliographic codes.** Shipping 27 more languages against that table would have multiplied the problem.

The alias table now covers all 37, carrying both bibliographic and terminological forms where ISO 639-2 has both (`cze`/`ces`, `gre`/`ell`, `may`/`msa`, `per`/`fas`, …), plus the pre-1989 codes `iw` → `he` and `in` → `id` that older muxing tools still emit. Norwegian folds `nor`/`nob`/`nno` into the single offered `no`, since Bokmål and Nynorsk are one choice in the picker.

Dutch itself was already mapped (`dut`, `nld` → `nl`), so the reported case needed only the picker entry — but it would have been the only one of the 27 additions that worked.

## Tests

`SubtitleLanguageTest` (new, 9 cases) and `LanguageOptionsTest` (10) both pass, along with the full `:shared` suite; `:androidApp:assembleDebug` and `:androidTvApp:assembleDebug` both build.

The two that would catch a regression here:

- **every picker tag is already canonical** — an option that canonicalises to something else can never equal a matching track
- **every offered language is reachable from its 639-2 form** — if a language is in the picker, some bibliographic spelling of it must canonicalise back to the offered tag, or a server exposing that spelling can never match the choice

Plus the reported case directly: Dutch matches across `nl`, `nld`, `dut`, `NL`, `nl-NL`, `nl_BE`.

## Parity note

**silo-apple offers 12** — these ten plus Arabic and Hindi — and also cannot select Dutch. It needs the same treatment; this PR does not touch it.

---

## Follow-ups landed on this branch

### The alias table now mirrors the server instead of paraphrasing it

The first version of the map was hand-rolled and had already diverged on its third entry. The server's `canonical_language_code` (migration 121, mirroring `internal/lang`) keeps `nob` → `nb` and `nno` → `nn` **distinct**; the hand-rolled version folded both into `no`. The catalog stores what the server canonicalised, so that is not cosmetic — a Bokmål file is `nb` server-side and would have been compared against a client-side `no`, matching nothing.

It is now a faithful copy of all 90 server mappings. That covers far more languages than the pickers offer, which costs nothing and means an unlisted language synced from another surface still compares correctly.

Kept deliberately beyond the server's table: `iw` → `he` and `in` → `id`, the pre-1989 639-1 spellings Java's `Locale` still produces. These are 639-1 rather than 639-2, so the server's map does not carry them and passes them through unchanged — **worth adding server-side**, flagged in a comment.

### Language filter facets show names, not raw codes

`CatalogFilterState` and `TvLibraryBrowseFacets` mapped each vocabulary entry to itself, so library filters rendered `eng`, `nld`, `dut` instead of English and Dutch. New `LanguageOptions.displayLanguage` canonicalises before labelling, so all three Dutch spellings read "Dutch". A code no picker offers is returned unchanged rather than blanked — display and wire value stay the same string, and the filter still applies.

### The viewer's own languages come first

Thirty-seven entries is a long way to travel on a D-pad. The obvious shortcut — device locale — was **measured and rejected**: the Shield here ships `persist.sys.locale` empty, `system_locales` null, and `ro.product.locale` at the factory `en-US`, so locale-first would suggest English to a Dutch viewer.

The catalog is a real signal. Settings fetches `catalog/filters?include_technical=true` and lifts the languages the library actually carries to the top of all six language pickers (audio, subtitle, metadata × phone, TV). The current value is pinned above them so it stays reachable when the fetch fails. The tail is alphabetical — the web's prominence order stops meaning anything past the first ten.

The fetch is best-effort and silent on failure; the pickers work fine without it.

**Not done:** visual group headers ("In your library" / "All languages"). Both pickers render flat lists, so headers need a non-selectable row type on two platforms — worth its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language pickers now prioritize the current selection and languages found in your library.
  * Language codes are displayed using recognizable language names, including support for regional and script-specific codes.
  * Audio, subtitle, metadata, and catalog language filters now use consistent language labels.
  * Expanded language coverage and improved handling of alternate language codes.

* **Bug Fixes**
  * Preserved language codes that are not available in the picker instead of hiding them.
  * Prevented duplicate language options and ensured selections remain reversible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->