### PR TITLE
fix(settings): fall back to the profile endpoint when the settings API is absent

### DIFF
--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
@@ -92,8 +92,15 @@ val repositoryModule = module {
     single { org.siloserver.silo.repository.HomeRealtimeCoordinator(get(), get()) }
     single { SettingsRepository(get()) }
     // Profile-scoped canonical settings, shared by the phone and TV screens so
-    // one platform cannot grow a behavior the other lacks.
-    single { org.siloserver.silo.domain.settings.ProfileSettingsController(get()) }
+    // one platform cannot grow a behavior the other lacks. The second argument
+    // is the pre-contract fallback, so servers that 404 the settings API keep
+    // working instead of silently discarding every change.
+    single {
+        org.siloserver.silo.domain.settings.ProfileSettingsController(
+            get(),
+            org.siloserver.silo.domain.settings.ProfileBackedLegacySettings(get()),
+        )
+    }
     single { LibraryPlaybackPrefsRepository(get()) }
     single { DownloadsRepository(get(), getOrNull<org.siloserver.silo.repository.port.DownloadDeletionPort>() ?: org.siloserver.silo.repository.port.NoOpDownloadDeletionPort) }
     single { EbookReaderRepository(get()) }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/domain/settings/LegacyProfileSettings.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/domain/settings/LegacyProfileSettings.kt
@@ -1,0 +1,83 @@
+package org.siloserver.silo.domain.settings
+
+import org.siloserver.silo.model.profile.UpdateProfileRequest
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.repository.ProfileRepository
+
+/**
+ * The pre-contract path for the four profile playback preferences, kept alive
+ * for servers that do not serve the canonical settings API.
+ *
+ * These preferences moved to `/settings/values/…` on the assumption that every
+ * reachable server would speak the contract. Servers predating it answer 404
+ * to the whole family — contract probe, batched read and write alike — so on
+ * those the settings screen wrote into a void: every change was accepted
+ * optimistically, rejected, and rolled back, for every setting this controller
+ * owns, not just subtitles. The columns on `PUT /profiles/{id}` still work
+ * there, and the server mirrors them into canonical rows once upgraded, so
+ * falling back costs nothing and loses nothing.
+ */
+interface LegacyProfileSettings {
+
+    /** The four values as the profile record holds them, or null if unreadable. */
+    suspend fun load(): ProfileSettingsController.Snapshot?
+
+    /**
+     * Writes only the named preferences; nulls are left untouched.
+     *
+     * Returns the profile's values after the write so the caller can render
+     * what the server actually stored, or null when the write failed.
+     */
+    suspend fun update(
+        subtitleLanguage: String? = null,
+        subtitleMode: String? = null,
+        showForcedSubtitles: Boolean? = null,
+        metadataLanguage: String? = null,
+    ): ProfileSettingsController.Snapshot?
+}
+
+/**
+ * [LegacyProfileSettings] over the profile endpoint.
+ *
+ * Unset is the empty string here rather than an absent row: that is how the
+ * legacy columns have always spelled "no preference", and it is why the
+ * canonical path needs a DELETE for the same intent.
+ */
+class ProfileBackedLegacySettings(
+    private val profiles: ProfileRepository,
+) : LegacyProfileSettings {
+
+    override suspend fun load(): ProfileSettingsController.Snapshot? =
+        when (val result = profiles.getActiveProfileResult()) {
+            is ApiResult.Success -> ProfileSettingsController.Snapshot(
+                subtitleLanguage = result.data.subtitleLanguage.orEmpty(),
+                subtitleMode = ProfileSettingsController.normalizeSubtitleMode(result.data.subtitleMode.orEmpty()),
+                showForcedSubtitles = result.data.showForcedSubtitles ?: true,
+                metadataLanguage = result.data.preferredMetadataLanguage.orEmpty(),
+            )
+            is ApiResult.Error, is ApiResult.NetworkError -> null
+        }
+
+    override suspend fun update(
+        subtitleLanguage: String?,
+        subtitleMode: String?,
+        showForcedSubtitles: Boolean?,
+        metadataLanguage: String?,
+    ): ProfileSettingsController.Snapshot? {
+        val request = UpdateProfileRequest(
+            subtitleLanguage = subtitleLanguage,
+            subtitleMode = subtitleMode,
+            showForcedSubtitles = showForcedSubtitles,
+            preferredMetadataLanguage = metadataLanguage,
+        )
+        return when (val result = profiles.updateActiveProfile(request)) {
+            is ApiResult.Success -> ProfileSettingsController.Snapshot(
+                subtitleLanguage = result.data.subtitleLanguage.orEmpty(),
+                subtitleMode = ProfileSettingsController.normalizeSubtitleMode(result.data.subtitleMode.orEmpty()),
+                showForcedSubtitles = result.data.showForcedSubtitles ?: true,
+                metadataLanguage = result.data.preferredMetadataLanguage.orEmpty(),
+            )
+            is ApiResult.Error, is ApiResult.NetworkError -> null
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/domain/settings/ProfileSettingsController.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/domain/settings/ProfileSettingsController.kt
@@ -30,6 +30,12 @@ import kotlinx.serialization.json.jsonPrimitive
  */
 class ProfileSettingsController(
     private val repository: SettingsRepository,
+    /**
+     * The pre-contract path, used when the server does not serve the canonical
+     * settings API. Null disables the fallback entirely, which is what the
+     * canonical-path tests want.
+     */
+    private val legacy: LegacyProfileSettings? = null,
 ) {
 
     /**
@@ -93,7 +99,21 @@ class ProfileSettingsController(
             is SettingsCapabilitiesResult.Error,
             is SettingsCapabilitiesResult.NetworkError -> Availability.UNAVAILABLE
         }
-        if (availability != Availability.AVAILABLE) return LoadResult(availability, null)
+        // Remembered so the setters know which path to write on without
+        // re-probing per keystroke.
+        contractServed = availability == Availability.AVAILABLE
+
+        if (availability != Availability.AVAILABLE) {
+            // A server that never had the contract is not an error state: the
+            // legacy columns still hold these four preferences, so read them
+            // rather than leaving the screen on defaults it will then write
+            // back over the top of the user's real settings.
+            val fallback = legacy?.load()
+            return LoadResult(
+                availability = if (fallback != null) Availability.AVAILABLE else availability,
+                snapshot = fallback,
+            )
+        }
 
         return when (val result = repository.getEffectiveValues(PROFILE_KEYS)) {
             is ApiResult.Success -> LoadResult(availability, snapshotOf(result.data))
@@ -101,6 +121,13 @@ class ProfileSettingsController(
                 LoadResult(Availability.UNAVAILABLE, null)
         }
     }
+
+    /**
+     * False until [load] finds the contract. Starts true so a setter called
+     * before any load still tries the canonical path first and only falls back
+     * on its 404, rather than assuming the worst of an unprobed server.
+     */
+    private var contractServed: Boolean = true
 
     /**
      * Re-resolves every profile key after a successful write.
@@ -126,18 +153,59 @@ class ProfileSettingsController(
 
     /** [language] is a BCP 47 tag, or "" for no preference. */
     suspend fun setSubtitleLanguage(language: String): WriteResult =
-        resolved(writeLanguage(SettingKeys.PLAYBACK_SUBTITLE_LANGUAGE, language))
+        viaContractOrLegacy(
+            canonical = { writeLanguage(SettingKeys.PLAYBACK_SUBTITLE_LANGUAGE, language) },
+            legacyWrite = { it.update(subtitleLanguage = language.trim()) },
+        )
 
     /** [mode] is a `playback.subtitle_mode` member: "auto", "always" or "off". */
     suspend fun setSubtitleMode(mode: String): WriteResult =
-        resolved(write(SettingKeys.PLAYBACK_SUBTITLE_MODE, JsonPrimitive(normalizeSubtitleMode(mode))))
+        viaContractOrLegacy(
+            canonical = {
+                write(SettingKeys.PLAYBACK_SUBTITLE_MODE, JsonPrimitive(normalizeSubtitleMode(mode)))
+            },
+            legacyWrite = { it.update(subtitleMode = normalizeSubtitleMode(mode)) },
+        )
 
     suspend fun setShowForcedSubtitles(enabled: Boolean): WriteResult =
-        resolved(write(SettingKeys.PLAYBACK_SHOW_FORCED_SUBTITLES, JsonPrimitive(enabled)))
+        viaContractOrLegacy(
+            canonical = { write(SettingKeys.PLAYBACK_SHOW_FORCED_SUBTITLES, JsonPrimitive(enabled)) },
+            legacyWrite = { it.update(showForcedSubtitles = enabled) },
+        )
 
     /** [language] is a BCP 47 tag, or "" to inherit the library's language. */
     suspend fun setMetadataLanguage(language: String): WriteResult =
-        resolved(writeLanguage(SettingKeys.CATALOG_METADATA_LANGUAGE, language))
+        viaContractOrLegacy(
+            canonical = { writeLanguage(SettingKeys.CATALOG_METADATA_LANGUAGE, language) },
+            legacyWrite = { it.update(metadataLanguage = language.trim()) },
+        )
+
+    /**
+     * Writes on whichever path this server actually serves.
+     *
+     * The canonical path is tried whenever the contract is believed present.
+     * A 404 from it means the belief was wrong — an unprobed server, or one
+     * that changed under a long-lived session — so the fallback runs
+     * immediately and the belief is corrected for subsequent writes. Any other
+     * failure is a real failure and is reported as one; retrying a rejected
+     * value on the legacy path would only store what the contract refused.
+     */
+    private suspend fun viaContractOrLegacy(
+        canonical: suspend () -> ApiResult<Unit>,
+        legacyWrite: suspend (LegacyProfileSettings) -> Snapshot?,
+    ): WriteResult {
+        val fallback = legacy
+        if (contractServed) {
+            val result = canonical()
+            if (result is ApiResult.Success) return WriteResult(true, reresolve())
+            val absent = result is ApiResult.Error && result.code == HTTP_NOT_FOUND
+            if (!absent || fallback == null) return WriteResult(false, null)
+            contractServed = false
+        }
+        if (fallback == null) return WriteResult(false, null)
+        val snapshot = legacyWrite(fallback)
+        return WriteResult(succeeded = snapshot != null, snapshot = snapshot)
+    }
 
     private suspend fun resolved(write: ApiResult<Unit>): WriteResult =
         if (write is ApiResult.Success) {
@@ -172,7 +240,7 @@ class ProfileSettingsController(
             metadataLanguage = effective.stringOrEmpty(SettingKeys.CATALOG_METADATA_LANGUAGE),
         )
 
-    private companion object {
+    internal companion object {
         const val DEFAULT_SUBTITLE_MODE = "auto"
         val SUBTITLE_MODES = setOf("auto", "always", "off")
 
@@ -190,6 +258,13 @@ class ProfileSettingsController(
             SettingKeys.PLAYBACK_SHOW_FORCED_SUBTITLES,
             SettingKeys.CATALOG_METADATA_LANGUAGE,
         )
+
+        /**
+         * A server without the canonical settings API answers 404 to the whole
+         * family, which is what distinguishes "this route does not exist here"
+         * from "this value was rejected".
+         */
+        private const val HTTP_NOT_FOUND = 404
 
         fun normalizeSubtitleMode(value: String): String {
             val v = value.trim().lowercase()

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/domain/settings/LegacyProfileSettingsFallbackTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/domain/settings/LegacyProfileSettingsFallbackTest.kt
@@ -1,0 +1,186 @@
+package org.siloserver.silo.domain.settings
+
+import kotlinx.coroutines.test.runTest
+import io.ktor.client.HttpClient
+import kotlinx.serialization.json.JsonElement
+import org.siloserver.silo.model.settings.EffectiveSettingValuesResponse
+import org.siloserver.silo.model.settings.SettingScopeIdentity
+import org.siloserver.silo.model.settings.StoredSettingValue
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.api.SettingsApi
+import org.siloserver.silo.network.api.SettingsCapabilitiesResult
+import org.siloserver.silo.repository.SettingsRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Servers predating the canonical settings API answer 404 to the whole family.
+ * Before the fallback, every profile setting — subtitle language, subtitle
+ * mode, forced subtitles, metadata language — was accepted optimistically by
+ * the screen, rejected by the server, and rolled back, with no error shown.
+ * Confirmed in production: `PUT /api/v1/settings/values/playback.subtitle_language`
+ * returning 404 while `PUT /api/v1/profiles/{id}` served the same preference.
+ */
+class LegacyProfileSettingsFallbackTest {
+
+    private class FakeLegacy(
+        var stored: ProfileSettingsController.Snapshot? =
+            ProfileSettingsController.Snapshot(subtitleLanguage = "de"),
+        var writeSucceeds: Boolean = true,
+    ) : LegacyProfileSettings {
+        var loads = 0
+        val writes = mutableListOf<ProfileSettingsController.Snapshot>()
+
+        override suspend fun load(): ProfileSettingsController.Snapshot? {
+            loads++
+            return stored
+        }
+
+        override suspend fun update(
+            subtitleLanguage: String?,
+            subtitleMode: String?,
+            showForcedSubtitles: Boolean?,
+            metadataLanguage: String?,
+        ): ProfileSettingsController.Snapshot? {
+            if (!writeSucceeds) return null
+            val next = (stored ?: ProfileSettingsController.Snapshot()).copy(
+                subtitleLanguage = subtitleLanguage ?: stored?.subtitleLanguage.orEmpty(),
+                subtitleMode = subtitleMode ?: stored?.subtitleMode ?: "auto",
+                showForcedSubtitles = showForcedSubtitles ?: stored?.showForcedSubtitles ?: true,
+                metadataLanguage = metadataLanguage ?: stored?.metadataLanguage.orEmpty(),
+            )
+            stored = next
+            writes += next
+            return next
+        }
+    }
+
+    /** Answers 404 to everything, like a pre-contract server. */
+    private class NoContractApi : SettingsApi(HttpClient()) {
+        var putCalls = 0
+
+        override suspend fun getContractCapabilities(): SettingsCapabilitiesResult =
+            SettingsCapabilitiesResult.ServerUpgradeRequired
+
+        override suspend fun getEffectiveValues(
+            keys: List<String>,
+            libraryIds: List<Int>,
+            seriesIds: List<String>,
+        ): ApiResult<EffectiveSettingValuesResponse> = notFound()
+
+        override suspend fun putValue(
+            key: String,
+            scope: SettingScopeIdentity,
+            value: JsonElement,
+            mutationId: String,
+            profileId: String?,
+        ): ApiResult<StoredSettingValue> {
+            putCalls++
+            return notFound()
+        }
+
+        override suspend fun deleteValue(
+            key: String,
+            scope: SettingScopeIdentity,
+            profileId: String?,
+        ): ApiResult<Unit> {
+            putCalls++
+            return notFound()
+        }
+
+        private fun <T> notFound(): ApiResult<T> =
+            ApiResult.Error(code = 404, error = "not_found", message = "no such route")
+    }
+
+    private fun controller(api: SettingsApi, legacy: LegacyProfileSettings?) =
+        ProfileSettingsController(SettingsRepository(api), legacy)
+
+    @Test
+    fun `a subtitle language survives on a server without the settings API`() = runTest {
+        val legacy = FakeLegacy()
+        val controller = controller(NoContractApi(), legacy)
+        controller.load()
+
+        val result = controller.setSubtitleLanguage("nl")
+
+        assertTrue(result.succeeded, "write should land on the legacy path")
+        assertEquals("nl", result.snapshot?.subtitleLanguage)
+        assertEquals("nl", legacy.writes.single().subtitleLanguage)
+    }
+
+    @Test
+    fun `the load reads real values rather than leaving the screen on defaults`() = runTest {
+        // Returning no snapshot would render defaults, and the next edit would
+        // write those defaults over preferences the viewer never changed.
+        val legacy = FakeLegacy(ProfileSettingsController.Snapshot(subtitleLanguage = "de"))
+        val result = controller(NoContractApi(), legacy).load()
+
+        assertEquals("de", result.snapshot?.subtitleLanguage)
+        assertEquals(1, legacy.loads)
+    }
+
+    @Test
+    fun `every profile setting falls back, not just subtitle language`() = runTest {
+        val legacy = FakeLegacy()
+        val controller = controller(NoContractApi(), legacy)
+        controller.load()
+
+        assertTrue(controller.setSubtitleMode("always").succeeded)
+        assertTrue(controller.setShowForcedSubtitles(false).succeeded)
+        assertTrue(controller.setMetadataLanguage("fr").succeeded)
+
+        assertEquals("always", legacy.stored?.subtitleMode)
+        assertEquals(false, legacy.stored?.showForcedSubtitles)
+        assertEquals("fr", legacy.stored?.metadataLanguage)
+    }
+
+    @Test
+    fun `an unprobed server still tries the contract first and falls back on its 404`() = runTest {
+        // No load() call, so the contract has not been probed. The canonical
+        // path must still be attempted — assuming the worst would push every
+        // modern server onto the legacy columns.
+        val api = NoContractApi()
+        val legacy = FakeLegacy()
+
+        val result = controller(api, legacy).setSubtitleLanguage("nl")
+
+        assertTrue(api.putCalls > 0, "canonical path should have been tried")
+        assertTrue(result.succeeded)
+        assertEquals("nl", legacy.writes.single().subtitleLanguage)
+    }
+
+    @Test
+    fun `the contract is only abandoned once, not re-probed per write`() = runTest {
+        val api = NoContractApi()
+        val legacy = FakeLegacy()
+        val controller = controller(api, legacy)
+
+        controller.setSubtitleLanguage("nl")
+        val callsAfterFirst = api.putCalls
+        controller.setSubtitleLanguage("fr")
+
+        assertEquals(callsAfterFirst, api.putCalls, "second write should skip the dead route")
+        assertEquals(2, legacy.writes.size)
+    }
+
+    @Test
+    fun `without a fallback the failure is still reported`() = runTest {
+        val result = controller(NoContractApi(), legacy = null).setSubtitleLanguage("nl")
+
+        assertFalse(result.succeeded)
+    }
+
+    @Test
+    fun `a failing legacy write is reported rather than claimed as success`() = runTest {
+        val legacy = FakeLegacy(writeSucceeds = false)
+        val controller = controller(NoContractApi(), legacy)
+        controller.load()
+
+        val result = controller.setSubtitleLanguage("nl")
+
+        assertFalse(result.succeeded)
+        assertEquals(null, result.snapshot)
+    }
+}


### PR DESCRIPTION
## Every profile setting is silently discarded on servers without the settings API

Reported as "I can't set Dutch as my default subtitle language — it snaps back to Off." It turned out to have nothing to do with subtitles, or with which languages the picker offers. Captured from a production server's own logs:

```
PUT /api/v1/settings/values/playback.subtitle_language  ->  404
GET /api/v1/settings/values/effective                   ->  404
GET /api/v1/settings/contract/capabilities              ->  404
GET /api/v1/settings/overlay-config                     ->  200   (older routes fine)
```

The server predates the canonical settings API and answers 404 to the whole family. The settings screen applies the change optimistically, the write 404s, and the ViewModel rolls back — so the row snaps straight back to its previous value **with no error shown**.

The diagnostic that isolates it: *does English fail too?* It does. That separates a picker problem from a write-path problem in one step.

### Scope

Not subtitles — everything `ProfileSettingsController` owns:

| Setting | Behaviour before this PR |
|---|---|
| `playback.subtitle_language` | silently reverted |
| `playback.subtitle_mode` | silently reverted |
| `playback.show_forced_subtitles` | silently reverted |
| `catalog.metadata_language` | silently reverted |

Subtitles are simply where a user notices first.

`Availability.SERVER_UPGRADE_REQUIRED` already exists for exactly this case — the screen is supposed to explain, *"instead of rendering rows whose edits would silently go nowhere."* The probe fires and returns that value, but the setters never consulted it, so the rows rendered as editable regardless.

### The fix

These preferences rode `PUT /profiles/{id}` as named columns before the contract landed, and the class doc records the assumption that replaced it:

> Android no longer depends on the profile endpoint accepting `subtitle_language`, `subtitle_mode`, `show_forced_subtitles` or `preferred_metadata_language`

That does not hold for servers without the contract. Those columns still work there, and the server mirrors them into canonical rows once upgraded, so the fallback loses nothing.

**Writes** — the canonical path is tried whenever the contract is believed present, so a modern server is never pushed onto legacy columns. Only a **404** triggers the fallback, and it flips the belief so subsequent writes skip the dead route rather than re-probing per keystroke. Any other failure is reported as a failure: retrying a rejected value on the legacy path would store precisely what the contract refused.

**Reads** — this mattered more than it first appears. `load()` returned a *null* snapshot on these servers, so the screen rendered defaults, and the next edit would write those defaults over preferences the viewer had never touched. It now reads the profile's real values.

### Verification

Confirmed end-to-end against the same production server that produced the 404s, from a device build:

```
PUT /api/v1/profiles/29e8bb8f-…   status=200
```

The UI renders the profile returned by that PUT (no re-read, by design), so the value persisting *is* the confirmation the response carried it.

Seven unit tests, covering the two ways this is easy to get wrong:

- **an unprobed server still tries the contract first** — assuming the worst would push every modern server onto legacy columns
- **a failing legacy write is reported, not claimed as success**

plus: the contract is abandoned once rather than re-probed per write; the load returns real values instead of defaults; all four settings fall back, not just subtitle language; and with no fallback configured the failure still surfaces.

`./gradlew test` green.

### Notes for review

- `ProfileSettingsController`'s companion moves from `private` to `internal` so the legacy implementation can share `normalizeSubtitleMode`. Same normalisation on both paths, rather than a second copy that drifts.
- The fallback is constructor-injected and nullable; passing `null` disables it, which is what the existing canonical-path tests want.
- Independent of #152 (the language-list PR) — they touch different problems and can land in either order.
