### PR TITLE
fix(tv): improve Fire TV selection and episode continuity

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt
@@ -1,0 +1,238 @@
+package org.siloserver.silo.common.player.video
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.siloserver.silo.common.player.normalizedSubtitleCodecFamily
+import org.siloserver.silo.common.player.subtitleLabelIndicatesHearingImpaired
+import org.siloserver.silo.model.catalog.FileVersion
+import org.siloserver.silo.model.playback.PlayerSubtitleInfo
+import org.siloserver.silo.player.DolbyVisionDetection
+import org.siloserver.silo.playback.canonicalSubtitleLanguage
+
+/**
+ * Session-only, cross-episode playback intent. It deliberately carries no
+ * episode-local identity: target IDs and subtitle indexes are resolved only
+ * after the next episode's catalog detail is available.
+ */
+@Serializable
+data class EpisodeSelectionHandoff(
+    val source: EpisodeSourceIntent? = null,
+    val subtitle: EpisodeSubtitleIntent = EpisodeSubtitleIntent.auto(),
+)
+
+@Serializable
+data class EpisodeSourceIntent(
+    val resolution: String,
+    val videoCodec: String? = null,
+    val dynamicRange: EpisodeDynamicRange? = null,
+    val container: String? = null,
+)
+
+@Serializable
+enum class EpisodeDynamicRange { SDR, HDR, DOLBY_VISION }
+
+@Serializable
+enum class EpisodeSubtitleMode { AUTO, OFF, TRACK }
+
+@Serializable
+data class EpisodeSubtitleIntent(
+    val mode: EpisodeSubtitleMode,
+    val language: String? = null,
+    val codecFamily: String? = null,
+    val forced: Boolean? = null,
+    val hearingImpaired: Boolean? = null,
+    val external: Boolean? = null,
+) {
+    companion object {
+        fun auto() = EpisodeSubtitleIntent(EpisodeSubtitleMode.AUTO)
+        fun off() = EpisodeSubtitleIntent(EpisodeSubtitleMode.OFF)
+    }
+}
+
+data class ResolvedEpisodeSubtitle(
+    val trackIndex: Int?,
+    val intentSpecified: Boolean,
+)
+
+data class ResolvedEpisodeSelection(
+    val fileId: Int?,
+    val subtitleTrackIndex: Int?,
+    val subtitleIntentSpecified: Boolean,
+)
+
+fun captureEpisodeSourceIntent(version: FileVersion?): EpisodeSourceIntent? {
+    val version = version ?: return null
+    val resolution = normalizedEpisodeResolution(
+        version.resolution ?: version.videoTracks?.firstOrNull()?.resolution,
+    ) ?: return null
+    return EpisodeSourceIntent(
+        resolution = resolution,
+        videoCodec = normalizedEpisodeToken(
+            version.codecVideo ?: version.videoTracks?.firstOrNull()?.codec,
+        ),
+        dynamicRange = version.episodeDynamicRange(),
+        container = normalizedEpisodeToken(version.container),
+    )
+}
+
+fun captureEpisodeSubtitleIntent(
+    selectedTrackIndex: Int?,
+    subtitles: List<PlayerSubtitleInfo>,
+): EpisodeSubtitleIntent = when (selectedTrackIndex) {
+    null -> EpisodeSubtitleIntent.auto()
+    -1 -> EpisodeSubtitleIntent.off()
+    else -> subtitles
+        .singleOrNull { it.index == selectedTrackIndex }
+        ?.toEpisodeSubtitleIntent()
+        ?: EpisodeSubtitleIntent.auto()
+}
+
+fun resolveEpisodeSourceIntent(
+    intent: EpisodeSourceIntent?,
+    targetVersions: List<FileVersion>,
+): Int? {
+    val intent = intent ?: return null
+    val candidates = targetVersions.filter {
+        normalizedEpisodeResolution(it.resolution ?: it.videoTracks?.firstOrNull()?.resolution) == intent.resolution
+    }
+    if (candidates.isEmpty()) return null
+
+    val highestScore = candidates.maxOf { candidate ->
+        candidate.episodeSourceScore(intent)
+    }
+    return candidates
+        .filter { it.episodeSourceScore(intent) == highestScore }
+        .singleOrNull()
+        ?.fileId
+}
+
+fun resolveEpisodeSubtitleIntent(
+    intent: EpisodeSubtitleIntent,
+    targetSubtitles: List<PlayerSubtitleInfo>,
+): ResolvedEpisodeSubtitle = when (intent.mode) {
+    EpisodeSubtitleMode.AUTO -> ResolvedEpisodeSubtitle(
+        trackIndex = null,
+        intentSpecified = false,
+    )
+    EpisodeSubtitleMode.OFF -> ResolvedEpisodeSubtitle(
+        trackIndex = -1,
+        intentSpecified = true,
+    )
+    EpisodeSubtitleMode.TRACK -> ResolvedEpisodeSubtitle(
+        trackIndex = targetSubtitles
+            .filter { it.matchesEpisodeSubtitleIntent(intent) }
+            .singleOrNull()
+            ?.index,
+        intentSpecified = true,
+    )
+}
+
+fun resolveEpisodeSelectionHandoff(
+    handoff: EpisodeSelectionHandoff?,
+    targetVersions: List<FileVersion>,
+    targetSubtitles: List<PlayerSubtitleInfo>,
+): ResolvedEpisodeSelection {
+    val subtitle = resolveEpisodeSubtitleIntent(
+        handoff?.subtitle ?: EpisodeSubtitleIntent.auto(),
+        targetSubtitles,
+    )
+    return ResolvedEpisodeSelection(
+        fileId = resolveEpisodeSourceIntent(handoff?.source, targetVersions),
+        subtitleTrackIndex = subtitle.trackIndex,
+        subtitleIntentSpecified = subtitle.intentSpecified,
+    )
+}
+
+fun encodeEpisodeSelectionHandoff(handoff: EpisodeSelectionHandoff): String =
+    episodeSelectionHandoffJson.encodeToString(handoff)
+
+fun decodeEpisodeSelectionHandoff(value: String?): EpisodeSelectionHandoff? =
+    value?.takeIf { it.isNotBlank() }?.let { encoded ->
+        runCatching { episodeSelectionHandoffJson.decodeFromString<EpisodeSelectionHandoff>(encoded) }
+            .getOrNull()
+    }
+
+private fun FileVersion.episodeSourceScore(intent: EpisodeSourceIntent): Int {
+    var score = 0
+    if (
+        intent.videoCodec != null &&
+        normalizedEpisodeToken(codecVideo ?: videoTracks?.firstOrNull()?.codec) == intent.videoCodec
+    ) {
+        score++
+    }
+    if (intent.dynamicRange != null && episodeDynamicRange() == intent.dynamicRange) score++
+    if (intent.container != null && normalizedEpisodeToken(container) == intent.container) score++
+    return score
+}
+
+private fun FileVersion.episodeDynamicRange(): EpisodeDynamicRange {
+    val tracks = videoTracks.orEmpty()
+    val isDolbyVision = tracks.any { track ->
+        DolbyVisionDetection.isDolbyVision(
+            dolbyVisionProfile = track.dolbyVisionProfile,
+            hdrFormat = track.hdrFormat,
+            videoCodec = track.codec,
+        )
+    } || DolbyVisionDetection.isDolbyVision(videoCodec = codecVideo)
+    return when {
+        isDolbyVision -> EpisodeDynamicRange.DOLBY_VISION
+        hdr || tracks.any { it.hdr } -> EpisodeDynamicRange.HDR
+        else -> EpisodeDynamicRange.SDR
+    }
+}
+
+private fun PlayerSubtitleInfo.toEpisodeSubtitleIntent(): EpisodeSubtitleIntent = EpisodeSubtitleIntent(
+    mode = EpisodeSubtitleMode.TRACK,
+    language = canonicalSubtitleLanguage(language),
+    codecFamily = normalizedSubtitleCodecFamily(codec),
+    forced = forced,
+    hearingImpaired = subtitleLabelIndicatesHearingImpaired(catalogLabel ?: label),
+    external = episodeSubtitleExternal(),
+)
+
+private fun PlayerSubtitleInfo.matchesEpisodeSubtitleIntent(intent: EpisodeSubtitleIntent): Boolean =
+    (intent.language == null || canonicalSubtitleLanguage(language) == intent.language) &&
+        (intent.codecFamily == null || normalizedSubtitleCodecFamily(codec) == intent.codecFamily) &&
+        (intent.forced == null || forced == intent.forced) &&
+        (intent.hearingImpaired == null || episodeSubtitleHearingImpaired() == intent.hearingImpaired) &&
+        (intent.external == null || episodeSubtitleExternal() == intent.external)
+
+private fun PlayerSubtitleInfo.episodeSubtitleHearingImpaired(): Boolean =
+    subtitleLabelIndicatesHearingImpaired(catalogLabel ?: label)
+
+private fun PlayerSubtitleInfo.episodeSubtitleExternal(): Boolean? = when (
+    (catalogSource ?: source)?.trim()?.lowercase()
+) {
+    "embedded" -> false
+    "external", "downloaded" -> true
+    else -> null
+}
+
+private fun normalizedEpisodeResolution(value: String?): String? {
+    val normalized = value?.trim()?.lowercase()?.takeIf { it.isNotEmpty() } ?: return null
+    return when {
+        normalized.contains("4320") || normalized.contains("8k") -> "4320p"
+        normalized.contains("2160") || normalized.contains("4k") || normalized.contains("uhd") -> "2160p"
+        normalized.contains("1440") || normalized.contains("qhd") -> "1440p"
+        normalized.contains("1080") || normalized.contains("fhd") -> "1080p"
+        normalized.contains("720") || normalized.contains("hd") -> "720p"
+        normalized.contains("576") -> "576p"
+        normalized.contains("480") || normalized.contains("sd") -> "480p"
+        else -> normalized
+    }
+}
+
+private fun normalizedEpisodeToken(value: String?): String? =
+    value
+        ?.trim()
+        ?.lowercase()
+        ?.filter(Char::isLetterOrDigit)
+        ?.takeIf { it.isNotEmpty() }
+
+private val episodeSelectionHandoffJson = Json {
+    encodeDefaults = false
+    explicitNulls = false
+    ignoreUnknownKeys = true
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt
@@ -99,11 +99,14 @@ fun resolveEpisodeSourceIntent(
     }
     if (candidates.isEmpty()) return null
 
-    val highestScore = candidates.maxOf { candidate ->
-        candidate.episodeSourceScore(intent)
-    }
+    val priority = compareBy<FileVersion>(
+        { it.matchesEpisodeVideoCodec(intent) },
+        { it.matchesEpisodeDynamicRange(intent) },
+        { it.matchesEpisodeContainer(intent) },
+    )
+    val best = candidates.maxWithOrNull(priority) ?: return null
     return candidates
-        .filter { it.episodeSourceScore(intent) == highestScore }
+        .filter { priority.compare(it, best) == 0 }
         .singleOrNull()
         ?.fileId
 }
@@ -154,18 +157,15 @@ fun decodeEpisodeSelectionHandoff(value: String?): EpisodeSelectionHandoff? =
             .getOrNull()
     }
 
-private fun FileVersion.episodeSourceScore(intent: EpisodeSourceIntent): Int {
-    var score = 0
-    if (
-        intent.videoCodec != null &&
+private fun FileVersion.matchesEpisodeVideoCodec(intent: EpisodeSourceIntent): Boolean =
+    intent.videoCodec != null &&
         normalizedEpisodeToken(codecVideo ?: videoTracks?.firstOrNull()?.codec) == intent.videoCodec
-    ) {
-        score++
-    }
-    if (intent.dynamicRange != null && episodeDynamicRange() == intent.dynamicRange) score++
-    if (intent.container != null && normalizedEpisodeToken(container) == intent.container) score++
-    return score
-}
+
+private fun FileVersion.matchesEpisodeDynamicRange(intent: EpisodeSourceIntent): Boolean =
+    intent.dynamicRange != null && episodeDynamicRange() == intent.dynamicRange
+
+private fun FileVersion.matchesEpisodeContainer(intent: EpisodeSourceIntent): Boolean =
+    intent.container != null && normalizedEpisodeToken(container) == intent.container
 
 private fun FileVersion.episodeDynamicRange(): EpisodeDynamicRange {
     val tracks = videoTracks.orEmpty()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt
@@ -125,9 +125,16 @@ fun resolveEpisodeSubtitleIntent(
     )
     EpisodeSubtitleMode.TRACK -> ResolvedEpisodeSubtitle(
         trackIndex = targetSubtitles
-            .filter { it.matchesEpisodeSubtitleIntent(intent) }
-            .singleOrNull()
-            ?.index,
+            .map { track -> EpisodeSubtitleMatch(track, track.episodeSubtitleMatchScore(intent)) }
+            .filter { it.score.isMeaningfulFor(intent) }
+            .let { matches ->
+                val best = matches.maxWithOrNull(episodeSubtitleMatchComparator) ?: return@let null
+                matches
+                    .filter { episodeSubtitleMatchComparator.compare(it, best) == 0 }
+                    .singleOrNull()
+                    ?.track
+                    ?.index
+            },
         intentSpecified = true,
     )
 }
@@ -192,12 +199,44 @@ private fun PlayerSubtitleInfo.toEpisodeSubtitleIntent(): EpisodeSubtitleIntent 
     external = episodeSubtitleExternal(),
 )
 
-private fun PlayerSubtitleInfo.matchesEpisodeSubtitleIntent(intent: EpisodeSubtitleIntent): Boolean =
-    (intent.language == null || canonicalSubtitleLanguage(language) == intent.language) &&
-        (intent.codecFamily == null || normalizedSubtitleCodecFamily(codec) == intent.codecFamily) &&
-        (intent.forced == null || forced == intent.forced) &&
-        (intent.hearingImpaired == null || episodeSubtitleHearingImpaired() == intent.hearingImpaired) &&
-        (intent.external == null || episodeSubtitleExternal() == intent.external)
+private data class EpisodeSubtitleMatch(
+    val track: PlayerSubtitleInfo,
+    val score: EpisodeSubtitleMatchScore,
+)
+
+private data class EpisodeSubtitleMatchScore(
+    val language: Boolean,
+    val forced: Boolean,
+    val hearingImpaired: Boolean,
+    val external: Boolean,
+    val codecFamily: Boolean,
+) {
+    fun isMeaningfulFor(intent: EpisodeSubtitleIntent): Boolean = when {
+        intent.language != null -> language
+        intent.forced == true -> forced
+        intent.hearingImpaired == true -> hearingImpaired
+        else -> external || codecFamily
+    }
+}
+
+private val episodeSubtitleMatchComparator = compareBy<EpisodeSubtitleMatch>(
+    { it.score.language },
+    { it.score.forced },
+    { it.score.hearingImpaired },
+    { it.score.external },
+    { it.score.codecFamily },
+)
+
+private fun PlayerSubtitleInfo.episodeSubtitleMatchScore(
+    intent: EpisodeSubtitleIntent,
+): EpisodeSubtitleMatchScore = EpisodeSubtitleMatchScore(
+    language = intent.language != null && canonicalSubtitleLanguage(language) == intent.language,
+    forced = intent.forced != null && forced == intent.forced,
+    hearingImpaired = intent.hearingImpaired != null &&
+        episodeSubtitleHearingImpaired() == intent.hearingImpaired,
+    external = intent.external != null && episodeSubtitleExternal() == intent.external,
+    codecFamily = intent.codecFamily != null && normalizedSubtitleCodecFamily(codec) == intent.codecFamily,
+)
 
 private fun PlayerSubtitleInfo.episodeSubtitleHearingImpaired(): Boolean =
     subtitleLabelIndicatesHearingImpaired(catalogLabel ?: label)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackSessionCoordinator.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackSessionCoordinator.kt
@@ -46,6 +46,7 @@ class VideoPlaybackSessionCoordinator(
                     seriesId = result.seriesId,
                     seasonNumber = result.seasonNumber,
                     episodeNumber = result.episodeNumber,
+                    resolvedEpisodeSelection = result.resolvedEpisodeSelection,
                 )
             }
             is VideoPlaybackStartResult.Error -> {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartRequest.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartRequest.kt
@@ -29,4 +29,9 @@ data class VideoPlaybackStartRequest(
      * unreachable (issue #33). Default false = the gate applies.
      */
     val force: Boolean = false,
+    /**
+     * Session-only intent captured from the preceding episode. TV resolves it
+     * against this request's target catalog only after loading its watch detail.
+     */
+    val episodeSelectionHandoff: EpisodeSelectionHandoff? = null,
 )

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResult.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResult.kt
@@ -50,6 +50,8 @@ sealed interface VideoPlaybackStartResult {
         val seriesId: String? = null,
         val seasonNumber: Int? = null,
         val episodeNumber: Int? = null,
+        /** TV's target-catalog resolution of [VideoPlaybackStartRequest.episodeSelectionHandoff]. */
+        val resolvedEpisodeSelection: ResolvedEpisodeSelection? = null,
     ) : VideoPlaybackStartResult
 
     data class Error(

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlayerUiState.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlayerUiState.kt
@@ -76,6 +76,8 @@ sealed interface VideoPlayerUiState {
         val seriesId: String? = null,
         val seasonNumber: Int? = null,
         val episodeNumber: Int? = null,
+        /** Target-catalog decision for the one-shot episode-selection handoff. */
+        val resolvedEpisodeSelection: ResolvedEpisodeSelection? = null,
     ) : VideoPlayerUiState {
         override val hasPlayableMedia: Boolean = true
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoffTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoffTest.kt
@@ -161,6 +161,100 @@ class EpisodeSelectionHandoffTest {
     }
 
     @Test
+    fun explicitSubtitleKeepsLanguageAndAccessibilityWhenFormatAndSourceChange() {
+        val intent = captureEpisodeSubtitleIntent(
+            selectedTrackIndex = 7,
+            subtitles = listOf(
+                subtitle(7, "en", "srt", "English SDH", "external", forced = false),
+            ),
+        )
+
+        val resolved = resolveEpisodeSubtitleIntent(
+            intent,
+            targetSubtitles = listOf(
+                subtitle(12, "eng", "webvtt", "English SDH", "embedded", forced = false),
+            ),
+        )
+
+        assertEquals(12, resolved.trackIndex)
+        assertTrue(resolved.intentSpecified)
+    }
+
+    @Test
+    fun subtitleLanguageOutranksFormatAndSourceKind() {
+        val intent = captureEpisodeSubtitleIntent(
+            selectedTrackIndex = 7,
+            subtitles = listOf(
+                subtitle(7, "en", "srt", "English", "external", forced = false),
+            ),
+        )
+
+        val resolved = resolveEpisodeSubtitleIntent(
+            intent,
+            targetSubtitles = listOf(
+                subtitle(2, "fr", "srt", "French", "external", forced = false),
+                subtitle(9, "eng", "webvtt", "English", "embedded", forced = false),
+            ),
+        )
+
+        assertEquals(9, resolved.trackIndex)
+    }
+
+    @Test
+    fun subtitleAccessibilityOutranksFormatAndSourceKind() {
+        val intent = captureEpisodeSubtitleIntent(
+            selectedTrackIndex = 7,
+            subtitles = listOf(
+                subtitle(7, "en", "srt", "English", "external", forced = false),
+            ),
+        )
+
+        val resolved = resolveEpisodeSubtitleIntent(
+            intent,
+            targetSubtitles = listOf(
+                subtitle(2, "en", "srt", "English SDH", "external", forced = false),
+                subtitle(9, "eng", "webvtt", "English", "embedded", forced = false),
+            ),
+        )
+
+        assertEquals(9, resolved.trackIndex)
+    }
+
+    @Test
+    fun ambiguousBestSubtitleUsesProfileAuto() {
+        val intent = captureEpisodeSubtitleIntent(
+            selectedTrackIndex = 7,
+            subtitles = listOf(
+                subtitle(7, "en", "srt", "English", "external", forced = false),
+            ),
+        )
+
+        val resolved = resolveEpisodeSubtitleIntent(
+            intent,
+            targetSubtitles = listOf(
+                subtitle(2, "eng", "srt", "English", "external", forced = false),
+                subtitle(9, "en", "srt", "English", "external", forced = false),
+            ),
+        )
+
+        assertNull(resolved.trackIndex)
+        assertTrue(resolved.intentSpecified)
+    }
+
+    @Test
+    fun underSpecifiedTrackIntentUsesProfileAuto() {
+        val resolved = resolveEpisodeSubtitleIntent(
+            EpisodeSubtitleIntent(mode = EpisodeSubtitleMode.TRACK),
+            targetSubtitles = listOf(
+                subtitle(2, "en", "srt", "English", "external", forced = false),
+            ),
+        )
+
+        assertNull(resolved.trackIndex)
+        assertTrue(resolved.intentSpecified)
+    }
+
+    @Test
     fun explicitNonSdhSubtitleDoesNotResolveToAnSdhTarget() {
         val intent = captureEpisodeSubtitleIntent(
             selectedTrackIndex = 7,

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoffTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoffTest.kt
@@ -53,6 +53,27 @@ class EpisodeSelectionHandoffTest {
     }
 
     @Test
+    fun sourceUsesCodecBeforeDynamicRangeAndContainerWhenCriteriaConflict() {
+        val source = version(
+            fileId = 101,
+            resolution = "2160p",
+            codec = "hevc",
+            hdr = true,
+            container = "mkv",
+            hdrFormat = "Dolby Vision",
+        )
+        val targets = listOf(
+            version(201, "2160p", "h264", hdr = true, container = "mkv", hdrFormat = "Dolby Vision"),
+            version(202, "2160p", "hevc", hdr = false, container = "mp4"),
+        )
+
+        assertEquals(
+            202,
+            resolveEpisodeSourceIntent(captureEpisodeSourceIntent(source), targets),
+        )
+    }
+
+    @Test
     fun ambiguousBestSourceFallsBackToAutomaticSelection() {
         val source = version(101, "2160p", "hevc", hdr = true, container = "mkv")
         val targets = listOf(

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoffTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoffTest.kt
@@ -1,0 +1,246 @@
+package org.siloserver.silo.common.player.video
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.siloserver.silo.model.catalog.FileVersion
+import org.siloserver.silo.model.catalog.VideoTrack
+import org.siloserver.silo.model.playback.PlayerSubtitleInfo
+
+class EpisodeSelectionHandoffTest {
+    @Test
+    fun sourceUsesResolutionBeforeCodecAndContainer() {
+        val source = version(
+            fileId = 101,
+            resolution = "2160p",
+            codec = "hevc",
+            hdr = true,
+            container = "mkv",
+        )
+        val targets = listOf(
+            version(201, "1080p", "hevc", hdr = true, container = "mkv"),
+            version(202, "2160p", "h264", hdr = false, container = "mp4"),
+        )
+
+        assertEquals(
+            202,
+            resolveEpisodeSourceIntent(captureEpisodeSourceIntent(source), targets),
+        )
+    }
+
+    @Test
+    fun sourceUsesCodecDynamicRangeAndContainerAsTieBreakers() {
+        val source = version(
+            fileId = 101,
+            resolution = "2160p",
+            codec = "hevc",
+            hdr = true,
+            container = "mkv",
+            hdrFormat = "Dolby Vision",
+        )
+        val targets = listOf(
+            version(201, "2160p", "hevc", hdr = true, container = "mp4", hdrFormat = "Dolby Vision"),
+            version(202, "2160p", "hevc", hdr = true, container = "mkv", hdrFormat = "Dolby Vision"),
+            version(203, "2160p", "h264", hdr = true, container = "mkv", hdrFormat = "HDR10"),
+        )
+
+        assertEquals(
+            202,
+            resolveEpisodeSourceIntent(captureEpisodeSourceIntent(source), targets),
+        )
+    }
+
+    @Test
+    fun ambiguousBestSourceFallsBackToAutomaticSelection() {
+        val source = version(101, "2160p", "hevc", hdr = true, container = "mkv")
+        val targets = listOf(
+            version(201, "2160p", "hevc", hdr = true, container = "mkv"),
+            version(202, "2160p", "hevc", hdr = true, container = "mkv"),
+        )
+
+        assertNull(resolveEpisodeSourceIntent(captureEpisodeSourceIntent(source), targets))
+    }
+
+    @Test
+    fun unavailableResolutionFallsBackToAutomaticSelection() {
+        val source = version(101, "2160p", "hevc", hdr = true, container = "mkv")
+        val targets = listOf(
+            version(201, "1080p", "hevc", hdr = true, container = "mkv"),
+            version(202, "720p", "hevc", hdr = true, container = "mkv"),
+        )
+
+        assertNull(resolveEpisodeSourceIntent(captureEpisodeSourceIntent(source), targets))
+    }
+
+    @Test
+    fun sourceIntentNeverSerializesTheOriginalFileId() {
+        val handoff = EpisodeSelectionHandoff(
+            source = captureEpisodeSourceIntent(
+                version(4242, "2160p", "hevc", hdr = true, container = "mkv").copy(
+                    fileName = "source-file-name.mkv",
+                    filePath = "/private/source-file-path.mkv",
+                ),
+            ),
+            subtitle = captureEpisodeSubtitleIntent(
+                selectedTrackIndex = 31,
+                subtitles = listOf(
+                    PlayerSubtitleInfo(
+                        index = 31,
+                        language = "en",
+                        codec = "srt",
+                        label = "English",
+                        source = "downloaded",
+                        url = "/private/source-subtitle.srt",
+                        downloadId = 3131,
+                        mediaTrackId = "source-media-track-id",
+                    ),
+                ),
+            ),
+        )
+
+        val encoded = encodeEpisodeSelectionHandoff(handoff)
+
+        assertFalse(encoded.contains("4242"))
+        assertFalse(encoded.contains("31"))
+        assertFalse(encoded.contains("3131"))
+        assertFalse(encoded.contains("source-file-name"))
+        assertFalse(encoded.contains("source-file-path"))
+        assertFalse(encoded.contains("source-subtitle"))
+        assertFalse(encoded.contains("source-media-track-id"))
+        assertTrue(encoded.contains("2160p"))
+    }
+
+    @Test
+    fun explicitSubtitleMatchesSemanticsAtADifferentTargetIndex() {
+        val intent = captureEpisodeSubtitleIntent(
+            selectedTrackIndex = 7,
+            subtitles = listOf(
+                subtitle(
+                    index = 7,
+                    language = "eng",
+                    codec = "application/x-subrip",
+                    label = "English SDH",
+                    source = "external",
+                    forced = false,
+                ),
+            ),
+        )
+        val resolved = resolveEpisodeSubtitleIntent(
+            intent = intent,
+            targetSubtitles = listOf(
+                subtitle(2, "en", "srt", "English SDH", "external", forced = false),
+                subtitle(9, "en", "srt", "English SDH", "embedded", forced = false),
+            ),
+        )
+
+        assertEquals(2, resolved.trackIndex)
+        assertTrue(resolved.intentSpecified)
+    }
+
+    @Test
+    fun explicitNonSdhSubtitleDoesNotResolveToAnSdhTarget() {
+        val intent = captureEpisodeSubtitleIntent(
+            selectedTrackIndex = 7,
+            subtitles = listOf(
+                subtitle(7, "en", "srt", "English", "external", forced = false),
+            ),
+        )
+
+        val resolved = resolveEpisodeSubtitleIntent(
+            intent,
+            targetSubtitles = listOf(
+                subtitle(2, "en", "srt", "English", "external", forced = false),
+                subtitle(9, "en", "srt", "English SDH", "external", forced = false),
+            ),
+        )
+
+        assertEquals(2, resolved.trackIndex)
+        assertTrue(resolved.intentSpecified)
+    }
+
+    @Test
+    fun explicitOffRemainsOff() {
+        val resolved = resolveEpisodeSubtitleIntent(
+            EpisodeSubtitleIntent.off(),
+            targetSubtitles = emptyList(),
+        )
+
+        assertEquals(-1, resolved.trackIndex)
+        assertTrue(resolved.intentSpecified)
+    }
+
+    @Test
+    fun automaticSubtitleRemainsUnspecified() {
+        val resolved = resolveEpisodeSubtitleIntent(
+            EpisodeSubtitleIntent.auto(),
+            targetSubtitles = emptyList(),
+        )
+
+        assertNull(resolved.trackIndex)
+        assertFalse(resolved.intentSpecified)
+    }
+
+    @Test
+    fun unavailableExplicitSubtitleUsesProfileAutoWithoutTargetDurableRestore() {
+        val resolved = resolveEpisodeSubtitleIntent(
+            EpisodeSubtitleIntent(
+                mode = EpisodeSubtitleMode.TRACK,
+                language = "nl",
+                codecFamily = "subrip",
+                external = true,
+            ),
+            targetSubtitles = listOf(
+                subtitle(4, "en", "srt", "English", "external", forced = false),
+            ),
+        )
+
+        assertNull(resolved.trackIndex)
+        assertTrue(resolved.intentSpecified)
+    }
+
+    @Test
+    fun malformedPayloadDecodesToNull() {
+        assertNull(decodeEpisodeSelectionHandoff("{not-json"))
+    }
+
+    private fun version(
+        fileId: Int,
+        resolution: String,
+        codec: String,
+        hdr: Boolean,
+        container: String,
+        hdrFormat: String? = null,
+    ) = FileVersion(
+        fileId = fileId,
+        resolution = resolution,
+        codecVideo = codec,
+        hdr = hdr,
+        container = container,
+        videoTracks = listOf(
+            VideoTrack(
+                codec = codec,
+                hdr = hdr,
+                hdrFormat = hdrFormat,
+            ),
+        ),
+    )
+
+    private fun subtitle(
+        index: Int,
+        language: String,
+        codec: String,
+        label: String,
+        source: String,
+        forced: Boolean,
+    ) = PlayerSubtitleInfo(
+        index = index,
+        language = language,
+        codec = codec,
+        label = label,
+        source = source,
+        forced = forced,
+        url = "/subtitles/$index",
+    )
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoffTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoffTest.kt
@@ -320,6 +320,24 @@ class EpisodeSelectionHandoffTest {
         assertNull(decodeEpisodeSelectionHandoff("{not-json"))
     }
 
+    @Test
+    fun encodedPayloadRoundTripsSemanticIntentAndRestoresAutoDefault() {
+        val handoff = EpisodeSelectionHandoff(
+            source = captureEpisodeSourceIntent(
+                version(101, "2160p", "hevc", hdr = true, container = "mkv"),
+            ),
+            subtitle = EpisodeSubtitleIntent(
+                mode = EpisodeSubtitleMode.TRACK,
+                language = "en",
+                codecFamily = "subrip",
+                external = true,
+            ),
+        )
+
+        assertEquals(handoff, decodeEpisodeSelectionHandoff(encodeEpisodeSelectionHandoff(handoff)))
+        assertEquals(EpisodeSubtitleIntent.auto(), decodeEpisodeSelectionHandoff("{}")?.subtitle)
+    }
+
     private fun version(
         fileId: Int,
         resolution: String,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -425,6 +425,8 @@ val androidTvModule = module {
             userItemState = getOrNull<org.siloserver.silo.repository.port.UserItemStatePort>()
                 ?: org.siloserver.silo.repository.port.NoOpUserItemStatePort,
             recommendationRepository = getOrNull(),
+            tokenManager = get(),
+            identityTransitions = get(),
         )
     }
     // Watch Together entry (create/join orchestration) — backs the entry +

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
@@ -157,12 +157,10 @@ fun TvAnchoredSelectorMenu(
             }
         }
 
-        // Known limitation: this is the phone Material3 DropdownMenu rather
-        // than a TV-native popup. Its items are focusable clickables, so d-pad
-        // up/down + OK work inside the popup, but it lacks the TV focus
-        // grammar (scale/border) of the rest of the module. A TV-styled
-        // anchored popup would need a bespoke Popup — deliberate deferral,
-        // audit 2026-07-20.
+        // Known limitation: this still uses the phone Material3 DropdownMenu
+        // rather than a TV-native popup. Rows provide explicit TV focus colors
+        // and borders below, while a fully TV-native anchored popup (including
+        // scale behavior) would require a bespoke Popup.
         DropdownMenu(
             expanded = interactive && expanded,
             onDismissRequest = {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
@@ -1,12 +1,18 @@
 package org.siloserver.silo.tv.ui.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -20,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.selected
@@ -54,6 +61,7 @@ import org.siloserver.silo.tv.ui.theme.SiloOnSurface
  *  [enabled] = false renders a non-selectable row (Apple's disabled "Unknown"
  *  audio fallback / unavailable subtitle entries). */
 data class TvSelectorOption(
+    val key: String,
     val title: String,
     val detail: String,
     val selected: Boolean,
@@ -168,13 +176,22 @@ fun TvAnchoredSelectorMenu(
             shadowElevation = 18.dp,
         ) {
             options.forEach { option ->
+                val interactionSource = remember(option.key) { MutableInteractionSource() }
+                val focused by interactionSource.collectIsFocusedAsState()
+                val visual = tvSelectorRowVisualState(focused, option.selected, option.enabled)
                 val labelText = if (option.detail.isBlank()) {
                     option.title
                 } else {
                     "${option.title} — ${option.detail}"
                 }
                 DropdownMenuItem(
-                    modifier = Modifier.semantics { this.selected = option.selected },
+                    interactionSource = interactionSource,
+                    modifier = Modifier
+                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(visual.container)
+                        .border(1.dp, visual.border, RoundedCornerShape(8.dp))
+                        .semantics { this.selected = option.selected },
                     enabled = option.enabled,
                     text = {
                         androidx.compose.material3.Text(
@@ -200,10 +217,10 @@ fun TvAnchoredSelectorMenu(
                         null
                     },
                     colors = MenuDefaults.itemColors(
-                        textColor = SiloOnSurface,
-                        leadingIconColor = SiloOnSurface,
-                        disabledTextColor = SiloOnSurface.copy(alpha = 0.38f),
-                        disabledLeadingIconColor = SiloOnSurface.copy(alpha = 0.38f),
+                        textColor = visual.content,
+                        leadingIconColor = visual.content,
+                        disabledTextColor = visual.content,
+                        disabledLeadingIconColor = visual.content,
                     ),
                     onClick = {
                         option.onSelect()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSelectorRowVisualState.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSelectorRowVisualState.kt
@@ -1,0 +1,36 @@
+package org.siloserver.silo.tv.ui.components
+
+import androidx.compose.ui.graphics.Color
+import org.siloserver.silo.tv.ui.theme.DarkSurfaceElevated
+import org.siloserver.silo.tv.ui.theme.FocusedContainer
+import org.siloserver.silo.tv.ui.theme.FocusedContent
+import org.siloserver.silo.tv.ui.theme.SiloOnSurface
+
+internal data class TvSelectorRowVisualState(
+    val container: Color,
+    val content: Color,
+    val border: Color,
+)
+
+internal fun tvSelectorRowVisualState(
+    focused: Boolean,
+    selected: Boolean,
+    enabled: Boolean,
+): TvSelectorRowVisualState = when {
+    !enabled -> TvSelectorRowVisualState(
+        DarkSurfaceElevated,
+        SiloOnSurface.copy(alpha = 0.38f),
+        Color.Transparent,
+    )
+    focused -> TvSelectorRowVisualState(
+        FocusedContainer,
+        FocusedContent,
+        FocusedContent.copy(alpha = 0.22f),
+    )
+    selected -> TvSelectorRowVisualState(
+        SiloOnSurface.copy(alpha = 0.14f),
+        SiloOnSurface,
+        SiloOnSurface.copy(alpha = 0.28f),
+    )
+    else -> TvSelectorRowVisualState(DarkSurfaceElevated, SiloOnSurface, Color.Transparent)
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -21,6 +21,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import org.siloserver.silo.common.player.video.VideoPlayerRouteArgs
+import org.siloserver.silo.common.player.video.decodeEpisodeSelectionHandoff
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.repository.AuthRepository
 import org.siloserver.silo.repository.ProfileRepository
@@ -790,6 +791,11 @@ fun TvAppNavigation(
                     nullable = true
                     defaultValue = null
                 },
+                navArgument(TvRoute.Player.ARG_EPISODE_SELECTION_HANDOFF) {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
             ),
         ) { backStack ->
             val contentId = backStack.arguments
@@ -814,6 +820,9 @@ fun TvAppNavigation(
             val autoAdvanceCount = backStack.arguments
                 ?.getString(TvRoute.Player.ARG_AUTO_ADVANCE_COUNT)
                 ?.toIntOrNull() ?: 0
+            val episodeSelectionHandoff = decodeEpisodeSelectionHandoff(
+                backStack.arguments?.getString(TvRoute.Player.ARG_EPISODE_SELECTION_HANDOFF),
+            )
             TvPlayerScreen(
                 contentId = contentId,
                 preferredFileId = preferredFileId,
@@ -823,11 +832,16 @@ fun TvAppNavigation(
                 initialAudioTrackIndex = audioTrackIndex,
                 initialSubtitleTrackIndex = subtitleTrackIndex,
                 autoAdvanceCount = autoAdvanceCount,
-                onPlayNext = { nextContentId, nextCount, nextQuality ->
+                episodeSelectionHandoff = episodeSelectionHandoff,
+                onPlayNext = { nextContentId, nextCount, handoff ->
                     // Replace the current player in the back stack so an
                     // auto-played chain doesn't pile up episodes behind Back.
                     navController.navigate(
-                        TvRoute.Player(contentId = nextContentId, quality = nextQuality, autoAdvanceCount = nextCount).route,
+                        TvRoute.Player(
+                            contentId = nextContentId,
+                            autoAdvanceCount = nextCount,
+                            episodeSelectionHandoff = handoff,
+                        ).route,
                     ) {
                         popUpTo(TvRoute.Player.ROUTE) { inclusive = true }
                     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.collectAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,7 +22,6 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import org.siloserver.silo.common.player.video.VideoPlayerRouteArgs
-import org.siloserver.silo.common.player.video.decodeEpisodeSelectionHandoff
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.repository.AuthRepository
 import org.siloserver.silo.repository.ProfileRepository
@@ -791,7 +791,7 @@ fun TvAppNavigation(
                     nullable = true
                     defaultValue = null
                 },
-                navArgument(TvRoute.Player.ARG_EPISODE_SELECTION_HANDOFF) {
+                navArgument(TvRoute.Player.ARG_EPISODE_SELECTION_HANDOFF_NONCE) {
                     type = NavType.StringType
                     nullable = true
                     defaultValue = null
@@ -820,9 +820,19 @@ fun TvAppNavigation(
             val autoAdvanceCount = backStack.arguments
                 ?.getString(TvRoute.Player.ARG_AUTO_ADVANCE_COUNT)
                 ?.toIntOrNull() ?: 0
-            val episodeSelectionHandoff = decodeEpisodeSelectionHandoff(
-                backStack.arguments?.getString(TvRoute.Player.ARG_EPISODE_SELECTION_HANDOFF),
-            )
+            val episodeSelectionHandoffNonce = backStack.arguments
+                ?.getString(TvRoute.Player.ARG_EPISODE_SELECTION_HANDOFF_NONCE)
+                ?.takeIf(::isValidTvEpisodeSelectionHandoffNonce)
+            val episodeSelectionHandoff = remember(
+                backStack,
+                contentId,
+                episodeSelectionHandoffNonce,
+            ) {
+                processTvEpisodeSelectionHandoffRegistry.claim(
+                    nonce = episodeSelectionHandoffNonce,
+                    targetContentId = contentId,
+                )
+            }
             TvPlayerScreen(
                 contentId = contentId,
                 preferredFileId = preferredFileId,
@@ -834,13 +844,17 @@ fun TvAppNavigation(
                 autoAdvanceCount = autoAdvanceCount,
                 episodeSelectionHandoff = episodeSelectionHandoff,
                 onPlayNext = { nextContentId, nextCount, handoff ->
+                    val handoffNonce = processTvEpisodeSelectionHandoffRegistry.register(
+                        targetContentId = nextContentId,
+                        handoff = handoff,
+                    )
                     // Replace the current player in the back stack so an
                     // auto-played chain doesn't pile up episodes behind Back.
                     navController.navigate(
                         TvRoute.Player(
                             contentId = nextContentId,
                             autoAdvanceCount = nextCount,
-                            episodeSelectionHandoff = handoff,
+                            episodeSelectionHandoffNonce = handoffNonce,
                         ).route,
                     ) {
                         popUpTo(TvRoute.Player.ROUTE) { inclusive = true }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvEpisodeSelectionHandoffRegistry.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvEpisodeSelectionHandoffRegistry.kt
@@ -1,0 +1,99 @@
+package org.siloserver.silo.tv.ui.navigation
+
+import java.util.LinkedHashMap
+import java.util.UUID
+import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
+
+private const val MIN_HANDOFF_NONCE_LENGTH = 16
+private const val MAX_HANDOFF_NONCE_LENGTH = 32
+private const val DEFAULT_MAX_HANDOFFS = 32
+private const val DEFAULT_HANDOFF_TTL_MILLIS = 5 * 60 * 1_000L
+private val handoffNoncePattern = Regex("^[A-Za-z0-9_-]+$")
+
+internal fun isValidTvEpisodeSelectionHandoffNonce(nonce: String?): Boolean =
+    nonce != null &&
+        nonce.length in MIN_HANDOFF_NONCE_LENGTH..MAX_HANDOFF_NONCE_LENGTH &&
+        handoffNoncePattern.matches(nonce)
+
+/**
+ * Process-only transport for the semantic episode handoff.
+ *
+ * Navigation persists only an opaque nonce. Entries are target-content bound,
+ * single-use, short-lived, and capacity bounded so a restored back stack cannot
+ * recreate selection intent after process death.
+ */
+internal class TvEpisodeSelectionHandoffRegistry(
+    private val maxEntries: Int = DEFAULT_MAX_HANDOFFS,
+    private val ttlMillis: Long = DEFAULT_HANDOFF_TTL_MILLIS,
+    private val nowMillis: () -> Long = { System.nanoTime() / 1_000_000L },
+    private val nonceFactory: () -> String = {
+        UUID.randomUUID().toString().replace("-", "")
+    },
+) {
+    private data class Entry(
+        val targetContentId: String,
+        val handoff: EpisodeSelectionHandoff,
+        val expiresAtMillis: Long,
+    )
+
+    private val entries = LinkedHashMap<String, Entry>()
+
+    init {
+        require(maxEntries > 0)
+        require(ttlMillis > 0L)
+    }
+
+    @Synchronized
+    fun register(
+        targetContentId: String,
+        handoff: EpisodeSelectionHandoff,
+    ): String {
+        require(targetContentId.isNotBlank())
+        val now = nowMillis()
+        removeExpired(now)
+        while (entries.size >= maxEntries) {
+            val eldest = entries.keys.firstOrNull() ?: break
+            entries.remove(eldest)
+        }
+        repeat(MAX_NONCE_GENERATION_ATTEMPTS) {
+            val nonce = nonceFactory()
+            if (isValidTvEpisodeSelectionHandoffNonce(nonce) && nonce !in entries) {
+                entries[nonce] = Entry(
+                    targetContentId = targetContentId,
+                    handoff = handoff,
+                    expiresAtMillis = now + ttlMillis,
+                )
+                return nonce
+            }
+        }
+        error("Could not allocate a unique episode handoff nonce.")
+    }
+
+    /** Claim removes the entry before checking its target, making every attempt single-use. */
+    @Synchronized
+    fun claim(
+        nonce: String?,
+        targetContentId: String,
+    ): EpisodeSelectionHandoff? {
+        if (!isValidTvEpisodeSelectionHandoffNonce(nonce)) return null
+        removeExpired(nowMillis())
+        val entry = entries.remove(nonce) ?: return null
+        return entry.handoff.takeIf { entry.targetContentId == targetContentId }
+    }
+
+    @Synchronized
+    fun clear() {
+        entries.clear()
+    }
+
+    private fun removeExpired(now: Long) {
+        entries.entries.removeAll { (_, entry) -> now >= entry.expiresAtMillis }
+    }
+
+    private companion object {
+        const val MAX_NONCE_GENERATION_ATTEMPTS = 8
+    }
+}
+
+/** Empty in a recreated process by construction; never persisted or saved. */
+internal val processTvEpisodeSelectionHandoffRegistry = TvEpisodeSelectionHandoffRegistry()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvRoute.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvRoute.kt
@@ -1,6 +1,8 @@
 package org.siloserver.silo.tv.ui.navigation
 
 import org.siloserver.silo.common.player.video.VideoPlayerRouteArgs
+import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
+import org.siloserver.silo.common.player.video.encodeEpisodeSelectionHandoff
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -93,6 +95,8 @@ sealed class TvRoute(val route: String) {
         val subtitleTrackIndex: Int? = null,
         /** Consecutive auto-advance count for pass-out protection (0 = manual start). */
         val autoAdvanceCount: Int = 0,
+        /** Session-only source/subtitle intent captured from the preceding episode. */
+        val episodeSelectionHandoff: EpisodeSelectionHandoff? = null,
     ) : TvRoute(
         buildString {
             append("player/$contentId")
@@ -105,6 +109,9 @@ sealed class TvRoute(val route: String) {
                 if (audioTrackIndex != null) add("audioTrackIndex=$audioTrackIndex")
                 if (subtitleTrackIndex != null) add("subtitleTrackIndex=$subtitleTrackIndex")
                 if (autoAdvanceCount > 0) add("autoAdvanceCount=$autoAdvanceCount")
+                episodeSelectionHandoff?.let { handoff ->
+                    add("$ARG_EPISODE_SELECTION_HANDOFF=${encodeEpisodeSelectionHandoff(handoff).routeEncode()}")
+                }
                 VideoPlayerRouteArgs.encodeResumePosition(resumePositionSeconds)?.let { value ->
                     add("${VideoPlayerRouteArgs.RESUME_POSITION}=$value")
                 }
@@ -115,7 +122,8 @@ sealed class TvRoute(val route: String) {
         companion object {
             const val ROUTE = "player/{contentId}?fileId={fileId}&quality={quality}&roomId={roomId}" +
                 "&audioTrackIndex={audioTrackIndex}&subtitleTrackIndex={subtitleTrackIndex}" +
-                "&autoAdvanceCount={autoAdvanceCount}&resumePosition={resumePosition}"
+                "&autoAdvanceCount={autoAdvanceCount}&resumePosition={resumePosition}" +
+                "&episodeSelectionHandoff={episodeSelectionHandoff}"
             const val ARG_CONTENT_ID = "contentId"
             const val ARG_FILE_ID = "fileId"
             const val ARG_QUALITY = "quality"
@@ -124,6 +132,7 @@ sealed class TvRoute(val route: String) {
             const val ARG_SUBTITLE_TRACK_INDEX = "subtitleTrackIndex"
             const val ARG_AUTO_ADVANCE_COUNT = "autoAdvanceCount"
             const val ARG_RESUME_POSITION = VideoPlayerRouteArgs.RESUME_POSITION
+            const val ARG_EPISODE_SELECTION_HANDOFF = "episodeSelectionHandoff"
         }
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvRoute.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvRoute.kt
@@ -1,8 +1,6 @@
 package org.siloserver.silo.tv.ui.navigation
 
 import org.siloserver.silo.common.player.video.VideoPlayerRouteArgs
-import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
-import org.siloserver.silo.common.player.video.encodeEpisodeSelectionHandoff
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -95,8 +93,8 @@ sealed class TvRoute(val route: String) {
         val subtitleTrackIndex: Int? = null,
         /** Consecutive auto-advance count for pass-out protection (0 = manual start). */
         val autoAdvanceCount: Int = 0,
-        /** Session-only source/subtitle intent captured from the preceding episode. */
-        val episodeSelectionHandoff: EpisodeSelectionHandoff? = null,
+        /** Opaque key for a process-only, target-bound episode selection handoff. */
+        val episodeSelectionHandoffNonce: String? = null,
     ) : TvRoute(
         buildString {
             append("player/$contentId")
@@ -109,9 +107,9 @@ sealed class TvRoute(val route: String) {
                 if (audioTrackIndex != null) add("audioTrackIndex=$audioTrackIndex")
                 if (subtitleTrackIndex != null) add("subtitleTrackIndex=$subtitleTrackIndex")
                 if (autoAdvanceCount > 0) add("autoAdvanceCount=$autoAdvanceCount")
-                episodeSelectionHandoff?.let { handoff ->
-                    add("$ARG_EPISODE_SELECTION_HANDOFF=${encodeEpisodeSelectionHandoff(handoff).routeEncode()}")
-                }
+                episodeSelectionHandoffNonce
+                    ?.takeIf(::isValidTvEpisodeSelectionHandoffNonce)
+                    ?.let { nonce -> add("$ARG_EPISODE_SELECTION_HANDOFF_NONCE=$nonce") }
                 VideoPlayerRouteArgs.encodeResumePosition(resumePositionSeconds)?.let { value ->
                     add("${VideoPlayerRouteArgs.RESUME_POSITION}=$value")
                 }
@@ -123,7 +121,7 @@ sealed class TvRoute(val route: String) {
             const val ROUTE = "player/{contentId}?fileId={fileId}&quality={quality}&roomId={roomId}" +
                 "&audioTrackIndex={audioTrackIndex}&subtitleTrackIndex={subtitleTrackIndex}" +
                 "&autoAdvanceCount={autoAdvanceCount}&resumePosition={resumePosition}" +
-                "&episodeSelectionHandoff={episodeSelectionHandoff}"
+                "&episodeSelectionHandoffNonce={episodeSelectionHandoffNonce}"
             const val ARG_CONTENT_ID = "contentId"
             const val ARG_FILE_ID = "fileId"
             const val ARG_QUALITY = "quality"
@@ -132,7 +130,7 @@ sealed class TvRoute(val route: String) {
             const val ARG_SUBTITLE_TRACK_INDEX = "subtitleTrackIndex"
             const val ARG_AUTO_ADVANCE_COUNT = "autoAdvanceCount"
             const val ARG_RESUME_POSITION = VideoPlayerRouteArgs.RESUME_POSITION
-            const val ARG_EPISODE_SELECTION_HANDOFF = "episodeSelectionHandoff"
+            const val ARG_EPISODE_SELECTION_HANDOFF_NONCE = "episodeSelectionHandoffNonce"
         }
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -1065,6 +1065,7 @@ class TvItemDetailViewModel(
                         episodeContentId = episodeContentId,
                         detail = playbackDetail,
                         handoff = pending?.handoff,
+                        preferredQuality = _uiState.value.preferredQuality,
                     )
                     if (
                         !ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration) ||
@@ -1143,7 +1144,12 @@ class TvItemDetailViewModel(
         val detail = state.nextUpPlaybackDetail ?: return null
         val selectedVersion = state.selectedNextUpFileId
             ?.let { fileId -> detail.versions.firstOrNull { it.fileId == fileId } }
-        val activeVersion = selectedVersion ?: detail.versions.firstOrNull()
+        val activeVersion = selectTvDetailDisplayVersion(
+            versions = detail.versions,
+            selectedFileId = state.selectedNextUpFileId,
+            lastFileId = detail.userData?.lastFileId,
+            preferredQuality = state.preferredQuality,
+        )
         val subtitleChoices = buildPlaybackSubtitleChoices(
             catalogTracks = activeVersion?.subtitleTracks.orEmpty(),
             plannedTracks = emptyList(),
@@ -1161,18 +1167,27 @@ class TvItemDetailViewModel(
         episodeContentId: String,
         detail: ItemDetail,
         handoff: EpisodeSelectionHandoff?,
+        preferredQuality: String,
     ): ResolvedNextUpTrackSelection {
         val session = TvDetailTrackSelectionSession.recall(episodeContentId)
         val sourceSpecified = handoff?.source != null
         val carriedFileId = resolveEpisodeSourceIntent(handoff?.source, detail.versions)
         val sessionFileId = session?.fileId?.takeIf { fileId -> detail.versions.any { it.fileId == fileId } }
         val selectedFileId = if (sourceSpecified) carriedFileId else sessionFileId
-        val selectedVersion = selectedFileId
-            ?.let { fileId -> detail.versions.firstOrNull { it.fileId == fileId } }
-            ?: detail.versions.firstOrNull()
+        val selectedVersion = selectTvDetailDisplayVersion(
+            versions = detail.versions,
+            selectedFileId = selectedFileId,
+            lastFileId = detail.userData?.lastFileId,
+            preferredQuality = preferredQuality,
+        )
             ?: return ResolvedNextUpTrackSelection(selectedFileId, null, null)
 
-        val sessionVersionId = sessionFileId ?: detail.versions.firstOrNull()?.fileId
+        val sessionVersionId = selectTvDetailDisplayVersion(
+            versions = detail.versions,
+            selectedFileId = sessionFileId,
+            lastFileId = detail.userData?.lastFileId,
+            preferredQuality = preferredQuality,
+        )?.fileId
         val sessionMatchesSelectedVersion = session != null && sessionVersionId == selectedVersion.fileId
         val targetSubtitleChoices = buildPlaybackSubtitleChoices(
             catalogTracks = selectedVersion.subtitleTracks.orEmpty(),

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -3,10 +3,11 @@ package org.siloserver.silo.tv.ui.screens.detail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
+import org.siloserver.silo.common.player.video.EpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.EpisodeSubtitleMode
 import org.siloserver.silo.common.player.video.captureEpisodeSourceIntent
 import org.siloserver.silo.common.player.video.captureEpisodeSubtitleIntent
-import org.siloserver.silo.common.player.video.resolveEpisodeSelectionHandoff
+import org.siloserver.silo.common.player.video.resolveEpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.resolveEpisodeSourceIntent
 import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.domain.settings.ProfileSettingsController
@@ -720,6 +721,7 @@ class TvItemDetailViewModel(
 
     private var episodeLoadJob: kotlinx.coroutines.Job? = null
     private var moreLikeThisJob: Job? = null
+    private var nextUpDetailJob: Job? = null
     // The season number the currently-shown episodes/next-up actually belong to.
     // Lets a failed load revert the optimistic season selection so the chips and
     // the rail stay consistent (T15).
@@ -1005,7 +1007,8 @@ class TvItemDetailViewModel(
         identityGeneration: Long,
         handoff: EpisodeSelectionHandoff?,
     ) {
-        viewModelScope.launch {
+        nextUpDetailJob?.cancel()
+        nextUpDetailJob = viewModelScope.launch {
             val requestIdentity = captureNextUpIdentity(identityGeneration)
             if (!ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration) || requestIdentity == null) {
                 clearPendingNextUpHandoff(episodeContentId, refreshGeneration)
@@ -1116,6 +1119,8 @@ class TvItemDetailViewModel(
     }
 
     private fun invalidateNextUpPlaybackDetailRequest() {
+        nextUpDetailJob?.cancel()
+        nextUpDetailJob = null
         nextUpPlaybackDetailGeneration += 1
         pendingNextUpSelectionHandoff = null
     }
@@ -1154,6 +1159,10 @@ class TvItemDetailViewModel(
             catalogTracks = activeVersion?.subtitleTracks.orEmpty(),
             plannedTracks = emptyList(),
         )
+        // Source intent is carried only for an explicit version choice; an
+        // automatic last-file/quality choice must remain automatic on the
+        // target. Subtitle intent uses the displayed version because its
+        // combined index belongs to that version's track list.
         val handoff = EpisodeSelectionHandoff(
             source = selectedVersion?.let(::captureEpisodeSourceIntent),
             subtitle = captureEpisodeSubtitleIntent(state.selectedNextUpSubtitleIndex, subtitleChoices),
@@ -1193,9 +1202,8 @@ class TvItemDetailViewModel(
             catalogTracks = selectedVersion.subtitleTracks.orEmpty(),
             plannedTracks = emptyList(),
         )
-        val carried = resolveEpisodeSelectionHandoff(
-            handoff = handoff,
-            targetVersions = detail.versions,
+        val carriedSubtitle = resolveEpisodeSubtitleIntent(
+            intent = handoff?.subtitle ?: EpisodeSubtitleIntent.auto(),
             targetSubtitles = targetSubtitleChoices,
         )
         val durable = userItemState.localTrackSelection(episodeContentId, selectedVersion.fileId)
@@ -1206,8 +1214,8 @@ class TvItemDetailViewModel(
         return ResolvedNextUpTrackSelection(
             fileId = selectedFileId,
             audioIndex = sessionAudio ?: durable?.audioIndex,
-            subtitleIndex = if (carried.subtitleIntentSpecified) {
-                carried.subtitleTrackIndex
+            subtitleIndex = if (carriedSubtitle.intentSpecified) {
+                carriedSubtitle.trackIndex
             } else {
                 sessionSubtitle ?: durable?.subtitleIndex
             },

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -2,6 +2,12 @@ package org.siloserver.silo.tv.ui.screens.detail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
+import org.siloserver.silo.common.player.video.EpisodeSubtitleMode
+import org.siloserver.silo.common.player.video.captureEpisodeSourceIntent
+import org.siloserver.silo.common.player.video.captureEpisodeSubtitleIntent
+import org.siloserver.silo.common.player.video.resolveEpisodeSelectionHandoff
+import org.siloserver.silo.common.player.video.resolveEpisodeSourceIntent
 import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.domain.settings.ProfileSettingsController
 import org.siloserver.silo.model.catalog.BrowseItem
@@ -14,6 +20,7 @@ import org.siloserver.silo.model.catalog.Season
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.catalog.initialSeasonDisplayPlan
 import org.siloserver.silo.model.playback.combinedSubtitleSelectionIndexes
+import org.siloserver.silo.model.playback.buildPlaybackSubtitleChoices
 import org.siloserver.silo.playback.SUBTITLE_OFF_FINGERPRINT
 import org.siloserver.silo.playback.audioTrackFingerprint
 import org.siloserver.silo.playback.resolveAudioTrackOrdinal
@@ -21,6 +28,9 @@ import org.siloserver.silo.playback.resolveSubtitleTrackOrdinal
 import org.siloserver.silo.playback.subtitleTrackFingerprint
 import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.IdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionPhase
+import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.repository.CatalogRepository
 import org.siloserver.silo.repository.PersonalDataRepository
 import org.siloserver.silo.repository.ProfileRepository
@@ -206,6 +216,8 @@ class TvItemDetailViewModel(
     private val contentId: String,
     private val userItemState: UserItemStatePort = NoOpUserItemStatePort,
     private val recommendationRepository: org.siloserver.silo.repository.RecommendationRepository? = null,
+    private val tokenManager: TokenManager,
+    private val identityTransitions: IdentityTransitionBarrier,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TvItemDetailUiState())
@@ -220,6 +232,13 @@ class TvItemDetailViewModel(
         descriptionTranslation.phase
 
     init {
+        viewModelScope.launch {
+            identityTransitions.transitions.collect { transition ->
+                if (transition.phase == IdentityTransitionPhase.WILL_CHANGE) {
+                    pendingNextUpSelectionHandoff = null
+                }
+            }
+        }
         observePreferredQuality()
         if (contentId.isNotBlank()) {
             // Restore this title's pre-play track choices (QA 2026-07-08: a
@@ -710,6 +729,27 @@ class TvItemDetailViewModel(
     private val episodeWatchMutationGenerations = mutableMapOf<String, Long>()
     private var nextEpisodeFavoriteMutationGeneration: Long = 0
     private val episodeFavoriteMutationGenerations = mutableMapOf<String, Long>()
+    private var nextUpPlaybackDetailGeneration: Long = 0
+    private var pendingNextUpSelectionHandoff: PendingNextUpSelectionHandoff? = null
+
+    private data class NextUpIdentity(
+        val serverId: String?,
+        val profileId: String?,
+        val generation: Long,
+    )
+
+    private data class PendingNextUpSelectionHandoff(
+        val targetContentId: String,
+        val refreshGeneration: Long,
+        val identity: NextUpIdentity,
+        val handoff: EpisodeSelectionHandoff,
+    )
+
+    private data class ResolvedNextUpTrackSelection(
+        val fileId: Int?,
+        val audioIndex: Int?,
+        val subtitleIndex: Int?,
+    )
 
     /**
      * Loads a season's episodes. [quiet] suppresses the loading spinner and is
@@ -875,9 +915,11 @@ class TvItemDetailViewModel(
      * `loadSeriesNextUpPlaybackDetail` / `loadSeasonNextUpPlaybackDetail`.
      */
     private fun refreshNextUp(episodes: List<EpisodeListItem>) {
-        val detail = _uiState.value.detail
+        val oldState = _uiState.value
+        val detail = oldState.detail
         val type = detail?.type?.lowercase()
         if (detail == null || (type != "series" && type != "season")) {
+            invalidateNextUpPlaybackDetailRequest()
             // Movie / episode detail does not drive next-up; clear any state.
             if (_uiState.value.nextUpEpisode != null || _uiState.value.nextUpPlaybackDetail != null) {
                 _uiState.update {
@@ -905,6 +947,7 @@ class TvItemDetailViewModel(
         }
 
         if (nextUp == null) {
+            invalidateNextUpPlaybackDetailRequest()
             _uiState.update {
                 it.copy(
                     nextUpEpisode = null,
@@ -919,6 +962,13 @@ class TvItemDetailViewModel(
             return
         }
 
+        // Capture portable intent while the old target's selected version and
+        // combined subtitle index are still available. Raw file IDs and indexes
+        // never cross the episode boundary.
+        val handoff = captureNextUpSelectionHandoff(oldState)
+        val refreshGeneration = ++nextUpPlaybackDetailGeneration
+        val identityGeneration = identityTransitions.generation.value
+        pendingNextUpSelectionHandoff = null
         _uiState.update {
             it.copy(
                 nextUpEpisode = nextUp,
@@ -930,7 +980,12 @@ class TvItemDetailViewModel(
                 selectedNextUpSubtitleIndex = null,
             )
         }
-        loadNextUpPlaybackDetail(nextUp.contentId)
+        loadNextUpPlaybackDetail(
+            episodeContentId = nextUp.contentId,
+            refreshGeneration = refreshGeneration,
+            identityGeneration = identityGeneration,
+            handoff = handoff,
+        )
     }
 
     private fun resolveNextUpEpisode(episodes: List<EpisodeListItem>): EpisodeListItem? {
@@ -939,32 +994,187 @@ class TvItemDetailViewModel(
         return episodes.firstOrNull()
     }
 
-    private fun loadNextUpPlaybackDetail(episodeContentId: String) {
+    private fun loadNextUpPlaybackDetail(
+        episodeContentId: String,
+        refreshGeneration: Long,
+        identityGeneration: Long,
+        handoff: EpisodeSelectionHandoff?,
+    ) {
         viewModelScope.launch {
-            val result = catalogRepository.getItemDetail(episodeContentId)
-            // Ignore a late result if the next-up target moved on.
-            if (_uiState.value.nextUpEpisode?.contentId != episodeContentId) return@launch
-            when (result) {
-                is ApiResult.Success -> {
-                    val playbackDetail = withLocalProgress(result.data)
-                    _uiState.update {
-                        it.copy(
-                            nextUpPlaybackDetail = playbackDetail,
-                            isLoadingNextUpPlaybackDetail = false,
-                            didLoadNextUpPlaybackDetail = true,
-                        )
-                    }
-                    restoreNextUpTrackSelection(episodeContentId, playbackDetail)
-                }
-                else -> _uiState.update {
-                    it.copy(
+            val requestIdentity = captureNextUpIdentity(identityGeneration)
+            if (!ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration) || requestIdentity == null) {
+                clearPendingNextUpHandoff(episodeContentId, refreshGeneration)
+                _uiState.update {
+                    if (!ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration)) it else it.copy(
                         nextUpPlaybackDetail = null,
                         isLoadingNextUpPlaybackDetail = false,
                         didLoadNextUpPlaybackDetail = true,
                     )
                 }
+                return@launch
+            }
+            if (handoff != null) {
+                pendingNextUpSelectionHandoff = PendingNextUpSelectionHandoff(
+                    targetContentId = episodeContentId,
+                    refreshGeneration = refreshGeneration,
+                    identity = requestIdentity,
+                    handoff = handoff,
+                )
+            }
+            val result = catalogRepository.getItemDetail(episodeContentId)
+            if (!ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration)) {
+                clearPendingNextUpHandoff(episodeContentId, refreshGeneration)
+                return@launch
+            }
+            val completionIdentity = captureNextUpIdentity(identityGeneration)
+            if (completionIdentity != requestIdentity) {
+                clearPendingNextUpHandoff(episodeContentId, refreshGeneration)
+                _uiState.update {
+                    if (!ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration)) it else it.copy(
+                        nextUpPlaybackDetail = null,
+                        isLoadingNextUpPlaybackDetail = false,
+                        didLoadNextUpPlaybackDetail = true,
+                    )
+                }
+                return@launch
+            }
+            when (result) {
+                is ApiResult.Success -> {
+                    val playbackDetail = withLocalProgress(result.data)
+                    if (
+                        !ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration) ||
+                        captureNextUpIdentity(identityGeneration) != requestIdentity
+                    ) {
+                        clearPendingNextUpHandoff(episodeContentId, refreshGeneration)
+                        return@launch
+                    }
+                    val pending = pendingNextUpSelectionHandoff?.takeIf {
+                        it.targetContentId == episodeContentId &&
+                            it.refreshGeneration == refreshGeneration &&
+                            it.identity == requestIdentity
+                    }
+                    val selection = resolveNextUpTrackSelection(
+                        episodeContentId = episodeContentId,
+                        detail = playbackDetail,
+                        handoff = pending?.handoff,
+                    )
+                    if (
+                        !ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration) ||
+                        captureNextUpIdentity(identityGeneration) != requestIdentity
+                    ) {
+                        clearPendingNextUpHandoff(episodeContentId, refreshGeneration)
+                        return@launch
+                    }
+                    _uiState.update {
+                        if (!ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration)) it else it.copy(
+                            nextUpPlaybackDetail = playbackDetail,
+                            isLoadingNextUpPlaybackDetail = false,
+                            didLoadNextUpPlaybackDetail = true,
+                            selectedNextUpFileId = selection.fileId,
+                            selectedNextUpAudioIndex = selection.audioIndex,
+                            selectedNextUpSubtitleIndex = selection.subtitleIndex,
+                        )
+                    }
+                    // This transition resolution is display/session input only.
+                    // Selector callbacks remain the sole writers to session/Room.
+                    clearPendingNextUpHandoff(episodeContentId, refreshGeneration)
+                }
+                else -> {
+                    clearPendingNextUpHandoff(episodeContentId, refreshGeneration)
+                    _uiState.update {
+                        if (!ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration)) it else it.copy(
+                            nextUpPlaybackDetail = null,
+                            isLoadingNextUpPlaybackDetail = false,
+                            didLoadNextUpPlaybackDetail = true,
+                        )
+                    }
+                }
             }
         }
+    }
+
+    private fun invalidateNextUpPlaybackDetailRequest() {
+        nextUpPlaybackDetailGeneration += 1
+        pendingNextUpSelectionHandoff = null
+    }
+
+    private fun ownsNextUpPlaybackDetailRequest(episodeContentId: String, refreshGeneration: Long): Boolean =
+        nextUpPlaybackDetailGeneration == refreshGeneration &&
+            _uiState.value.nextUpEpisode?.contentId == episodeContentId
+
+    private fun clearPendingNextUpHandoff(episodeContentId: String, refreshGeneration: Long) {
+        pendingNextUpSelectionHandoff = pendingNextUpSelectionHandoff?.takeUnless {
+            it.targetContentId == episodeContentId && it.refreshGeneration == refreshGeneration
+        }
+    }
+
+    private suspend fun captureNextUpIdentity(expectedGeneration: Long): NextUpIdentity? {
+        if (identityTransitions.generation.value != expectedGeneration) return null
+        val scope = tokenManager.snapshotCurrentScope()
+        val serverId = scope?.serverId ?: tokenManager.getCurrentServerId()
+        val profileId = scope?.profileId ?: tokenManager.getProfileId()
+        if (identityTransitions.generation.value != expectedGeneration) return null
+        return NextUpIdentity(serverId, profileId, expectedGeneration)
+    }
+
+    private fun captureNextUpSelectionHandoff(state: TvItemDetailUiState): EpisodeSelectionHandoff? {
+        val detail = state.nextUpPlaybackDetail ?: return null
+        val selectedVersion = state.selectedNextUpFileId
+            ?.let { fileId -> detail.versions.firstOrNull { it.fileId == fileId } }
+        val activeVersion = selectedVersion ?: detail.versions.firstOrNull()
+        val subtitleChoices = buildPlaybackSubtitleChoices(
+            catalogTracks = activeVersion?.subtitleTracks.orEmpty(),
+            plannedTracks = emptyList(),
+        )
+        val handoff = EpisodeSelectionHandoff(
+            source = selectedVersion?.let(::captureEpisodeSourceIntent),
+            subtitle = captureEpisodeSubtitleIntent(state.selectedNextUpSubtitleIndex, subtitleChoices),
+        )
+        return handoff.takeIf {
+            it.source != null || it.subtitle.mode != EpisodeSubtitleMode.AUTO
+        }
+    }
+
+    private suspend fun resolveNextUpTrackSelection(
+        episodeContentId: String,
+        detail: ItemDetail,
+        handoff: EpisodeSelectionHandoff?,
+    ): ResolvedNextUpTrackSelection {
+        val session = TvDetailTrackSelectionSession.recall(episodeContentId)
+        val sourceSpecified = handoff?.source != null
+        val carriedFileId = resolveEpisodeSourceIntent(handoff?.source, detail.versions)
+        val sessionFileId = session?.fileId?.takeIf { fileId -> detail.versions.any { it.fileId == fileId } }
+        val selectedFileId = if (sourceSpecified) carriedFileId else sessionFileId
+        val selectedVersion = selectedFileId
+            ?.let { fileId -> detail.versions.firstOrNull { it.fileId == fileId } }
+            ?: detail.versions.firstOrNull()
+            ?: return ResolvedNextUpTrackSelection(selectedFileId, null, null)
+
+        val sessionVersionId = sessionFileId ?: detail.versions.firstOrNull()?.fileId
+        val sessionMatchesSelectedVersion = session != null && sessionVersionId == selectedVersion.fileId
+        val targetSubtitleChoices = buildPlaybackSubtitleChoices(
+            catalogTracks = selectedVersion.subtitleTracks.orEmpty(),
+            plannedTracks = emptyList(),
+        )
+        val carried = resolveEpisodeSelectionHandoff(
+            handoff = handoff,
+            targetVersions = detail.versions,
+            targetSubtitles = targetSubtitleChoices,
+        )
+        val durable = userItemState.localTrackSelection(episodeContentId, selectedVersion.fileId)
+            ?.let { restoreTrackSelection(selectedVersion, it) }
+
+        val sessionAudio = session?.audio.takeIf { sessionMatchesSelectedVersion }
+        val sessionSubtitle = session?.subtitle.takeIf { sessionMatchesSelectedVersion }
+        return ResolvedNextUpTrackSelection(
+            fileId = selectedFileId,
+            audioIndex = sessionAudio ?: durable?.audioIndex,
+            subtitleIndex = if (carried.subtitleIntentSpecified) {
+                carried.subtitleTrackIndex
+            } else {
+                sessionSubtitle ?: durable?.subtitleIndex
+            },
+        )
     }
 
 
@@ -998,6 +1208,7 @@ class TvItemDetailViewModel(
     }
 
     fun onNextUpVersionSelected(fileId: Int?) {
+        pendingNextUpSelectionHandoff = null
         _uiState.update {
             it.copy(
                 selectedNextUpFileId = fileId,
@@ -1010,12 +1221,14 @@ class TvItemDetailViewModel(
     }
 
     fun onNextUpAudioTrackSelected(index: Int?) {
+        pendingNextUpSelectionHandoff = null
         _uiState.update { it.copy(selectedNextUpAudioIndex = index) }
         rememberNextUpTrackSelection()
         persistNextUpTrackSelection()
     }
 
     fun onNextUpSubtitleTrackSelected(index: Int?) {
+        pendingNextUpSelectionHandoff = null
         _uiState.update { it.copy(selectedNextUpSubtitleIndex = index) }
         rememberNextUpTrackSelection()
         persistNextUpTrackSelection()
@@ -1043,24 +1256,6 @@ class TvItemDetailViewModel(
             selectedAudioIndex = state.selectedNextUpAudioIndex,
             selectedSubtitleIndex = state.selectedNextUpSubtitleIndex,
         )
-    }
-
-    private fun restoreNextUpTrackSelection(episodeContentId: String, detail: ItemDetail) {
-        val session = TvDetailTrackSelectionSession.recall(episodeContentId)
-        if (session != null) {
-            _uiState.update {
-                if (it.nextUpEpisode?.contentId != episodeContentId) it else it.copy(
-                    selectedNextUpFileId = session.fileId,
-                    selectedNextUpAudioIndex = session.audio,
-                    selectedNextUpSubtitleIndex = session.subtitle,
-                )
-            }
-        }
-        // A session can intentionally select a file before its durable track
-        // fingerprints have loaded (file B / null / null). Always merge the
-        // selected file's durable dimensions after applying session state;
-        // the guarded update below preserves any non-null session choices.
-        seedPersistedNextUpTrackSelection(episodeContentId, detail)
     }
 
     private fun seedPersistedNextUpTrackSelection(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -730,6 +730,7 @@ class TvItemDetailViewModel(
     private var nextEpisodeFavoriteMutationGeneration: Long = 0
     private val episodeFavoriteMutationGenerations = mutableMapOf<String, Long>()
     private var nextUpPlaybackDetailGeneration: Long = 0
+    private var nextUpSelectorRevision: Long = 0
     private var pendingNextUpSelectionHandoff: PendingNextUpSelectionHandoff? = null
 
     private data class NextUpIdentity(
@@ -741,6 +742,7 @@ class TvItemDetailViewModel(
     private data class PendingNextUpSelectionHandoff(
         val targetContentId: String,
         val refreshGeneration: Long,
+        val selectorRevision: Long,
         val identity: NextUpIdentity,
         val handoff: EpisodeSelectionHandoff,
     )
@@ -967,6 +969,7 @@ class TvItemDetailViewModel(
         // never cross the episode boundary.
         val handoff = captureNextUpSelectionHandoff(oldState)
         val refreshGeneration = ++nextUpPlaybackDetailGeneration
+        val selectorRevision = nextUpSelectorRevision
         val identityGeneration = identityTransitions.generation.value
         pendingNextUpSelectionHandoff = null
         _uiState.update {
@@ -983,6 +986,7 @@ class TvItemDetailViewModel(
         loadNextUpPlaybackDetail(
             episodeContentId = nextUp.contentId,
             refreshGeneration = refreshGeneration,
+            selectorRevision = selectorRevision,
             identityGeneration = identityGeneration,
             handoff = handoff,
         )
@@ -997,6 +1001,7 @@ class TvItemDetailViewModel(
     private fun loadNextUpPlaybackDetail(
         episodeContentId: String,
         refreshGeneration: Long,
+        selectorRevision: Long,
         identityGeneration: Long,
         handoff: EpisodeSelectionHandoff?,
     ) {
@@ -1013,10 +1018,11 @@ class TvItemDetailViewModel(
                 }
                 return@launch
             }
-            if (handoff != null) {
+            if (handoff != null && nextUpSelectorRevision == selectorRevision) {
                 pendingNextUpSelectionHandoff = PendingNextUpSelectionHandoff(
                     targetContentId = episodeContentId,
                     refreshGeneration = refreshGeneration,
+                    selectorRevision = selectorRevision,
                     identity = requestIdentity,
                     handoff = handoff,
                 )
@@ -1051,8 +1057,10 @@ class TvItemDetailViewModel(
                     val pending = pendingNextUpSelectionHandoff?.takeIf {
                         it.targetContentId == episodeContentId &&
                             it.refreshGeneration == refreshGeneration &&
+                            it.selectorRevision == nextUpSelectorRevision &&
                             it.identity == requestIdentity
                     }
+                    val selectionRevision = nextUpSelectorRevision
                     val selection = resolveNextUpTrackSelection(
                         episodeContentId = episodeContentId,
                         detail = playbackDetail,
@@ -1066,14 +1074,27 @@ class TvItemDetailViewModel(
                         return@launch
                     }
                     _uiState.update {
-                        if (!ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration)) it else it.copy(
-                            nextUpPlaybackDetail = playbackDetail,
-                            isLoadingNextUpPlaybackDetail = false,
-                            didLoadNextUpPlaybackDetail = true,
-                            selectedNextUpFileId = selection.fileId,
-                            selectedNextUpAudioIndex = selection.audioIndex,
-                            selectedNextUpSubtitleIndex = selection.subtitleIndex,
-                        )
+                        if (!ownsNextUpPlaybackDetailRequest(episodeContentId, refreshGeneration)) {
+                            it
+                        } else if (nextUpSelectorRevision != selectionRevision) {
+                            // An explicit selector callback ran while a durable
+                            // read was suspended. Finish loading the target but
+                            // leave that newer explicit choice untouched.
+                            it.copy(
+                                nextUpPlaybackDetail = playbackDetail,
+                                isLoadingNextUpPlaybackDetail = false,
+                                didLoadNextUpPlaybackDetail = true,
+                            )
+                        } else {
+                            it.copy(
+                                nextUpPlaybackDetail = playbackDetail,
+                                isLoadingNextUpPlaybackDetail = false,
+                                didLoadNextUpPlaybackDetail = true,
+                                selectedNextUpFileId = selection.fileId,
+                                selectedNextUpAudioIndex = selection.audioIndex,
+                                selectedNextUpSubtitleIndex = selection.subtitleIndex,
+                            )
+                        }
                     }
                     // This transition resolution is display/session input only.
                     // Selector callbacks remain the sole writers to session/Room.
@@ -1110,11 +1131,12 @@ class TvItemDetailViewModel(
 
     private suspend fun captureNextUpIdentity(expectedGeneration: Long): NextUpIdentity? {
         if (identityTransitions.generation.value != expectedGeneration) return null
-        val scope = tokenManager.snapshotCurrentScope()
-        val serverId = scope?.serverId ?: tokenManager.getCurrentServerId()
-        val profileId = scope?.profileId ?: tokenManager.getProfileId()
+        // A snapshot is the only internally-consistent server/profile read.
+        // Null means this TokenManager cannot pin the active identity; fail
+        // closed instead of composing separately-timed getters.
+        val scope = tokenManager.snapshotCurrentScope() ?: return null
         if (identityTransitions.generation.value != expectedGeneration) return null
-        return NextUpIdentity(serverId, profileId, expectedGeneration)
+        return NextUpIdentity(scope.serverId, scope.profileId, expectedGeneration)
     }
 
     private fun captureNextUpSelectionHandoff(state: TvItemDetailUiState): EpisodeSelectionHandoff? {
@@ -1208,7 +1230,7 @@ class TvItemDetailViewModel(
     }
 
     fun onNextUpVersionSelected(fileId: Int?) {
-        pendingNextUpSelectionHandoff = null
+        markNextUpSelectorInput()
         _uiState.update {
             it.copy(
                 selectedNextUpFileId = fileId,
@@ -1221,17 +1243,22 @@ class TvItemDetailViewModel(
     }
 
     fun onNextUpAudioTrackSelected(index: Int?) {
-        pendingNextUpSelectionHandoff = null
+        markNextUpSelectorInput()
         _uiState.update { it.copy(selectedNextUpAudioIndex = index) }
         rememberNextUpTrackSelection()
         persistNextUpTrackSelection()
     }
 
     fun onNextUpSubtitleTrackSelected(index: Int?) {
-        pendingNextUpSelectionHandoff = null
+        markNextUpSelectorInput()
         _uiState.update { it.copy(selectedNextUpSubtitleIndex = index) }
         rememberNextUpTrackSelection()
         persistNextUpTrackSelection()
+    }
+
+    private fun markNextUpSelectorInput() {
+        nextUpSelectorRevision += 1
+        pendingNextUpSelectionHandoff = null
     }
 
     private fun rememberNextUpTrackSelection() {
@@ -1265,6 +1292,8 @@ class TvItemDetailViewModel(
         val targetContentId = episodeContentId ?: return
         val playbackDetail = detail ?: return
         val selectedFileId = _uiState.value.selectedNextUpFileId
+        val selectorRevision = nextUpSelectorRevision
+        val refreshGeneration = nextUpPlaybackDetailGeneration
         val version = selectedFileId
             ?.let { fileId -> playbackDetail.versions.firstOrNull { it.fileId == fileId } }
             ?: playbackDetail.versions.firstOrNull()
@@ -1272,28 +1301,50 @@ class TvItemDetailViewModel(
         viewModelScope.launch {
             val saved = userItemState.localTrackSelection(targetContentId, version.fileId) ?: return@launch
             val restored = restoreTrackSelection(version, saved)
-            _uiState.update {
-                if (!shouldApplyNextUpTrackRestore(
-                        currentContentId = it.nextUpEpisode?.contentId,
+            var remembered: TvDetailTrackSelectionSession.Saved? = null
+            while (true) {
+                val current = _uiState.value
+                if (
+                    nextUpPlaybackDetailGeneration != refreshGeneration ||
+                    nextUpSelectorRevision != selectorRevision ||
+                    !shouldApplyNextUpTrackRestore(
+                        currentContentId = current.nextUpEpisode?.contentId,
                         requestedContentId = targetContentId,
-                        currentSelectedFileId = it.selectedNextUpFileId,
+                        currentSelectedFileId = current.selectedNextUpFileId,
                         requestedSelectedFileId = selectedFileId,
                     )
                 ) {
-                    it
-                } else {
-                    val merged = mergeTrackSelection(
-                        currentAudioIndex = it.selectedNextUpAudioIndex,
-                        currentSubtitleIndex = it.selectedNextUpSubtitleIndex,
-                        durable = restored,
+                    break
+                }
+                val merged = mergeTrackSelection(
+                    currentAudioIndex = current.selectedNextUpAudioIndex,
+                    currentSubtitleIndex = current.selectedNextUpSubtitleIndex,
+                    durable = restored,
+                )
+                val updated = current.copy(
+                    selectedNextUpSubtitleIndex = merged.subtitleIndex,
+                    selectedNextUpAudioIndex = merged.audioIndex,
+                )
+                if (_uiState.compareAndSet(current, updated)) {
+                    remembered = TvDetailTrackSelectionSession.Saved(
+                        fileId = updated.selectedNextUpFileId,
+                        audio = updated.selectedNextUpAudioIndex,
+                        subtitle = updated.selectedNextUpSubtitleIndex,
                     )
-                    it.copy(
-                        selectedNextUpSubtitleIndex = merged.subtitleIndex,
-                        selectedNextUpAudioIndex = merged.audioIndex,
-                    )
+                    break
                 }
             }
-            rememberNextUpTrackSelection()
+            // Remember exactly the successfully-owned target snapshot. Never
+            // reread the now-current UI after a suspension: it may be a carried
+            // selection for a different episode.
+            remembered?.let { selection ->
+                TvDetailTrackSelectionSession.remember(
+                    contentId = targetContentId,
+                    fileId = selection.fileId,
+                    audio = selection.audio,
+                    subtitle = selection.subtitle,
+                )
+            }
         }
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackSelectorRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackSelectorRow.kt
@@ -95,6 +95,7 @@ fun TvPlaybackSelectorRow(
                 options = editions.map { edition ->
                     val count = edition.versions.size
                     TvSelectorOption(
+                        key = "edition:${edition.id}",
                         title = edition.label,
                         detail = "$count version${if (count == 1) "" else "s"}",
                         selected = currentEdition?.id == edition.id,
@@ -117,6 +118,7 @@ fun TvPlaybackSelectorRow(
             options = buildList {
                 add(
                     TvSelectorOption(
+                        key = "version:auto",
                         title = "Auto",
                         detail = "Best match for this device",
                         selected = selectedVersionFileId == null,
@@ -126,6 +128,7 @@ fun TvPlaybackSelectorRow(
                 scopedVersions.forEach { version ->
                     add(
                         TvSelectorOption(
+                            key = "version:${version.fileId}",
                             title = TvPlaybackFormatting.versionShortLabel(version),
                             detail = TvPlaybackFormatting.versionDetailLabel(version),
                             selected = selectedVersionFileId == version.fileId,
@@ -146,6 +149,7 @@ fun TvPlaybackSelectorRow(
             options = buildList {
                 add(
                     TvSelectorOption(
+                        key = "audio:auto",
                         title = "Auto",
                         detail = "Use the file default track",
                         selected = isAudioSelectorOptionSelected(null, selectedAudioTrackIndex),
@@ -157,6 +161,7 @@ fun TvPlaybackSelectorRow(
                 if (audioOptions.isEmpty()) {
                     add(
                         TvSelectorOption(
+                            key = "audio:unknown",
                             title = "Unknown",
                             detail = "",
                             selected = false,
@@ -168,6 +173,7 @@ fun TvPlaybackSelectorRow(
                     audioOptions.forEach { option ->
                         add(
                             TvSelectorOption(
+                                key = "audio:${option.ordinal}",
                                 title = option.title,
                                 detail = option.detail,
                                 selected = option.isSelected,
@@ -203,6 +209,7 @@ fun TvPlaybackSelectorRow(
             options = buildList {
                 add(
                     TvSelectorOption(
+                        key = "subtitle:auto",
                         title = "Auto",
                         detail = "Use your subtitle preferences",
                         selected = selectedSubtitleTrackIndex == null,
@@ -211,6 +218,7 @@ fun TvPlaybackSelectorRow(
                 )
                 add(
                     TvSelectorOption(
+                        key = "subtitle:off",
                         title = "Off",
                         detail = "Start without subtitles",
                         selected = selectedSubtitleTrackIndex == -1,
@@ -226,6 +234,7 @@ fun TvPlaybackSelectorRow(
                     .forEach { option ->
                         add(
                             TvSelectorOption(
+                                key = "subtitle:${option.stableId}",
                                 title = option.title,
                                 detail = option.detail,
                                 selected = option.isSelected,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt
@@ -32,6 +32,8 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -45,6 +47,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -83,6 +86,7 @@ import org.siloserver.silo.model.settings.SubtitleBackgroundStylePreset
 import org.siloserver.silo.model.settings.SubtitleFontSizePreset
 import org.siloserver.silo.model.settings.SubtitlePositionPreset
 import org.siloserver.silo.tv.ui.theme.DarkSurfaceElevated
+import kotlinx.coroutines.launch
 
 private val HudMaxWidth = 680.dp
 private val HudMinHeight = 290.dp
@@ -2100,7 +2104,7 @@ internal fun HudPickerDialog(
                 ),
             )
             // Fully compose this small modal list so every D-pad destination is
-            // present in the focus graph. LazyColumn made below-fold rows look
+            // present in the focus graph. A lazy list made below-fold rows look
             // like the end of the modal and either trapped or leaked focus.
             Column(
                 modifier = Modifier
@@ -2136,6 +2140,8 @@ private fun HudPickerOptionRow(
     onSelect: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+    val scope = rememberCoroutineScope()
     val isFocused by interactionSource.collectIsFocusedAsState()
 
     val bg = when {
@@ -2155,7 +2161,13 @@ private fun HudPickerOptionRow(
             .clip(RoundedCornerShape(8.dp))
             .background(bg)
             .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
-            .onFocusChanged { if (it.isFocused) onFocused() }
+            .bringIntoViewRequester(bringIntoViewRequester)
+            .onFocusChanged { state ->
+                if (state.isFocused) {
+                    onFocused()
+                    scope.launch { bringIntoViewRequester.bringIntoView() }
+                }
+            }
             .clickable(interactionSource = interactionSource, indication = null) { onSelect() }
             .semantics { this.selected = isSelected }
             .padding(horizontal = 10.dp, vertical = 8.dp),

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -245,7 +245,7 @@ fun TvPlayerScreen(
     // the detail screen and replaying actually spins up a fresh player
     // session instead of reusing the cached one bound to the first fileId.
     viewModel: TvPlayerViewModel = koinViewModel(
-        key = "tv-player-$contentId-${preferredFileId ?: "auto"}-${preferredQuality ?: "quality-auto"}-${roomId ?: "solo"}-${resumePositionOverride ?: "server"}-${initialAudioTrackIndex ?: "a"}-${initialSubtitleTrackIndex ?: "s"}-${episodeSelectionHandoff?.hashCode() ?: "no-handoff"}",
+        key = "tv-player-$contentId-${preferredFileId ?: "auto"}-${preferredQuality ?: "quality-auto"}-${roomId ?: "solo"}-${resumePositionOverride ?: "server"}-${initialAudioTrackIndex ?: "a"}-${initialSubtitleTrackIndex ?: "s"}",
         parameters = {
             parametersOf(
                 TvPlayerLaunchArgs(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -233,14 +233,19 @@ fun TvPlayerScreen(
     initialSubtitleTrackIndex: Int? = null,
     // Consecutive auto-advance count (pass-out protection); 0 = manual start.
     autoAdvanceCount: Int = 0,
+    episodeSelectionHandoff: org.siloserver.silo.common.player.video.EpisodeSelectionHandoff? = null,
     // Navigate to the next episode (auto-advance / "Continue"), carrying the
     // updated streak count.
-    onPlayNext: (contentId: String, autoAdvanceCount: Int, preferredQuality: String?) -> Unit = { _, _, _ -> },
+    onPlayNext: (
+        contentId: String,
+        autoAdvanceCount: Int,
+        episodeSelectionHandoff: org.siloserver.silo.common.player.video.EpisodeSelectionHandoff,
+    ) -> Unit = { _, _, _ -> },
     // Scope the ViewModel key by fileId too so switching 4K <-> 1080p on
     // the detail screen and replaying actually spins up a fresh player
     // session instead of reusing the cached one bound to the first fileId.
     viewModel: TvPlayerViewModel = koinViewModel(
-        key = "tv-player-$contentId-${preferredFileId ?: "auto"}-${preferredQuality ?: "quality-auto"}-${roomId ?: "solo"}-${resumePositionOverride ?: "server"}-${initialAudioTrackIndex ?: "a"}-${initialSubtitleTrackIndex ?: "s"}",
+        key = "tv-player-$contentId-${preferredFileId ?: "auto"}-${preferredQuality ?: "quality-auto"}-${roomId ?: "solo"}-${resumePositionOverride ?: "server"}-${initialAudioTrackIndex ?: "a"}-${initialSubtitleTrackIndex ?: "s"}-${episodeSelectionHandoff?.hashCode() ?: "no-handoff"}",
         parameters = {
             parametersOf(
                 TvPlayerLaunchArgs(
@@ -252,6 +257,7 @@ fun TvPlayerScreen(
                     initialAudioTrackIndex = initialAudioTrackIndex,
                     initialSubtitleTrackIndex = initialSubtitleTrackIndex,
                     autoAdvanceCount = autoAdvanceCount,
+                    episodeSelectionHandoff = episodeSelectionHandoff,
                 ),
             )
         },
@@ -547,7 +553,7 @@ fun TvPlayerScreen(
             // singleton, so a late stop() could clobber the next episode's freshly
             // adopted session, and popUpTo would otherwise cancel it mid-flight.
             viewModel.stopSessionForExit()
-            onPlayNext(req.contentId, req.autoAdvanceCount, req.preferredQuality)
+            onPlayNext(req.contentId, req.autoAdvanceCount, req.episodeSelectionHandoff)
         }
     }
     val latestIntroSkipState by rememberUpdatedState(introSkipState)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -193,13 +193,57 @@ internal fun captureTvEpisodeSelectionHandoff(
     },
 )
 
-/** One-shot handoff ownership; replacement loads are new local sessions. */
+internal class TvEpisodeSelectionHandoffLease internal constructor(
+    val ownerGeneration: Long,
+    val sequence: Long,
+    val handoff: EpisodeSelectionHandoff,
+)
+
+/** Recoverable-start lease; only the current owner can retain or acknowledge it. */
 internal class TvEpisodeSelectionHandoffSlot(
     handoff: EpisodeSelectionHandoff?,
 ) {
     private var pending = handoff
+    private var currentLease: TvEpisodeSelectionHandoffLease? = null
+    private var sequence = 0L
 
-    fun takeForStart(): EpisodeSelectionHandoff? = pending.also { pending = null }
+    @Synchronized
+    fun leaseForStart(ownerGeneration: Long): TvEpisodeSelectionHandoffLease? {
+        val handoff = pending ?: return null
+        currentLease?.let { lease ->
+            if (lease.ownerGeneration == ownerGeneration) return lease
+            // A newer launch owner supersedes this transition rather than
+            // inheriting an older in-flight selection intent.
+            invalidate()
+            return null
+        }
+        return TvEpisodeSelectionHandoffLease(
+            ownerGeneration = ownerGeneration,
+            sequence = ++sequence,
+            handoff = handoff,
+        ).also { currentLease = it }
+    }
+
+    @Synchronized
+    fun retainForRetry(lease: TvEpisodeSelectionHandoffLease?): Boolean {
+        if (lease == null || currentLease != lease) return false
+        currentLease = null
+        return true
+    }
+
+    @Synchronized
+    fun acknowledgeReady(lease: TvEpisodeSelectionHandoffLease?): Boolean {
+        if (lease == null || currentLease != lease) return false
+        currentLease = null
+        pending = null
+        return true
+    }
+
+    @Synchronized
+    fun invalidate() {
+        currentLease = null
+        pending = null
+    }
 }
 
 internal data class TvEpisodeInitialSubtitleSelection(
@@ -664,8 +708,8 @@ class TvPlayerViewModel(
     private var qualityOverride: String? = null
     private val roomId: String? = launchArgs.roomId
     private val resumePositionOverride: Double? = launchArgs.resumePositionOverride
-    // The handoff belongs to one cross-screen transition. Consume it before the
-    // first start so profile/server/version replacement loads cannot replay it.
+    // The handoff belongs to one cross-screen transition. A recoverable start
+    // leases it until Ready publication; replacement/exit invalidates it.
     private val episodeSelectionHandoffSlot = TvEpisodeSelectionHandoffSlot(launchArgs.episodeSelectionHandoff)
 
     // Pre-playback track selections from the detail screen. Audio is sent to the
@@ -1516,11 +1560,15 @@ class TvPlayerViewModel(
             finalPositionScope = finalPlaybackPositionWriter.captureScope()
             val unpublishedReadySession =
                 TvUnpublishedLoadSessionOwnership(::rollbackUnpublishedTvLoadSession)
+            var episodeSelectionHandoffLease: TvEpisodeSelectionHandoffLease? = null
             try {
                 if (!subtitleTransactions.invalidateAndAwaitSettlement()) return@launch
                 runCatching { playerSettingsStore.refreshFromServer() }
                 if (!loadOwners.owns(loadOwner)) return@launch
-                val episodeSelectionHandoff = episodeSelectionHandoffSlot.takeForStart()
+                episodeSelectionHandoffLease = episodeSelectionHandoffSlot.leaseForStart(
+                    ownerGeneration = loadOwner.generation,
+                )
+                val episodeSelectionHandoff = episodeSelectionHandoffLease?.handoff
                 val request = VideoPlaybackStartRequest(
                         contentId = contentId,
                         preferredFileId = preferredFileIdOverride ?: preferredFileId,
@@ -1776,25 +1824,38 @@ class TvPlayerViewModel(
                             fail("Playback publication could not be confirmed.")
                             return@launch
                         }
+                        if (result.resolvedEpisodeSelection != null) {
+                            episodeSelectionHandoffSlot.acknowledgeReady(
+                                episodeSelectionHandoffLease,
+                            )
+                        }
                         startIntroAutoSkipObserver()
                         resolveNextEpisode()
                     }
                     is VideoPlayerUiState.Error -> {
+                        episodeSelectionHandoffSlot.retainForRetry(
+                            episodeSelectionHandoffLease,
+                        )
                         if (preserveCurrentPlaybackOnFailure) {
                             _uiState.update { failTvReplacementLoad(it, result.message) }
                         } else {
                             fail(result.message)
                         }
                     }
-                    is VideoPlayerUiState.ServerUnreachable -> _uiState.update {
-                        if (preserveCurrentPlaybackOnFailure) {
-                            failTvReplacementLoad(it, SERVER_UNREACHABLE_MESSAGE)
-                        } else {
-                            it.copy(
-                                isLoading = false,
-                                error = SERVER_UNREACHABLE_MESSAGE,
-                                serverUnreachable = true,
-                            )
+                    is VideoPlayerUiState.ServerUnreachable -> {
+                        episodeSelectionHandoffSlot.retainForRetry(
+                            episodeSelectionHandoffLease,
+                        )
+                        _uiState.update {
+                            if (preserveCurrentPlaybackOnFailure) {
+                                failTvReplacementLoad(it, SERVER_UNREACHABLE_MESSAGE)
+                            } else {
+                                it.copy(
+                                    isLoading = false,
+                                    error = SERVER_UNREACHABLE_MESSAGE,
+                                    serverUnreachable = true,
+                                )
+                            }
                         }
                     }
                     is VideoPlayerUiState.Loading -> Unit
@@ -1806,6 +1867,7 @@ class TvPlayerViewModel(
                 unpublishedReadySession.rollbackIfOwned()
                 Log.e(TAG, "Error loading content", e)
                 if (generation != contentLoadGeneration || !loadOwners.owns(loadOwner)) return@launch
+                episodeSelectionHandoffSlot.retainForRetry(episodeSelectionHandoffLease)
                 val message = "Unexpected error: ${e.message}"
                 if (preserveCurrentPlaybackOnFailure) {
                     _uiState.update { failTvReplacementLoad(it, message) }
@@ -3794,6 +3856,7 @@ class TvPlayerViewModel(
 
     private fun prepareSessionExit() {
         contentLoadGeneration++
+        episodeSelectionHandoffSlot.invalidate()
         subtitleSnapshotSettlement.reset()
         resetSeekRecoveryForContentChange()
         transportMountGate.reset()
@@ -4015,6 +4078,7 @@ class TvPlayerViewModel(
         val state = _uiState.value
         if (fileId == (state.selectedFileId ?: state.mediaFileId)) return
         if (state.fileVersions.none { it.fileId == fileId }) return
+        episodeSelectionHandoffSlot.invalidate()
         resetSeekRecoveryForContentChange()
         transportMountGate.beginLoad()
         val resumeAt = state.position.takeIf { it > 0.0 }
@@ -4074,6 +4138,7 @@ class TvPlayerViewModel(
     }
 
     override fun onCleared() {
+        episodeSelectionHandoffSlot.invalidate()
         val teardownSessionId = exitSessionId
         val subtitlePersistenceReservation =
             subtitleTransactions.reserveDurableFinalPersistence()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -42,9 +42,12 @@ import org.siloserver.silo.common.network.ServerReachabilityMonitor
 import org.siloserver.silo.common.player.video.VideoPlaybackSessionCoordinator
 import org.siloserver.silo.common.player.video.VideoPlaybackStartRequest
 import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
+import org.siloserver.silo.common.player.video.EpisodeSubtitleIntent
+import org.siloserver.silo.common.player.video.EpisodeSubtitleMode
 import org.siloserver.silo.common.player.video.ResolvedEpisodeSelection
 import org.siloserver.silo.common.player.video.captureEpisodeSourceIntent
 import org.siloserver.silo.common.player.video.captureEpisodeSubtitleIntent
+import org.siloserver.silo.common.player.normalizedSubtitleCodecFamily
 import org.siloserver.silo.common.player.video.VideoPlayerUiState
 import org.siloserver.silo.common.player.video.resolvedPlaybackDelivery
 import org.siloserver.silo.common.settings.PlayerSettingsStore
@@ -63,6 +66,7 @@ import org.siloserver.silo.model.playback.PlaybackRouteFamily
 import org.siloserver.silo.model.playback.PlaybackSessionResponse
 import org.siloserver.silo.model.playback.PlayerSubtitleInfo
 import org.siloserver.silo.model.playback.SubtitleIdentity
+import org.siloserver.silo.model.playback.SubtitleMediaIdentity
 import org.siloserver.silo.model.playback.buildPlaybackSubtitleChoices
 import org.siloserver.silo.model.playback.mergeDownloadedSubtitles
 import org.siloserver.silo.model.subtitles.SubtitleAiQuota
@@ -78,6 +82,7 @@ import org.siloserver.silo.network.errorMessage
 import org.siloserver.silo.playback.nextEpisodeAfter
 import org.siloserver.silo.playback.resolveMountedSubtitleOrdinal
 import org.siloserver.silo.playback.subtitleTrackFingerprint
+import org.siloserver.silo.playback.canonicalSubtitleLanguage
 import org.siloserver.silo.player.DolbyVisionPolicy
 import org.siloserver.silo.repository.SubtitlesRepository
 import org.siloserver.silo.repository.port.PlaybackWriteScope
@@ -146,6 +151,17 @@ private fun SubtitleIdentity.serverTrackIndexForTv(): Int = when (this) {
     -> -1
 }
 
+private fun SubtitleMediaIdentity.toEpisodeSubtitleIntent(
+    external: Boolean?,
+): EpisodeSubtitleIntent = EpisodeSubtitleIntent(
+    mode = EpisodeSubtitleMode.TRACK,
+    language = canonicalSubtitleLanguage(language),
+    codecFamily = normalizedSubtitleCodecFamily(codecFamily),
+    forced = forced,
+    hearingImpaired = hearingImpaired,
+    external = external,
+)
+
 /**
  * Captures only episode-portable intent. Server, download, and Media3 identities
  * remain local to the current item and therefore cannot cross this boundary.
@@ -169,9 +185,10 @@ internal fun captureTvEpisodeSelectionHandoff(
                 committedSubtitleIdentity.serverTrackIndexForTv(),
                 catalogSubtitles,
             )
-            is SubtitleIdentity.Downloaded,
-            is SubtitleIdentity.LocalMedia3,
-            -> org.siloserver.silo.common.player.video.EpisodeSubtitleIntent.auto()
+            is SubtitleIdentity.Downloaded -> committedSubtitleIdentity.media
+                .toEpisodeSubtitleIntent(external = true)
+            is SubtitleIdentity.LocalMedia3 -> committedSubtitleIdentity.media
+                .toEpisodeSubtitleIntent(external = null)
         }
     },
 )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -41,6 +41,10 @@ import org.siloserver.silo.common.player.seek.sourcePositionForPlayer
 import org.siloserver.silo.common.network.ServerReachabilityMonitor
 import org.siloserver.silo.common.player.video.VideoPlaybackSessionCoordinator
 import org.siloserver.silo.common.player.video.VideoPlaybackStartRequest
+import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
+import org.siloserver.silo.common.player.video.ResolvedEpisodeSelection
+import org.siloserver.silo.common.player.video.captureEpisodeSourceIntent
+import org.siloserver.silo.common.player.video.captureEpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.VideoPlayerUiState
 import org.siloserver.silo.common.player.video.resolvedPlaybackDelivery
 import org.siloserver.silo.common.settings.PlayerSettingsStore
@@ -48,6 +52,7 @@ import org.siloserver.silo.common.settings.dolbyVisionPolicySnapshot
 import org.siloserver.silo.domain.player.IntroAutoSkipController
 import org.siloserver.silo.domain.player.IntroAutoSkipState
 import org.siloserver.silo.model.catalog.AudioTrack
+import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.catalog.TimeRange
 import org.siloserver.silo.model.catalog.VersionChapter
 import org.siloserver.silo.model.settings.SubtitleAppearance
@@ -139,6 +144,68 @@ private fun SubtitleIdentity.serverTrackIndexForTv(): Int = when (this) {
     is SubtitleIdentity.Downloaded,
     is SubtitleIdentity.LocalMedia3,
     -> -1
+}
+
+/**
+ * Captures only episode-portable intent. Server, download, and Media3 identities
+ * remain local to the current item and therefore cannot cross this boundary.
+ */
+internal fun captureTvEpisodeSelectionHandoff(
+    activeVersion: FileVersion?,
+    committedSubtitleIdentity: SubtitleIdentity,
+    catalogSubtitles: List<PlayerSubtitleInfo>,
+    hasExplicitSubtitleSelection: Boolean,
+): EpisodeSelectionHandoff = EpisodeSelectionHandoff(
+    source = captureEpisodeSourceIntent(activeVersion),
+    subtitle = if (!hasExplicitSubtitleSelection) {
+        org.siloserver.silo.common.player.video.EpisodeSubtitleIntent.auto()
+    } else {
+        when (committedSubtitleIdentity) {
+            SubtitleIdentity.Off -> captureEpisodeSubtitleIntent(-1, catalogSubtitles)
+            is SubtitleIdentity.ServerSidecar,
+            is SubtitleIdentity.ServerBurnIn,
+            is SubtitleIdentity.Embedded,
+            -> captureEpisodeSubtitleIntent(
+                committedSubtitleIdentity.serverTrackIndexForTv(),
+                catalogSubtitles,
+            )
+            is SubtitleIdentity.Downloaded,
+            is SubtitleIdentity.LocalMedia3,
+            -> org.siloserver.silo.common.player.video.EpisodeSubtitleIntent.auto()
+        }
+    },
+)
+
+/** One-shot handoff ownership; replacement loads are new local sessions. */
+internal class TvEpisodeSelectionHandoffSlot(
+    handoff: EpisodeSelectionHandoff?,
+) {
+    private var pending = handoff
+
+    fun takeForStart(): EpisodeSelectionHandoff? = pending.also { pending = null }
+}
+
+internal data class TvEpisodeInitialSubtitleSelection(
+    val pendingInitialSubtitleIndex: Int?,
+    val suppressDurableSubtitleRestore: Boolean,
+)
+
+/** Applies a target-only resolution without changing ordinary/manual starts. */
+internal fun resolveTvEpisodeInitialSubtitleSelection(
+    episodeSelectionHandoff: EpisodeSelectionHandoff?,
+    resolvedEpisodeSelection: ResolvedEpisodeSelection?,
+    existingPendingInitialSubtitleIndex: Int?,
+): TvEpisodeInitialSubtitleSelection {
+    if (episodeSelectionHandoff == null || resolvedEpisodeSelection == null) {
+        return TvEpisodeInitialSubtitleSelection(
+            pendingInitialSubtitleIndex = existingPendingInitialSubtitleIndex,
+            suppressDurableSubtitleRestore = false,
+        )
+    }
+    return TvEpisodeInitialSubtitleSelection(
+        pendingInitialSubtitleIndex = resolvedEpisodeSelection.subtitleTrackIndex,
+        suppressDurableSubtitleRestore = resolvedEpisodeSelection.subtitleIntentSpecified,
+    )
 }
 
 private val hearingImpairedSubtitleTokenRegex = Regex(
@@ -427,10 +494,15 @@ data class TvPlayerLaunchArgs(
      * instead of auto-advancing.
      */
     val autoAdvanceCount: Int = 0,
+    val episodeSelectionHandoff: EpisodeSelectionHandoff? = null,
 )
 
 /** Emitted to ask the screen to navigate to the next episode (auto-advance / Continue). */
-data class PlayNextRequest(val contentId: String, val autoAdvanceCount: Int, val preferredQuality: String?)
+data class PlayNextRequest(
+    val contentId: String,
+    val autoAdvanceCount: Int,
+    val episodeSelectionHandoff: EpisodeSelectionHandoff,
+)
 
 /**
  * Subtitle provider search/download state backing the TV subtitle search
@@ -575,6 +647,9 @@ class TvPlayerViewModel(
     private var qualityOverride: String? = null
     private val roomId: String? = launchArgs.roomId
     private val resumePositionOverride: Double? = launchArgs.resumePositionOverride
+    // The handoff belongs to one cross-screen transition. Consume it before the
+    // first start so profile/server/version replacement loads cannot replay it.
+    private val episodeSelectionHandoffSlot = TvEpisodeSelectionHandoffSlot(launchArgs.episodeSelectionHandoff)
 
     // Pre-playback track selections from the detail screen. Audio is sent to the
     // server session start; subtitle is applied once the player's tracks land
@@ -1428,6 +1503,7 @@ class TvPlayerViewModel(
                 if (!subtitleTransactions.invalidateAndAwaitSettlement()) return@launch
                 runCatching { playerSettingsStore.refreshFromServer() }
                 if (!loadOwners.owns(loadOwner)) return@launch
+                val episodeSelectionHandoff = episodeSelectionHandoffSlot.takeForStart()
                 val request = VideoPlaybackStartRequest(
                         contentId = contentId,
                         preferredFileId = preferredFileIdOverride ?: preferredFileId,
@@ -1439,6 +1515,7 @@ class TvPlayerViewModel(
                         playbackQualityIntent = qualityOverride,
                         suppressResumeRewind = suppressResumeRewind,
                         force = force,
+                        episodeSelectionHandoff = episodeSelectionHandoff,
                     )
                 val result = loadOwners.withOwner(loadOwner) {
                     videoPlaybackCoordinator.start(request)
@@ -1467,6 +1544,15 @@ class TvPlayerViewModel(
                             )
                             return@launch
                         }
+                        val subtitleSelection = resolveTvEpisodeInitialSubtitleSelection(
+                            episodeSelectionHandoff = episodeSelectionHandoff,
+                            resolvedEpisodeSelection = result.resolvedEpisodeSelection,
+                            existingPendingInitialSubtitleIndex = pendingInitialSubtitleIndex,
+                        )
+                        pendingInitialSubtitleIndex = subtitleSelection.pendingInitialSubtitleIndex
+                        if (episodeSelectionHandoff != null && result.resolvedEpisodeSelection != null) {
+                            pendingInitialSubtitleAttempts = 0
+                        }
                         val localTrackSelection = result.fileId
                             ?.let { fileId -> userItemStatePort.localTrackSelection(contentId, fileId) }
                         if (!loadOwners.owns(loadOwner)) {
@@ -1484,7 +1570,10 @@ class TvPlayerViewModel(
                             .firstOrNull { it.fileId == (result.fileId ?: readyMediaFileId) }
                             ?.subtitleTracks
                             .orEmpty()
-                        val restorePreference = if (pendingInitialSubtitleIndex == null) {
+                        val restorePreference = if (
+                            pendingInitialSubtitleIndex == null &&
+                            !subtitleSelection.suppressDurableSubtitleRestore
+                        ) {
                             localTrackSelection?.subtitleFingerprint
                         } else {
                             null
@@ -2881,9 +2970,17 @@ class TvPlayerViewModel(
         nextUpCountdownJob = null
         val state = _uiState.value
         val next = state.nextEpisode ?: return
-        val selectedQuality = state.selectedFileResolution
         _uiState.update { it.copy(showNextUp = false, nextUpCountdownSeconds = null) }
-        _playNextRequests.tryEmit(PlayNextRequest(next.contentId, nextAutoAdvanceCount, selectedQuality))
+        val activeVersion = state.fileVersions.firstOrNull { version ->
+            version.fileId == (state.selectedFileId ?: state.mediaFileId)
+        }
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = activeVersion,
+            committedSubtitleIdentity = state.committedSubtitleIdentity,
+            catalogSubtitles = state.subtitleUrls,
+            hasExplicitSubtitleSelection = manualSubtitleSelectionApplied,
+        )
+        _playNextRequests.tryEmit(PlayNextRequest(next.contentId, nextAutoAdvanceCount, handoff))
     }
 
     /** Up-Next "Keep Watching" — dismiss the overlay and stay on the current episode. */

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -1596,6 +1596,9 @@ class TvPlayerViewModel(
                         val allocatedSessionId = result.sessionId
                             ?.takeIf(String::isNotBlank)
                             ?: run {
+                                episodeSelectionHandoffSlot.retainForRetry(
+                                    episodeSelectionHandoffLease,
+                                )
                                 fail("Playback start returned no session.")
                                 return@launch
                             }
@@ -1821,6 +1824,9 @@ class TvPlayerViewModel(
                         }
                         if (!jointlyConfirmed) {
                             unpublishedReadySession.rollbackIfOwned(publishedSessionId)
+                            episodeSelectionHandoffSlot.retainForRetry(
+                                episodeSelectionHandoffLease,
+                            )
                             fail("Playback publication could not be confirmed.")
                             return@launch
                         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -11,10 +11,16 @@ import org.siloserver.silo.common.player.video.VideoPlaybackStartRequest
 import org.siloserver.silo.common.player.video.VideoPlaybackStartResult
 import org.siloserver.silo.common.player.video.VideoPlaybackStarter
 import org.siloserver.silo.common.player.video.PlaybackDiagnosticsCode
+import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
+import org.siloserver.silo.common.player.video.EpisodeSubtitleIntent
+import org.siloserver.silo.common.player.video.ResolvedEpisodeSelection
+import org.siloserver.silo.common.player.video.resolveEpisodeSourceIntent
+import org.siloserver.silo.common.player.video.resolveEpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.resolvedPlaybackDelivery
 import org.siloserver.silo.common.player.video.shouldReachServerForPlayback
 import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.common.settings.dolbyVisionPolicySnapshot
+import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.playback.applyResumeRewind
 import org.siloserver.silo.model.playback.buildPlaybackSubtitleChoices
 import org.siloserver.silo.model.playback.resolvePlaybackStartRequestPosition
@@ -72,13 +78,20 @@ class TvVideoPlaybackStarter(
             val preferredQuality = request.preferredQualityOverride
                 ?: playerSettingsStore.preferredQualityFlow.first()
             val playbackQualityIntent = request.playbackQualityIntent ?: preferredQuality
-            val version = request.preferredFileId
-                ?.let { id -> watchDetail.versions.firstOrNull { it.fileId == id } }
-                ?: selectPlaybackVersion(
-                    watchDetail.versions,
-                    watchDetail.userData?.lastFileId,
-                    preferredQuality,
-                )
+            val resolvedEpisodeSelection = resolveTvPlaybackStartSelection(
+                preferredFileId = request.preferredFileId,
+                episodeSelectionHandoff = request.episodeSelectionHandoff,
+                targetVersions = watchDetail.versions,
+                targetLastFileId = watchDetail.userData?.lastFileId,
+                preferredQuality = preferredQuality,
+            )
+            val version = watchDetail.versions.first { it.fileId == resolvedEpisodeSelection.fileId }
+            // The server rejects -1, while the Ready result retains it for the
+            // client-side Media3 selection that represents explicit Off.
+            val serverSubtitleTrackIndex = resolveTvServerSubtitleTrackIndex(
+                resolvedEpisodeSelection = resolvedEpisodeSelection,
+                requestedSubtitleTrackIndex = request.subtitleTrackIndex,
+            )
             val activeProfile = profileRepository.getActiveProfile()
             val profileId = activeProfile?.id ?: profileRepository.getActiveProfileId()
                 ?: return failure(
@@ -131,7 +144,7 @@ class TvVideoPlaybackStarter(
                     capabilities = capabilities,
                     clientPlaybackContext = playbackContext,
                     audioTrackIndex = request.audioTrackIndex,
-                    subtitleTrackIndex = request.subtitleTrackIndex,
+                    subtitleTrackIndex = serverSubtitleTrackIndex,
                     qualityPreference = playbackQualityIntent,
                     startPosition = startRequestPosition,
                     // The bandwidth half of the quality choice. The server
@@ -259,6 +272,7 @@ class TvVideoPlaybackStarter(
                 seriesId = watchDetail.seriesId,
                 seasonNumber = watchDetail.seasonNumber,
                 episodeNumber = watchDetail.episodeNumber,
+                resolvedEpisodeSelection = resolvedEpisodeSelection,
             )
         } catch (e: CancellationException) {
             throw e
@@ -287,4 +301,53 @@ class TvVideoPlaybackStarter(
     private companion object {
         const val TAG = "TvVideoPlaybackStarter"
     }
+}
+
+/**
+ * Resolves session-only episode intent after the target detail is available.
+ *
+ * The target subtitle list depends on the chosen version, so source precedence
+ * is decided first; the existing shared source/subtitle resolvers then provide
+ * the semantic matching without duplicating their policy here.
+ */
+fun resolveTvPlaybackStartSelection(
+    preferredFileId: Int?,
+    episodeSelectionHandoff: EpisodeSelectionHandoff?,
+    targetVersions: List<FileVersion>,
+    targetLastFileId: Int?,
+    preferredQuality: String?,
+): ResolvedEpisodeSelection {
+    require(targetVersions.isNotEmpty()) { "targetVersions must not be empty" }
+
+    val semanticFileId = resolveEpisodeSourceIntent(
+        intent = episodeSelectionHandoff?.source,
+        targetVersions = targetVersions,
+    )
+    val selectedVersion = preferredFileId
+        ?.let { preferredId -> targetVersions.firstOrNull { it.fileId == preferredId } }
+        ?: semanticFileId
+            ?.let { handoffFileId -> targetVersions.firstOrNull { it.fileId == handoffFileId } }
+        ?: selectPlaybackVersion(targetVersions, targetLastFileId, preferredQuality)
+    val resolvedSubtitle = resolveEpisodeSubtitleIntent(
+        intent = episodeSelectionHandoff?.subtitle ?: EpisodeSubtitleIntent.auto(),
+        targetSubtitles = buildPlaybackSubtitleChoices(
+            catalogTracks = selectedVersion.subtitleTracks.orEmpty(),
+            plannedTracks = emptyList(),
+        ),
+    )
+    return ResolvedEpisodeSelection(
+        fileId = selectedVersion.fileId,
+        subtitleTrackIndex = resolvedSubtitle.trackIndex,
+        subtitleIntentSpecified = resolvedSubtitle.intentSpecified,
+    )
+}
+
+/** Converts the client-side selection to the server's non-negative index contract. */
+fun resolveTvServerSubtitleTrackIndex(
+    resolvedEpisodeSelection: ResolvedEpisodeSelection,
+    requestedSubtitleTrackIndex: Int?,
+): Int? = if (resolvedEpisodeSelection.subtitleIntentSpecified) {
+    resolvedEpisodeSelection.subtitleTrackIndex?.takeIf { it >= 0 }
+} else {
+    requestedSubtitleTrackIndex?.takeIf { it >= 0 }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -89,6 +89,7 @@ class TvVideoPlaybackStarter(
             // The server rejects -1, while the Ready result retains it for the
             // client-side Media3 selection that represents explicit Off.
             val serverSubtitleTrackIndex = resolveTvServerSubtitleTrackIndex(
+                episodeSelectionHandoff = request.episodeSelectionHandoff,
                 resolvedEpisodeSelection = resolvedEpisodeSelection,
                 requestedSubtitleTrackIndex = request.subtitleTrackIndex,
             )
@@ -208,7 +209,11 @@ class TvVideoPlaybackStarter(
                     fileId = effectiveFileId,
                     capabilities = capabilities,
                     audioTrackIndex = resolved.audioTrackIndex,
-                    subtitleTrackIndex = request.subtitleTrackIndex,
+                    subtitleTrackIndex = if (request.episodeSelectionHandoff != null) {
+                        serverSubtitleTrackIndex
+                    } else {
+                        request.subtitleTrackIndex
+                    },
                     qualityPreference = playbackQualityIntent,
                     startPosition = sourceStartPos,
                     clientPlaybackContext = playbackContext,
@@ -344,9 +349,10 @@ fun resolveTvPlaybackStartSelection(
 
 /** Converts the client-side selection to the server's non-negative index contract. */
 fun resolveTvServerSubtitleTrackIndex(
+    episodeSelectionHandoff: EpisodeSelectionHandoff?,
     resolvedEpisodeSelection: ResolvedEpisodeSelection,
     requestedSubtitleTrackIndex: Int?,
-): Int? = if (resolvedEpisodeSelection.subtitleIntentSpecified) {
+): Int? = if (episodeSelectionHandoff != null) {
     resolvedEpisodeSelection.subtitleTrackIndex?.takeIf { it >= 0 }
 } else {
     requestedSubtitleTrackIndex?.takeIf { it >= 0 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvSelectorRowVisualStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvSelectorRowVisualStateTest.kt
@@ -1,0 +1,36 @@
+package org.siloserver.silo.tv.ui.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import org.siloserver.silo.tv.ui.theme.FocusedContainer
+import org.siloserver.silo.tv.ui.theme.FocusedContent
+
+class TvSelectorRowVisualStateTest {
+
+    @Test
+    fun focusedRowsUseInvertedTvContrast() {
+        val state = tvSelectorRowVisualState(focused = true, selected = false, enabled = true)
+
+        assertEquals(FocusedContainer, state.container)
+        assertEquals(FocusedContent, state.content)
+        assertTrue(state.border.alpha > 0f)
+    }
+
+    @Test
+    fun selectedIdleRowsRemainDistinctFromIdleRows() {
+        val selected = tvSelectorRowVisualState(focused = false, selected = true, enabled = true)
+        val idle = tvSelectorRowVisualState(focused = false, selected = false, enabled = true)
+
+        assertNotEquals(idle.container, selected.container)
+        assertNotEquals(idle.border, selected.border)
+    }
+
+    @Test
+    fun disabledRowsStayMutedEvenWhenSelected() {
+        val state = tvSelectorRowVisualState(focused = false, selected = true, enabled = false)
+
+        assertTrue(state.content.alpha < 0.5f)
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/navigation/TvPlayerRouteTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/navigation/TvPlayerRouteTest.kt
@@ -1,8 +1,14 @@
 package org.siloserver.silo.tv.ui.navigation
 
+import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
+import org.siloserver.silo.common.player.video.EpisodeSourceIntent
+import org.siloserver.silo.common.player.video.EpisodeSubtitleIntent
+import org.siloserver.silo.common.player.video.EpisodeSubtitleMode
+import org.siloserver.silo.common.player.video.decodeEpisodeSelectionHandoff
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class TvPlayerRouteTest {
@@ -53,6 +59,44 @@ class TvPlayerRouteTest {
         ).route
 
         assertFalse(route.contains("resumePosition="))
+    }
+
+    @Test
+    fun playerRouteRoundTripsEpisodeSelectionHandoff() {
+        val handoff = EpisodeSelectionHandoff(
+            source = EpisodeSourceIntent(resolution = "1080p", videoCodec = "h264"),
+            subtitle = EpisodeSubtitleIntent(
+                mode = EpisodeSubtitleMode.TRACK,
+                language = "en",
+                codecFamily = "srt",
+            ),
+        )
+
+        val route = TvRoute.Player(
+            contentId = "episode-123",
+            episodeSelectionHandoff = handoff,
+        ).route
+
+        val payload = route.substringAfter("episodeSelectionHandoff=")
+        assertTrue(payload.contains("%"), "handoff JSON must be URL-encoded in the route")
+        assertTrue(
+            decodeEpisodeSelectionHandoff(java.net.URLDecoder.decode(payload, Charsets.UTF_8)) == handoff,
+            "decoded route payload must preserve semantic selection intent",
+        )
+    }
+
+    @Test
+    fun playerRouteWithoutHandoffKeepsExistingDefaults() {
+        val route = TvRoute.Player(contentId = "episode-123").route
+
+        assertFalse(route.contains("episodeSelectionHandoff="))
+        assertFalse(route.contains("fileId="))
+        assertFalse(route.contains("subtitleTrackIndex="))
+    }
+
+    @Test
+    fun malformedEpisodeHandoffIsIgnored() {
+        assertNull(decodeEpisodeSelectionHandoff("{not-json"))
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/navigation/TvPlayerRouteTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/navigation/TvPlayerRouteTest.kt
@@ -4,9 +4,9 @@ import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
 import org.siloserver.silo.common.player.video.EpisodeSourceIntent
 import org.siloserver.silo.common.player.video.EpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.EpisodeSubtitleMode
-import org.siloserver.silo.common.player.video.decodeEpisodeSelectionHandoff
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -62,7 +62,7 @@ class TvPlayerRouteTest {
     }
 
     @Test
-    fun playerRouteRoundTripsEpisodeSelectionHandoff() {
+    fun sameProcessRegistryDeliversHandoffOnceToMatchingContent() {
         val handoff = EpisodeSelectionHandoff(
             source = EpisodeSourceIntent(resolution = "1080p", videoCodec = "h264"),
             subtitle = EpisodeSubtitleIntent(
@@ -71,32 +71,121 @@ class TvPlayerRouteTest {
                 codecFamily = "srt",
             ),
         )
+        val registry = registryWithNonces("abcdefghijklmnop")
+        val nonce = registry.register(targetContentId = "episode-123", handoff = handoff)
 
         val route = TvRoute.Player(
             contentId = "episode-123",
-            episodeSelectionHandoff = handoff,
+            episodeSelectionHandoffNonce = nonce,
         ).route
 
-        val payload = route.substringAfter("episodeSelectionHandoff=")
-        assertTrue(payload.contains("%"), "handoff JSON must be URL-encoded in the route")
-        assertTrue(
-            decodeEpisodeSelectionHandoff(java.net.URLDecoder.decode(payload, Charsets.UTF_8)) == handoff,
-            "decoded route payload must preserve semantic selection intent",
+        val routedNonce = route.substringAfter("episodeSelectionHandoffNonce=")
+        assertEquals(handoff, registry.claim(routedNonce, targetContentId = "episode-123"))
+        assertNull(registry.claim(routedNonce, targetContentId = "episode-123"))
+    }
+
+    @Test
+    fun playerRouteDoesNotPersistSemanticHandoffData() {
+        val handoff = EpisodeSelectionHandoff(
+            source = EpisodeSourceIntent(resolution = "1080p", videoCodec = "h264"),
+            subtitle = EpisodeSubtitleIntent(
+                mode = EpisodeSubtitleMode.TRACK,
+                language = "en",
+                codecFamily = "srt",
+            ),
         )
+        val registry = registryWithNonces("abcdefghijklmnop")
+        val route = TvRoute.Player(
+            contentId = "episode-123",
+            episodeSelectionHandoffNonce = registry.register("episode-123", handoff),
+        ).route
+
+        assertFalse(route.contains("1080p"), "semantic source intent must not enter saved routes")
+        assertFalse(route.contains("h264"), "codec intent must not enter saved routes")
+        assertFalse(route.contains("srt"), "subtitle intent must not enter saved routes")
+        assertFalse(route.contains("language"), "semantic field names must not enter saved routes")
+        assertFalse(route.contains("{"), "handoff JSON must not enter saved routes")
     }
 
     @Test
     fun playerRouteWithoutHandoffKeepsExistingDefaults() {
         val route = TvRoute.Player(contentId = "episode-123").route
 
-        assertFalse(route.contains("episodeSelectionHandoff="))
+        assertFalse(route.contains("episodeSelectionHandoffNonce="))
         assertFalse(route.contains("fileId="))
         assertFalse(route.contains("subtitleTrackIndex="))
     }
 
     @Test
-    fun malformedEpisodeHandoffIsIgnored() {
-        assertNull(decodeEpisodeSelectionHandoff("{not-json"))
+    fun contentMismatchRejectsAndConsumesRegistryEntry() {
+        val registry = registryWithNonces("abcdefghijklmnop")
+        val nonce = registry.register("episode-123", handoff())
+
+        assertNull(registry.claim(nonce, targetContentId = "episode-456"))
+        assertNull(registry.claim(nonce, targetContentId = "episode-123"))
+    }
+
+    @Test
+    fun registryClearModelsProcessRecreation() {
+        val registry = registryWithNonces("abcdefghijklmnop")
+        val nonce = registry.register("episode-123", handoff())
+
+        registry.clear()
+
+        assertNull(registry.claim(nonce, targetContentId = "episode-123"))
+    }
+
+    @Test
+    fun malformedAndOversizedNoncesAreIgnoredAndOmitted() {
+        val registry = registryWithNonces("abcdefghijklmnop")
+
+        assertNull(registry.claim("not valid!", targetContentId = "episode-123"))
+        assertNull(registry.claim("a".repeat(256), targetContentId = "episode-123"))
+        assertFalse(
+            TvRoute.Player(
+                contentId = "episode-123",
+                episodeSelectionHandoffNonce = "not valid!",
+            ).route.contains("episodeSelectionHandoffNonce="),
+        )
+        assertFalse(
+            TvRoute.Player(
+                contentId = "episode-123",
+                episodeSelectionHandoffNonce = "a".repeat(256),
+            ).route.contains("episodeSelectionHandoffNonce="),
+        )
+    }
+
+    @Test
+    fun registryEvictsOldestEntryAtCapacity() {
+        val registry = registryWithNonces(
+            "abcdefghijklmnop",
+            "bcdefghijklmnopq",
+            "cdefghijklmnopqr",
+            maxEntries = 2,
+        )
+        val first = registry.register("episode-1", handoff())
+        val second = registry.register("episode-2", handoff())
+        val third = registry.register("episode-3", handoff())
+
+        assertNull(registry.claim(first, "episode-1"))
+        assertEquals(handoff(), registry.claim(second, "episode-2"))
+        assertEquals(handoff(), registry.claim(third, "episode-3"))
+    }
+
+    @Test
+    fun registryExpiresEntriesAfterBoundedLifetime() {
+        var nowMillis = 1_000L
+        val registry = TvEpisodeSelectionHandoffRegistry(
+            maxEntries = 2,
+            ttlMillis = 500L,
+            nowMillis = { nowMillis },
+            nonceFactory = { "abcdefghijklmnop" },
+        )
+        val nonce = registry.register("episode-123", handoff())
+
+        nowMillis += 500L
+
+        assertNull(registry.claim(nonce, "episode-123"))
     }
 
     @Test
@@ -106,4 +195,22 @@ class TvPlayerRouteTest {
             "Start Over must pass an explicit 0.0 override; null falls back to stored progress",
         )
     }
+
+    private fun registryWithNonces(
+        vararg nonces: String,
+        maxEntries: Int = 8,
+    ): TvEpisodeSelectionHandoffRegistry {
+        val iterator = nonces.iterator()
+        return TvEpisodeSelectionHandoffRegistry(
+            maxEntries = maxEntries,
+            ttlMillis = 60_000L,
+            nowMillis = { 1_000L },
+            nonceFactory = { iterator.next() },
+        )
+    }
+
+    private fun handoff() = EpisodeSelectionHandoff(
+        source = EpisodeSourceIntent(resolution = "1080p", videoCodec = "h264"),
+        subtitle = EpisodeSubtitleIntent.off(),
+    )
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailSubtitlePreferenceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailSubtitlePreferenceTest.kt
@@ -149,14 +149,17 @@ class TvItemDetailSubtitlePreferenceTest {
         profileShowForced: Boolean? = null,
     ): TvItemDetailViewModel {
         val client = detailClient(profileSubtitleLanguage, profileSubtitleMode, profileShowForced)
+        val tokenManager = FakeTokenManager()
         return TvItemDetailViewModel(
             catalogRepository = CatalogRepository(CatalogApi(client)),
             personalDataRepository = PersonalDataRepository(PersonalDataApi(client)),
             playerSettingsStore = FakePlayerSettingsStore(),
-            profileRepository = ProfileRepository(ProfileApi(client), FakeTokenManager()),
+            profileRepository = ProfileRepository(ProfileApi(client), tokenManager),
             profileSettings = ProfileSettingsController(SettingsRepository(settingsApi)),
             metadataAiRepository = MetadataAiRepository(DefaultMetadataAiApi(client)),
             contentId = CONTENT_ID,
+            tokenManager = tokenManager,
+            identityTransitions = org.siloserver.silo.network.DefaultIdentityTransitionBarrier(),
         ).also { createdViewModels += it }
     }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
@@ -1,0 +1,546 @@
+package org.siloserver.silo.tv.ui.screens.detail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.siloserver.silo.domain.settings.ProfileSettingsController
+import org.siloserver.silo.model.catalog.AudioTrack
+import org.siloserver.silo.model.catalog.SubtitleTrack
+import org.siloserver.silo.model.settings.SettingsContractCapabilities
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionKind
+import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.api.CatalogApi
+import org.siloserver.silo.network.api.DefaultMetadataAiApi
+import org.siloserver.silo.network.api.PersonalDataApi
+import org.siloserver.silo.network.api.ProfileApi
+import org.siloserver.silo.network.api.SettingsApi
+import org.siloserver.silo.network.api.SettingsCapabilitiesResult
+import org.siloserver.silo.playback.audioTrackFingerprint
+import org.siloserver.silo.playback.subtitleTrackFingerprint
+import org.siloserver.silo.repository.CatalogRepository
+import org.siloserver.silo.repository.MetadataAiRepository
+import org.siloserver.silo.repository.PersonalDataRepository
+import org.siloserver.silo.repository.ProfileRepository
+import org.siloserver.silo.repository.SettingsRepository
+import org.siloserver.silo.repository.port.LocalTrackSelection
+import org.siloserver.silo.repository.port.OutboxHandle
+import org.siloserver.silo.repository.port.UserItemStatePort
+import org.siloserver.silo.repository.port.WriteOutcome
+import org.siloserver.silo.tv.testing.FakePlayerSettingsStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Exercises the real detail ViewModel refresh path: series -> seasons -> episodes
+ * -> asynchronous target detail, including session and durable track merging.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvNextUpSelectionHandoffTest {
+
+    @Test
+    fun changingNextUpResolvesOldSourceAgainstNewEpisodeFiles() = runDetailTest {
+        val scenario = Scenario(
+            suffix = "-source",
+            oldVersions = listOf(version(101, "720p"), version(102, "1080p", codec = "hevc")),
+            newVersions = listOf(version(201, "480p"), version(202, "1080p", codec = "hevc")),
+        )
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onNextUpVersionSelected(102)
+
+        advanceToEpisodeTwo(fixture.viewModel, scenario)
+
+        assertEquals(202, fixture.viewModel.uiState.value.selectedNextUpFileId)
+    }
+
+    @Test
+    fun changingNextUpResolvesSubtitleAtDifferentCombinedIndex() = runDetailTest {
+        val french = subtitle(index = 4, language = "fre", external = true, title = "French")
+        val scenario = Scenario(
+            suffix = "-subtitle-index",
+            oldVersions = listOf(
+                version(
+                    101,
+                    "1080p",
+                    subtitles = listOf(
+                        subtitle(index = 9, language = "eng"),
+                        french,
+                    ),
+                ),
+            ),
+            newVersions = listOf(
+                version(
+                    201,
+                    "1080p",
+                    subtitles = listOf(
+                        subtitle(index = 2, language = "spa", external = true),
+                        subtitle(index = 8, language = "eng"),
+                        french.copy(index = 7),
+                    ),
+                ),
+            ),
+        )
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        // Old combined index 0 is the sole external track. On the target,
+        // French is the second external track and therefore combined index 1.
+        fixture.viewModel.onNextUpSubtitleTrackSelected(0)
+
+        advanceToEpisodeTwo(fixture.viewModel, scenario)
+
+        assertEquals(1, fixture.viewModel.uiState.value.selectedNextUpSubtitleIndex)
+    }
+
+    @Test
+    fun explicitOffRemainsOffAcrossNextUpRefresh() = runDetailTest {
+        val scenario = Scenario(suffix = "-off")
+        TvDetailTrackSelectionSession.remember(
+            scenario.episodeTwoId,
+            fileId = 201,
+            audio = null,
+            subtitle = 0,
+        )
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(-1)
+
+        advanceToEpisodeTwo(fixture.viewModel, scenario)
+
+        assertEquals(-1, fixture.viewModel.uiState.value.selectedNextUpSubtitleIndex)
+    }
+
+    @Test
+    fun missingExplicitSubtitleUsesAutoAndDoesNotRestoreTargetDurableSubtitle() = runDetailTest {
+        val oldFrench = subtitle(index = 4, language = "fre", external = true, title = "French")
+        val targetEnglish = subtitle(index = 8, language = "eng", title = "English")
+        val targetAudio = listOf(
+            AudioTrack(index = 3, codec = "aac", language = "eng"),
+            AudioTrack(index = 7, codec = "ac3", language = "jpn"),
+        )
+        val scenario = Scenario(
+            suffix = "-missing-subtitle",
+            oldVersions = listOf(version(101, "1080p", subtitles = listOf(oldFrench))),
+            newVersions = listOf(
+                version(201, "1080p", subtitles = listOf(targetEnglish), audio = targetAudio),
+            ),
+        )
+        val fixture = createFixture(scenario)
+        fixture.userState.saved[scenario.episodeTwoId to 201] = LocalTrackSelection(
+            audioFingerprint = audioTrackFingerprint(targetAudio[1]),
+            subtitleFingerprint = subtitleTrackFingerprint(targetEnglish),
+        )
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(0)
+
+        advanceToEpisodeTwo(fixture.viewModel, scenario)
+
+        val state = fixture.viewModel.uiState.value
+        assertNull(state.selectedNextUpSubtitleIndex)
+        assertEquals(1, state.selectedNextUpAudioIndex, "durable audio behavior stays unchanged")
+    }
+
+    @Test
+    fun autoAllowsExistingTargetDurableSubtitleRestore() = runDetailTest {
+        val targetEnglish = subtitle(index = 8, language = "eng", title = "English")
+        val scenario = Scenario(
+            suffix = "-auto-durable",
+            newVersions = listOf(version(201, "1080p", subtitles = listOf(targetEnglish))),
+        )
+        val fixture = createFixture(scenario)
+        fixture.userState.saved[scenario.episodeTwoId to 201] = LocalTrackSelection(
+            audioFingerprint = null,
+            subtitleFingerprint = subtitleTrackFingerprint(targetEnglish),
+        )
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+
+        advanceToEpisodeTwo(fixture.viewModel, scenario)
+
+        assertEquals(0, fixture.viewModel.uiState.value.selectedNextUpSubtitleIndex)
+    }
+
+    @Test
+    fun staleRefreshCompletionCannotApplyHandoffToAnotherEpisode() = runDetailTest {
+        val scenario = Scenario(suffix = "-stale")
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+
+        advanceToEpisodeTwo(fixture.viewModel, scenario)
+
+        val staleGate = CompletableDeferred<Unit>()
+        val freshGate = CompletableDeferred<Unit>()
+        scenario.episodeOneResponses.addLast(
+            DetailResponse(staleGate, itemDetailJson(scenario.episodeOneId, listOf(version(801, "720p")))),
+        )
+        scenario.episodeOneResponses.addLast(
+            DetailResponse(freshGate, itemDetailJson(scenario.episodeOneId, listOf(version(901, "2160p")))),
+        )
+
+        fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, false)
+        awaitCondition { scenario.pendingEpisodeOneResponses == 1 }
+        fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
+        awaitEpisode(fixture.viewModel, scenario.episodeTwoId)
+        fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, false)
+        staleGate.complete(Unit)
+        awaitCondition { scenario.pendingEpisodeOneResponses == 0 }
+        delay(20)
+
+        assertNotEquals(
+            801,
+            fixture.viewModel.uiState.value.nextUpPlaybackDetail?.versions?.singleOrNull()?.fileId,
+        )
+        freshGate.complete(Unit)
+    }
+
+    @Test
+    fun carriedSelectionIsNotPersistedBeforeExplicitUserInput() = runDetailTest {
+        val scenario = Scenario(
+            suffix = "-no-persist",
+            oldVersions = listOf(version(101, "1080p", subtitles = listOf(subtitle(4, "fre", external = true)))),
+            newVersions = listOf(version(201, "1080p", subtitles = listOf(subtitle(7, "fre", external = true)))),
+        )
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onNextUpVersionSelected(101)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(0)
+        awaitCondition { fixture.userState.writes.isNotEmpty() }
+        fixture.userState.writes.clear()
+
+        advanceToEpisodeTwo(fixture.viewModel, scenario)
+
+        assertTrue(fixture.userState.writes.none { it.contentId == scenario.episodeTwoId })
+        assertNull(TvDetailTrackSelectionSession.recall(scenario.episodeTwoId))
+    }
+
+    @Test
+    fun profileOrServerChangeClearsPendingNextUpHandoff() = runDetailTest {
+        for (kind in listOf(IdentityTransitionKind.PROFILE_SWITCH, IdentityTransitionKind.SERVER_SWITCH)) {
+            val scenario = Scenario(suffix = "-${kind.name.lowercase()}")
+            val gate = CompletableDeferred<Unit>()
+            scenario.episodeTwoGate = gate
+            val fixture = createFixture(scenario)
+            awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+            fixture.viewModel.onNextUpVersionSelected(101)
+            fixture.viewModel.onNextUpSubtitleTrackSelected(-1)
+
+            fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
+            awaitCondition { scenario.episodeTwoRequests > 0 }
+            fixture.identityTransitions.changing(kind) {
+                when (kind) {
+                    IdentityTransitionKind.PROFILE_SWITCH -> fixture.tokenManager.profileId = "profile-2"
+                    IdentityTransitionKind.SERVER_SWITCH -> fixture.tokenManager.serverId = "server-2"
+                    else -> error("unexpected kind")
+                }
+            }
+            gate.complete(Unit)
+            awaitCondition {
+                val state = fixture.viewModel.uiState.value
+                state.nextUpEpisode?.contentId == scenario.episodeTwoId &&
+                    state.didLoadNextUpPlaybackDetail &&
+                    !state.isLoadingNextUpPlaybackDetail
+            }
+
+            val state = fixture.viewModel.uiState.value
+            assertNull(state.selectedNextUpFileId)
+            assertNull(state.selectedNextUpSubtitleIndex)
+        }
+    }
+
+    // ------------------------------------------------------------------
+
+    private val createdViewModels = mutableListOf<ViewModel>()
+
+    private fun runDetailTest(block: suspend () -> Unit) = runTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            block()
+        } finally {
+            createdViewModels.forEach { it.viewModelScope.cancel() }
+            createdViewModels.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun createFixture(scenario: Scenario): Fixture {
+        val identityTransitions = DefaultIdentityTransitionBarrier()
+        val tokenManager = FakeTokenManager(identityTransitions)
+        val client = scenario.client()
+        val userState = RecordingUserItemState()
+        val catalogRepository = CatalogRepository(
+            catalogApi = CatalogApi(client),
+            identityTransitions = identityTransitions,
+        )
+        val personalDataRepository = PersonalDataRepository(
+            personalDataApi = PersonalDataApi(client),
+            userItemStatePort = userState,
+            identityTransitions = identityTransitions,
+        )
+        val profileRepository = ProfileRepository(
+            profileApi = ProfileApi(client),
+            tokenManager = tokenManager,
+            identityTransitions = identityTransitions,
+        )
+        val viewModel = TvItemDetailViewModel(
+            catalogRepository = catalogRepository,
+            personalDataRepository = personalDataRepository,
+            playerSettingsStore = FakePlayerSettingsStore(),
+            profileRepository = profileRepository,
+            profileSettings = ProfileSettingsController(SettingsRepository(UnavailableSettingsApi())),
+            metadataAiRepository = MetadataAiRepository(DefaultMetadataAiApi(client)),
+            contentId = scenario.seriesId,
+            userItemState = userState,
+            tokenManager = tokenManager,
+            identityTransitions = identityTransitions,
+        ).also { createdViewModels += it }
+        return Fixture(viewModel, userState, tokenManager, identityTransitions)
+    }
+
+    private suspend fun advanceToEpisodeTwo(viewModel: TvItemDetailViewModel, scenario: Scenario) {
+        viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
+        awaitEpisode(viewModel, scenario.episodeTwoId)
+    }
+
+    private suspend fun awaitEpisode(viewModel: TvItemDetailViewModel, contentId: String) {
+        awaitCondition {
+            val state = viewModel.uiState.value
+            state.nextUpEpisode?.contentId == contentId &&
+                state.nextUpPlaybackDetail?.contentId == contentId &&
+                state.didLoadNextUpPlaybackDetail
+        }
+    }
+
+    private suspend fun awaitCondition(predicate: () -> Boolean) {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(30_000) {
+                while (!predicate()) delay(10)
+            }
+        }
+    }
+
+    private data class Fixture(
+        val viewModel: TvItemDetailViewModel,
+        val userState: RecordingUserItemState,
+        val tokenManager: FakeTokenManager,
+        val identityTransitions: DefaultIdentityTransitionBarrier,
+    )
+
+    private class Scenario(
+        val suffix: String = "",
+        val oldVersions: List<VersionFixture> = listOf(version(101, "1080p")),
+        val newVersions: List<VersionFixture> = listOf(version(201, "1080p")),
+    ) {
+        val seriesId = "series$suffix"
+        val episodeOneId = "episode-1$suffix"
+        val episodeTwoId = "episode-2$suffix"
+        var episodeOneWatched = false
+        var episodeTwoWatched = false
+        var episodeTwoGate: CompletableDeferred<Unit>? = null
+        var episodeTwoRequests = 0
+        var pendingEpisodeOneResponses = 0
+        val episodeOneResponses = ArrayDeque<DetailResponse>()
+
+        fun client(): HttpClient = HttpClient(
+            MockEngine { request ->
+                fun json(content: String) = respond(
+                    content = content,
+                    status = HttpStatusCode.OK,
+                    headers = JSON_HEADERS,
+                )
+                when (request.url.encodedPath) {
+                    "/api/v1/catalog/items/$seriesId" -> json(
+                        """{"content_id":"$seriesId","type":"series","title":"Series"}""",
+                    )
+                    "/api/v1/catalog/series/$seriesId/seasons" -> json(
+                        """{"seasons":[{"content_id":"season$suffix","season_number":1,"title":"Season 1"}]}""",
+                    )
+                    "/api/v1/catalog/series/$seriesId/seasons/1/episodes" -> json(episodesJson())
+                    "/api/v1/catalog/items/$episodeOneId" -> {
+                        val queued = episodeOneResponses.removeFirstOrNull()
+                        if (queued == null) {
+                            json(itemDetailJson(episodeOneId, oldVersions))
+                        } else {
+                            pendingEpisodeOneResponses = episodeOneResponses.size
+                            queued.gate?.await()
+                            json(queued.json)
+                        }
+                    }
+                    "/api/v1/catalog/items/$episodeTwoId" -> {
+                        episodeTwoRequests += 1
+                        episodeTwoGate?.await()
+                        json(itemDetailJson(episodeTwoId, newVersions))
+                    }
+                    "/api/v1/watched/$episodeOneId" -> {
+                        episodeOneWatched = request.method.value != "DELETE"
+                        respond("", HttpStatusCode.NoContent)
+                    }
+                    "/api/v1/watched/$episodeTwoId" -> {
+                        episodeTwoWatched = request.method.value != "DELETE"
+                        respond("", HttpStatusCode.NoContent)
+                    }
+                    "/api/v1/profiles" -> json(
+                        """{"profiles":[{"id":"profile-1","name":"Profile"}]}""",
+                    )
+                    else -> respond(
+                        content = """{"error":"not_found","message":"not found"}""",
+                        status = HttpStatusCode.NotFound,
+                        headers = JSON_HEADERS,
+                    )
+                }
+            },
+        ) {
+            install(ContentNegotiation) { json(SiloJson) }
+        }
+
+        private fun episodesJson(): String =
+            """{"episodes":[
+                {"content_id":"$episodeOneId","season_number":1,"episode_number":1,"title":"One","user_data":{"played":$episodeOneWatched}},
+                {"content_id":"$episodeTwoId","season_number":1,"episode_number":2,"title":"Two","user_data":{"played":$episodeTwoWatched}}
+            ]}""".trimIndent()
+    }
+
+    private class RecordingUserItemState : UserItemStatePort {
+        data class Write(val contentId: String, val fileId: Int, val kind: String, val fingerprint: String?)
+
+        val saved = mutableMapOf<Pair<String, Int>, LocalTrackSelection>()
+        val writes = mutableListOf<Write>()
+
+        override suspend fun recordWatched(contentId: String, watched: Boolean) = OutboxHandle.NONE
+        override suspend fun recordFavorite(contentId: String, favorite: Boolean) = OutboxHandle.NONE
+        override suspend fun recordRating(contentId: String, rating: Int?) = OutboxHandle.NONE
+        override suspend fun resolve(handle: OutboxHandle, outcome: WriteOutcome) = Unit
+
+        override suspend fun recordAudioTrackSelection(
+            contentId: String,
+            fileId: Int,
+            audioFingerprint: String?,
+        ) {
+            writes += Write(contentId, fileId, "audio", audioFingerprint)
+        }
+
+        override suspend fun recordSubtitleTrackSelection(
+            contentId: String,
+            fileId: Int,
+            subtitleFingerprint: String?,
+        ) {
+            writes += Write(contentId, fileId, "subtitle", subtitleFingerprint)
+        }
+
+        override suspend fun localTrackSelection(contentId: String, fileId: Int): LocalTrackSelection? =
+            saved[contentId to fileId]
+    }
+
+    private class FakeTokenManager(
+        private val identityTransitions: IdentityTransitionBarrier,
+    ) : TokenManager {
+        var serverId = "server-1"
+        var profileId = "profile-1"
+
+        override val sessionExpired: SharedFlow<Unit> = MutableSharedFlow()
+        override suspend fun getAccessToken(): String = "token"
+        override suspend fun getRefreshToken(): String? = null
+        override suspend fun saveTokens(accessToken: String, refreshToken: String, expiresIn: Long) = Unit
+        override suspend fun clearTokens() = Unit
+        override suspend fun invalidateSession() = Unit
+        override suspend fun getProfileId(): String = profileId
+        override suspend fun setProfileId(profileId: String?) {
+            this.profileId = profileId.orEmpty()
+        }
+        override suspend fun getProfileToken(): String? = null
+        override suspend fun setProfileToken(token: String?) = Unit
+        override suspend fun getServerUrl(): String = "https://tv.example"
+        override suspend fun setServerUrl(url: String) = Unit
+        override suspend fun getCurrentServerId(): String = serverId
+        override suspend fun switchActiveServer(serverId: String?) {
+            this.serverId = serverId.orEmpty()
+        }
+        override suspend fun signOutCurrentServer() = Unit
+        override suspend fun snapshotCurrentScope() = AuthScopeSnapshot(
+            serverId = serverId,
+            profileId = profileId,
+            serverUrl = getServerUrl(),
+            profileToken = null,
+            identityGeneration = identityTransitions.generation.value,
+        )
+    }
+
+    private class UnavailableSettingsApi : SettingsApi(HttpClient()) {
+        override suspend fun getContractCapabilities(): SettingsCapabilitiesResult =
+            SettingsCapabilitiesResult.ServerUpgradeRequired
+    }
+
+    private data class DetailResponse(val gate: CompletableDeferred<Unit>?, val json: String)
+
+    private data class VersionFixture(
+        val fileId: Int,
+        val resolution: String,
+        val codec: String?,
+        val container: String?,
+        val subtitles: List<SubtitleTrack>,
+        val audio: List<AudioTrack>,
+    )
+
+    private companion object {
+        val JSON_HEADERS = headersOf(HttpHeaders.ContentType, "application/json")
+
+        fun version(
+            fileId: Int,
+            resolution: String,
+            codec: String? = "h264",
+            container: String? = "mkv",
+            subtitles: List<SubtitleTrack> = emptyList(),
+            audio: List<AudioTrack> = emptyList(),
+        ) = VersionFixture(fileId, resolution, codec, container, subtitles, audio)
+
+        fun subtitle(
+            index: Int,
+            language: String,
+            external: Boolean = false,
+            title: String? = null,
+        ) = SubtitleTrack(
+            index = index,
+            codec = "srt",
+            language = language,
+            title = title,
+            external = external,
+        )
+
+        fun itemDetailJson(contentId: String, versions: List<VersionFixture>): String =
+            """{"content_id":"$contentId","type":"episode","title":"Episode","versions":[${versions.joinToString(",", transform = ::versionJson)}]}"""
+
+        private fun versionJson(version: VersionFixture): String =
+            """{"file_id":${version.fileId},"resolution":"${version.resolution}","codec_video":"${version.codec}","container":"${version.container}","subtitle_tracks":[${version.subtitles.joinToString(",", transform = ::subtitleJson)}],"audio_tracks":[${version.audio.joinToString(",", transform = ::audioJson)}]}"""
+
+        private fun subtitleJson(track: SubtitleTrack): String =
+            """{"index":${track.index},"codec":"${track.codec}","language":"${track.language}","title":${track.title?.let { "\"$it\"" } ?: "null"},"forced":${track.forced},"external":${track.external}}"""
+
+        private fun audioJson(track: AudioTrack): String =
+            """{"index":${track.index},"codec":"${track.codec}","language":"${track.language}"}"""
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
@@ -53,6 +53,10 @@ import org.siloserver.silo.repository.port.OutboxHandle
 import org.siloserver.silo.repository.port.UserItemStatePort
 import org.siloserver.silo.repository.port.WriteOutcome
 import org.siloserver.silo.tv.testing.FakePlayerSettingsStore
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -65,6 +69,21 @@ import kotlin.test.assertTrue
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvNextUpSelectionHandoffTest {
+
+    @Test
+    fun absentVersionCodecAndContainerDecodeAsNull() = runDetailTest {
+        val scenario = Scenario(
+            suffix = "-null-version-metadata",
+            oldVersions = listOf(version(101, "1080p", codec = null, container = null)),
+        )
+        val fixture = createFixture(scenario)
+
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+
+        val version = fixture.viewModel.uiState.value.nextUpPlaybackDetail?.versions?.single()
+        assertNull(version?.codecVideo)
+        assertNull(version?.container)
+    }
 
     @Test
     fun changingNextUpResolvesOldSourceAgainstNewEpisodeFiles() = runDetailTest {
@@ -270,12 +289,12 @@ class TvNextUpSelectionHandoffTest {
         scenario.episodeOneDefaultVersions = listOf(version(901, "2160p"))
 
         fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, false)
-        awaitCondition { scenario.pendingEpisodeOneResponses == 1 }
+        awaitCondition { scenario.pendingEpisodeOneResponses.get() == 1 }
         fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
         awaitEpisode(fixture.viewModel, scenario.episodeTwoId)
         fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, false)
         staleGate.complete(Unit)
-        awaitCondition { scenario.pendingEpisodeOneResponses == 0 }
+        awaitCondition { scenario.pendingEpisodeOneResponses.get() == 0 }
         delay(20)
 
         assertNotEquals(
@@ -320,7 +339,7 @@ class TvNextUpSelectionHandoffTest {
             fixture.viewModel.onNextUpSubtitleTrackSelected(-1)
 
             fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
-            awaitCondition { scenario.episodeTwoRequests > 0 }
+            awaitCondition { scenario.episodeTwoRequests.get() > 0 }
             fixture.identityTransitions.changing(kind) {
                 when (kind) {
                     IdentityTransitionKind.PROFILE_SWITCH -> fixture.tokenManager.profileId = "profile-2"
@@ -362,12 +381,12 @@ class TvNextUpSelectionHandoffTest {
         fixture.viewModel.onNextUpSubtitleTrackSelected(0)
 
         val identityGate = CompletableDeferred<Unit>()
-        val previousSnapshotCalls = fixture.tokenManager.snapshotCalls
+        val previousSnapshotCalls = fixture.tokenManager.snapshotCalls.get()
         fixture.tokenManager.snapshotResponses.addLast(
             SnapshotResponse(identityGate, fixture.tokenManager.currentScope()),
         )
         fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
-        awaitCondition { fixture.tokenManager.snapshotCalls > previousSnapshotCalls }
+        awaitCondition { fixture.tokenManager.snapshotCalls.get() > previousSnapshotCalls }
 
         fixture.viewModel.onNextUpVersionSelected(201)
         fixture.viewModel.onNextUpSubtitleTrackSelected(-1)
@@ -430,7 +449,7 @@ class TvNextUpSelectionHandoffTest {
                 !state.isLoadingNextUpPlaybackDetail
         }
 
-        assertEquals(0, scenario.episodeTwoRequests)
+        assertEquals(0, scenario.episodeTwoRequests.get())
         assertNull(fixture.viewModel.uiState.value.selectedNextUpSubtitleIndex)
     }
 
@@ -581,10 +600,10 @@ class TvNextUpSelectionHandoffTest {
         var episodeTwoWatched = false
         var episodeTwoGate: CompletableDeferred<Unit>? = null
         var episodeOneWatchGate: CompletableDeferred<Unit>? = null
-        var episodeTwoRequests = 0
-        var pendingEpisodeOneResponses = 0
+        val episodeTwoRequests = AtomicInteger()
+        val pendingEpisodeOneResponses = AtomicInteger()
         var episodeOneDefaultVersions = oldVersions
-        val episodeOneResponses = ArrayDeque<DetailResponse>()
+        val episodeOneResponses = ConcurrentLinkedDeque<DetailResponse>()
 
         fun client(): HttpClient = HttpClient(
             MockEngine { request ->
@@ -602,17 +621,17 @@ class TvNextUpSelectionHandoffTest {
                     )
                     "/api/v1/catalog/series/$seriesId/seasons/1/episodes" -> json(episodesJson())
                     "/api/v1/catalog/items/$episodeOneId" -> {
-                        val queued = episodeOneResponses.removeFirstOrNull()
+                        val queued = episodeOneResponses.pollFirst()
                         if (queued == null) {
                             json(itemDetailJson(episodeOneId, episodeOneDefaultVersions, oldLastFileId))
                         } else {
-                            pendingEpisodeOneResponses = episodeOneResponses.size
+                            pendingEpisodeOneResponses.set(episodeOneResponses.size)
                             queued.gate?.await()
                             json(queued.json)
                         }
                     }
                     "/api/v1/catalog/items/$episodeTwoId" -> {
-                        episodeTwoRequests += 1
+                        episodeTwoRequests.incrementAndGet()
                         episodeTwoGate?.await()
                         json(itemDetailJson(episodeTwoId, newVersions, newLastFileId))
                     }
@@ -649,10 +668,10 @@ class TvNextUpSelectionHandoffTest {
     private class RecordingUserItemState : UserItemStatePort {
         data class Write(val contentId: String, val fileId: Int, val kind: String, val fingerprint: String?)
 
-        val saved = mutableMapOf<Pair<String, Int>, LocalTrackSelection>()
-        val writes = mutableListOf<Write>()
-        val readGates = mutableMapOf<Pair<String, Int>, CompletableDeferred<Unit>>()
-        val startedReads = mutableSetOf<Pair<String, Int>>()
+        val saved = ConcurrentHashMap<Pair<String, Int>, LocalTrackSelection>()
+        val writes = CopyOnWriteArrayList<Write>()
+        val readGates = ConcurrentHashMap<Pair<String, Int>, CompletableDeferred<Unit>>()
+        val startedReads: MutableSet<Pair<String, Int>> = ConcurrentHashMap.newKeySet()
 
         override suspend fun recordWatched(contentId: String, watched: Boolean) = OutboxHandle.NONE
         override suspend fun recordFavorite(contentId: String, favorite: Boolean) = OutboxHandle.NONE
@@ -688,8 +707,8 @@ class TvNextUpSelectionHandoffTest {
     ) : TokenManager {
         var serverId = "server-1"
         var profileId = "profile-1"
-        var snapshotCalls = 0
-        val snapshotResponses = ArrayDeque<SnapshotResponse>()
+        val snapshotCalls = AtomicInteger()
+        val snapshotResponses = ConcurrentLinkedDeque<SnapshotResponse>()
 
         override val sessionExpired: SharedFlow<Unit> = MutableSharedFlow()
         override suspend fun getAccessToken(): String = "token"
@@ -719,8 +738,8 @@ class TvNextUpSelectionHandoffTest {
         )
 
         override suspend fun snapshotCurrentScope(): AuthScopeSnapshot? {
-            snapshotCalls += 1
-            val queued = snapshotResponses.removeFirstOrNull()
+            snapshotCalls.incrementAndGet()
+            val queued = snapshotResponses.pollFirst()
             queued?.gate?.await()
             return if (queued != null) queued.scope else currentScope()
         }
@@ -778,8 +797,10 @@ class TvNextUpSelectionHandoffTest {
         ): String =
             """{"content_id":"$contentId","type":"episode","title":"Episode","user_data":{"last_file_id":$lastFileId},"versions":[${versions.joinToString(",", transform = ::versionJson)}]}"""
 
+        private fun jsonString(value: String?): String = value?.let { "\"$it\"" } ?: "null"
+
         private fun versionJson(version: VersionFixture): String =
-            """{"file_id":${version.fileId},"resolution":"${version.resolution}","codec_video":"${version.codec}","container":"${version.container}","subtitle_tracks":[${version.subtitles.joinToString(",", transform = ::subtitleJson)}],"audio_tracks":[${version.audio.joinToString(",", transform = ::audioJson)}]}"""
+            """{"file_id":${version.fileId},"resolution":"${version.resolution}","codec_video":${jsonString(version.codec)},"container":${jsonString(version.container)},"subtitle_tracks":[${version.subtitles.joinToString(",", transform = ::subtitleJson)}],"audio_tracks":[${version.audio.joinToString(",", transform = ::audioJson)}]}"""
 
         private fun subtitleJson(track: SubtitleTrack): String =
             """{"index":${track.index},"codec":"${track.codec}","language":"${track.language}","title":${track.title?.let { "\"$it\"" } ?: "null"},"forced":${track.forced},"external":${track.external}}"""

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
@@ -121,6 +121,69 @@ class TvNextUpSelectionHandoffTest {
     }
 
     @Test
+    fun lastPlayedAutoSourceCapturesAndResolvesSubtitleAgainstTheDisplayedVersions() = runDetailTest {
+        val scenario = Scenario(
+            suffix = "-auto-source-subtitle",
+            oldVersions = listOf(
+                version(101, "1080p", subtitles = listOf(subtitle(1, "eng"))),
+                version(102, "720p", subtitles = listOf(subtitle(2, "fre", external = true))),
+            ),
+            newVersions = listOf(
+                version(201, "1080p", subtitles = listOf(subtitle(3, "eng"))),
+                version(
+                    202,
+                    "720p",
+                    subtitles = listOf(
+                        subtitle(4, "spa", external = true),
+                        subtitle(5, "fre", external = true),
+                    ),
+                ),
+            ),
+            oldLastFileId = 102,
+            newLastFileId = 202,
+        )
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(0)
+
+        advanceToEpisodeTwo(fixture.viewModel, scenario)
+
+        assertNull(fixture.viewModel.uiState.value.selectedNextUpFileId)
+        assertEquals(1, fixture.viewModel.uiState.value.selectedNextUpSubtitleIndex)
+    }
+
+    @Test
+    fun preferredQualityAutoSourceCapturesAndResolvesSubtitleAgainstTheDisplayedVersions() = runDetailTest {
+        val scenario = Scenario(
+            suffix = "-preferred-quality-subtitle",
+            oldVersions = listOf(
+                version(101, "1080p", subtitles = listOf(subtitle(1, "eng"))),
+                version(102, "720p", subtitles = listOf(subtitle(2, "fre", external = true))),
+            ),
+            newVersions = listOf(
+                version(201, "1080p", subtitles = listOf(subtitle(3, "eng"))),
+                version(
+                    202,
+                    "720p",
+                    subtitles = listOf(
+                        subtitle(4, "spa", external = true),
+                        subtitle(5, "fre", external = true),
+                    ),
+                ),
+            ),
+            preferredQuality = "720p",
+        )
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(0)
+
+        advanceToEpisodeTwo(fixture.viewModel, scenario)
+
+        assertNull(fixture.viewModel.uiState.value.selectedNextUpFileId)
+        assertEquals(1, fixture.viewModel.uiState.value.selectedNextUpSubtitleIndex)
+    }
+
+    @Test
     fun explicitOffRemainsOffAcrossNextUpRefresh() = runDetailTest {
         val scenario = Scenario(suffix = "-off")
         TvDetailTrackSelectionSession.remember(
@@ -460,7 +523,9 @@ class TvNextUpSelectionHandoffTest {
         val viewModel = TvItemDetailViewModel(
             catalogRepository = catalogRepository,
             personalDataRepository = personalDataRepository,
-            playerSettingsStore = FakePlayerSettingsStore(),
+            playerSettingsStore = FakePlayerSettingsStore().apply {
+                preferredQualityFlow.value = scenario.preferredQuality
+            },
             profileRepository = profileRepository,
             profileSettings = ProfileSettingsController(SettingsRepository(UnavailableSettingsApi())),
             metadataAiRepository = MetadataAiRepository(DefaultMetadataAiApi(client)),
@@ -505,6 +570,9 @@ class TvNextUpSelectionHandoffTest {
         val suffix: String = "",
         val oldVersions: List<VersionFixture> = listOf(version(101, "1080p")),
         val newVersions: List<VersionFixture> = listOf(version(201, "1080p")),
+        val oldLastFileId: Int? = null,
+        val newLastFileId: Int? = null,
+        val preferredQuality: String = "auto",
     ) {
         val seriesId = "series$suffix"
         val episodeOneId = "episode-1$suffix"
@@ -536,7 +604,7 @@ class TvNextUpSelectionHandoffTest {
                     "/api/v1/catalog/items/$episodeOneId" -> {
                         val queued = episodeOneResponses.removeFirstOrNull()
                         if (queued == null) {
-                            json(itemDetailJson(episodeOneId, episodeOneDefaultVersions))
+                            json(itemDetailJson(episodeOneId, episodeOneDefaultVersions, oldLastFileId))
                         } else {
                             pendingEpisodeOneResponses = episodeOneResponses.size
                             queued.gate?.await()
@@ -546,7 +614,7 @@ class TvNextUpSelectionHandoffTest {
                     "/api/v1/catalog/items/$episodeTwoId" -> {
                         episodeTwoRequests += 1
                         episodeTwoGate?.await()
-                        json(itemDetailJson(episodeTwoId, newVersions))
+                        json(itemDetailJson(episodeTwoId, newVersions, newLastFileId))
                     }
                     "/api/v1/watched/$episodeOneId" -> {
                         episodeOneWatchGate?.await()
@@ -703,8 +771,12 @@ class TvNextUpSelectionHandoffTest {
             external = external,
         )
 
-        fun itemDetailJson(contentId: String, versions: List<VersionFixture>): String =
-            """{"content_id":"$contentId","type":"episode","title":"Episode","versions":[${versions.joinToString(",", transform = ::versionJson)}]}"""
+        fun itemDetailJson(
+            contentId: String,
+            versions: List<VersionFixture>,
+            lastFileId: Int? = null,
+        ): String =
+            """{"content_id":"$contentId","type":"episode","title":"Episode","user_data":{"last_file_id":$lastFileId},"versions":[${versions.joinToString(",", transform = ::versionJson)}]}"""
 
         private fun versionJson(version: VersionFixture): String =
             """{"file_id":${version.fileId},"resolution":"${version.resolution}","codec_video":"${version.codec}","container":"${version.container}","subtitle_tracks":[${version.subtitles.joinToString(",", transform = ::subtitleJson)}],"audio_tracks":[${version.audio.joinToString(",", transform = ::audioJson)}]}"""

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
@@ -13,7 +13,8 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -189,6 +190,7 @@ class TvNextUpSelectionHandoffTest {
     @Test
     fun staleRefreshCompletionCannotApplyHandoffToAnotherEpisode() = runDetailTest {
         val scenario = Scenario(suffix = "-stale")
+        scenario.episodeOneWatchGate = CompletableDeferred()
         val fixture = createFixture(scenario)
         awaitEpisode(fixture.viewModel, scenario.episodeOneId)
 
@@ -202,6 +204,7 @@ class TvNextUpSelectionHandoffTest {
         scenario.episodeOneResponses.addLast(
             DetailResponse(freshGate, itemDetailJson(scenario.episodeOneId, listOf(version(901, "2160p")))),
         )
+        scenario.episodeOneDefaultVersions = listOf(version(901, "2160p"))
 
         fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, false)
         awaitCondition { scenario.pendingEpisodeOneResponses == 1 }
@@ -217,6 +220,9 @@ class TvNextUpSelectionHandoffTest {
             fixture.viewModel.uiState.value.nextUpPlaybackDetail?.versions?.singleOrNull()?.fileId,
         )
         freshGate.complete(Unit)
+        awaitCondition {
+            fixture.viewModel.uiState.value.nextUpPlaybackDetail?.versions?.singleOrNull()?.fileId == 901
+        }
     }
 
     @Test
@@ -273,6 +279,148 @@ class TvNextUpSelectionHandoffTest {
         }
     }
 
+    @Test
+    fun explicitSelectorInputBeforePendingInstallWins() = runDetailTest {
+        val french = subtitle(index = 4, language = "fre", external = true)
+        val scenario = Scenario(
+            suffix = "-selector-before-install",
+            oldVersions = listOf(
+                version(101, "720p"),
+                version(102, "1080p", codec = "hevc", subtitles = listOf(french)),
+            ),
+            newVersions = listOf(
+                version(201, "720p"),
+                version(202, "1080p", codec = "hevc", subtitles = listOf(french.copy(index = 7))),
+            ),
+        )
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onNextUpVersionSelected(102)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(0)
+
+        val identityGate = CompletableDeferred<Unit>()
+        val previousSnapshotCalls = fixture.tokenManager.snapshotCalls
+        fixture.tokenManager.snapshotResponses.addLast(
+            SnapshotResponse(identityGate, fixture.tokenManager.currentScope()),
+        )
+        fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
+        awaitCondition { fixture.tokenManager.snapshotCalls > previousSnapshotCalls }
+
+        fixture.viewModel.onNextUpVersionSelected(201)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(-1)
+        identityGate.complete(Unit)
+        awaitEpisode(fixture.viewModel, scenario.episodeTwoId)
+
+        val state = fixture.viewModel.uiState.value
+        assertEquals(201, state.selectedNextUpFileId)
+        assertEquals(-1, state.selectedNextUpSubtitleIndex)
+    }
+
+    @Test
+    fun explicitSelectorInputDuringDurableResolutionWins() = runDetailTest {
+        val french = subtitle(index = 4, language = "fre", external = true)
+        val scenario = Scenario(
+            suffix = "-selector-during-durable",
+            oldVersions = listOf(
+                version(101, "720p"),
+                version(102, "1080p", codec = "hevc", subtitles = listOf(french)),
+            ),
+            newVersions = listOf(
+                version(201, "720p"),
+                version(202, "1080p", codec = "hevc", subtitles = listOf(french.copy(index = 7))),
+            ),
+        )
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onNextUpVersionSelected(102)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(0)
+
+        val durableGate = CompletableDeferred<Unit>()
+        val targetKey = scenario.episodeTwoId to 202
+        fixture.userState.readGates[targetKey] = durableGate
+        fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
+        awaitCondition { targetKey in fixture.userState.startedReads }
+
+        fixture.viewModel.onNextUpVersionSelected(201)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(-1)
+        durableGate.complete(Unit)
+        awaitEpisode(fixture.viewModel, scenario.episodeTwoId)
+
+        val state = fixture.viewModel.uiState.value
+        assertEquals(201, state.selectedNextUpFileId)
+        assertEquals(-1, state.selectedNextUpSubtitleIndex)
+    }
+
+    @Test
+    fun nullAuthScopeFailsClosedBeforeHandoffInstall() = runDetailTest {
+        val scenario = Scenario(suffix = "-null-scope")
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(-1)
+        fixture.tokenManager.snapshotResponses.addLast(SnapshotResponse(gate = null, scope = null))
+
+        fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
+        awaitCondition {
+            val state = fixture.viewModel.uiState.value
+            state.nextUpEpisode?.contentId == scenario.episodeTwoId &&
+                state.didLoadNextUpPlaybackDetail &&
+                !state.isLoadingNextUpPlaybackDetail
+        }
+
+        assertEquals(0, scenario.episodeTwoRequests)
+        assertNull(fixture.viewModel.uiState.value.selectedNextUpSubtitleIndex)
+    }
+
+    @Test
+    fun nullProfileSnapshotIsNotFilledFromSeparateTokenRead() = runDetailTest {
+        val scenario = Scenario(suffix = "-null-profile")
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onNextUpSubtitleTrackSelected(-1)
+        fixture.tokenManager.snapshotResponses.addLast(
+            SnapshotResponse(gate = null, scope = fixture.tokenManager.currentScope(profileId = null)),
+        )
+
+        fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
+        awaitCondition {
+            val state = fixture.viewModel.uiState.value
+            state.nextUpEpisode?.contentId == scenario.episodeTwoId &&
+                state.didLoadNextUpPlaybackDetail &&
+                !state.isLoadingNextUpPlaybackDetail
+        }
+
+        val state = fixture.viewModel.uiState.value
+        assertNull(state.nextUpPlaybackDetail)
+        assertNull(state.selectedNextUpSubtitleIndex)
+    }
+
+    @Test
+    fun lateDurableSeedForPriorEpisodeCannotRememberCarriedTarget() = runDetailTest {
+        val scenario = Scenario(
+            suffix = "-late-seed",
+            oldVersions = listOf(version(101, "1080p")),
+            newVersions = listOf(version(201, "1080p")),
+        )
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        val oldKey = scenario.episodeOneId to 101
+        fixture.userState.saved[oldKey] = LocalTrackSelection(
+            audioFingerprint = null,
+            subtitleFingerprint = null,
+        )
+        val seedGate = CompletableDeferred<Unit>()
+        fixture.userState.readGates[oldKey] = seedGate
+
+        fixture.viewModel.onNextUpVersionSelected(101)
+        awaitCondition { oldKey in fixture.userState.startedReads }
+        fixture.viewModel.onSetEpisodeWatched(scenario.episodeOneId, true)
+        awaitEpisode(fixture.viewModel, scenario.episodeTwoId)
+        seedGate.complete(Unit)
+        delay(20)
+
+        assertNull(TvDetailTrackSelectionSession.recall(scenario.episodeTwoId))
+    }
+
     // ------------------------------------------------------------------
 
     private val createdViewModels = mutableListOf<ViewModel>()
@@ -282,7 +430,9 @@ class TvNextUpSelectionHandoffTest {
         try {
             block()
         } finally {
-            createdViewModels.forEach { it.viewModelScope.cancel() }
+            createdViewModels.forEach { viewModel ->
+                viewModel.viewModelScope.coroutineContext[Job]?.cancelAndJoin()
+            }
             createdViewModels.clear()
             Dispatchers.resetMain()
         }
@@ -362,8 +512,10 @@ class TvNextUpSelectionHandoffTest {
         var episodeOneWatched = false
         var episodeTwoWatched = false
         var episodeTwoGate: CompletableDeferred<Unit>? = null
+        var episodeOneWatchGate: CompletableDeferred<Unit>? = null
         var episodeTwoRequests = 0
         var pendingEpisodeOneResponses = 0
+        var episodeOneDefaultVersions = oldVersions
         val episodeOneResponses = ArrayDeque<DetailResponse>()
 
         fun client(): HttpClient = HttpClient(
@@ -384,7 +536,7 @@ class TvNextUpSelectionHandoffTest {
                     "/api/v1/catalog/items/$episodeOneId" -> {
                         val queued = episodeOneResponses.removeFirstOrNull()
                         if (queued == null) {
-                            json(itemDetailJson(episodeOneId, oldVersions))
+                            json(itemDetailJson(episodeOneId, episodeOneDefaultVersions))
                         } else {
                             pendingEpisodeOneResponses = episodeOneResponses.size
                             queued.gate?.await()
@@ -397,6 +549,7 @@ class TvNextUpSelectionHandoffTest {
                         json(itemDetailJson(episodeTwoId, newVersions))
                     }
                     "/api/v1/watched/$episodeOneId" -> {
+                        episodeOneWatchGate?.await()
                         episodeOneWatched = request.method.value != "DELETE"
                         respond("", HttpStatusCode.NoContent)
                     }
@@ -430,6 +583,8 @@ class TvNextUpSelectionHandoffTest {
 
         val saved = mutableMapOf<Pair<String, Int>, LocalTrackSelection>()
         val writes = mutableListOf<Write>()
+        val readGates = mutableMapOf<Pair<String, Int>, CompletableDeferred<Unit>>()
+        val startedReads = mutableSetOf<Pair<String, Int>>()
 
         override suspend fun recordWatched(contentId: String, watched: Boolean) = OutboxHandle.NONE
         override suspend fun recordFavorite(contentId: String, favorite: Boolean) = OutboxHandle.NONE
@@ -452,8 +607,12 @@ class TvNextUpSelectionHandoffTest {
             writes += Write(contentId, fileId, "subtitle", subtitleFingerprint)
         }
 
-        override suspend fun localTrackSelection(contentId: String, fileId: Int): LocalTrackSelection? =
-            saved[contentId to fileId]
+        override suspend fun localTrackSelection(contentId: String, fileId: Int): LocalTrackSelection? {
+            val key = contentId to fileId
+            startedReads += key
+            readGates[key]?.await()
+            return saved[key]
+        }
     }
 
     private class FakeTokenManager(
@@ -461,6 +620,8 @@ class TvNextUpSelectionHandoffTest {
     ) : TokenManager {
         var serverId = "server-1"
         var profileId = "profile-1"
+        var snapshotCalls = 0
+        val snapshotResponses = ArrayDeque<SnapshotResponse>()
 
         override val sessionExpired: SharedFlow<Unit> = MutableSharedFlow()
         override suspend fun getAccessToken(): String = "token"
@@ -481,13 +642,20 @@ class TvNextUpSelectionHandoffTest {
             this.serverId = serverId.orEmpty()
         }
         override suspend fun signOutCurrentServer() = Unit
-        override suspend fun snapshotCurrentScope() = AuthScopeSnapshot(
+        fun currentScope(profileId: String? = this.profileId) = AuthScopeSnapshot(
             serverId = serverId,
             profileId = profileId,
-            serverUrl = getServerUrl(),
+            serverUrl = "https://tv.example",
             profileToken = null,
             identityGeneration = identityTransitions.generation.value,
         )
+
+        override suspend fun snapshotCurrentScope(): AuthScopeSnapshot? {
+            snapshotCalls += 1
+            val queued = snapshotResponses.removeFirstOrNull()
+            queued?.gate?.await()
+            return if (queued != null) queued.scope else currentScope()
+        }
     }
 
     private class UnavailableSettingsApi : SettingsApi(HttpClient()) {
@@ -496,6 +664,10 @@ class TvNextUpSelectionHandoffTest {
     }
 
     private data class DetailResponse(val gate: CompletableDeferred<Unit>?, val json: String)
+    private data class SnapshotResponse(
+        val gate: CompletableDeferred<Unit>?,
+        val scope: AuthScopeSnapshot?,
+    )
 
     private data class VersionFixture(
         val fileId: Int,

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt
@@ -85,6 +85,18 @@ class TvTrackSelectionPersistenceTest {
         assertEquals(0, merged.subtitleIndex)
     }
 
+    @Test
+    fun explicitSubtitleOffWinsDurableSubtitleWhileAudioStillRestores() {
+        val merged = mergeTrackSelection(
+            currentAudioIndex = null,
+            currentSubtitleIndex = -1,
+            durable = TvRestoredTrackSelection(audioIndex = 1, subtitleIndex = 0),
+        )
+
+        assertEquals(1, merged.audioIndex)
+        assertEquals(-1, merged.subtitleIndex)
+    }
+
     private fun version() = FileVersion(
         fileId = 22,
         audioTracks = listOf(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvEpisodeHandoffPlaybackStartTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvEpisodeHandoffPlaybackStartTest.kt
@@ -1,0 +1,149 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
+import org.siloserver.silo.common.player.video.EpisodeSourceIntent
+import org.siloserver.silo.common.player.video.EpisodeSubtitleIntent
+import org.siloserver.silo.common.player.video.EpisodeSubtitleMode
+import org.siloserver.silo.model.catalog.FileVersion
+import org.siloserver.silo.model.catalog.SubtitleTrack
+
+class TvEpisodeHandoffPlaybackStartTest {
+    @Test
+    fun explicitDetailFileIdWinsOverEpisodeHandoff() {
+        val resolved = resolveTvPlaybackStartSelection(
+            preferredFileId = 1080,
+            episodeSelectionHandoff = handoff(sourceResolution = "2160p"),
+            targetVersions = versions(),
+            targetLastFileId = 2160,
+            preferredQuality = "2160p",
+        )
+
+        assertEquals(1080, resolved.fileId)
+    }
+
+    @Test
+    fun episodeHandoffWinsOverTargetLastFileAndQuality() {
+        val resolved = resolveTvPlaybackStartSelection(
+            preferredFileId = null,
+            episodeSelectionHandoff = handoff(sourceResolution = "1080p"),
+            targetVersions = versions(),
+            targetLastFileId = 2160,
+            preferredQuality = "2160p",
+        )
+
+        assertEquals(1080, resolved.fileId)
+    }
+
+    @Test
+    fun noHandoffPreservesExistingLastFileAndQualitySelection() {
+        val lastFileResolved = resolveTvPlaybackStartSelection(
+            preferredFileId = null,
+            episodeSelectionHandoff = null,
+            targetVersions = versions(),
+            targetLastFileId = 2160,
+            preferredQuality = "1080p",
+        )
+        val qualityResolved = resolveTvPlaybackStartSelection(
+            preferredFileId = null,
+            episodeSelectionHandoff = null,
+            targetVersions = versions(),
+            targetLastFileId = null,
+            preferredQuality = "1080p",
+        )
+
+        assertEquals(2160, lastFileResolved.fileId)
+        assertEquals(1080, qualityResolved.fileId)
+    }
+
+    @Test
+    fun subtitleIsResolvedAgainstTheChosenTargetVersion() {
+        val resolved = resolveTvPlaybackStartSelection(
+            preferredFileId = null,
+            episodeSelectionHandoff = handoff(
+                sourceResolution = "1080p",
+                subtitle = EpisodeSubtitleIntent(
+                    mode = EpisodeSubtitleMode.TRACK,
+                    language = "nl",
+                    codecFamily = "subrip",
+                    external = false,
+                ),
+            ),
+            targetVersions = versions(),
+            targetLastFileId = 2160,
+            preferredQuality = "2160p",
+        )
+
+        assertEquals(1080, resolved.fileId)
+        assertEquals(1, resolved.subtitleTrackIndex)
+        assertTrue(resolved.subtitleIntentSpecified)
+    }
+
+    @Test
+    fun missingExplicitSubtitleReturnsSpecifiedProfileAuto() {
+        val resolved = resolveTvPlaybackStartSelection(
+            preferredFileId = 1080,
+            episodeSelectionHandoff = handoff(
+                subtitle = EpisodeSubtitleIntent(
+                    mode = EpisodeSubtitleMode.TRACK,
+                    language = "fr",
+                ),
+            ),
+            targetVersions = versions(),
+            targetLastFileId = null,
+            preferredQuality = null,
+        )
+
+        assertNull(resolved.subtitleTrackIndex)
+        assertTrue(resolved.subtitleIntentSpecified)
+    }
+
+    @Test
+    fun explicitOffIsRetainedClientSide() {
+        val resolved = resolveTvPlaybackStartSelection(
+            preferredFileId = 1080,
+            episodeSelectionHandoff = handoff(subtitle = EpisodeSubtitleIntent.off()),
+            targetVersions = versions(),
+            targetLastFileId = null,
+            preferredQuality = null,
+        )
+
+        assertEquals(-1, resolved.subtitleTrackIndex)
+        assertTrue(resolved.subtitleIntentSpecified)
+        assertNull(
+            resolveTvServerSubtitleTrackIndex(
+                resolvedEpisodeSelection = resolved,
+                requestedSubtitleTrackIndex = 4,
+            ),
+        )
+    }
+
+    private fun handoff(
+        sourceResolution: String? = null,
+        subtitle: EpisodeSubtitleIntent = EpisodeSubtitleIntent.auto(),
+    ) = EpisodeSelectionHandoff(
+        source = sourceResolution?.let(::EpisodeSourceIntent),
+        subtitle = subtitle,
+    )
+
+    private fun versions() = listOf(
+        FileVersion(
+            fileId = 2160,
+            resolution = "2160p",
+            subtitleTracks = listOf(
+                SubtitleTrack(index = 9, language = "nl", codec = "srt", external = true),
+            ),
+        ),
+        FileVersion(
+            fileId = 1080,
+            resolution = "1080p",
+            subtitleTracks = listOf(
+                SubtitleTrack(index = 17, language = "en", codec = "srt", external = true),
+                SubtitleTrack(index = 18, language = "nl", codec = "srt", external = false),
+            ),
+        ),
+    )
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvEpisodeHandoffPlaybackStartTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvEpisodeHandoffPlaybackStartTest.kt
@@ -103,9 +103,10 @@ class TvEpisodeHandoffPlaybackStartTest {
 
     @Test
     fun explicitOffIsRetainedClientSide() {
+        val handoff = handoff(subtitle = EpisodeSubtitleIntent.off())
         val resolved = resolveTvPlaybackStartSelection(
             preferredFileId = 1080,
-            episodeSelectionHandoff = handoff(subtitle = EpisodeSubtitleIntent.off()),
+            episodeSelectionHandoff = handoff,
             targetVersions = versions(),
             targetLastFileId = null,
             preferredQuality = null,
@@ -115,6 +116,27 @@ class TvEpisodeHandoffPlaybackStartTest {
         assertTrue(resolved.subtitleIntentSpecified)
         assertNull(
             resolveTvServerSubtitleTrackIndex(
+                episodeSelectionHandoff = handoff,
+                resolvedEpisodeSelection = resolved,
+                requestedSubtitleTrackIndex = 4,
+            ),
+        )
+    }
+
+    @Test
+    fun automaticHandoffDropsStaleRequestedSubtitleIndex() {
+        val handoff = handoff()
+        val resolved = resolveTvPlaybackStartSelection(
+            preferredFileId = 1080,
+            episodeSelectionHandoff = handoff,
+            targetVersions = versions(),
+            targetLastFileId = null,
+            preferredQuality = null,
+        )
+
+        assertNull(
+            resolveTvServerSubtitleTrackIndex(
+                episodeSelectionHandoff = handoff,
                 resolvedEpisodeSelection = resolved,
                 requestedSubtitleTrackIndex = 4,
             ),

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvHudPickerFocusWiringSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvHudPickerFocusWiringSourceTest.kt
@@ -9,19 +9,40 @@ class TvHudPickerFocusWiringSourceTest {
     private val source = File(
         "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt",
     ).readText()
+    private val pickerDialog = composableBody(
+        start = "internal fun HudPickerDialog(",
+        end = "@Composable\nprivate fun HudPickerOptionRow(",
+    )
+    private val pickerOptionRow = composableBody(
+        start = "private fun HudPickerOptionRow(",
+        end = "private fun formatTime",
+    )
 
     @Test
-    fun focusedPickerRowsAreExplicitlyBroughtIntoView() {
-        assertContains(source, "remember { BringIntoViewRequester() }")
-        assertContains(source, ".bringIntoViewRequester(bringIntoViewRequester)")
-        assertContains(source, "bringIntoViewRequester.bringIntoView()")
+    fun focusedPickerRowsBringTheirOwnFocusedRowIntoView() {
+        assertContains(pickerOptionRow, "val bringIntoViewRequester = remember { BringIntoViewRequester() }")
+        assertContains(pickerOptionRow, ".bringIntoViewRequester(bringIntoViewRequester)")
+
+        val focusHandler = pickerOptionRow.substringAfter(".onFocusChanged { state ->")
+            .substringBefore(".clickable(")
+        assertContains(focusHandler, "if (state.isFocused)")
+
+        val focusedBranch = focusHandler.substringAfter("if (state.isFocused)")
+        assertContains(focusedBranch, "onFocused()")
+        assertContains(focusedBranch, "scope.launch { bringIntoViewRequester.bringIntoView() }")
     }
 
     @Test
     fun pickerKeepsTheEagerFocusGraph() {
-        val picker = source.substringAfter("internal fun HudPickerDialog")
-            .substringBefore("private fun formatTime")
-        assertContains(picker, ".verticalScroll(rememberScrollState())")
-        assertFalse(picker.contains("LazyColumn"))
+        assertContains(pickerDialog, "Column(")
+        assertContains(pickerDialog, ".verticalScroll(rememberScrollState())")
+        assertFalse(Regex("\\bLazyColumn\\s*\\(").containsMatchIn(pickerDialog.withoutComments()))
     }
+
+    private fun composableBody(start: String, end: String): String =
+        source.substringAfter(start).substringBefore(end)
+
+    private fun String.withoutComments(): String =
+        replace(Regex("/\\*.*?\\*/", setOf(RegexOption.DOT_MATCHES_ALL)), "")
+            .replace(Regex("//.*$", setOf(RegexOption.MULTILINE)), "")
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvHudPickerFocusWiringSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvHudPickerFocusWiringSourceTest.kt
@@ -1,0 +1,27 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+class TvHudPickerFocusWiringSourceTest {
+    private val source = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt",
+    ).readText()
+
+    @Test
+    fun focusedPickerRowsAreExplicitlyBroughtIntoView() {
+        assertContains(source, "remember { BringIntoViewRequester() }")
+        assertContains(source, ".bringIntoViewRequester(bringIntoViewRequester)")
+        assertContains(source, "bringIntoViewRequester.bringIntoView()")
+    }
+
+    @Test
+    fun pickerKeepsTheEagerFocusGraph() {
+        val picker = source.substringAfter("internal fun HudPickerDialog")
+            .substringBefore("private fun formatTime")
+        assertContains(picker, ".verticalScroll(rememberScrollState())")
+        assertFalse(picker.contains("LazyColumn"))
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayNextSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayNextSelectionHandoffTest.kt
@@ -15,6 +15,89 @@ import kotlin.test.assertTrue
 
 class TvPlayNextSelectionHandoffTest {
     @Test
+    fun serverUnreachableStartKeepsHandoffForOwnedRetry() {
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = FileVersion(fileId = 42, resolution = "1080p"),
+            committedSubtitleIdentity = SubtitleIdentity.Off,
+            catalogSubtitles = emptyList(),
+            hasExplicitSubtitleSelection = true,
+        )
+        val slot = TvEpisodeSelectionHandoffSlot(handoff)
+
+        val failedStart = requireNotNull(slot.leaseForStart(ownerGeneration = 1L))
+        assertEquals(handoff, failedStart.handoff)
+        assertTrue(slot.retainForRetry(failedStart))
+
+        assertEquals(handoff, slot.leaseForStart(ownerGeneration = 2L)?.handoff)
+    }
+
+    @Test
+    fun startErrorKeepsHandoffForOwnedRetry() {
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = FileVersion(fileId = 42, resolution = "2160p"),
+            committedSubtitleIdentity = SubtitleIdentity.ServerSidecar(serverIndex = 3),
+            catalogSubtitles = listOf(subtitle(index = 3, language = "nl", codec = "srt")),
+            hasExplicitSubtitleSelection = true,
+        )
+        val slot = TvEpisodeSelectionHandoffSlot(handoff)
+
+        val failedStart = requireNotNull(slot.leaseForStart(ownerGeneration = 7L))
+        assertTrue(slot.retainForRetry(failedStart))
+
+        assertEquals(handoff, slot.leaseForStart(ownerGeneration = 8L)?.handoff)
+    }
+
+    @Test
+    fun successfulReadyAcknowledgesHandoffOnlyForItsLease() {
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = FileVersion(fileId = 42, resolution = "1080p"),
+            committedSubtitleIdentity = SubtitleIdentity.Off,
+            catalogSubtitles = emptyList(),
+            hasExplicitSubtitleSelection = true,
+        )
+        val slot = TvEpisodeSelectionHandoffSlot(handoff)
+        val readyStart = requireNotNull(slot.leaseForStart(ownerGeneration = 11L))
+
+        assertTrue(slot.acknowledgeReady(readyStart))
+        assertNull(slot.leaseForStart(ownerGeneration = 12L))
+        assertTrue(slot.acknowledgeReady(readyStart).not(), "a Ready completion can ack only once")
+    }
+
+    @Test
+    fun explicitReplacementInvalidatesHandoffAndStaleCompletionCannotRestoreIt() {
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = FileVersion(fileId = 42, resolution = "1080p"),
+            committedSubtitleIdentity = SubtitleIdentity.Off,
+            catalogSubtitles = emptyList(),
+            hasExplicitSubtitleSelection = true,
+        )
+        val slot = TvEpisodeSelectionHandoffSlot(handoff)
+        val staleStart = requireNotNull(slot.leaseForStart(ownerGeneration = 21L))
+
+        slot.invalidate()
+
+        assertTrue(slot.retainForRetry(staleStart).not())
+        assertTrue(slot.acknowledgeReady(staleStart).not())
+        assertNull(slot.leaseForStart(ownerGeneration = 22L))
+    }
+
+    @Test
+    fun newerLaunchOwnerInvalidatesOlderLease() {
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = FileVersion(fileId = 42, resolution = "1080p"),
+            committedSubtitleIdentity = SubtitleIdentity.Off,
+            catalogSubtitles = emptyList(),
+            hasExplicitSubtitleSelection = true,
+        )
+        val slot = TvEpisodeSelectionHandoffSlot(handoff)
+        val staleStart = requireNotNull(slot.leaseForStart(ownerGeneration = 31L))
+
+        assertNull(slot.leaseForStart(ownerGeneration = 32L))
+        assertTrue(slot.retainForRetry(staleStart).not())
+        assertTrue(slot.acknowledgeReady(staleStart).not())
+    }
+
+    @Test
     fun nextEpisodeCapturesCurrentSourceAndCommittedSubtitleSemantics() {
         val handoff = captureTvEpisodeSelectionHandoff(
             activeVersion = FileVersion(
@@ -143,8 +226,15 @@ class TvPlayNextSelectionHandoffTest {
             ),
         )
 
-        assertEquals(EpisodeSubtitleMode.OFF, slot.takeForStart()?.subtitle?.mode)
-        assertNull(slot.takeForStart(), "replacement starts must not reuse a prior episode handoff")
+        assertEquals(
+            EpisodeSubtitleMode.OFF,
+            slot.leaseForStart(ownerGeneration = 1L)?.handoff?.subtitle?.mode,
+        )
+        slot.invalidate()
+        assertNull(
+            slot.leaseForStart(ownerGeneration = 2L),
+            "profile/server replacement starts must not reuse a prior episode handoff",
+        )
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayNextSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayNextSelectionHandoffTest.kt
@@ -1,0 +1,163 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import org.siloserver.silo.common.player.video.EpisodeSubtitleMode
+import org.siloserver.silo.common.player.video.ResolvedEpisodeSelection
+import org.siloserver.silo.model.catalog.FileVersion
+import org.siloserver.silo.model.playback.PlayerSubtitleInfo
+import org.siloserver.silo.model.playback.SubtitleIdentity
+import org.siloserver.silo.model.playback.SubtitleMediaIdentity
+import org.siloserver.silo.watchtogether.shouldNavigateToLocalNext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TvPlayNextSelectionHandoffTest {
+    @Test
+    fun nextEpisodeCapturesCurrentSourceAndCommittedSubtitleSemantics() {
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = FileVersion(
+                fileId = 42,
+                resolution = "2160p",
+                codecVideo = "hevc",
+                container = "mkv",
+            ),
+            committedSubtitleIdentity = SubtitleIdentity.ServerSidecar(serverIndex = 9),
+            catalogSubtitles = listOf(subtitle(index = 9, language = "nl", codec = "srt")),
+            hasExplicitSubtitleSelection = true,
+        )
+
+        assertEquals("2160p", handoff.source?.resolution)
+        assertEquals("hevc", handoff.source?.videoCodec)
+        assertEquals("nl", handoff.subtitle.language)
+        assertEquals("subrip", handoff.subtitle.codecFamily)
+        assertTrue(handoff.toString().contains("42").not(), "episode-local file IDs must not cross episodes")
+        assertTrue(handoff.toString().contains("9").not(), "episode-local subtitle indexes must not cross episodes")
+    }
+
+    @Test
+    fun nextEpisodeCarriesExplicitOff() {
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = null,
+            committedSubtitleIdentity = SubtitleIdentity.Off,
+            catalogSubtitles = emptyList(),
+            hasExplicitSubtitleSelection = true,
+        )
+
+        assertEquals(EpisodeSubtitleMode.OFF, handoff.subtitle.mode)
+    }
+
+    @Test
+    fun nextEpisodeCarriesAutoWhenNoExplicitSubtitleWasCommitted() {
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = null,
+            committedSubtitleIdentity = SubtitleIdentity.ServerSidecar(serverIndex = 9),
+            catalogSubtitles = listOf(subtitle(index = 9, language = "nl", codec = "srt")),
+            hasExplicitSubtitleSelection = false,
+        )
+
+        assertEquals(EpisodeSubtitleMode.AUTO, handoff.subtitle.mode)
+    }
+
+    @Test
+    fun downloadedPlaybackDropsDownloadIdentityButKeepsMediaSemantics() {
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = FileVersion(fileId = 42, resolution = "1080p", codecVideo = "h264"),
+            committedSubtitleIdentity = SubtitleIdentity.Downloaded(
+                downloadId = 777,
+                media = SubtitleMediaIdentity(language = "nl", codecFamily = "srt"),
+            ),
+            catalogSubtitles = listOf(subtitle(index = 9, language = "nl", codec = "srt")),
+            hasExplicitSubtitleSelection = true,
+        )
+
+        assertEquals("1080p", handoff.source?.resolution)
+        assertEquals(EpisodeSubtitleMode.AUTO, handoff.subtitle.mode)
+        assertTrue(handoff.toString().contains("777").not(), "download identity is episode-local")
+    }
+
+    @Test
+    fun watchTogetherStillSuppressesSoloAutoAdvance() {
+        assertTrue(shouldNavigateToLocalNext(inWatchTogetherRoom = false))
+        assertTrue(shouldNavigateToLocalNext(inWatchTogetherRoom = true).not())
+    }
+
+    @Test
+    fun profileOrServerReplacementDoesNotReuseAnOldHandoff() {
+        val slot = TvEpisodeSelectionHandoffSlot(
+            captureTvEpisodeSelectionHandoff(
+                activeVersion = FileVersion(fileId = 42, resolution = "1080p"),
+                committedSubtitleIdentity = SubtitleIdentity.Off,
+                catalogSubtitles = emptyList(),
+                hasExplicitSubtitleSelection = true,
+            ),
+        )
+
+        assertEquals(EpisodeSubtitleMode.OFF, slot.takeForStart()?.subtitle?.mode)
+        assertNull(slot.takeForStart(), "replacement starts must not reuse a prior episode handoff")
+    }
+
+    @Test
+    fun resolvedExplicitTargetSubtitleBlocksDurableTargetRestore() {
+        val application = resolveTvEpisodeInitialSubtitleSelection(
+            episodeSelectionHandoff = captureTvEpisodeSelectionHandoff(
+                activeVersion = null,
+                committedSubtitleIdentity = SubtitleIdentity.Off,
+                catalogSubtitles = emptyList(),
+                hasExplicitSubtitleSelection = true,
+            ),
+            resolvedEpisodeSelection = ResolvedEpisodeSelection(
+                fileId = 1080,
+                subtitleTrackIndex = null,
+                subtitleIntentSpecified = true,
+            ),
+            existingPendingInitialSubtitleIndex = 4,
+        )
+
+        assertNull(application.pendingInitialSubtitleIndex)
+        assertTrue(application.suppressDurableSubtitleRestore)
+    }
+
+    @Test
+    fun resolvedOffAppliesMedia3OffAndAutoPreservesDurableRestore() {
+        val off = resolveTvEpisodeInitialSubtitleSelection(
+            episodeSelectionHandoff = captureTvEpisodeSelectionHandoff(
+                activeVersion = null,
+                committedSubtitleIdentity = SubtitleIdentity.Off,
+                catalogSubtitles = emptyList(),
+                hasExplicitSubtitleSelection = true,
+            ),
+            resolvedEpisodeSelection = ResolvedEpisodeSelection(
+                fileId = null,
+                subtitleTrackIndex = -1,
+                subtitleIntentSpecified = true,
+            ),
+            existingPendingInitialSubtitleIndex = null,
+        )
+        val automatic = resolveTvEpisodeInitialSubtitleSelection(
+            episodeSelectionHandoff = captureTvEpisodeSelectionHandoff(
+                activeVersion = null,
+                committedSubtitleIdentity = SubtitleIdentity.Off,
+                catalogSubtitles = emptyList(),
+                hasExplicitSubtitleSelection = false,
+            ),
+            resolvedEpisodeSelection = ResolvedEpisodeSelection(
+                fileId = null,
+                subtitleTrackIndex = null,
+                subtitleIntentSpecified = false,
+            ),
+            existingPendingInitialSubtitleIndex = null,
+        )
+
+        assertEquals(-1, off.pendingInitialSubtitleIndex)
+        assertTrue(off.suppressDurableSubtitleRestore)
+        assertTrue(automatic.suppressDurableSubtitleRestore.not())
+    }
+
+    private fun subtitle(index: Int, language: String, codec: String) = PlayerSubtitleInfo(
+        index = index,
+        language = language,
+        codec = codec,
+        url = "https://example.test/$index.$codec",
+    )
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayNextSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayNextSelectionHandoffTest.kt
@@ -2,6 +2,7 @@ package org.siloserver.silo.tv.ui.screens.player
 
 import org.siloserver.silo.common.player.video.EpisodeSubtitleMode
 import org.siloserver.silo.common.player.video.ResolvedEpisodeSelection
+import org.siloserver.silo.common.player.video.encodeEpisodeSelectionHandoff
 import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.playback.PlayerSubtitleInfo
 import org.siloserver.silo.model.playback.SubtitleIdentity
@@ -60,20 +61,69 @@ class TvPlayNextSelectionHandoffTest {
     }
 
     @Test
-    fun downloadedPlaybackDropsDownloadIdentityButKeepsMediaSemantics() {
+    fun downloadedPlaybackDropsDownloadIdentityButKeepsPortableMediaSemantics() {
         val handoff = captureTvEpisodeSelectionHandoff(
-            activeVersion = FileVersion(fileId = 42, resolution = "1080p", codecVideo = "h264"),
+            activeVersion = FileVersion(
+                fileId = 42,
+                fileName = "source-42.mkv",
+                filePath = "/media/source-42.mkv",
+                resolution = "1080p",
+                codecVideo = "h264",
+            ),
             committedSubtitleIdentity = SubtitleIdentity.Downloaded(
                 downloadId = 777,
-                media = SubtitleMediaIdentity(language = "nl", codecFamily = "srt"),
+                media = SubtitleMediaIdentity(
+                    trackId = "download-track-777",
+                    language = "NL",
+                    codecFamily = "srt",
+                    forced = true,
+                    hearingImpaired = true,
+                ),
             ),
             catalogSubtitles = listOf(subtitle(index = 9, language = "nl", codec = "srt")),
             hasExplicitSubtitleSelection = true,
         )
 
         assertEquals("1080p", handoff.source?.resolution)
-        assertEquals(EpisodeSubtitleMode.AUTO, handoff.subtitle.mode)
-        assertTrue(handoff.toString().contains("777").not(), "download identity is episode-local")
+        assertEquals(EpisodeSubtitleMode.TRACK, handoff.subtitle.mode)
+        assertEquals("nl", handoff.subtitle.language)
+        assertEquals("subrip", handoff.subtitle.codecFamily)
+        assertEquals(true, handoff.subtitle.forced)
+        assertEquals(true, handoff.subtitle.hearingImpaired)
+        assertEquals(true, handoff.subtitle.external)
+        val encoded = encodeEpisodeSelectionHandoff(handoff)
+        assertTrue(encoded.contains("777").not(), "download identity is episode-local")
+        assertTrue(encoded.contains("download-track").not(), "Media3 identity is episode-local")
+        assertTrue(encoded.contains("fileId").not(), "file identity is episode-local")
+        assertTrue(encoded.contains("index").not(), "subtitle indexes are episode-local")
+        assertTrue(encoded.contains("source-42").not(), "file name and path are episode-local")
+        assertTrue(encoded.contains("example.test").not(), "subtitle URLs are episode-local")
+    }
+
+    @Test
+    fun localMedia3PlaybackKeepsPortableMediaSemanticsWithoutTrackId() {
+        val handoff = captureTvEpisodeSelectionHandoff(
+            activeVersion = null,
+            committedSubtitleIdentity = SubtitleIdentity.LocalMedia3(
+                SubtitleMediaIdentity(
+                    trackId = "media3-opaque-id",
+                    language = "EN-us",
+                    codecFamily = "webvtt",
+                    forced = false,
+                    hearingImpaired = true,
+                ),
+            ),
+            catalogSubtitles = emptyList(),
+            hasExplicitSubtitleSelection = true,
+        )
+
+        assertEquals(EpisodeSubtitleMode.TRACK, handoff.subtitle.mode)
+        assertEquals("en", handoff.subtitle.language)
+        assertEquals("webvtt", handoff.subtitle.codecFamily)
+        assertEquals(false, handoff.subtitle.forced)
+        assertEquals(true, handoff.subtitle.hearingImpaired)
+        assertNull(handoff.subtitle.external)
+        assertTrue(encodeEpisodeSelectionHandoff(handoff).contains("media3-opaque-id").not())
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackFreshLoadOwnershipTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackFreshLoadOwnershipTest.kt
@@ -129,6 +129,31 @@ class TvPlaybackFreshLoadOwnershipTest {
     }
 
     @Test
+    fun `retryable Ready failures retain the episode handoff before exposing retry UI`() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt",
+        ).readText()
+        val ready = source
+            .substringAfter("is VideoPlayerUiState.Ready ->")
+            .substringBefore("is VideoPlayerUiState.Error ->")
+        val missingSession = ready
+            .substringAfter("?: run {")
+            .substringBefore("unpublishedReadySession.acquire")
+        val failedPublication = ready
+            .substringAfter("if (!jointlyConfirmed) {")
+            .substringBefore("if (result.resolvedEpisodeSelection != null)")
+
+        assertTrue(
+            missingSession.indexOf("episodeSelectionHandoffSlot.retainForRetry(") in
+                0 until missingSession.indexOf("fail(\"Playback start returned no session.\")"),
+        )
+        assertTrue(
+            failedPublication.indexOf("episodeSelectionHandoffSlot.retainForRetry(") in
+                0 until failedPublication.indexOf("fail(\"Playback publication could not be confirmed.\")"),
+        )
+    }
+
+    @Test
     fun `post Ready local selection hydration and publish exceptions rollback exactly once`() =
         runTest {
             for (stage in listOf("local-selection", "hydration", "publish")) {

--- a/docs/superpowers/plans/2026-08-01-fire-tv-playback-selection-ux.md
+++ b/docs/superpowers/plans/2026-08-01-fire-tv-playback-selection-ux.md
@@ -1,0 +1,716 @@
+# Fire TV Playback Selection UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Android TV detail-selector contrast, preserve semantic source/subtitle intent across episode transitions, and keep long in-player subtitle pickers scrolled to D-pad focus.
+
+**Architecture:** Keep the existing detail popup, eager HUD focus graph, playback coordinator, and per-item durable preferences. Add pure visual-state and episode-handoff policies, pass the handoff through the existing TV route/start request, resolve it only after the target episode's catalog detail is known, and apply it without transferring raw file IDs or track indexes.
+
+**Tech Stack:** Kotlin 2.1, Kotlin serialization, Jetpack Compose/Compose for TV, Navigation Compose, Media3, Kotlin test/JUnit, Gradle, repository supply-chain scripts.
+
+## Global Constraints
+
+- Android TV behavior only; phone production behavior remains unchanged.
+- No server, API, schema, database, proxy, or production-configuration changes.
+- Keep durable track selections scoped to `(server, profile, contentId, fileId)`.
+- Never transfer a raw file ID or subtitle index between episodes.
+- Explicit subtitle Off remains Off; Auto remains Auto; a missing explicit match falls back to profile Auto.
+- Source matching uses resolution first, then codec, Dolby Vision/HDR, and container as deterministic tie-breakers.
+- Do not add cross-episode audio continuity.
+- Keep Watch Together auto-advance suppression and playback shutdown ordering unchanged.
+- Keep the eager HUD option `Column`; do not restore the removed lazy focus graph.
+- Do not install on a physical Fire TV, Shield, phone, or other device without a new explicit request.
+
+---
+
+## File Map
+
+- `androidTvApp/.../ui/components/TvSelectorRowVisualState.kt`: pure focused/selected/disabled color policy for anchored selector rows.
+- `androidTvApp/.../ui/components/TvAnchoredSelectorMenu.kt`: renders the existing anchored popup with explicit TV focus state.
+- `androidTvApp/.../ui/screens/player/TvPlayerHud.kt`: explicitly brings a focused HUD picker row into the clipped viewport.
+- `android-shared/.../player/video/EpisodeSelectionHandoff.kt`: serializable semantic source/subtitle intent plus pure capture/resolve policy.
+- `android-shared/.../player/video/VideoPlaybackStartRequest.kt`: optional episode handoff on the existing coordinator request.
+- `android-shared/.../player/video/VideoPlaybackStartResult.kt`: reports the target decision back to the TV view model.
+- `androidTvApp/.../ui/navigation/TvRoute.kt`: carries one URL-encoded handoff payload through player replacement.
+- `androidTvApp/.../ui/navigation/TvAppNavigation.kt`: decodes the payload and passes it into the next TV player.
+- `androidTvApp/.../ui/screens/player/TvVideoPlaybackStarter.kt`: resolves source and subtitle against the target episode before session start.
+- `androidTvApp/.../ui/screens/player/TvPlayerViewModel.kt`: captures outgoing intent and prevents a stale target override.
+- `androidTvApp/.../ui/screens/player/TvPlayerScreen.kt`: threads the handoff through launch arguments and next navigation.
+- `androidTvApp/.../ui/screens/detail/TvItemDetailViewModel.kt`: resolves old next-up selection after the new watch detail loads.
+
+---
+
+### Task 1: Define and test a semantic episode-selection handoff
+
+**Files:**
+- Create: `android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt`
+- Create test: `android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoffTest.kt`
+
+**Interfaces:**
+- Produces: a serializable `EpisodeSelectionHandoff` containing semantic source and subtitle intent only.
+- Consumes: `FileVersion`, `PlayerSubtitleInfo`, and the existing normalized codec/language metadata.
+- Security boundary: payloads contain no server URL, token, file ID, download ID, track ID, or track index.
+
+- [ ] **Step 1: Write failing source-resolution tests**
+
+Cover these cases in `EpisodeSelectionHandoffTest`:
+
+```kotlin
+@Test fun sourceUsesResolutionBeforeCodecAndContainer() { /* 2160p remains 2160p */ }
+@Test fun sourceUsesCodecDynamicRangeAndContainerAsTieBreakers() { /* exact semantic candidate wins */ }
+@Test fun ambiguousBestSourceFallsBackToAutomaticSelection() { /* tied best candidates return null */ }
+@Test fun unavailableResolutionFallsBackToAutomaticSelection() { /* no forced upscale/downgrade */ }
+@Test fun sourceIntentNeverSerializesTheOriginalFileId() { /* encoded payload omits raw IDs */ }
+```
+
+Use actual `FileVersion` fixtures with different IDs so the test proves resolution returns a target ID selected from the target list rather than the source episode's ID.
+
+- [ ] **Step 2: Write failing subtitle-resolution tests**
+
+```kotlin
+@Test fun explicitSubtitleMatchesSemanticsAtADifferentTargetIndex() { /* language/accessibility/source/codec */ }
+@Test fun explicitOffRemainsOff() { /* result is -1 and intentSpecified=true */ }
+@Test fun automaticSubtitleRemainsUnspecified() { /* null and intentSpecified=false */ }
+@Test fun unavailableExplicitSubtitleUsesProfileAutoWithoutTargetDurableRestore() {
+    /* null and intentSpecified=true */
+}
+@Test fun malformedPayloadDecodesToNull() { /* navigation cannot crash */ }
+```
+
+The explicit-missing case is load-bearing: `subtitleTrackIndex = null` selects profile Auto, while `intentSpecified = true` prevents the target episode's durable per-file subtitle from overriding that fallback.
+
+- [ ] **Step 3: Run the focused tests and verify RED**
+
+```bash
+./gradlew :android-shared:testDebugUnitTest \
+  --tests '*EpisodeSelectionHandoffTest' --no-daemon
+```
+
+Expected: compilation fails because the handoff contract and policy do not exist.
+
+- [ ] **Step 4: Implement the minimal serializable contract**
+
+```kotlin
+@Serializable
+data class EpisodeSelectionHandoff(
+    val source: EpisodeSourceIntent? = null,
+    val subtitle: EpisodeSubtitleIntent = EpisodeSubtitleIntent.auto(),
+)
+
+@Serializable
+data class EpisodeSourceIntent(
+    val resolution: String,
+    val videoCodec: String? = null,
+    val dynamicRange: EpisodeDynamicRange? = null,
+    val container: String? = null,
+)
+
+@Serializable enum class EpisodeDynamicRange { SDR, HDR, DOLBY_VISION }
+@Serializable enum class EpisodeSubtitleMode { AUTO, OFF, TRACK }
+
+@Serializable
+data class EpisodeSubtitleIntent(
+    val mode: EpisodeSubtitleMode,
+    val language: String? = null,
+    val codecFamily: String? = null,
+    val forced: Boolean? = null,
+    val hearingImpaired: Boolean? = null,
+    val external: Boolean? = null,
+) {
+    companion object {
+        fun auto() = EpisodeSubtitleIntent(EpisodeSubtitleMode.AUTO)
+        fun off() = EpisodeSubtitleIntent(EpisodeSubtitleMode.OFF)
+    }
+}
+
+data class ResolvedEpisodeSubtitle(val trackIndex: Int?, val intentSpecified: Boolean)
+data class ResolvedEpisodeSelection(
+    val fileId: Int?,
+    val subtitleTrackIndex: Int?,
+    val subtitleIntentSpecified: Boolean,
+)
+```
+
+Add pure capture/resolve helpers and JSON encode/decode helpers. Source resolution must require an exact normalized resolution, then score codec, Dolby Vision/HDR, and container. Return a target file ID only when the highest-scoring candidate is unique. Subtitle resolution must compare normalized language, codec family, forced, hearing-impaired, and embedded/external semantics. Do not reuse `TrackSelectionFingerprint`: its index is intentionally file-scoped.
+
+- [ ] **Step 5: Verify the contract and serialization boundary**
+
+```bash
+./gradlew :android-shared:testDebugUnitTest \
+  --tests '*EpisodeSelectionHandoffTest' --no-daemon
+rg -n 'fileId|downloadId|trackId|trackIndex|accessToken|serverUrl' \
+  android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt
+```
+
+Expected: tests pass; restricted names appear only in resolved target result types where needed, never in serialized intent fields.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt \
+  android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoffTest.kt
+git commit -m "feat(tv): define semantic episode selection handoff"
+```
+
+---
+
+### Task 2: Resolve the handoff at the playback-start boundary
+
+**Files:**
+- Modify: `android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartRequest.kt`
+- Modify: `android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResult.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt`
+- Create test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvEpisodeHandoffPlaybackStartTest.kt`
+
+**Interfaces:**
+- `VideoPlaybackStartRequest.episodeSelectionHandoff: EpisodeSelectionHandoff? = null` keeps phone and existing callers source-compatible.
+- `VideoPlaybackStartResult.Ready.resolvedEpisodeSelection: ResolvedEpisodeSelection? = null` reports exactly what was chosen after target catalog resolution.
+
+- [ ] **Step 1: Write failing precedence and fallback tests**
+
+Extract a pure `resolveTvPlaybackStartSelection(...)` policy and test:
+
+```kotlin
+@Test fun explicitDetailFileIdWinsOverEpisodeHandoff() { /* manual launch remains authoritative */ }
+@Test fun episodeHandoffWinsOverTargetLastFileAndQuality() { /* autoplay carries current intent */ }
+@Test fun noHandoffPreservesExistingLastFileAndQualitySelection() { /* regression guard */ }
+@Test fun subtitleIsResolvedAgainstTheChosenTargetVersion() { /* not another version's indexes */ }
+@Test fun missingExplicitSubtitleReturnsSpecifiedProfileAuto() { /* null + true */ }
+@Test fun explicitOffIsRetainedClientSide() { /* -1 is not sent to server */ }
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvEpisodeHandoffPlaybackStartTest' --no-daemon
+```
+
+Expected: compilation fails because the request/result fields and resolver do not exist.
+
+- [ ] **Step 3: Add the optional request/result fields**
+
+Add the two nullable fields with defaults. Do not change constructor behavior for Android phone, explicit detail launches, retries, Watch Together, or download playback.
+
+- [ ] **Step 4: Resolve only after target watch detail is available**
+
+In `TvVideoPlaybackStarter`, feed target `FileVersion` and subtitle lists into `resolveTvPlaybackStartSelection`. Apply precedence in this exact order:
+
+1. explicit `preferredFileId` from the detail screen;
+2. unique semantic source handoff match;
+3. existing target `lastFileId` / quality / automatic selection.
+
+Resolve subtitle against the selected target version. Forward only a non-negative target subtitle index to the server start request because the server rejects `-1`; retain Off as `-1` in `resolvedEpisodeSelection` for the client-side Media3 selection. Populate the resolved result on `Ready`.
+
+- [ ] **Step 5: Run focused and neighboring coordinator tests**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvEpisodeHandoffPlaybackStartTest' \
+  --tests '*TvPlaybackFreshLoadOwnershipTest' \
+  :androidTvApp:compileDebugKotlinAndroid --no-daemon
+```
+
+Expected: all selected tests pass and TV compilation succeeds.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartRequest.kt \
+  android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResult.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvEpisodeHandoffPlaybackStartTest.kt
+git commit -m "feat(tv): resolve episode selection during playback start"
+```
+
+---
+
+### Task 3: Give anchored selector rows an explicit TV focus state
+
+**Files:**
+- Create: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSelectorRowVisualState.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt:152-214`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackSelectorRow.kt:80-220`
+- Create test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvSelectorRowVisualStateTest.kt`
+
+**Interfaces:**
+- Produces: `tvSelectorRowVisualState(focused: Boolean, selected: Boolean, enabled: Boolean): TvSelectorRowVisualState`.
+- Consumes: existing `FocusedContainer`, `FocusedContent`, `DarkSurfaceElevated`, and `SiloOnSurface` theme colors.
+
+- [ ] **Step 1: Write failing visual-state tests**
+
+```kotlin
+class TvSelectorRowVisualStateTest {
+    @Test fun focusedRowsUseInvertedTvContrast() {
+        val state = tvSelectorRowVisualState(focused = true, selected = false, enabled = true)
+        assertEquals(FocusedContainer, state.container)
+        assertEquals(FocusedContent, state.content)
+        assertTrue(state.border.alpha > 0f)
+    }
+
+    @Test fun selectedIdleRowsRemainDistinctFromIdleRows() {
+        val selected = tvSelectorRowVisualState(false, true, true)
+        val idle = tvSelectorRowVisualState(false, false, true)
+        assertNotEquals(idle.container, selected.container)
+        assertNotEquals(idle.border, selected.border)
+    }
+
+    @Test fun disabledRowsStayMutedEvenWhenSelected() {
+        val state = tvSelectorRowVisualState(false, true, false)
+        assertTrue(state.content.alpha < 0.5f)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvSelectorRowVisualStateTest' --no-daemon
+```
+
+Expected: compilation fails because the visual-state types do not exist.
+
+- [ ] **Step 3: Implement the minimal pure policy**
+
+```kotlin
+internal data class TvSelectorRowVisualState(
+    val container: Color,
+    val content: Color,
+    val border: Color,
+)
+
+internal fun tvSelectorRowVisualState(
+    focused: Boolean,
+    selected: Boolean,
+    enabled: Boolean,
+): TvSelectorRowVisualState = when {
+    !enabled -> TvSelectorRowVisualState(
+        DarkSurfaceElevated,
+        SiloOnSurface.copy(alpha = 0.38f),
+        Color.Transparent,
+    )
+    focused -> TvSelectorRowVisualState(
+        FocusedContainer,
+        FocusedContent,
+        FocusedContent.copy(alpha = 0.22f),
+    )
+    selected -> TvSelectorRowVisualState(
+        SiloOnSurface.copy(alpha = 0.14f),
+        SiloOnSurface,
+        SiloOnSurface.copy(alpha = 0.28f),
+    )
+    else -> TvSelectorRowVisualState(DarkSurfaceElevated, SiloOnSurface, Color.Transparent)
+}
+```
+
+- [ ] **Step 4: Wire the policy into every anchored menu row**
+
+Add a stable `key: String` to `TvSelectorOption` and populate it from file ID, audio/subtitle stable identity, or edition key at all `TvPlaybackSelectorRow` call sites. For each option, remember a `MutableInteractionSource` by key, collect focus, pass that interaction source to `DropdownMenuItem`, and apply the resolved background, border, text, and icon colors. Keep anchoring, semantics, enablement, callbacks, and trigger focus restoration unchanged.
+
+```kotlin
+val interactionSource = remember(option.key) { MutableInteractionSource() }
+val focused by interactionSource.collectIsFocusedAsState()
+val visual = tvSelectorRowVisualState(focused, option.selected, option.enabled)
+
+DropdownMenuItem(
+    interactionSource = interactionSource,
+    modifier = Modifier
+        .padding(horizontal = 6.dp, vertical = 2.dp)
+        .clip(RoundedCornerShape(8.dp))
+        .background(visual.container)
+        .border(1.dp, visual.border, RoundedCornerShape(8.dp))
+        .semantics { selected = option.selected },
+    colors = MenuDefaults.itemColors(
+        textColor = visual.content,
+        leadingIconColor = visual.content,
+        disabledTextColor = visual.content,
+        disabledLeadingIconColor = visual.content,
+    ),
+    // retain the existing text, leading icon, enabled value, and onClick body
+)
+```
+
+- [ ] **Step 5: Run focused tests and compile**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvSelectorRowVisualStateTest' \
+  --tests '*TvPlaybackFormattingTest' \
+  :androidTvApp:compileDebugKotlinAndroid --no-daemon
+```
+
+Expected: selected tests pass and Android TV Kotlin compilation succeeds.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackSelectorRow.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvSelectorRowVisualStateTest.kt
+git commit -m "fix(tv): make detail selector focus legible"
+```
+
+---
+
+### Task 4: Keep long HUD picker lists aligned with D-pad focus
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt:2060-2190`
+- Create test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvHudPickerFocusWiringSourceTest.kt`
+
+**Interfaces:**
+- Produces: every `HudPickerOptionRow` owns one `BringIntoViewRequester` and relocates only when focus enters.
+- Preserves: eager `Column.verticalScroll`, modal focus trap, stable option keys, and Select-to-commit behavior.
+
+- [ ] **Step 1: Write the failing wiring regression**
+
+```kotlin
+class TvHudPickerFocusWiringSourceTest {
+    private val source = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt",
+    ).readText()
+
+    @Test fun focusedPickerRowsAreExplicitlyBroughtIntoView() {
+        assertContains(source, "remember { BringIntoViewRequester() }")
+        assertContains(source, ".bringIntoViewRequester(bringIntoViewRequester)")
+        assertContains(source, "bringIntoViewRequester.bringIntoView()")
+    }
+
+    @Test fun pickerKeepsTheEagerFocusGraph() {
+        val picker = source.substringAfter("internal fun HudPickerDialog")
+            .substringBefore("private fun formatTime")
+        assertContains(picker, ".verticalScroll(rememberScrollState())")
+        assertFalse(picker.contains("LazyColumn"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvHudPickerFocusWiringSourceTest' --no-daemon
+```
+
+Expected: bring-into-view assertions fail against the implicit-scroll implementation.
+
+- [ ] **Step 3: Add focused-row relocation**
+
+```kotlin
+val bringIntoViewRequester = remember { BringIntoViewRequester() }
+val scope = rememberCoroutineScope()
+
+Modifier
+    .bringIntoViewRequester(bringIntoViewRequester)
+    .onFocusChanged { state ->
+        if (state.isFocused) {
+            onFocused()
+            scope.launch { bringIntoViewRequester.bringIntoView() }
+        }
+    }
+```
+
+Remove the old one-line `onFocusChanged` so `onFocused()` fires exactly once per focus entry.
+
+- [ ] **Step 4: Run the regression and neighboring HUD tests**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvHudPickerFocusWiringSourceTest' \
+  --tests '*TvPlayerHudTabsTest' \
+  --tests '*TvSubtitleHudStateTest' \
+  :androidTvApp:compileDebugKotlinAndroid --no-daemon
+```
+
+Expected: all tests and compilation pass.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvHudPickerFocusWiringSourceTest.kt
+git commit -m "fix(tv): scroll HUD pickers with focus"
+```
+
+---
+
+### Task 5: Carry the semantic handoff through next-episode navigation
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvRoute.kt:84-145`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt:780-835`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt:412-433,1431-1515,2879-2910`
+- Modify test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/navigation/TvPlayerRouteTest.kt`
+- Create test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayNextSelectionHandoffTest.kt`
+
+**Interfaces:**
+- `TvRoute.Player` adds one optional URL-encoded `episodeSelectionHandoff` query value.
+- `TvPlayerLaunchArgs` and `PlayNextRequest` add `episodeSelectionHandoff: EpisodeSelectionHandoff?`.
+- `onPlayNext` passes one semantic handoff object instead of using `preferredQuality` as cross-episode authority.
+
+- [ ] **Step 1: Extend route tests and verify RED**
+
+Test payload round-trip, absent-payload compatibility, malformed-payload fallback, and query-value encoding:
+
+```kotlin
+@Test fun playerRouteRoundTripsEpisodeSelectionHandoff() { /* semantic payload survives replacement */ }
+@Test fun playerRouteWithoutHandoffKeepsExistingDefaults() { /* existing deep links work */ }
+@Test fun malformedEpisodeHandoffIsIgnored() { /* player still opens */ }
+```
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvPlayerRouteTest' --no-daemon
+```
+
+Expected: new route assertions fail.
+
+- [ ] **Step 2: Add the optional route and launch fields**
+
+Serialize with `encodeEpisodeSelectionHandoff`, route-encode the result once, declare a nullable string navigation argument, route-decode it once, and parse with `decodeEpisodeSelectionHandoff`. A malformed value becomes null rather than aborting navigation. Thread it through `TvPlayerScreen`, `TvPlayerLaunchArgs`, and `VideoPlaybackStartRequest`.
+
+- [ ] **Step 3: Write failing outgoing-handoff tests**
+
+Use production-shaped `FileVersion`, downloaded playback identity, and `PlayerSubtitleInfo` fixtures:
+
+```kotlin
+@Test fun nextEpisodeCapturesCurrentSourceAndCommittedSubtitleSemantics() { /* no IDs */ }
+@Test fun nextEpisodeCarriesExplicitOff() { /* OFF survives */ }
+@Test fun nextEpisodeCarriesAutoWhenNoExplicitSubtitleWasCommitted() { /* AUTO */ }
+@Test fun downloadedPlaybackDropsDownloadIdentityButKeepsMediaSemantics() { /* safe handoff */ }
+@Test fun watchTogetherStillSuppressesSoloAutoAdvance() { /* unchanged guard */ }
+@Test fun profileOrServerReplacementDoesNotReuseAnOldHandoff() { /* session boundary */ }
+```
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvPlayNextSelectionHandoffTest' --no-daemon
+```
+
+Expected: the new continuity tests fail.
+
+- [ ] **Step 4: Capture and emit semantic intent**
+
+At `advanceToNextEpisode`, capture source intent from the active `FileVersion` and subtitle intent from the committed subtitle identity. Strip `fileId`, `downloadId`, `trackId`, server index, and Media3 index. Preserve `autoAdvanceCount`. Keep Watch Together suppression and shutdown order untouched. Navigate with the handoff payload and remove `preferredQuality` as the episode-continuity mechanism; it remains available for ordinary playback-quality semantics.
+
+- [ ] **Step 5: Apply the resolved target decision without stale override**
+
+When `VideoPlaybackStartResult.Ready.resolvedEpisodeSelection` exists:
+
+- set the pending initial subtitle index, including `-1` for Off;
+- apply an explicit target match or Off after Media3 tracks appear;
+- when `subtitleIntentSpecified` is true, skip the target file's durable `localTrackSelection.subtitleFingerprint` restore;
+- for a missing explicit match, leave the index null so profile Auto applies;
+- keep audio restore and all no-handoff launch behavior unchanged.
+
+- [ ] **Step 6: Run focused player and route tests**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvPlayerRouteTest' \
+  --tests '*TvPlayNextSelectionHandoffTest' \
+  --tests '*TvTrackSelectionPersistenceTest' \
+  --tests '*TvPlaybackFreshLoadOwnershipTest' \
+  :androidTvApp:compileDebugKotlinAndroid --no-daemon
+```
+
+Expected: all selected tests pass and TV compilation succeeds.
+
+- [ ] **Step 7: Commit Task 5**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/navigation/TvPlayerRouteTest.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayNextSelectionHandoffTest.kt
+git commit -m "fix(tv): preserve episode source and subtitle intent"
+```
+
+---
+
+### Task 6: Preserve the same intent when choosing Next Up on detail pages
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt:877-1110`
+- Modify test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt`
+- Create test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt`
+
+**Interfaces:**
+- Produces: an in-memory pending `EpisodeSelectionHandoff` tied to the expected target content/generation.
+- Preserves: per-item Room persistence and audio restore; the carried selection is not persisted until the user explicitly changes it on the target item.
+
+- [ ] **Step 1: Write failing target-refresh tests**
+
+```kotlin
+@Test fun changingNextUpResolvesOldSourceAgainstNewEpisodeFiles() { /* semantic source carries */ }
+@Test fun changingNextUpResolvesSubtitleAtDifferentCombinedIndex() { /* semantic track carries */ }
+@Test fun explicitOffRemainsOffAcrossNextUpRefresh() { /* -1 */ }
+@Test fun missingExplicitSubtitleUsesAutoAndDoesNotRestoreTargetDurableSubtitle() { /* null */ }
+@Test fun autoAllowsExistingTargetDurableSubtitleRestore() { /* existing behavior */ }
+@Test fun staleRefreshCompletionCannotApplyHandoffToAnotherEpisode() { /* generation fence */ }
+@Test fun carriedSelectionIsNotPersistedBeforeExplicitUserInput() { /* Room remains item-scoped */ }
+@Test fun profileOrServerChangeClearsPendingNextUpHandoff() { /* identity boundary */ }
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvNextUpSelectionHandoffTest' \
+  --tests '*TvTrackSelectionPersistenceTest' --no-daemon
+```
+
+Expected: continuity assertions fail against the current reset-to-null behavior.
+
+- [ ] **Step 3: Capture before clearing and resolve after loading**
+
+Before `refreshNextUp` clears `selectedNextUpFileId` and `selectedNextUpSubtitleIndex`, capture semantic intent from the old selected version and subtitle. Store it with the expected target content ID and refresh generation. After the new watch detail loads, resolve it against the new file list and selected target version before merging session/durable state.
+
+Merge rules:
+
+1. carried source/subtitle intent for the new target;
+2. existing in-memory target session selection where the handoff is Auto/unspecified;
+3. existing per-item durable file/audio/subtitle restore where not suppressed;
+4. profile Auto fallback.
+
+Keep durable audio behavior unchanged. If a subtitle handoff was specified, block target durable subtitle restore even when no match exists. Do not save the resolved handoff to Room until an explicit selector callback occurs. Clear pending intent on success, error, content mismatch, or generation mismatch.
+
+- [ ] **Step 4: Run focused detail tests and compile**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvNextUpSelectionHandoffTest' \
+  --tests '*TvTrackSelectionPersistenceTest' \
+  --tests '*TvItemDetailSubtitlePreferenceTest' \
+  :androidTvApp:compileDebugKotlinAndroid --no-daemon
+```
+
+Expected: all selected tests pass and TV compilation succeeds.
+
+- [ ] **Step 5: Commit Task 6**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
+git commit -m "fix(tv): retain selection across next-up detail refresh"
+```
+
+---
+
+### Task 7: Verify the complete Android TV change and publish a draft
+
+**Files:**
+- Modify only if evidence changes: tests or production files from Tasks 1-6.
+- Review: `docs/superpowers/specs/2026-07-31-fire-tv-playback-selection-ux-design.md`
+- Review: `docs/superpowers/plans/2026-08-01-fire-tv-playback-selection-ux.md`
+
+- [ ] **Step 1: Audit scope and forbidden changes**
+
+```bash
+git diff --check upstream/main...HEAD
+git diff --name-only upstream/main...HEAD
+git diff --stat upstream/main...HEAD
+git diff upstream/main...HEAD -- androidApp silo-server
+```
+
+Expected: no whitespace errors; no phone production, server, API, schema, database, proxy, or production-configuration diff.
+
+- [ ] **Step 2: Run supply-chain policy checks**
+
+```bash
+./scripts/test-check-build-supply-chain.sh
+./scripts/check-build-supply-chain.sh
+```
+
+Expected: both scripts exit zero without changing verification metadata.
+
+- [ ] **Step 3: Run the full shared and TV unit-test gate**
+
+```bash
+./gradlew --no-daemon --max-workers=2 \
+  :android-shared:testDebugUnitTest \
+  :androidTvApp:testDebugUnitTest
+```
+
+Expected: both unit-test tasks pass. If a failure appears, use `superpowers:systematic-debugging`; do not widen timeouts or rerun blindly.
+
+- [ ] **Step 4: Build debug and minified release variants**
+
+```bash
+./gradlew --no-daemon --max-workers=2 \
+  :androidTvApp:assembleDebug \
+  :androidTvApp:assembleRelease \
+  -PallowDebugReleaseSigning=true
+```
+
+Expected: both Android TV assemblies succeed. This gate builds artifacts only; it does not install them.
+
+- [ ] **Step 5: Run emulator-only D-pad smoke if a dedicated TV emulator is already available**
+
+Use only an explicitly identified emulator serial. Do not target a physical Shield, Fire TV, phone, or unknown ADB device. Verify:
+
+1. Version, Audio, Subtitle, and Edition popup focus is clearly visible over bright and dark art.
+2. A subtitle list longer than the viewport follows focus to its first and last options and Back restores the trigger.
+3. Episode 1 to Episode 2 keeps a semantically matching resolution and subtitle even when IDs/indexes differ.
+4. Explicit Off remains Off.
+5. A missing explicit subtitle falls back to profile Auto.
+6. Manual target selection and ordinary no-handoff launches remain unchanged.
+
+Capture serial-scoped screenshots/logs in a temporary directory outside the repository. If no suitable emulator is available, record that limitation in the PR instead of touching a physical device.
+
+- [ ] **Step 6: Request independent focused review**
+
+Use `superpowers:requesting-code-review` with the spec, plan, and `upstream/main...HEAD` diff. Require the reviewer to check:
+
+- serialized intent contains no raw IDs/indexes or credentials;
+- explicit detail selection beats handoff, which beats target durable/automatic source choice;
+- explicit missing subtitle cannot resurrect a target durable subtitle;
+- Auto still permits existing target behavior;
+- durable preference scope and write timing remain unchanged;
+- generation fencing prevents a stale next-up refresh;
+- Watch Together and playback shutdown sequencing remain unchanged;
+- selector focus and HUD scroll fixes retain Back/focus behavior;
+- Android phone behavior is unchanged.
+
+Address every substantive finding with a focused regression and rerun the smallest affected gate, then repeat review until approved.
+
+- [ ] **Step 7: Re-run final evidence after review fixes**
+
+```bash
+git diff --check upstream/main...HEAD
+./scripts/check-build-supply-chain.sh
+./gradlew --no-daemon --max-workers=2 \
+  :android-shared:testDebugUnitTest \
+  :androidTvApp:testDebugUnitTest \
+  :androidTvApp:assembleRelease \
+  -PallowDebugReleaseSigning=true
+git status --short --branch
+```
+
+Expected: clean diff checks, green tests/build, and a clean branch.
+
+- [ ] **Step 8: Push and open a draft pull request**
+
+```bash
+git push -u origin fix/firetv-playback-selection-ux
+gh pr create --draft --base main --head fix/firetv-playback-selection-ux \
+  --title "fix(tv): improve Fire TV selection and episode continuity" \
+  --body-file /tmp/firetv-playback-selection-ux-pr.md
+```
+
+The PR body must list the three original defects, behavior decisions, exact test/build evidence, emulator limitation or evidence, security/privacy boundary, and confirmation that phone/server behavior is unchanged. Do not merge.
+
+---
+
+## Plan Self-Review Checklist
+
+- [x] Every approved behavior in the design spec maps to a production step and a regression test.
+- [x] Every named type and file exists now or is explicitly created by an earlier task.
+- [x] No placeholder instructions, deferred hardening, arbitrary timeout changes, or raw cross-episode IDs/indexes remain.
+- [x] Task ordering is dependency-safe and each task ends with focused verification and a small commit.
+- [x] Full verification covers supply-chain policy, shared tests, TV tests, debug/release compilation, review, and emulator-only smoke without physical-device installation.
+
+Self-review found and corrected task-number drift introduced while composing the plan, removed test selectors for classes that do not exist on current `upstream/main`, and added explicit profile/server identity-boundary regressions. No unresolved contradiction or material ambiguity remains.

--- a/docs/superpowers/specs/2026-07-31-fire-tv-playback-selection-ux-design.md
+++ b/docs/superpowers/specs/2026-07-31-fire-tv-playback-selection-ux-design.md
@@ -1,0 +1,134 @@
+# Fire TV Playback Selection UX Design
+
+**Date:** 2026-07-31  
+**Status:** Approved for implementation planning  
+**Baseline:** `Silo-Server/silo-android` `main` at `3b2044c8`
+
+## Problem
+
+The current Android TV release has three related playback-selection defects:
+
+1. The Version, Audio, Subtitles, and Edition menus on item detail pages do not show a legible TV focus state. Version and Subtitles are the reported cases.
+2. Moving from one episode to the next does not carry the viewer's active source-resolution intent or subtitle choice. This affects automatic/explicit Up Next and the refreshed next-up controls on series and season detail pages.
+3. Long in-player option lists, most visibly Subtitle Track, can move focus below the clipped viewport without scrolling the focused row into view.
+
+These are Android TV client defects. They require no server, API, database, or profile-preference changes.
+
+## Verified Causes
+
+### Detail selector contrast
+
+`TvAnchoredSelectorMenu` embeds phone Material 3 `DropdownMenu` and `DropdownMenuItem` components inside the TV Material theme. The rows have explicit idle foreground colors but no TV-focused container/content treatment. Selection adds only a checkmark and semantics. The component itself documents this missing TV focus grammar.
+
+### Episode-to-episode selection continuity
+
+Durable track selections are correctly scoped to `(server, profile, contentId, fileId)`. A different episode necessarily has different content and file identities. The detail refresh path clears the old next-up state and restores only state already saved for the new episode. The player Up Next path carries only a resolution-shaped quality string; it drops subtitle intent and cannot distinguish versions sharing a resolution. The target episode's `lastFileId` may also override the carried quality.
+
+Raw file IDs and subtitle indexes must not cross episode boundaries. Android's current `FileVersion` model also lacks a stable edition identity.
+
+### In-player picker scrolling
+
+`HudPickerDialog` eagerly composes all rows in a clipped `Column.verticalScroll`, preserving a complete modal focus graph, but assumes focus movement will relocate that scroll container. Fire TV may focus a clipped child without scrolling it onscreen. A previous `LazyColumn` implementation performed explicit scrolling but was removed because lazy composition caused focus-boundary leakage.
+
+## Apple Comparison
+
+Current `Silo-Server/silo-apple` `main` at `e7de923a` has the same episode-continuity gap on both iOS and tvOS. `PlayerViewModel.playNextEpisodeNow()` starts the next episode with file, audio, and subtitle overrides all `nil`, then applies the new item's stored/profile preferences. Series and season detail also reset next-up selections when identity changes.
+
+Apple is therefore not the continuity behavior to copy. Its native tvOS menu and picker controls do not share Android's contrast or scrolling implementation defects.
+
+## Chosen Design
+
+### 1. TV-native focused selector rows
+
+Keep the existing anchored detail menu and selection callbacks. Replace the implicit phone-menu focus appearance with an explicit row visual-state policy:
+
+- Focused: existing TV `FocusedContainer` background, `FocusedContent` text/icons, and a visible focused border.
+- Selected but not focused: restrained selected fill/border plus the existing checkmark.
+- Idle: current dark surface and high-contrast foreground.
+- Disabled: current disabled semantics and visibly muted content.
+
+The same treatment applies to every `TvAnchoredSelectorMenu` consumer so Audio and Edition do not retain the latent defect.
+
+### 2. Session-scoped semantic episode handoff
+
+Represent the outgoing viewer intent without reusing episode-local IDs:
+
+- Source intent: normalized resolution plus available codec, HDR/Dolby Vision, and container characteristics. This is a preference, not an exact file identity.
+- Subtitle intent:
+  - `Auto`
+  - explicit `Off`
+  - explicit semantic track fingerprint: normalized language, forced/SDH flags, source kind, and codec/format where available.
+
+When the next episode's watch detail is available, resolve the intent deterministically:
+
+1. Preserve `Off` exactly.
+2. For an explicit subtitle, select the best semantic match. Prefer language and accessibility/forced meaning over incidental index or filename. If no valid match exists, return to the normal profile `Auto` behavior.
+3. For source selection, prefer the closest semantic version match. Resolution is primary; codec/HDR/container break ties. Never transfer a raw file ID. If no meaningful match exists, use the existing automatic version policy.
+4. A carried explicit session choice takes precedence over the target episode's stale `lastFileId` for that transition. With no carried choice, existing target-episode state and automatic behavior remain unchanged.
+
+Carry this handoff through both TV paths:
+
+- Player Up Next request and navigation route into the next player.
+- Series/season next-up identity refresh while the detail screen remains alive.
+
+The handoff is process/session scoped. It does not rewrite the per-episode durable preference key, create a series-wide preference, or alter server profile settings. Once the target episode resolves and the viewer changes a selection, existing per-item persistence continues normally.
+
+Audio continuity is not added in this change because it was not reported and materially expands matching semantics. Existing audio behavior remains unchanged.
+
+### 3. Explicit focused-row relocation in the HUD picker
+
+Keep the eager `Column` so every modal row remains in the focus graph. Give each option row a `BringIntoViewRequester`; when it gains focus, request that the row be brought into the clipped viewport. This covers initial programmatic focus and every D-pad transition without restoring the previous lazy-list focus-boundary regression.
+
+The shared correction applies to Subtitle Track and all other long HUD pickers, including delay lists.
+
+## State and Lifecycle Rules
+
+- The semantic handoff belongs to a single active TV browsing/playback flow.
+- It is discarded when the next episode consumes it, the user exits the flow, or process state is lost.
+- Profile/server changes do not inherit it.
+- Explicit `Off` is distinct from `Auto` throughout routing and resolution.
+- Watch Together authority and its auto-advance suppression are unchanged.
+- Playback session shutdown ordering is unchanged.
+
+## Testing
+
+### Focus contrast
+
+- Unit-test a pure selector-row visual-state resolver for focused, selected, idle, and disabled states.
+- Verify focused foreground/background meet the established TV inverted-focus policy.
+- Manually D-pad through Version, Subtitle, Audio, and Edition menus where present.
+
+### Episode handoff
+
+- E1 explicit resolution/source intent resolves to the closest E2 version.
+- A previously watched E2 `lastFileId` does not override an active carried choice.
+- Same-resolution candidates use codec/HDR/container tie-breakers deterministically.
+- No meaningful source match falls back to existing automatic selection.
+- Explicit subtitle language/forced/SDH/source/format resolves to the closest E2 track.
+- Missing subtitle match falls back to profile Auto.
+- Explicit Off remains Off.
+- Auto remains Auto.
+- Raw file IDs and track indexes are never transferred.
+- Both Player Up Next and series/season next-up refresh use the same resolver.
+- Existing same-episode persistence tests remain green.
+
+### Picker scrolling
+
+- A picker opened with an offscreen selected/focused row brings it onscreen.
+- Repeated D-pad Down/Up keeps the focused row visible across viewport boundaries.
+- Focus remains trapped within the modal at the first and last rows.
+- A short list does not move unnecessarily.
+
+## Verification
+
+Run focused Android TV unit tests for the new policies and affected existing suites, then the complete Android TV unit suite, supply-chain verification required by the repository, and Android TV debug/release compilation. Perform a Fire TV or TV-emulator D-pad smoke covering detail selector contrast, long subtitle-list scrolling, and E1-to-E2 continuity when an appropriate device/test fixture is available. No device installation is authorized by this design.
+
+## Out of Scope
+
+- Server/API/schema changes.
+- Series-wide durable playback preferences.
+- Stable edition identity additions to the Android model.
+- Cross-episode audio-track continuity.
+- Phone behavior changes.
+- Replacing the entire anchored selector popup architecture.
+- Installing a build on a physical device.

--- a/docs/superpowers/specs/2026-07-31-fire-tv-playback-selection-ux-design.md
+++ b/docs/superpowers/specs/2026-07-31-fire-tv-playback-selection-ux-design.md
@@ -1,7 +1,7 @@
 # Fire TV Playback Selection UX Design
 
-**Date:** 2026-07-31  
-**Status:** Approved for implementation planning  
+**Date:** 2026-07-31
+**Status:** Approved for implementation planning
 **Baseline:** `Silo-Server/silo-android` `main` at `3b2044c8`
 
 ## Problem


### PR DESCRIPTION
## Summary

This fixes three related Android TV playback-selection defects:

1. Version, Audio, Subtitle, and Edition popup rows had no legible TV focus treatment.
2. Player Up Next and series/season Next Up lost the viewer's active source-resolution and subtitle intent between episodes.
3. Long in-player option lists could move D-pad focus below the clipped viewport without scrolling the focused row into view.

## Behavior decisions

- Detail selector rows now use explicit focused, selected, idle, and disabled TV visual states while retaining the existing anchored popup and trigger focus restoration.
- Episode transitions carry session-only semantic source and subtitle intent. Resolution is primary for source selection, with codec, dynamic range, and container as deterministic tie-breakers.
- Subtitle matching prioritizes language and forced/SDH meaning, then source kind and codec. Explicit Off remains Off; missing or ambiguous explicit matches fall back to profile Auto without restoring a stale target durable subtitle; Auto retains existing target behavior.
- Explicit detail source selection wins over handoff, which wins over target durable/automatic source selection.
- Series/season Auto source selection resolves subtitles against the same effective version shown by the UI, including `lastFileId` and preferred quality.
- HUD pickers retain the eager focus graph and explicitly bring each focused row into view.
- Durable selections remain scoped to `(server, profile, contentId, fileId)` and are written only through existing explicit selector callbacks. Watch Together suppression and playback shutdown ordering are unchanged.

## Security and privacy boundary

The serialized handoff contains semantic resolution/codec/dynamic-range/container and subtitle language/accessibility/source/format intent only. It contains no file IDs, download IDs, track IDs or indexes, filenames, paths, credentials, tokens, or server URLs. The handoff is process/session scoped and is fenced across target generation and server/profile identity changes.

## Verification

- `git diff --check upstream/main...HEAD` — passed.
- `./scripts/test-check-build-supply-chain.sh` — passed (`All supply-chain policy self-tests passed`).
- `./scripts/check-build-supply-chain.sh` — passed and changed no tracked/staged verification metadata.
- `./gradlew --no-daemon --max-workers=2 :android-shared:testDebugUnitTest :androidTvApp:testDebugUnitTest` — passed; the initial complete gate was `BUILD SUCCESSFUL in 17s`.
- `./gradlew --no-daemon --max-workers=2 :androidTvApp:assembleDebug :androidTvApp:assembleRelease -PallowDebugReleaseSigning=true` — passed; `BUILD SUCCESSFUL in 2m 22s`.
- Post-review final gate: `./gradlew --no-daemon --max-workers=2 :android-shared:testDebugUnitTest :androidTvApp:testDebugUnitTest :androidTvApp:assembleRelease -PallowDebugReleaseSigning=true` — passed; `BUILD SUCCESSFUL in 1m 50s`.
- Final generated unit-test XML: 1,786 tests, 0 failures, 0 errors, 0 skipped.
- Independent whole-diff code/security review found two Important issues; both were fixed test-first. Re-review approved publication with no Critical, Important, or Minor correctness findings.

## Emulator limitation

Live D-pad smoke was not feasible under current authorization. `adb devices -l` listed only a physical NVIDIA Shield (`192.168.1.128:5555`), which was not queried, installed to, or otherwise touched. A dedicated `Silo_TV` AVD exists but was not running, so the exact current feature build was not already installed on a dedicated emulator. No older installed build is being claimed as validation.

## Scope

Production changes are limited to `android-shared` and `androidTvApp`. There are no Android phone production, server, API, schema, database, proxy, or production-configuration changes. Phone and server behavior are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved video quality, source, and subtitle preferences when moving between TV episodes.
  * Added support for automatic, disabled, and explicitly selected subtitles, with intelligent fallback when tracks differ.
  * Improved Android TV selector focus states, contrast, selection styling, and scrolling for long pickers.
  * Added safer handling when switching profiles, servers, or during interrupted playback transitions.
* **Bug Fixes**
  * Prevented stale selections from being applied to the wrong episode.
  * Ensured explicit subtitle-off choices override saved preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->