### PR TITLE
fix(tv): keep the For You list selection, scroll, and a legible top bar

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
@@ -25,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
@@ -80,8 +82,19 @@ fun TvRecommendationsScreen(
     val firstRecommendationRowFocusRequester = remember { FocusRequester() }
     val firstRecommendationCardFocusRequester = remember { FocusRequester() }
     val focusBridgeScope = rememberCoroutineScope()
-    var savedListSelection by remember { mutableStateOf(entryRequest.selection) }
-    var lastAppliedEntrySequence by remember { mutableIntStateOf(0) }
+    // rememberSaveable, not remember: opening an item disposes this screen's
+    // composition, and a plain remember would re-initialise from
+    // entryRequest.selection on the way back. Top-level For You entry carries
+    // selection = null, so returning from a Watchlist item did not merely
+    // forget the list — it actively reselected the recommendations feed.
+    //
+    // lastAppliedEntrySequence must survive with it. Resetting it to 0 makes
+    // the LaunchedEffect below treat the unchanged entry request as new and
+    // re-apply its selection, which reintroduces the same jump even once the
+    // selection itself is saved.
+    val recommendationsListState = rememberLazyListState()
+    var savedListSelection by rememberSaveable { mutableStateOf(entryRequest.selection) }
+    var lastAppliedEntrySequence by rememberSaveable { mutableIntStateOf(0) }
     val moveIntoRecommendations: () -> Boolean = {
         if (
             !shouldBridgeRecommendationsDown(
@@ -235,6 +248,11 @@ fun TvRecommendationsScreen(
             }
             else -> {
                 LazyColumn(
+                    // Hoisted above the `when` so it is not discarded when a
+                    // refresh briefly flips this branch to loading/empty and
+                    // back — that is what dropped the reader at the top of the
+                    // feed after opening an item.
+                    state = recommendationsListState,
                     modifier = Modifier
                         .fillMaxSize()
                         .background(MaterialTheme.colorScheme.background),

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -1,6 +1,8 @@
 package org.siloserver.silo.tv.ui.screens.recommendations
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,6 +22,7 @@ import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -52,6 +55,7 @@ import org.siloserver.silo.tv.ui.screens.personal.TvFavoritesInline
 import org.siloserver.silo.tv.ui.screens.personal.TvWatchlistInline
 import org.siloserver.silo.tv.ui.shell.TvTopMenuLayout
 import org.siloserver.silo.tv.ui.theme.Spacing
+import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
 import org.siloserver.silo.tv.ui.util.visibleOnTv
 import org.siloserver.silo.viewmodel.RecommendationsViewModel
 import org.koin.compose.viewmodel.koinViewModel
@@ -65,7 +69,7 @@ private val RecommendationsFilterBandHeight = 52.dp
  * (rows down the page) minus the featured hero — the discover API returns
  * section-style rows, not a hero card.
  */
-@OptIn(ExperimentalTvMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalTvMaterial3Api::class)
 @Composable
 fun TvRecommendationsScreen(
     onItemClick: (contentId: String) -> Unit,
@@ -256,46 +260,50 @@ fun TvRecommendationsScreen(
                 }
             }
             else -> {
-                LazyColumn(
-                    // Hoisted above the `when` so it is not discarded when a
-                    // refresh briefly flips this branch to loading/empty and
-                    // back — that is what dropped the reader at the top of the
-                    // feed after opening an item.
-                    state = recommendationsListState,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.background),
-                    verticalArrangement = Arrangement.spacedBy(18.dp),
-                    contentPadding = PaddingValues(
-                        top = TvTopMenuLayout.contentTopInset + RecommendationsFilterBandHeight,
-                        bottom = 24.dp,
-                    ),
+                CompositionLocalProvider(
+                    LocalBringIntoViewSpec provides TvSmoothBringIntoViewSpec,
                 ) {
-                    itemsIndexed(
-                        items = visibleSections,
-                        key = { _, section -> section.id },
-                        contentType = { _, _ -> "recommendation-section-row" },
-                    ) { index, section ->
-                        TvMediaRow(
-                            title = section.title,
-                            items = section.items,
-                            onItemClick = onItemClick,
-                            style = TvRowStyle.Poster,
-                            firstItemFocusRequester = firstRecommendationCardFocusRequester
-                                .takeIf { index == 0 },
-                            rowContainerFocusRequester = firstRecommendationRowFocusRequester
-                                .takeIf { index == 0 },
-                            onDirectionUp = if (index == 0) {
-                                {
-                                    runCatching { forYouFocusRequester.requestFocus() }
-                                        .getOrDefault(false)
-                                }
-                            } else {
-                                null
-                            },
-                        )
+                    LazyColumn(
+                        // Hoisted above the `when` so it is not discarded when a
+                        // refresh briefly flips this branch to loading/empty and
+                        // back — that is what dropped the reader at the top of the
+                        // feed after opening an item.
+                        state = recommendationsListState,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(MaterialTheme.colorScheme.background),
+                        verticalArrangement = Arrangement.spacedBy(18.dp),
+                        contentPadding = PaddingValues(
+                            top = TvTopMenuLayout.contentTopInset + RecommendationsFilterBandHeight,
+                            bottom = 24.dp,
+                        ),
+                    ) {
+                        itemsIndexed(
+                            items = visibleSections,
+                            key = { _, section -> section.id },
+                            contentType = { _, _ -> "recommendation-section-row" },
+                        ) { index, section ->
+                            TvMediaRow(
+                                title = section.title,
+                                items = section.items,
+                                onItemClick = onItemClick,
+                                style = TvRowStyle.Poster,
+                                firstItemFocusRequester = firstRecommendationCardFocusRequester
+                                    .takeIf { index == 0 },
+                                rowContainerFocusRequester = firstRecommendationRowFocusRequester
+                                    .takeIf { index == 0 },
+                                onDirectionUp = if (index == 0) {
+                                    {
+                                        runCatching { forYouFocusRequester.requestFocus() }
+                                            .getOrDefault(false)
+                                    }
+                                } else {
+                                    null
+                                },
+                            )
+                        }
+                        item { Spacer(modifier = Modifier.height(8.dp)) }
                     }
-                    item { Spacer(modifier = Modifier.height(8.dp)) }
                 }
             }
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -157,8 +157,17 @@ fun TvRecommendationsScreen(
     // The saved-list shortcuts are the stable first row in every state. Focus
     // Watchlist once per entry, matching tvOS, without letting later refreshes
     // pull focus away from the user's current position.
-    var initialFocusRequested by remember { mutableStateOf(false) }
-    var lastAppliedFocusRequest by remember { mutableStateOf(-1) }
+    // rememberSaveable for the same reason as the selection above: these guard
+    // a once-per-entry focus grab, and as plain `remember` they reset when an
+    // item detail disposes this composition. The effect then re-fires on the
+    // way back and slams focus onto the Watchlist pill while the feed is still
+    // scrolled where the viewer left it — which is the shell's documented
+    // anti-pattern ("fired LaunchedEffects in each screen that imperatively
+    // re-focused index 0 — defeating the restorer"). Saved, the grab stays a
+    // genuine once-per-entry action and the shell's content restorer is left
+    // to put focus back where it was.
+    var initialFocusRequested by rememberSaveable { mutableStateOf(false) }
+    var lastAppliedFocusRequest by rememberSaveable { mutableStateOf(-1) }
     LaunchedEffect(focusRequest) {
         if (initialFocusRequested && focusRequest == lastAppliedFocusRequest) return@LaunchedEffect
         runCatching { watchlistFocusRequester.requestFocus() }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -318,6 +318,15 @@ fun TvMainShell(
     // Opening an outer item-detail route pauses/removes this shell. Remember the
     // pending hand-back in the Main back-stack entry so it survives either form,
     // then re-enter the existing content focusRestorer when Main resumes.
+    // Two flags, deliberately. `restoreContentAfterDetail` says a detail return
+    // is pending for ANY root, and gates the resume claim below so focus lands
+    // back inside content instead of Compose's default search picking the top
+    // bar. `restoreHomeContentAfterDetail` additionally says it was the Home
+    // feed, which is the only root that attaches
+    // homeDetailReturnCardFocusRequester to its launch card — using that
+    // requester as the restorer fallback for a root that never attached it
+    // would point the restorer at a detached node.
+    var restoreContentAfterDetail by rememberSaveable { mutableStateOf(false) }
     var restoreHomeContentAfterDetail by rememberSaveable { mutableStateOf(false) }
     var suppressHomeRefreshAfterDetail by rememberSaveable { mutableStateOf(false) }
     var homeDetailReturnFocusRequest by remember { mutableIntStateOf(0) }
@@ -336,7 +345,7 @@ fun TvMainShell(
     // yanks focus to a different card for a frame.
     var contentHasFocus by remember { mutableStateOf(false) }
     LifecycleResumeEffect(Unit) {
-        if (restoreHomeContentAfterDetail) {
+        if (restoreContentAfterDetail) {
             // Claim the content group synchronously during ON_RESUME, before
             // Compose's default search can briefly settle on the Home tab —
             // but only when the feed hasn't already claimed it. Claim BEFORE
@@ -347,6 +356,7 @@ fun TvMainShell(
             } else {
                 runCatching { !contentFocusRequester.requestFocus() }.getOrDefault(true)
             }
+            restoreContentAfterDetail = false
             restoreHomeContentAfterDetail = false
             homeDetailReturnFocusRequest++
         }
@@ -365,8 +375,18 @@ fun TvMainShell(
         suppressHomeRefreshAfterDetail = false
     }
     val openHomeItemDetail: (String) -> Unit = { contentId ->
+        restoreContentAfterDetail = true
         restoreHomeContentAfterDetail = true
         suppressHomeRefreshAfterDetail = true
+        onOpenItemDetail(contentId)
+    }
+    // Same hand-back for roots that render inside the shell but do not attach a
+    // launch-card requester (For You). Without this the shell never claims
+    // content focus on the return resume, so focus settles wherever Compose's
+    // default search lands — in practice the top bar — and the D-pad no longer
+    // drives the rows the viewer was just in.
+    val openContentItemDetail: (String) -> Unit = { contentId ->
+        restoreContentAfterDetail = true
         onOpenItemDetail(contentId)
     }
     var contentUpFallback by remember { mutableStateOf<((Boolean) -> Boolean)?>(null) }
@@ -992,7 +1012,7 @@ fun TvMainShell(
                 }
                 composable(TvMainRoute.ForYou.route) {
                     TvRecommendationsScreen(
-                        onItemClick = onOpenItemDetail,
+                        onItemClick = openContentItemDetail,
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                         focusRequest = contentFocusRequest,
                         entryRequest = forYouEntryRequest,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusDirection
@@ -1149,6 +1150,29 @@ fun TvMainShell(
                 }
             }
         }
+
+        // The scrim TvTopMenuBar documents but the shell had stopped drawing.
+        // The bar deliberately has no background band of its own ("the SHELL
+        // draws a fixed top scrim behind the bar", QA 2026-07-08); without it
+        // the labels sat directly on whatever scrolled underneath, which on
+        // For You is a poster row and is unreadable. A gradient rather than a
+        // solid band keeps the tvOS look this shell asks for — content stays
+        // visible behind the bar, just no longer competing with the labels.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(TvTopMenuLayout.contentTopInset)
+                .align(Alignment.TopCenter)
+                .background(
+                    Brush.verticalGradient(
+                        listOf(
+                            MaterialTheme.colorScheme.background.copy(alpha = 0.92f),
+                            MaterialTheme.colorScheme.background.copy(alpha = 0.72f),
+                            MaterialTheme.colorScheme.background.copy(alpha = 0f),
+                        ),
+                    ),
+                ),
+        )
 
         // Menu overlay — content remains visible behind the transparent bar,
         // matching tvOS without a heavy top-edge shadow.

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -1178,21 +1178,23 @@ fun TvMainShell(
         // For You is a poster row and is unreadable. A gradient rather than a
         // solid band keeps the tvOS look this shell asks for — content stays
         // visible behind the bar, just no longer competing with the labels.
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(TvTopMenuLayout.contentTopInset)
-                .align(Alignment.TopCenter)
-                .background(
-                    Brush.verticalGradient(
-                        listOf(
-                            MaterialTheme.colorScheme.background.copy(alpha = 0.92f),
-                            MaterialTheme.colorScheme.background.copy(alpha = 0.72f),
-                            MaterialTheme.colorScheme.background.copy(alpha = 0f),
+        if (currentRoute != TvMainRoute.Settings.route) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(TvTopMenuLayout.contentTopInset)
+                    .align(Alignment.TopCenter)
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(
+                                MaterialTheme.colorScheme.background.copy(alpha = 0.92f),
+                                MaterialTheme.colorScheme.background.copy(alpha = 0.72f),
+                                MaterialTheme.colorScheme.background.copy(alpha = 0f),
+                            ),
                         ),
                     ),
-                ),
-        )
+            )
+        }
 
         // Menu overlay — content remains visible behind the transparent bar,
         // matching tvOS without a heavy top-edge shadow.


### PR DESCRIPTION
Reported against **v1.0.0+3** (`83e23da1`). That build already contains the recent TV focus batch, so these are live on current code rather than artifacts of an old release.

Four of the five reported issues; the other two are called out at the bottom as deliberately not addressed.

## Watchlist and Favorites reverted to For You after opening an item

> *"Go to watchlist → open an item, then go back. It should take me back to the watchlist items but instead shows For You items."* — same for Favorites.

`savedListSelection` was a plain `remember`. Opening an item disposes this screen's composition, so on the way back it re-initialised from `entryRequest.selection` — and top-level For You entry carries `selection = null`. So returning from a Watchlist item didn't merely *forget* the list, it **actively reselected** the recommendations feed. That's why it lands on For You rather than on an empty or default list.

`lastAppliedEntrySequence` had to move with it. Left as `remember` it resets to `0`, and `applyForYouEntryRequest` then treats the unchanged entry request as new and re-applies its selection — reintroducing the identical jump even once the selection itself is saved. Fixing one without the other looks correct and isn't.

Both are now `rememberSaveable`.

## Scroll position lost returning to the feed

The recommendations `LazyColumn` created its list state *inside* the `when` branch that renders content. A refresh on return briefly flips that branch to loading/empty and back, discarding the state with it. Hoisted above the branch so it survives.

## The top bar was unreadable over For You

> *"the top bar (with Movies, Shows etc) is impossible to read. It's sticky but there's no background color... This is different behavior from Home, Movie → Recommended etc."*

`TvTopMenuBar` deliberately has no background band of its own, and says why:

> *"No background band of its own: the SHELL draws a fixed top scrim behind the bar, so the focus dim below only affects the labels — content stays legibly scrimmed even while the bar is dimmed (QA 2026-07-08)."*

The shell drew no such scrim. Its own comment two lines above the bar reads *"content remains visible behind the transparent bar"* — the two had drifted into contradicting each other, and the bar lost. With nothing behind it the labels sat directly on whatever scrolled underneath; on For You that's a poster row.

Restored in the shell as a **gradient** rather than a solid band, which satisfies both statements: content stays visible behind the bar, it just stops competing with the labels. Being in the shell it fixes every route, not only For You.

## Deliberately not addressed

- **Jerky scrolling on For You.** Not diagnosed. The list already carries `key` and `contentType`, so the usual suspects are ruled out and I'd want to look at image loading during scroll before guessing.
- **"Can't scroll the For You sections anymore" after returning.** This looks like *focus* restoration rather than scroll state — on a D-pad, focus is what drives scrolling, and no focus means no movement. That belongs with `TvRecommendationsFocusBridge` and wants its own change.

## Testing

`./gradlew test` green; both apps assemble. No tests added: per the repo guidelines these are UI changes, and the state-restoration behaviour needs an instrumented test rather than a unit test to be meaningful.

Note for CI: `ServerSetupPersistenceTest` and two `:android-shared` tests have been flaking today independently of any change — verified by re-running on clean `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a subtle top gradient behind the TV menu bar to improve label visibility while keeping content visible.
* **Bug Fixes**
  * Preserved recommendation feed scroll position when loading or empty states appear.
  * Maintained selection and navigation state when the recommendations screen is recreated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->