### PR TITLE
build(android): target API 36 for Play updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Built as a Kotlin Multiplatform project: one shared business-logic core, two Jet
 | **Persistence** | AndroidX DataStore · EncryptedSharedPreferences (tokens) · WorkManager (downloads) |
 | **Diagnostics** | Native bounded capture · local review/consent · self-hosted Silo upload |
 | **Images** | Coil 3 (Ktor-backed) |
-| **SDK** | Android 7.0+ / minSdk 24 · targetSdk 35 · compileSdk 36 · JDK 21 |
+| **SDK** | Android 7.0+ / minSdk 24 · targetSdk 36 · compileSdk 36 · JDK 21 |
 
 The clients talk to a Silo server over its `/api/v1/*` REST + WebSocket API. The server owns the library, scanning, metadata, transcoding decisions, and auth; the clients render it and drive playback.
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -143,7 +143,7 @@ android {
     defaultConfig {
         applicationId = "org.siloserver.silo"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         // Shares one Play listing with the TV app (same applicationId). Two
         // artifacts under one listing need distinct versionCodes: phone =
         // base*2, TV = base*2+1, so each release bumps both by 2 with no reuse.

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerControls.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerControls.kt
@@ -74,6 +74,7 @@ fun PlayerControls(
     chapters: List<org.siloserver.silo.model.catalog.VersionChapter> = emptyList(),
     intro: org.siloserver.silo.model.catalog.TimeRange? = null,
     isOrientationLocked: Boolean,
+    orientationLockSupported: Boolean = true,
     // Watch Together guest gate: when false the scrubber + skip buttons are
     // inert and dimmed (seek is host-only, so disabled for all guests).
     // Defaults true for solo playback.
@@ -149,6 +150,7 @@ fun PlayerControls(
                         castSlot()
                         PlayerToolbarOverflow(
                             isOrientationLocked = isOrientationLocked,
+                            orientationLockSupported = orientationLockSupported,
                             hasChapters = hasChapters,
                             hasTracks = hasTracks,
                             hasMultipleVersions = hasMultipleVersions,
@@ -161,6 +163,7 @@ fun PlayerControls(
                     } else {
                         PlayerToolbarActions(
                             isOrientationLocked = isOrientationLocked,
+                            orientationLockSupported = orientationLockSupported,
                             hasChapters = hasChapters,
                             hasTracks = hasTracks,
                             hasMultipleVersions = hasMultipleVersions,
@@ -265,6 +268,7 @@ private fun PlayerToolbarTitle(
 @Composable
 private fun PlayerToolbarActions(
     isOrientationLocked: Boolean,
+    orientationLockSupported: Boolean,
     hasChapters: Boolean,
     hasTracks: Boolean,
     hasMultipleVersions: Boolean,
@@ -276,9 +280,18 @@ private fun PlayerToolbarActions(
     castSlot: @Composable () -> Unit,
 ) {
     ControlButton(
-        icon = if (isOrientationLocked) Icons.Default.ScreenLockRotation else Icons.Default.ScreenRotation,
-        contentDescription = if (isOrientationLocked) "Landscape Locked" else "Rotate Freely",
+        icon = if (isOrientationLocked && orientationLockSupported) {
+            Icons.Default.ScreenLockRotation
+        } else {
+            Icons.Default.ScreenRotation
+        },
+        contentDescription = when {
+            !orientationLockSupported -> "Orientation follows device on large screens"
+            isOrientationLocked -> "Landscape Locked"
+            else -> "Rotate Freely"
+        },
         onClick = onToggleOrientationLock,
+        enabled = orientationLockSupported,
     )
     if (hasChapters) {
         ControlButton(
@@ -311,6 +324,7 @@ private fun PlayerToolbarActions(
 @Composable
 private fun PlayerToolbarOverflow(
     isOrientationLocked: Boolean,
+    orientationLockSupported: Boolean,
     hasChapters: Boolean,
     hasTracks: Boolean,
     hasMultipleVersions: Boolean,
@@ -334,8 +348,15 @@ private fun PlayerToolbarOverflow(
         ) {
             DropdownMenuItem(
                 text = {
-                    Text(if (isOrientationLocked) "Unlock orientation" else "Lock orientation")
+                    Text(
+                        when {
+                            !orientationLockSupported -> "Orientation follows device"
+                            isOrientationLocked -> "Unlock orientation"
+                            else -> "Lock orientation"
+                        },
+                    )
                 },
+                enabled = orientationLockSupported,
                 onClick = {
                     expanded = false
                     onToggleOrientationLock()

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerOrientationPolicy.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerOrientationPolicy.kt
@@ -1,0 +1,15 @@
+package org.siloserver.silo.android.ui.screens.player
+
+private const val ANDROID_16_API_LEVEL = 36
+private const val LARGE_SCREEN_SMALLEST_WIDTH_DP = 600
+
+/**
+ * Android 16 ignores requested orientation on displays whose smallest width is
+ * at least 600dp for apps targeting API 36. Keep the lock available everywhere
+ * the platform can honor it, and let large screens remain adaptive.
+ */
+internal fun supportsPlayerOrientationLock(
+    sdkInt: Int,
+    smallestScreenWidthDp: Int,
+): Boolean =
+    sdkInt < ANDROID_16_API_LEVEL || smallestScreenWidthDp < LARGE_SCREEN_SMALLEST_WIDTH_DP

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerOverlay.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerOverlay.kt
@@ -61,6 +61,7 @@ fun PlayerOverlay(
     viewModel: PlayerViewModel,
     roomSnapshot: RoomSnapshot? = null,
     isFastForwardHoldActive: Boolean = false,
+    orientationLockSupported: Boolean = true,
     onBack: () -> Unit,
     onPlayPause: () -> Unit,
     onSeek: (Double) -> Unit,
@@ -127,7 +128,8 @@ fun PlayerOverlay(
     // Orientation lock — toggled from the top-bar lock icon (iOS parity).
     // Persisted via the orientation-mode setting (default landscape-locked,
     // like iOS's PlayerOrientationCoordinator); PlayerScreen applies the
-    // matching requestedOrientation whenever the setting changes.
+    // matching requestedOrientation whenever the setting changes. Android 16
+    // large screens keep the preference but disable this no-op affordance.
     val isOrientationLocked by viewModel.orientationLocked.collectAsState()
     val context = LocalContext.current
 
@@ -332,6 +334,7 @@ fun PlayerOverlay(
                 hasTracks = state.subtitleTracks.isNotEmpty() || state.audioTracks.isNotEmpty(),
                 hasMultipleVersions = state.versions.size > 1,
                 isOrientationLocked = isOrientationLocked,
+                orientationLockSupported = orientationLockSupported,
                 seekEnabled = seekEnabled,
                 playPauseEnabled = playPauseEnabled,
                 onBack = handleBack,
@@ -340,7 +343,9 @@ fun PlayerOverlay(
                 onSkipForward = gatedSkipForward,
                 onSkipBackward = gatedSkipBackward,
                 onToggleOrientationLock = {
-                    viewModel.onSetOrientationLocked(!isOrientationLocked)
+                    if (orientationLockSupported) {
+                        viewModel.onSetOrientationLocked(!isOrientationLocked)
+                    }
                 },
                 onOpenChapters = { chaptersSheetVisible = true },
                 onOpenTracks = { tracksSheetVisible = true },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.ComponentName
 import android.content.pm.ActivityInfo
 import android.graphics.Rect
+import android.os.Build
 import android.os.SystemClock
 import android.util.Log
 import android.view.ViewGroup
@@ -35,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -535,17 +537,31 @@ fun PlayerScreen(
     // Orientation policy (iOS PlayerOrientationCoordinator parity): entering
     // the player locks to landscape by default; the persisted "rotateFreely"
     // opt-out (HUD lock toggle / synced setting) falls back to USER so the
-    // system rotation preference stays in charge. Released on exit by the
-    // immersive effect's originalOrientation restore above.
+    // system rotation preference stays in charge. Android 16 ignores requested
+    // orientation on 600dp+ displays, so those layouts stay adaptive and the
+    // overlay disables the lock affordance instead of claiming a no-op lock.
+    // Released on exit by the immersive effect's UNSPECIFIED restore above.
     // Wait for the persisted preference before touching the activity: the
     // resolved flow is null until it arrives, and applying the eager locked
     // default on the first frame would snap rotateFreely users back to
     // landscape on every player entry.
+    val smallestScreenWidthDp = LocalConfiguration.current.smallestScreenWidthDp
+    val orientationLockSupported = supportsPlayerOrientationLock(
+        sdkInt = Build.VERSION.SDK_INT,
+        smallestScreenWidthDp = smallestScreenWidthDp,
+    )
     val orientationLockedResolved by viewModel.orientationLockedResolved.collectAsState()
-    LaunchedEffect(activity, orientationLockedResolved, castState.isConnected) {
+    LaunchedEffect(
+        activity,
+        orientationLockedResolved,
+        castState.isConnected,
+        orientationLockSupported,
+    ) {
         // While casting, the screen shows the cast takeover panel, not video —
         // no reason to force landscape (and it must unlock if already forced).
-        if (castState.isConnected) {
+        // Large Android 16 displays likewise own their orientation by platform
+        // policy, so explicitly release any lock left by a smaller display.
+        if (castState.isConnected || !orientationLockSupported) {
             activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
             return@LaunchedEffect
         }
@@ -1175,6 +1191,7 @@ fun PlayerScreen(
                         state = uiState.withPlaybackClock(clock),
                         viewModel = viewModel,
                         roomSnapshot = roomSnapshot,
+                        orientationLockSupported = orientationLockSupported,
                         castSlot = {
                             SiloCastButton(
                                 castManager = castManager,

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/AndroidManifestPolicyTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/AndroidManifestPolicyTest.kt
@@ -16,9 +16,9 @@ class AndroidManifestPolicyTest {
     }
 
     @Test
-    fun mobileKeepsAndroid7InstallFloor() {
+    fun mobileKeepsAndroid7InstallFloorAndTargetsApi36() {
         assertTrue(buildFile.contains("minSdk = 24"))
-        assertTrue(buildFile.contains("targetSdk = 35"))
+        assertTrue(buildFile.contains("targetSdk = 36"))
         assertTrue(buildFile.contains("compileSdk = 36"))
     }
 

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerOrientationPolicyTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerOrientationPolicyTest.kt
@@ -1,0 +1,20 @@
+package org.siloserver.silo.android.ui.screens.player
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlayerOrientationPolicyTest {
+    @Test
+    fun android16LargeScreensFollowTheDeviceOrientation() {
+        assertFalse(supportsPlayerOrientationLock(sdkInt = 36, smallestScreenWidthDp = 600))
+        assertFalse(supportsPlayerOrientationLock(sdkInt = 36, smallestScreenWidthDp = 840))
+        assertFalse(supportsPlayerOrientationLock(sdkInt = 37, smallestScreenWidthDp = 600))
+    }
+
+    @Test
+    fun phonesAndOlderAndroidReleasesKeepThePlayerLock() {
+        assertTrue(supportsPlayerOrientationLock(sdkInt = 36, smallestScreenWidthDp = 599))
+        assertTrue(supportsPlayerOrientationLock(sdkInt = 35, smallestScreenWidthDp = 840))
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryDestinationTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/watchtogether/WatchTogetherEntryDestinationTest.kt
@@ -14,7 +14,7 @@ import org.robolectric.annotation.Config
 
 // Asserts on real Route.route strings, which call android.net.Uri.encode —
 // Robolectric provides the real Android impl under plain JVM unit tests.
-// Pinned to SDK 34 (the project targetSdk 35 is newer than this Robolectric
+// Pinned to SDK 34 (the project targetSdk 36 is newer than this Robolectric
 // release ships an emulated runtime for).
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], application = android.app.Application::class)

--- a/androidTvApp/build.gradle.kts
+++ b/androidTvApp/build.gradle.kts
@@ -133,7 +133,7 @@ android {
         // collide with the phone module.
         applicationId = "org.siloserver.silo"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         // Two artifacts under one listing need distinct versionCodes: phone =
         // base*2, TV = base*2+1, so each release bumps both by 2 with no reuse.
         versionCode = siloVersionCode.get() * 2 + 1

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryBrowseControls.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryBrowseControls.kt
@@ -351,7 +351,10 @@ fun TvBrowseFilterPanel(
         runCatching { screenFocusRequester.requestFocus() }
     }
 
-    BrowsePanelScrim(onClose = handleBack, dismissOnBack = false) {
+    // Popup's dismissOnBackPress uses the supported system callback on Android
+    // 16. onDismissRequest still runs this two-stage values -> filters -> close
+    // handler, while the key handler below remains an Escape/legacy fallback.
+    BrowsePanelScrim(onClose = handleBack) {
         Column(
             modifier = Modifier
                 .width(360.dp)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.tv.ui.screens.player
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -183,7 +184,6 @@ internal fun TvPlayerHud(
     onSelectChapter: (Int) -> Unit,
     onDismiss: () -> Unit,
     initialTab: HudTab = HudTab.Info,
-    onPickerOpenChanged: (Boolean) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val tabs = visibleHudTabs(
@@ -269,11 +269,10 @@ internal fun TvPlayerHud(
     val presentPicker: (HudPickerPresentation) -> Unit = { activePicker = it }
     val closePicker: () -> Unit = { activePicker = null }
 
-    // Hoist picker-open state up so the screen-level BackHandler can defer to
-    // the picker (Back should dismiss only the active picker, not the whole
-    // HUD, while a picker is open).
-    val pickerOpen = activePicker != null
-    LaunchedEffect(pickerOpen) { onPickerOpenChanged(pickerOpen) }
+    // Android 16 no longer dispatches KEYCODE_BACK to target-36 apps. Register
+    // the picker as the most specific callback; when it is closed, the player
+    // screen's callback remains responsible for dismissing the HUD itself.
+    BackHandler(enabled = activePicker != null) { closePicker() }
 
     // Top-center card. No full-screen scrim — the video stays visible behind it.
     Box(
@@ -292,7 +291,8 @@ internal fun TvPlayerHud(
                 if (ev.type == KeyEventType.KeyUp &&
                     (ev.key == Key.Back || ev.key == Key.Escape)
                 ) {
-                    // Back closes the picker first (if open), else dismisses the HUD.
+                    // Pre-Android-16 remote and keyboard fallback. System Back
+                    // uses the callbacks above and on TvPlayerScreen.
                     if (activePicker != null) {
                         activePicker = null
                     } else {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -311,12 +311,6 @@ fun TvPlayerScreen(
     var requestedHudTab by remember { mutableStateOf(HudTab.Info) }
     var showQuickSubtitlePicker by remember { mutableStateOf(false) }
     var subtitleFocusedStableId by remember { mutableStateOf<String?>(null) }
-    // Mirrors the HUD's internal active-picker slot so the screen-level
-    // BackHandler can defer to an open picker (Back closes only the picker).
-    var hudPickerOpen by remember { mutableStateOf(false) }
-    // Clear the mirror whenever the HUD itself is gone, so a stale "picker open"
-    // can never wedge the screen BackHandler off.
-    LaunchedEffect(state.hudOpen) { if (!state.hudOpen) hudPickerOpen = false }
     // Captured PlayerView reference so subtitleManager.applyAppearance can hit
     // the inflated subtitleView after the AndroidView factory runs. Mirrors
     // the phone PlayerScreen's `playerViewRef` pattern.
@@ -827,12 +821,14 @@ fun TvPlayerScreen(
         }
     }
 
-    // While a HUD picker dialog is open, the HUD owns Back: its onPreviewKeyEvent
-    // closes only the active picker and consumes the event, so the screen-level
-    // BackHandler must defer (disabled) rather than tearing down the whole HUD.
-    BackHandler(enabled = !(state.hudOpen && hudPickerOpen)) {
+    // More-specific overlays register their own BackHandlers later in the
+    // composition and therefore run first. This screen callback owns the
+    // remaining player-state ladder on Android 16, where KEYCODE_BACK is no
+    // longer dispatched to apps targeting API 36.
+    BackHandler {
         when {
             cleanSeekRate != 0 -> stopCleanPlaybackSeek()
+            state.isScrubbing -> viewModel.cancelScrub()
             showQuickSubtitlePicker -> showQuickSubtitlePicker = false
             state.showSubtitleStyleDialog -> viewModel.closeSubtitleStyleDialog()
             state.showSubtitleMenu -> viewModel.closeSubtitleMenu()
@@ -2002,7 +1998,6 @@ fun TvPlayerScreen(
                             },
                             onDismiss = { viewModel.closeHUD() },
                             initialTab = requestedHudTab,
-                            onPickerOpenChanged = { hudPickerOpen = it },
                         )
                         }
                     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.tv.ui.shell
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -45,6 +46,7 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -82,6 +84,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -696,70 +701,97 @@ fun TvMainShell(
         }
     }
 
+    fun handleShellBack(): Boolean {
+        // Settings owns a two-stage Back model (detail pane -> selected rail
+        // category -> Home), so its nested BackHandler must remain in charge.
+        if (currentRoute == TvMainRoute.Settings.route) return false
+
+        return when (focusState.onBack(
+            onTabRoot = selectedRoot != null,
+            menuFocusTarget = selectedMenuFocusTarget,
+        )) {
+            // Panel/dropdown already closed by onBack(): just consume.
+            TvShellBackAction.ClosePanel,
+            TvShellBackAction.CloseProfileMenu -> true
+            // Content on a tab root: onBack() already routed focus to the bar's
+            // selected tab -- just consume.
+            TvShellBackAction.MoveFocusToMenu -> true
+            // Bar focused: Home exits the app (fall through to the activity),
+            // any other section goes Home with the bar still focused.
+            TvShellBackAction.MenuBack -> {
+                if (selectedRoot == TvRootDestination.Home) {
+                    false
+                } else {
+                    navigateToRoute(firstTvRoute())
+                    focusState.requestMenuFocus()
+                    true
+                }
+            }
+            // Secondary screens: pop the flat inner NavHost when possible;
+            // otherwise let the activity-level callback finish the app.
+            TvShellBackAction.DelegateToNav -> {
+                if (currentRoute == TvMainRoute.Search.route && !searchInputHasFocus) {
+                    searchBackToInputRequest += 1
+                    true
+                } else if (nestedNav.previousBackStackEntry != null) {
+                    nestedNav.popBackStack()
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    // Android 16 no longer dispatches KEYCODE_BACK to apps targeting API 36.
+    // Register the shell's stateful routing through the supported callback and
+    // enable it only when this layer can consume the press, so child callbacks
+    // and the activity fallback retain their existing priority.
+    val pendingShellBackAction = tvShellBackAction(
+        panelOpen = focusState.openPanel != null,
+        profileMenuOpen = focusState.profileMenuOpen,
+        menuFocused = focusState.isMenuFocused,
+        onTabRoot = selectedRoot != null,
+    )
+    val shellHandlesBack = currentRoute != TvMainRoute.Settings.route && when (pendingShellBackAction) {
+        TvShellBackAction.ClosePanel,
+        TvShellBackAction.CloseProfileMenu,
+        TvShellBackAction.MoveFocusToMenu -> true
+        TvShellBackAction.MenuBack -> selectedRoot != TvRootDestination.Home
+        TvShellBackAction.DelegateToNav ->
+            (currentRoute == TvMainRoute.Search.route && !searchInputHasFocus) ||
+                nestedNav.previousBackStackEntry != null
+    }
+    // NavHost installs its own predictive-back callback before composing the
+    // active destination. Put the shell callback inside each destination so
+    // it registers after Navigation, but before screen-level dialogs and
+    // overlays. That preserves the intended priority: screen > shell > nav.
+    val latestShellHandlesBack = rememberUpdatedState(shellHandlesBack)
+    val latestHandleShellBack = rememberUpdatedState<() -> Unit>({ handleShellBack() })
+    fun NavGraphBuilder.shellComposable(
+        route: String,
+        arguments: List<NamedNavArgument> = emptyList(),
+        content: @Composable (NavBackStackEntry) -> Unit,
+    ) {
+        composable(route = route, arguments = arguments) { entry ->
+            BackHandler(enabled = latestShellHandlesBack.value) {
+                latestHandleShellBack.value()
+            }
+            content(entry)
+        }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            // Shell-level Back/Escape. Placed on the outer Box (an ancestor of
-            // BOTH the content layer and the top menu bar) so it fires no
-            // matter which has focus. When the menu is focused, Back returns to
-            // content instead of falling through to the activity and exiting.
+            // Keep the key-event path as a pre-Android-16 remote/keyboard
+            // fallback. API 36 Back presses arrive through BackHandler above.
             .onPreviewKeyEvent { ev ->
                 if (ev.type == KeyEventType.KeyUp &&
                     (ev.key == Key.Back || ev.key == Key.Escape)
                 ) {
-                    // Settings owns a two-stage Back model (detail pane →
-                    // selected rail category → Home). Let its BackHandler see
-                    // the event instead of applying the shell-wide routing.
-                    if (currentRoute == TvMainRoute.Settings.route) {
-                        return@onPreviewKeyEvent false
-                    }
-                    // Centralized shell Back. The 4-way priority (panel >
-                    // profile menu > focused bar > nav) is decided by
-                    // [TvShellFocusState.onBack], which also applies the state
-                    // half (close panel / dropdown); we run only the side effect
-                    // each action needs. Keeping it here — not in the selector or
-                    // the bar — means Back can never be double-handled.
-                    when (focusState.onBack(
-                        onTabRoot = selectedRoot != null,
-                        menuFocusTarget = selectedMenuFocusTarget,
-                    )) {
-                        // Panel/dropdown already closed by onBack(): just consume.
-                        TvShellBackAction.ClosePanel,
-                        TvShellBackAction.CloseProfileMenu -> true
-                        // Content on a tab root: onBack() already routed focus
-                        // to the bar's selected tab — just consume.
-                        TvShellBackAction.MoveFocusToMenu -> true
-                        // Bar focused: Home exits the app (fall through to the
-                        // activity), any other section goes Home with the bar
-                        // still focused (now on the Home tab).
-                        TvShellBackAction.MenuBack -> {
-                            if (selectedRoot == TvRootDestination.Home) {
-                                false
-                            } else {
-                                navigateToRoute(firstTvRoute())
-                                focusState.requestMenuFocus()
-                                true
-                            }
-                        }
-                        // Secondary screens (Settings, Search, admin, …): pop
-                        // the flat inner NavHost when there's history; otherwise
-                        // fall through so the activity finishes the app.
-                        TvShellBackAction.DelegateToNav -> {
-                            if (currentRoute == TvMainRoute.Search.route && !searchInputHasFocus) {
-                                searchBackToInputRequest += 1
-                                true
-                            } else if (nestedNav.previousBackStackEntry != null) {
-                                // Focus restoration after the pop is owned by the
-                                // restored screen itself (the section feed re-targets
-                                // its last-focused card via its recreation ladder).
-                                nestedNav.popBackStack()
-                                true
-                            } else {
-                                false
-                            }
-                        }
-                    }
+                    handleShellBack()
                 } else {
                     false
                 }
@@ -852,7 +884,7 @@ fun TvMainShell(
                 popEnterTransition = { fadeIn(tween(500)) },
                 popExitTransition = { fadeOut(tween(500)) },
             ) {
-                composable(TvMainRoute.Video.route) {
+                shellComposable(TvMainRoute.Video.route) {
                     TvHomeScreen(
                         onItemClick = openHomeItemDetail,
                         onPlayItem = onPlayItem,
@@ -873,7 +905,7 @@ fun TvMainShell(
                         onContentUpFallbackChanged = onContentUpFallback,
                     )
                 }
-                composable(TvMainRoute.Home.route) {
+                shellComposable(TvMainRoute.Home.route) {
                     TvHomeScreen(
                         onItemClick = openHomeItemDetail,
                         onPlayItem = onPlayItem,
@@ -894,7 +926,7 @@ fun TvMainShell(
                         onContentUpFallbackChanged = onContentUpFallback,
                     )
                 }
-                composable(TvMainRoute.Search.route) {
+                shellComposable(TvMainRoute.Search.route) {
                     TvSearchScreen(
                         onResultClick = { item ->
                             openBrowseItem(
@@ -912,7 +944,7 @@ fun TvMainShell(
                         onSearchFieldFocusChanged = { searchInputHasFocus = it },
                     )
                 }
-                composable(TvMainRoute.Audio.route) {
+                shellComposable(TvMainRoute.Audio.route) {
                     TvLibrariesScreen(
                         onItemClick = onOpenItemDetail,
                         onLibraryCollectionClick = onOpenLibraryCollectionDetail,
@@ -920,7 +952,7 @@ fun TvMainShell(
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                     )
                 }
-                composable(TvMainRoute.Libraries.route) {
+                shellComposable(TvMainRoute.Libraries.route) {
                     TvLibrariesScreen(
                         onItemClick = onOpenItemDetail,
                         onLibraryCollectionClick = onOpenLibraryCollectionDetail,
@@ -933,7 +965,7 @@ fun TvMainShell(
                 // picker stays the switch mechanism this stage (TvLibrariesScreen
                 // still hosts it for the legacy Libraries route); the cascade
                 // selector arrives in Stage 4.
-                composable(TvMainRoute.Movies.route) {
+                shellComposable(TvMainRoute.Movies.route) {
                     TvLibraryTypeContent(
                         type = TvLibraryTabType.Movies,
                         library = activeLibrary(TvLibraryTabType.Movies),
@@ -947,7 +979,7 @@ fun TvMainShell(
                         onContentUpFallbackChanged = onContentUpFallback,
                     )
                 }
-                composable(TvMainRoute.Series.route) {
+                shellComposable(TvMainRoute.Series.route) {
                     TvLibraryTypeContent(
                         type = TvLibraryTabType.Series,
                         library = activeLibrary(TvLibraryTabType.Series),
@@ -961,7 +993,7 @@ fun TvMainShell(
                         onContentUpFallbackChanged = onContentUpFallback,
                     )
                 }
-                composable(TvMainRoute.Music.route) {
+                shellComposable(TvMainRoute.Music.route) {
                     TvLibraryTypeContent(
                         type = TvLibraryTabType.Music,
                         library = activeLibrary(TvLibraryTabType.Music),
@@ -975,7 +1007,7 @@ fun TvMainShell(
                         onContentUpFallbackChanged = onContentUpFallback,
                     )
                 }
-                composable(TvMainRoute.Audiobooks.route) {
+                shellComposable(TvMainRoute.Audiobooks.route) {
                     TvLibraryTypeContent(
                         type = TvLibraryTabType.Audiobooks,
                         library = activeLibrary(TvLibraryTabType.Audiobooks),
@@ -989,7 +1021,7 @@ fun TvMainShell(
                         onContentUpFallbackChanged = onContentUpFallback,
                     )
                 }
-                composable(TvMainRoute.ForYou.route) {
+                shellComposable(TvMainRoute.ForYou.route) {
                     TvRecommendationsScreen(
                         onItemClick = onOpenItemDetail,
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
@@ -997,7 +1029,7 @@ fun TvMainShell(
                         entryRequest = forYouEntryRequest,
                     )
                 }
-                composable(TvMainRoute.Requests.route) {
+                shellComposable(TvMainRoute.Requests.route) {
                     TvRequestsScreen(
                         onOpenLibraryItem = onOpenItemDetail,
                         onOpenMyRequests = { navigateToSecondary(TvMainRoute.MyRequests.route) },
@@ -1007,7 +1039,7 @@ fun TvMainShell(
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                     )
                 }
-                composable(TvMainRoute.MyRequests.route) {
+                shellComposable(TvMainRoute.MyRequests.route) {
                     TvMyRequestsScreen(
                         onOpenLibraryItem = onOpenItemDetail,
                         onOpenRequestDetail = { mt, id ->
@@ -1016,7 +1048,7 @@ fun TvMainShell(
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                     )
                 }
-                composable(
+                shellComposable(
                     route = TvMainRoute.RequestDetail.ROUTE,
                     arguments = listOf(
                         navArgument(TvMainRoute.RequestDetail.ARG_MEDIA_TYPE) { type = NavType.StringType },
@@ -1029,31 +1061,31 @@ fun TvMainShell(
                         onBack = { if (nestedNav.previousBackStackEntry != null) nestedNav.popBackStack() },
                     )
                 }
-                composable(TvMainRoute.Collections.route) {
+                shellComposable(TvMainRoute.Collections.route) {
                     TvCollectionsScreen(
                         onCollectionClick = onOpenCollectionDetail,
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                     )
                 }
-                composable(TvMainRoute.Watchlist.route) {
+                shellComposable(TvMainRoute.Watchlist.route) {
                     TvWatchlistScreen(
                         onItemClick = onOpenItemDetail,
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                     )
                 }
-                composable(TvMainRoute.Favorites.route) {
+                shellComposable(TvMainRoute.Favorites.route) {
                     TvFavoritesScreen(
                         onItemClick = onOpenItemDetail,
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                     )
                 }
-                composable(TvMainRoute.History.route) {
+                shellComposable(TvMainRoute.History.route) {
                     TvHistoryScreen(
                         onItemClick = onOpenItemDetail,
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                     )
                 }
-                composable(TvMainRoute.Settings.route) {
+                shellComposable(TvMainRoute.Settings.route) {
                     TvSettingsScreen(
                         onNavigateToAdmin = {
                             // Apple parity: the stats dashboard is the whole
@@ -1074,10 +1106,10 @@ fun TvMainShell(
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                     )
                 }
-                composable(TvMainRoute.ManageSessions.route) {
+                shellComposable(TvMainRoute.ManageSessions.route) {
                     TvManageSessionsScreen(onBack = { if (nestedNav.previousBackStackEntry != null) nestedNav.popBackStack() })
                 }
-                composable(TvMainRoute.Calendar.route) {
+                shellComposable(TvMainRoute.Calendar.route) {
                     TvCalendarScreen(
                         onOpenItemDetail = onOpenItemDetail,
                         onInitialContentFocus = {
@@ -1093,13 +1125,13 @@ fun TvMainShell(
                         onContentUpFallbackChanged = onContentUpFallback,
                     )
                 }
-                composable(TvMainRoute.Browse.route) {
+                shellComposable(TvMainRoute.Browse.route) {
                     TvBrowseScreen(
                         onOpenItemDetail = onOpenItemDetail,
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                     )
                 }
-                composable(TvMainRoute.AdminHub.route) {
+                shellComposable(TvMainRoute.AdminHub.route) {
                     TvAdminHubScreen(
                         onOpenDashboard = { navigateToSecondary(TvMainRoute.AdminDashboard.route) },
                         onOpenUsers = { navigateToSecondary(TvMainRoute.AdminUsers.route) },
@@ -1109,17 +1141,17 @@ fun TvMainShell(
                         onBack = { if (nestedNav.previousBackStackEntry != null) nestedNav.popBackStack() },
                     )
                 }
-                composable(TvMainRoute.AdminDashboard.route) {
+                shellComposable(TvMainRoute.AdminDashboard.route) {
                     TvAdminScreen(onBack = { if (nestedNav.previousBackStackEntry != null) nestedNav.popBackStack() })
                 }
-                composable(TvMainRoute.AdminUsers.route) {
+                shellComposable(TvMainRoute.AdminUsers.route) {
                     TvAdminUsersScreen(
                         onBack = { if (nestedNav.previousBackStackEntry != null) nestedNav.popBackStack() },
                         onCreateUser = { navigateToForm(TvMainRoute.AdminUserEdit().route) },
                         onEditUser = { id -> navigateToForm(TvMainRoute.AdminUserEdit(id).route) },
                     )
                 }
-                composable(
+                shellComposable(
                     route = TvMainRoute.AdminUserEdit.ROUTE,
                     arguments = listOf(
                         navArgument(TvMainRoute.AdminUserEdit.ARG_USER_ID) {
@@ -1138,13 +1170,13 @@ fun TvMainShell(
                         onSaved = { if (nestedNav.previousBackStackEntry != null) nestedNav.popBackStack() },
                     )
                 }
-                composable(TvMainRoute.AdminSessions.route) {
+                shellComposable(TvMainRoute.AdminSessions.route) {
                     TvAdminSessionsScreen(onBack = { if (nestedNav.previousBackStackEntry != null) nestedNav.popBackStack() })
                 }
-                composable(TvMainRoute.AdminScans.route) {
+                shellComposable(TvMainRoute.AdminScans.route) {
                     TvAdminScansScreen(onBack = { if (nestedNav.previousBackStackEntry != null) nestedNav.popBackStack() })
                 }
-                composable(TvMainRoute.AdminLogs.route) {
+                shellComposable(TvMainRoute.AdminLogs.route) {
                     TvAdminLogsScreen(onBack = { if (nestedNav.previousBackStackEntry != null) nestedNav.popBackStack() })
                 }
             }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/TvAndroidManifestPolicyTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/TvAndroidManifestPolicyTest.kt
@@ -16,9 +16,9 @@ class TvAndroidManifestPolicyTest {
     }
 
     @Test
-    fun tvKeepsAndroid7InstallFloor() {
+    fun tvKeepsAndroid7InstallFloorAndTargetsApi36() {
         assertTrue(buildFile.contains("minSdk = 24"))
-        assertTrue(buildFile.contains("targetSdk = 35"))
+        assertTrue(buildFile.contains("targetSdk = 36"))
         assertTrue(buildFile.contains("compileSdk = 36"))
     }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryReviewWiringSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryReviewWiringSourceTest.kt
@@ -22,7 +22,7 @@ class TvLibraryReviewWiringSourceTest {
         val calendarScreen = extractBetween(
             source = mainShell,
             startAnchor = "TvCalendarScreen(",
-            endAnchor = "composable(TvMainRoute.Browse.route)",
+            endAnchor = "shellComposable(TvMainRoute.Browse.route)",
         )
 
         assertTrue(alphabetTab.contains("onContentUpFallbackChanged = onContentUpFallbackChanged"))

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         // Baseline Profile generation requires API 28+ (33+ recommended).
         minSdk = 28
-        targetSdk = 35
+        targetSdk = 36
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Summary

- target Android 16 / API 36 in both Play-distributed app modules
- keep the baseline-profile harness aligned with the phone target
- adapt the phone player orientation control to Android 16 large-screen behavior
- migrate Android TV Back routing to supported target-36 callbacks
- update SDK policy assertions and current SDK documentation
- retain Android 7 support (`minSdk = 24`)

## Android 16 compatibility review

- Phone already opts into edge-to-edge with `enableEdgeToEdge()`; TV already owns edge-to-edge insets with `WindowCompat.setDecorFitsSystemWindows(window, false)`.
- Android TV Back routing uses supported callbacks with screen/popup → shell → Navigation priority; `Key.Back` remains only as an Escape/pre-Android-16 fallback.
- On Android 16 displays at `sw600dp+`, the platform ignores requested orientation. The player now keeps those layouts adaptive, releases any prior activity lock, and disables/relabels the no-op lock control while preserving the saved preference for smaller displays.
- Android 16 local-network protection is still opt-in at API 36, so SiloCast/pairing NSD does not require a new runtime permission for this target update.
- No temporary Android 16 compatibility opt-outs were added.

## Validation

- `./gradlew :androidApp:testDebugUnitTest :androidTvApp:testDebugUnitTest`
- `./gradlew :androidApp:assembleDebug`
- `./gradlew :androidTvApp:assembleDebug`
- `./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx6g -Dfile.encoding=UTF-8" :androidApp:bundleRelease`
- `./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx6g -Dfile.encoding=UTF-8" :androidTvApp:bundleRelease`
- release merged manifests verified as `minSdkVersion=24`, `targetSdkVersion=36`
- focused orientation policy coverage for Android 15/16, phone, tablet, and future API behavior
- Android TV 16 AVD installed package reported `minSdk=24`, `targetSdk=36`; runtime Back checks covered Movies content → tab focus → Home, filter values → filter list → close, and player error → item detail, with no crashes or ANRs
- `:androidTvApp:lintDebug` passed. The standalone phone `lintDebug` task still reports its existing eight unrelated errors (notification permission check, Media3 opt-ins, and restricted media-router API); release lint-vital passes in the bundle build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated Android mobile, TV, and baseline profile builds to target Android API 36.
  * Refined player orientation-lock controls to reflect support, improve accessibility messaging, and disable the action on Android 16+ large screens.
  * Improved Android TV back navigation for filters, pickers, panels, menus, search, and nested routes, while retaining legacy keyboard and remote controls.
* **Tests**
  * Updated Android API targeting checks and added orientation-lock support coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->