### PR TITLE
fix(overlays): match web's card-badge rendering rules

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/overlays/OverlayBadge.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/overlays/OverlayBadge.kt
@@ -138,8 +138,14 @@ internal fun OverlayBadge(
                 renderedIcon = true
             }
         }
+        // A brand token (HDR10, ATMOS, …) already spells its text as the
+        // mark itself; when the label says the same thing, showing both
+        // reads "HDR10 HDR10". Mirrors web's `labelRedundantWithIcon`.
+        val labelRedundantWithIcon = renderedIcon &&
+            iconId != null &&
+            overlayBrandToken(iconId)?.equals(state.label.trim(), ignoreCase = true) == true
         // Apple: render text unless icon-only AND an icon was shown.
-        if (!state.iconOnly || !renderedIcon) {
+        if ((!state.iconOnly || !renderedIcon) && !labelRedundantWithIcon) {
             BadgeText(text = state.label, preset = preset, color = foreground)
         }
     }

--- a/shared/src/androidMain/kotlin/org/siloserver/silo/overlays/OverlayLanguageName.android.kt
+++ b/shared/src/androidMain/kotlin/org/siloserver/silo/overlays/OverlayLanguageName.android.kt
@@ -1,0 +1,16 @@
+package org.siloserver.silo.overlays
+
+import java.util.Locale
+
+internal actual fun overlayLanguageName(tag: String): String? {
+    val trimmed = tag.trim()
+    if (trimmed.isEmpty()) return null
+    val locale = Locale.forLanguageTag(trimmed.replace('_', '-'))
+    val name = locale.getDisplayName(Locale.ENGLISH)
+    // `getDisplayName` echoes the tag back when ICU has no name for it;
+    // treat that as "unnamed" and fall back to the uppercased code.
+    if (name.isBlank() || name.equals(trimmed, ignoreCase = true)) {
+        return trimmed.uppercase(Locale.ROOT)
+    }
+    return name
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/overlays/OverlayLanguageName.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/overlays/OverlayLanguageName.kt
@@ -1,0 +1,10 @@
+package org.siloserver.silo.overlays
+
+/**
+ * English display name for a language tag, matching web's `formatLanguage`
+ * (English CLDR names, so "en" → "English" not "EN") and the Apple
+ * clients' `formatLanguageName`. A tag the platform can't name falls back
+ * to the uppercased tag rather than web's "Unknown language (…)" sentence,
+ * which doesn't fit a badge.
+ */
+internal expect fun overlayLanguageName(tag: String): String?

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/overlays/OverlayRegistry.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/overlays/OverlayRegistry.kt
@@ -90,12 +90,22 @@ object OverlayRegistry {
         return if (value.contains("DV")) "DV" else "HDR"
     }
 
+    // Mirrors web's `hdrIcon`: only exact wordmark matches get a brand
+    // mark; anything else (HLG, combined strings like "HDR10+") renders
+    // as plain text with no icon rather than a wrong generic mark.
     private fun hdrIcon(value: String?): OverlayIconId? {
         if (value.isNullOrEmpty()) return null
         if (value.contains("DV")) return OverlayIconId.DolbyVision
-        if (value.contains("HDR10")) return OverlayIconId.Hdr10
-        return OverlayIconId.Hdr
+        if (value == "HDR10") return OverlayIconId.Hdr10
+        if (value == "HDR") return OverlayIconId.Hdr
+        return null
     }
+
+    // The combined badge's label already carries an "HDR" suffix, so the
+    // only icon worth doubling up is the Dolby Vision mark — mirrors
+    // web's `resolution_hdr.getIcon`.
+    private fun resolutionHdrIcon(value: String?): OverlayIconId? =
+        if (value != null && value.contains("DV")) OverlayIconId.DolbyVision else null
 
     private fun audioIcon(value: String?): OverlayIconId? {
         if (value.isNullOrEmpty()) return null
@@ -119,7 +129,9 @@ object OverlayRegistry {
             defaultEnabled = true,
             iconId = OverlayIconId.Monitor,
             iconCapable = true,
-            getValue = { it.resolution?.uppercase() },
+            // `prettyResolution`, not raw uppercase: web renders "4K" for a
+            // `2160p` payload and the standalone badge must match it.
+            getValue = { prettyResolution(it.resolution) },
         ),
         OverlayDef(
             id = OverlayId.Hdr,
@@ -145,7 +157,7 @@ object OverlayRegistry {
                 val hdr = compactHdrSuffix(data.hdr)
                 if (hdr != null) "$res $hdr" else res
             },
-            getIcon = { hdrIcon(it.hdr) },
+            getIcon = { resolutionHdrIcon(it.hdr) },
         ),
         OverlayDef(
             id = OverlayId.Audio,
@@ -368,7 +380,7 @@ object OverlayRegistry {
             defaultEnabled = false,
             iconId = OverlayIconId.Globe,
             iconCapable = true,
-            getValue = { it.originalLanguage?.uppercase() },
+            getValue = { data -> data.originalLanguage?.let { overlayLanguageName(it) } },
         ),
         OverlayDef(
             id = OverlayId.Studio,
@@ -396,12 +408,17 @@ object OverlayRegistry {
 
     // MARK: - Ribbons helpers
 
+    // Mirrors web's `formatShowStatus` — the recognized spellings and the
+    // pass-through default must stay identical or the same library renders
+    // different ribbons per platform.
     private fun formatShowStatus(value: String?): String? {
-        if (value == null) return null
+        if (value.isNullOrEmpty()) return null
         return when (value.lowercase()) {
-            "returning", "returning series", "in_production", "in production" -> "Returning"
+            "returning", "returning series", "continuing", "in_production", "in production" ->
+                "Returning"
             "ended" -> "Ended"
             "cancelled", "canceled" -> "Cancelled"
+            "upcoming", "planned" -> "Upcoming"
             else -> value
         }
     }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/overlays/OverlayRegistry.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/overlays/OverlayRegistry.kt
@@ -412,14 +412,14 @@ object OverlayRegistry {
     // pass-through default must stay identical or the same library renders
     // different ribbons per platform.
     private fun formatShowStatus(value: String?): String? {
-        if (value.isNullOrEmpty()) return null
-        return when (value.lowercase()) {
+        val normalized = value?.trim().takeUnless { it.isNullOrEmpty() } ?: return null
+        return when (normalized.lowercase()) {
             "returning", "returning series", "continuing", "in_production", "in production" ->
                 "Returning"
             "ended" -> "Ended"
             "cancelled", "canceled" -> "Cancelled"
             "upcoming", "planned" -> "Upcoming"
-            else -> value
+            else -> normalized
         }
     }
 

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/overlays/OverlayRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/overlays/OverlayRegistryTest.kt
@@ -79,4 +79,12 @@ class OverlayRegistryTest {
         assertEquals("45m", def.getValue(OverlayData(runtime = 45)))
         assertNull(def.getValue(OverlayData(runtime = 0)))
     }
+
+    @Test
+    fun showStatus_getValue_trimsBeforeMappingAndFallback() {
+        val def = OverlayRegistry.def(OverlayId.ShowStatus)!!
+        assertEquals("Returning", def.getValue(OverlayData(showStatus = "  returning series  ")))
+        assertEquals("Limited Series", def.getValue(OverlayData(showStatus = "  Limited Series  ")))
+        assertNull(def.getValue(OverlayData(showStatus = "   ")))
+    }
 }


### PR DESCRIPTION
## Summary

While fixing the "custom card overlay settings ignored on iOS/tvOS" report (silo-apple #118), I audited all three clients' overlay implementations against web `web/src/lib/overlays` and the contract's `card-overlays.json`. Android's prefs store already speaks the canonical `ui.card_overlays` API, but its badge *rendering* had drifted from web. Same library, different badges per platform.

## Changes

All in the shared overlay registry / Compose badge renderer, mirroring web exactly:

- Standalone `resolution` badge uses `prettyResolution` — a `2160p` payload renders "4K" (previously "2160P"). The combined badge already did this; now they agree with each other and with web.
- `formatShowStatus` recognizes `continuing` → "Returning" and `upcoming`/`planned` → "Upcoming", and drops empty strings instead of rendering an empty badge.
- HDR icon selection matches web's exact-match rules (`HDR10`/`HDR` exact, otherwise no mark), and the combined `resolution_hdr` badge only doubles up the Dolby Vision mark — its label already says "HDR".
- Brand tokens (HDR/HDR10/ATMOS/AV1) suppress a label with the same text, so icon-preferring presets don't render "HDR10 HDR10".
- `original_language` renders an English language name via a new `overlayLanguageName` expect/actual ("English", not "EN"), matching web's `formatLanguage`.

## Validation

- `:shared:testDebugUnitTest`: 973 tests, 0 failures (includes the overlay registry/schema/extractor suites).
- `:androidApp:assembleDebug` and `:androidTvApp:assembleDebug` build clean.

## Related

- silo-apple PR #118 lands the same parity fixes plus the settings-key migration iOS/tvOS still needed.
- A silo-server PR will update the contract manifest's `platforms` for `ui.card_overlays`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Overlay badges now avoid duplicate text when an icon already conveys the same label.
  - Resolution and HDR indicators are displayed more consistently, including improved Dolby Vision handling.
  - Language labels now use readable English names, with sensible fallbacks for unavailable names.
  - Show-status labels recognize continuing, upcoming, and planned content after trimming extra whitespace.
  - Empty or whitespace-only overlay values are no longer displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->