### PR TITLE
fix(ci): publish APK-only GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,7 @@ jobs:
 
       - name: Check build supply chain
         run: |
+          ./scripts/test-release-workflow.sh
           ./scripts/test-check-build-supply-chain.sh
           ./scripts/check-build-supply-chain.sh
 
@@ -397,6 +398,10 @@ jobs:
   publish-release:
     name: Publish GitHub Release
     needs: [setup, apks]
+    if: >-
+      ${{ !cancelled() &&
+          needs.setup.result == 'success' &&
+          needs.apks.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/superpowers/plans/2026-08-03-apk-only-release-publish.md
+++ b/docs/superpowers/plans/2026-08-03-apk-only-release-publish.md
@@ -1,0 +1,133 @@
+# APK-only GitHub Release Publishing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure APK-only release tags automatically publish their signed APKs as the normal GitHub `Latest` release when Google Play is intentionally skipped.
+
+**Architecture:** Keep the current release graph and add an explicit status-aware gate to the final `publish-release` job. Protect that gate with a focused shell invariant test executed by the release workflow before the Gradle test suite.
+
+**Tech Stack:** GitHub Actions YAML, Bash, `actionlint`, GitHub CLI.
+
+## Global Constraints
+
+- Play publishing must remain skipped for prerelease-suffixed tags.
+- Setup, test, Play, signing, or APK build failures must continue blocking GitHub releases.
+- Cancelled runs must not publish.
+- Release naming, asset naming, release classification, and GitHub `Latest` behavior must not change.
+- The validation process must not trigger a new release.
+
+---
+
+### Task 1: Add the release gate regression test
+
+**Files:**
+- Create: `scripts/test-release-workflow.sh`
+- Modify: `.github/workflows/release.yml`
+- Test: `scripts/test-release-workflow.sh`
+
+**Interfaces:**
+- Consumes: `.github/workflows/release.yml` and its `publish-release` job.
+- Produces: an executable self-test that exits nonzero unless the final release job explicitly requires non-cancellation and successful `setup` and `apks` jobs.
+
+- [ ] **Step 1: Create the focused workflow invariant test**
+
+Create `scripts/test-release-workflow.sh` with strict Bash mode. Resolve the repository root relative to the script, extract the `publish-release` job from `.github/workflows/release.yml`, and assert that it contains these exact invariants:
+
+```text
+needs: [setup, apks]
+if: >-
+!cancelled()
+needs.setup.result == 'success'
+needs.apks.result == 'success'
+```
+
+Each missing invariant must print `FAIL: publish-release must ...` to stderr and increment a failure counter. A clean run prints `All release workflow self-tests passed`.
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+chmod +x scripts/test-release-workflow.sh
+./scripts/test-release-workflow.sh
+```
+
+Expected: nonzero exit with `FAIL: publish-release must define an explicit job condition` because the current workflow has no `if` gate.
+
+- [ ] **Step 3: Add the minimal publish condition**
+
+Add this immediately after `needs: [setup, apks]`:
+
+```yaml
+if: >-
+  ${{ !cancelled() &&
+      needs.setup.result == 'success' &&
+      needs.apks.result == 'success' }}
+```
+
+- [ ] **Step 4: Execute the regression test in release CI**
+
+In the `unit-tests` job, add this command before the existing supply-chain checks:
+
+```bash
+./scripts/test-release-workflow.sh
+```
+
+- [ ] **Step 5: Verify GREEN**
+
+Run:
+
+```bash
+bash -n scripts/test-release-workflow.sh
+./scripts/test-release-workflow.sh
+./scripts/test-check-build-supply-chain.sh
+./scripts/check-build-supply-chain.sh
+```
+
+Expected: every command exits zero and both self-test suites print their success messages.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add scripts/test-release-workflow.sh .github/workflows/release.yml
+git commit -m "fix(ci): publish APK-only GitHub releases"
+```
+
+### Task 2: Validate and deliver
+
+**Files:**
+- Verify: `.github/workflows/release.yml`
+- Verify: `scripts/test-release-workflow.sh`
+
+**Interfaces:**
+- Consumes: the completed workflow fix and its regression test.
+- Produces: a validated branch and pull request against `Silo-Server/silo-android:main`.
+
+- [ ] **Step 1: Validate workflow syntax and repository state**
+
+Run:
+
+```bash
+actionlint .github/workflows/release.yml
+git diff --check upstream/main...HEAD
+git status --short --branch
+```
+
+Expected: `actionlint` and `git diff --check` exit zero; the worktree is clean and the branch is ahead of `upstream/main` only by the design, plan, and implementation commits.
+
+- [ ] **Step 2: Re-run the full focused verification**
+
+Run:
+
+```bash
+bash -n scripts/test-release-workflow.sh
+./scripts/test-release-workflow.sh
+./scripts/test-check-build-supply-chain.sh
+./scripts/check-build-supply-chain.sh
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 3: Push and open the pull request**
+
+Push `fix/apk-only-release-publish` to the writable fork remote and open a PR targeting `Silo-Server/silo-android:main`. The PR body must document run `30814079342` as the reproduction, explain the explicit status gate, state that Play and `Latest` behavior are unchanged, and list every verification command.

--- a/docs/superpowers/specs/2026-08-03-apk-only-release-publish-design.md
+++ b/docs/superpowers/specs/2026-08-03-apk-only-release-publish-design.md
@@ -1,0 +1,45 @@
+# APK-only GitHub Release Publishing Design
+
+## Problem
+
+The `v1.0.0-rc.1+4` release run built and uploaded both signed APK artifact sets, but GitHub Actions skipped the `publish-release` job. APK-only tags intentionally skip the `play` job. Although the `apks` matrix has an explicit condition that accepts a skipped Play job, `publish-release` has no explicit status condition. GitHub therefore propagates the skipped dependency through the job chain and applies its implicit success gate.
+
+Run `30814079342` demonstrates the failure: `play` was skipped, both `apks` matrix jobs succeeded, and `publish-release` was skipped without executing any steps.
+
+## Design
+
+Add a job-level condition to `publish-release`:
+
+```yaml
+if: >-
+  ${{ !cancelled() &&
+      needs.setup.result == 'success' &&
+      needs.apks.result == 'success' }}
+```
+
+The explicit status function disables the implicit success gate that propagates skipped ancestors. Requiring successful `setup` and `apks` results preserves the existing safety boundary: a setup, test, Play, signing, or APK-build failure cannot publish a GitHub release. `!cancelled()` prevents a cancelled workflow from publishing artifacts.
+
+No release naming, prerelease classification, Play behavior, asset naming, or `Latest` behavior changes.
+
+## Regression Protection
+
+Add a focused shell self-test for the release workflow. It will extract the `publish-release` job header and require:
+
+- `needs: [setup, apks]`;
+- an explicit `if` condition;
+- cancellation protection;
+- successful `setup` and `apks` result checks.
+
+The release workflow's unit-test job will run this self-test before Gradle tests so future edits cannot silently restore the transitive-skip bug. Existing supply-chain checks and workflow syntax validation will also run.
+
+## Validation
+
+Validation will cover:
+
+1. The new regression test fails against the current workflow.
+2. The minimal condition change makes it pass.
+3. Shell syntax checks pass for the new script.
+4. Existing supply-chain policy self-tests pass.
+5. The workflow parses and passes `actionlint`.
+
+The fix will not trigger a release; it will be delivered through a pull request from an isolated branch based on `upstream/main`.

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -22,30 +22,33 @@ publish_job="$({
     }
   ' "${workflow_file}"
 } | sed '/^[[:space:]]*#/d')"
+publish_job_header="$(
+  awk '/^    steps:[[:space:]]*$/ { exit } { print }' <<< "${publish_job}"
+)"
 
-expect_publish_job_to_contain() {
+expect_publish_job_header_to_contain() {
   local description="$1"
   local expected="$2"
 
-  if ! grep -Fq "${expected}" <<< "${publish_job}"; then
+  if ! grep -Fq "${expected}" <<< "${publish_job_header}"; then
     printf 'FAIL: publish-release must %s\n' "${description}" >&2
     failures=$((failures + 1))
   fi
 }
 
-expect_publish_job_to_contain \
+expect_publish_job_header_to_contain \
   "depend on setup and APK artifacts" \
   "needs: [setup, apks]"
-expect_publish_job_to_contain \
+expect_publish_job_header_to_contain \
   "define an explicit job condition" \
   "if: >-"
-expect_publish_job_to_contain \
+expect_publish_job_header_to_contain \
   "stop when the workflow is cancelled" \
   "!cancelled()"
-expect_publish_job_to_contain \
+expect_publish_job_header_to_contain \
   "require successful setup" \
   "needs.setup.result == 'success'"
-expect_publish_job_to_contain \
+expect_publish_job_header_to_contain \
   "require successful APK builds" \
   "needs.apks.result == 'success'"
 

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+workflow_file="${repo_root}/.github/workflows/release.yml"
+failures=0
+
+publish_job="$({
+  awk '
+    /^  publish-release:[[:space:]]*$/ {
+      in_publish_job = 1
+    }
+    in_publish_job &&
+      /^  [[:alnum:]_-]+:[[:space:]]*$/ &&
+      $0 !~ /^  publish-release:/ {
+      exit
+    }
+    in_publish_job {
+      print
+    }
+  ' "${workflow_file}"
+} | sed '/^[[:space:]]*#/d')"
+
+expect_publish_job_to_contain() {
+  local description="$1"
+  local expected="$2"
+
+  if ! grep -Fq "${expected}" <<< "${publish_job}"; then
+    printf 'FAIL: publish-release must %s\n' "${description}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+expect_publish_job_to_contain \
+  "depend on setup and APK artifacts" \
+  "needs: [setup, apks]"
+expect_publish_job_to_contain \
+  "define an explicit job condition" \
+  "if: >-"
+expect_publish_job_to_contain \
+  "stop when the workflow is cancelled" \
+  "!cancelled()"
+expect_publish_job_to_contain \
+  "require successful setup" \
+  "needs.setup.result == 'success'"
+expect_publish_job_to_contain \
+  "require successful APK builds" \
+  "needs.apks.result == 'success'"
+
+if ((failures > 0)); then
+  printf '%d release workflow self-test(s) failed\n' "${failures}" >&2
+  exit 1
+fi
+
+printf 'All release workflow self-tests passed\n'


### PR DESCRIPTION
## Summary
- allow the GitHub release job to run after APK-only tags intentionally skip Google Play
- keep release publishing blocked on cancellation, setup failure, or APK build failure
- add a focused release-workflow regression test and run it in release CI
- preserve normal, non-prerelease GitHub releases and existing `Latest` asset behavior

## Root cause
Release run 30814079342 skipped `play` by design and successfully built both APK artifact sets, but GitHub propagated the skipped dependency through the job chain because `publish-release` had no explicit status condition. The job was therefore skipped without executing any steps.

## Validation
- `./gradlew -Dorg.gradle.jvmargs="-Xmx4g -Dfile.encoding=UTF-8" test --max-workers=2`
- `bash -n scripts/test-release-workflow.sh`
- `./scripts/test-release-workflow.sh`
- `./scripts/test-check-build-supply-chain.sh`
- `./scripts/check-build-supply-chain.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- `git diff --check upstream/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved APK-only release publishing so signed APKs can be published as GitHub releases when setup and APK jobs succeed.
  * Prevented release publishing when the workflow is cancelled or required jobs fail.

* **Tests**
  * Added automated checks to verify release workflow conditions and dependencies.

* **Documentation**
  * Added implementation and design documentation for APK-only release publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->