### PR TITLE
fix(tv): address Fire TV rc.1+4 feedback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,6 +343,7 @@ jobs:
         shell: bash
         env:
           SILO_VERSION_NAME: ${{ needs.setup.outputs.version_name }}
+          SILO_DISPLAY_VERSION: ${{ needs.setup.outputs.version }}
           SILO_VERSION_CODE: ${{ needs.setup.outputs.version_code }}
           SILO_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.SILO_RELEASE_KEYSTORE_PASSWORD }}
           SILO_RELEASE_KEY_PASSWORD: ${{ secrets.SILO_RELEASE_KEY_PASSWORD }}
@@ -354,6 +355,7 @@ jobs:
             -Dorg.gradle.jvmargs="-Xmx4g -Dfile.encoding=UTF-8" \
             ":${{ matrix.module }}:assembleRelease" \
             "-PsiloVersionName=${SILO_VERSION_NAME}" \
+            "-PsiloDisplayVersion=${SILO_DISPLAY_VERSION}" \
             "-PsiloVersionCode=${SILO_VERSION_CODE}" \
             --max-workers=2
 

--- a/androidTvApp/build.gradle.kts
+++ b/androidTvApp/build.gradle.kts
@@ -12,6 +12,11 @@ val siloVersionName = providers
     // android-build.yml. Keep local/dev builds aligned with the latest release.
     .orElse("0.3.11")
 
+val siloDisplayVersion = providers
+    .gradleProperty("siloDisplayVersion")
+    .orElse(providers.environmentVariable("SILO_DISPLAY_VERSION"))
+    .orElse(siloVersionName)
+
 val siloVersionCode = providers
     .gradleProperty("siloVersionCode")
     .orElse(providers.environmentVariable("SILO_VERSION_CODE"))
@@ -138,6 +143,7 @@ android {
         // base*2, TV = base*2+1, so each release bumps both by 2 with no reuse.
         versionCode = siloVersionCode.get() * 2 + 1
         versionName = siloVersionName.get()
+        buildConfigField("String", "DISPLAY_VERSION", "\"${siloDisplayVersion.get()}\"")
         // Shadow the android-shared BuildConfig field so per-app flavors can
         // override without rebuilding the shared module. See androidApp's
         // build.gradle.kts for rationale.

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -20,6 +22,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -175,7 +178,11 @@ fun TvAnchoredSelectorMenu(
         ) {
             options.forEach { option ->
                 val interactionSource = remember(option.key) { MutableInteractionSource() }
+                val bringIntoViewRequester = remember(option.key) { BringIntoViewRequester() }
                 val focused by interactionSource.collectIsFocusedAsState()
+                LaunchedEffect(focused) {
+                    if (focused) bringIntoViewRequester.bringIntoView()
+                }
                 val visual = tvSelectorRowVisualState(focused, option.selected, option.enabled)
                 val labelText = if (option.detail.isBlank()) {
                     option.title
@@ -185,6 +192,7 @@ fun TvAnchoredSelectorMenu(
                 DropdownMenuItem(
                     interactionSource = interactionSource,
                     modifier = Modifier
+                        .bringIntoViewRequester(bringIntoViewRequester)
                         .padding(horizontal = 6.dp, vertical = 2.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .background(visual.container)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -104,6 +104,8 @@ fun TvMediaRow(
     /** Indexed focus callback for callers that maintain a rolling prefetch
      *  window around the currently focused card. */
     onItemFocusedAtIndex: ((SectionItem, Int) -> Unit)? = null,
+    /** Reports whether this row or any descendant card currently owns focus. */
+    onRowFocusChanged: ((Boolean) -> Unit)? = null,
     cardActions: (SectionItem) -> TvMediaCardActions = { TvMediaCardActions() },
 ) {
     if (items.isEmpty()) return
@@ -157,6 +159,15 @@ fun TvMediaRow(
                 .then(
                     if (rowContainerFocusRequester != null) {
                         Modifier.focusRequester(rowContainerFocusRequester)
+                    } else {
+                        Modifier
+                    },
+                )
+                .then(
+                    if (onRowFocusChanged != null) {
+                        Modifier.onFocusChanged { state ->
+                            onRowFocusChanged(state.hasFocus)
+                        }
                     } else {
                         Modifier
                     },

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt
@@ -865,7 +865,7 @@ private fun MatchCodeCard(code: String) {
                         text = "–",
                         style = TvServerSetupTextStyles.CodeSeparator,
                         color = Color.White.copy(alpha = 0.42f),
-                        modifier = Modifier.width(12.dp),
+                        modifier = Modifier.width(MATCH_CODE_SEPARATOR_WIDTH_DP.dp),
                     )
                 } else {
                     Box(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt
@@ -844,6 +844,7 @@ private fun completedSummary(names: List<String>): String =
 @Composable
 private fun MatchCodeCard(code: String) {
     if (code.isBlank()) return
+    val tileWidthDp = matchCodeTileWidthDp(code)
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
@@ -857,7 +858,7 @@ private fun MatchCodeCard(code: String) {
             style = TvServerSetupTextStyles.CodeLabel,
             color = Color.White.copy(alpha = 0.62f),
         )
-        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(MATCH_CODE_TILE_GAP_DP.dp)) {
             code.uppercase().forEach { ch ->
                 if (ch == '-' || ch == ' ') {
                     Text(
@@ -869,7 +870,7 @@ private fun MatchCodeCard(code: String) {
                 } else {
                     Box(
                         modifier = Modifier
-                            .size(width = 34.dp, height = 42.dp)
+                            .size(width = tileWidthDp.dp, height = 42.dp)
                             .background(Color.White.copy(alpha = 0.08f), RoundedCornerShape(7.dp))
                             .border(1.dp, Color.White.copy(alpha = 0.20f), RoundedCornerShape(7.dp)),
                         contentAlignment = Alignment.Center,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -433,16 +433,29 @@ class TvItemDetailViewModel(
      */
     fun refreshOnReturn() {
         val current = _uiState.value.detail ?: return
+        val playbackReturn = TvDetailTrackSelectionSession.consumePlaybackReturn(contentId)
+        playbackReturn?.let { saved ->
+            _uiState.update {
+                it.copy(
+                    detail = it.detail?.withPlaybackReturn(saved),
+                    selectedFileId = saved.fileId,
+                    selectedAudioIndex = saved.audio,
+                    selectedSubtitleIndex = saved.subtitle,
+                )
+            }
+        }
         viewModelScope.launch {
             // Local overlay first: the player's final position write is already
             // on disk, so the label corrects before the server round-trip.
             val overlaid = withLocalProgress(current)
+                .let { refreshed -> playbackReturn?.let(refreshed::withPlaybackReturn) ?: refreshed }
             if (overlaid != current) {
                 _uiState.update { it.copy(detail = overlaid) }
             }
             when (val result = catalogRepository.getItemDetail(contentId)) {
                 is ApiResult.Success -> {
                     val detail = withLocalProgress(result.data)
+                        .let { refreshed -> playbackReturn?.let(refreshed::withPlaybackReturn) ?: refreshed }
                     if (!isTvHiddenMediaType(detail.type)) {
                         _uiState.update {
                             it.copy(
@@ -1476,7 +1489,13 @@ private fun BrowseItem.toSectionItem(): SectionItem = SectionItem(
  * durable per-playback preferences are recorded by the player itself.
  */
 internal object TvDetailTrackSelectionSession {
-    internal data class Saved(val fileId: Int?, val audio: Int?, val subtitle: Int?)
+    internal data class Saved(
+        val fileId: Int?,
+        val audio: Int?,
+        val subtitle: Int?,
+        val positionSeconds: Double? = null,
+        val durationSeconds: Double? = null,
+    )
 
     private val byContent = HashMap<String, Saved>()
 
@@ -1485,5 +1504,55 @@ internal object TvDetailTrackSelectionSession {
         byContent[contentId] = Saved(fileId, audio, subtitle)
     }
 
+    fun rememberPlaybackReturn(
+        contentId: String,
+        fileId: Int?,
+        audio: Int?,
+        subtitle: Int?,
+        positionSeconds: Double,
+        durationSeconds: Double?,
+    ) {
+        if (contentId.isBlank() || !positionSeconds.isFinite() || positionSeconds < 0.0) return
+        val previous = byContent[contentId]
+        byContent[contentId] = Saved(
+            fileId = fileId,
+            // The player currently reports subtitle selection on exit but not
+            // audio selection. Keep the detail page's explicit audio choice
+            // instead of replacing it with an unknown/null value.
+            audio = audio ?: previous?.audio,
+            subtitle = subtitle,
+            positionSeconds = positionSeconds,
+            durationSeconds = durationSeconds?.takeIf { it.isFinite() && it > 0.0 },
+        )
+    }
+
     fun recall(contentId: String): Saved? = byContent[contentId]
+
+    /**
+     * Returns the pending player-exit progress once, while retaining the
+     * session's file and track choices for later detail-screen recreation.
+     */
+    fun consumePlaybackReturn(contentId: String): Saved? {
+        val saved = byContent[contentId]
+            ?.takeIf { it.positionSeconds != null }
+            ?: return null
+        byContent[contentId] = saved.copy(
+            positionSeconds = null,
+            durationSeconds = null,
+        )
+        return saved
+    }
+}
+
+private fun ItemDetail.withPlaybackReturn(saved: TvDetailTrackSelectionSession.Saved): ItemDetail {
+    val position = saved.positionSeconds?.takeIf { it.isFinite() && it >= 0.0 } ?: return this
+    val current = userData ?: LeafItemUserData()
+    return copy(
+        userData = current.copy(
+            isInProgress = position > 0.0,
+            positionSeconds = position.takeIf { it > 0.0 },
+            durationSeconds = saved.durationSeconds ?: current.durationSeconds,
+            lastFileId = saved.fileId ?: current.lastFileId,
+        ),
+    )
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -1520,7 +1520,9 @@ internal object TvDetailTrackSelectionSession {
             // audio selection. Keep the detail page's explicit audio choice
             // instead of replacing it with an unknown/null value.
             audio = audio ?: previous?.audio,
-            subtitle = subtitle,
+            // A null player result means the mounted track could not be
+            // resolved to a stable server index (keep current), not Off.
+            subtitle = subtitle ?: previous?.subtitle,
             positionSeconds = positionSeconds,
             durationSeconds = durationSeconds?.takeIf { it.isFinite() && it > 0.0 },
         )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -1515,7 +1515,9 @@ internal object TvDetailTrackSelectionSession {
         if (contentId.isBlank() || !positionSeconds.isFinite() || positionSeconds < 0.0) return
         val previous = byContent[contentId]
         byContent[contentId] = Saved(
-            fileId = fileId,
+            // Exit can race teardown before either player file identifier is
+            // available. Keep the detail page's selected version in that case.
+            fileId = fileId ?: previous?.fileId,
             // The player currently reports subtitle selection on exit but not
             // audio selection. Keep the detail page's explicit audio choice
             // instead of replacing it with an unknown/null value.

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -523,15 +523,14 @@ fun TvPlayerScreen(
             // idempotent local departure follows behind it.
             roomController?.leave(closeRoom = false)
             mediaController?.let { controller ->
-                viewModel.onPositionChanged(
-                    controller.currentPosition,
-                    controller.duration.coerceAtLeast(0L),
+                viewModel.stopSessionForExitAsync(
+                    positionMs = controller.currentPosition,
+                    durationMs = controller.duration.coerceAtLeast(0L),
                 )
                 controller.pause()
                 controller.stop()
                 controller.clearMediaItems()
-            }
-            viewModel.stopSessionForExitAsync()
+            } ?: viewModel.stopSessionForExitAsync()
             latestOnExit()
         }
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -64,6 +64,7 @@ import org.siloserver.silo.model.playback.PlayMethod
 import org.siloserver.silo.model.playback.PlaybackExecutionPlan
 import org.siloserver.silo.model.playback.PlaybackRouteFamily
 import org.siloserver.silo.model.playback.PlaybackSessionResponse
+import org.siloserver.silo.model.playback.PlaybackTimeline
 import org.siloserver.silo.model.playback.PlayerSubtitleInfo
 import org.siloserver.silo.model.playback.SubtitleIdentity
 import org.siloserver.silo.model.playback.SubtitleMediaIdentity
@@ -3915,8 +3916,22 @@ class TvPlayerViewModel(
         positionMs: Long? = null,
         durationMs: Long? = null,
     ) {
-        if (positionMs != null && durationMs != null) {
-            onPositionChanged(positionMs, durationMs)
+        // This is the controller's final sample. It must bypass transient
+        // seek/mount presentation gates, while still mapping a shortened
+        // Media3 timeline back onto source/movie time.
+        _uiState.update { current ->
+            val snapshot = resolveTvPlaybackExitSnapshot(
+                currentPositionSeconds = current.position,
+                currentDurationSeconds = current.duration,
+                positionMs = positionMs,
+                durationMs = durationMs,
+                timeline = current.playbackPlan?.timeline,
+                serverDurationSeconds = current.serverDuration,
+            )
+            current.copy(
+                position = snapshot.positionSeconds,
+                duration = snapshot.durationSeconds,
+            )
         }
         val subtitlePersistenceReservation =
             subtitleTransactions.reserveDurableFinalPersistence()
@@ -4201,6 +4216,41 @@ class TvPlayerViewModel(
         introAutoSkipController.reset()
     }
 
+}
+
+internal data class TvPlaybackExitSnapshot(
+    val positionSeconds: Double,
+    val durationSeconds: Double,
+)
+
+internal fun resolveTvPlaybackExitSnapshot(
+    currentPositionSeconds: Double,
+    currentDurationSeconds: Double,
+    positionMs: Long?,
+    durationMs: Long?,
+    timeline: PlaybackTimeline?,
+    serverDurationSeconds: Double,
+): TvPlaybackExitSnapshot {
+    if (positionMs == null || durationMs == null || positionMs < 0L) {
+        return TvPlaybackExitSnapshot(currentPositionSeconds, currentDurationSeconds)
+    }
+
+    val serverDuration = serverDurationSeconds.takeIf { it.isFinite() && it > 0.0 }
+    val playerPositionSeconds = positionMs / 1_000.0
+    val sourcePositionSeconds = (
+        timeline?.sourcePositionForPlayer(playerPositionSeconds) ?: playerPositionSeconds
+        ).let { position -> serverDuration?.let(position::coerceAtMost) ?: position }
+    val sourceDurationSeconds = if (durationMs > 0L) {
+        val playerDurationSeconds = durationMs / 1_000.0
+        timeline?.sourcePositionForPlayer(playerDurationSeconds) ?: playerDurationSeconds
+    } else {
+        currentDurationSeconds
+    }.let { duration -> serverDuration?.let(duration::coerceAtMost) ?: duration }
+
+    return TvPlaybackExitSnapshot(
+        positionSeconds = sourcePositionSeconds.coerceAtLeast(0.0),
+        durationSeconds = maxOf(currentDurationSeconds, sourceDurationSeconds),
+    )
 }
 
 data class PlaybackClock(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -87,6 +87,7 @@ import org.siloserver.silo.player.DolbyVisionPolicy
 import org.siloserver.silo.repository.SubtitlesRepository
 import org.siloserver.silo.repository.port.PlaybackWriteScope
 import org.siloserver.silo.repository.port.TrackSelectionFingerprintUpdate
+import org.siloserver.silo.tv.ui.screens.detail.TvDetailTrackSelectionSession
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -3910,13 +3911,30 @@ class TvPlayerViewModel(
     }
 
     /** Ordinary Back/remote-stop path: snapshot locally and return to detail immediately. */
-    fun stopSessionForExitAsync() {
+    fun stopSessionForExitAsync(
+        positionMs: Long? = null,
+        durationMs: Long? = null,
+    ) {
+        if (positionMs != null && durationMs != null) {
+            onPositionChanged(positionMs, durationMs)
+        }
+        val subtitlePersistenceReservation =
+            subtitleTransactions.reserveDurableFinalPersistence()
+        val state = _uiState.value
+        TvDetailTrackSelectionSession.rememberPlaybackReturn(
+            contentId = contentId,
+            fileId = state.selectedFileId ?: state.mediaFileId,
+            audio = null,
+            subtitle = selectedSubtitleTrackIndex(state),
+            positionSeconds = state.position,
+            durationSeconds = state.duration.takeIf { it > 0.0 },
+        )
         subtitleTransactions.invalidate()
         playbackMutationFence.invalidateAll()
         prepareSessionExit()
-        // Final-position durability is owned by the application-scoped
-        // finalPlaybackPositionWriter; only the subtitle flush needs a scope here.
-        viewModelScope.launch { subtitleTransactions.persistCommittedSelectionAndFlush() }
+        subtitlePersistenceReservation?.let(
+            subtitleTransactions::requestDurableFinalPersistence,
+        )
         sessionLifecycle.stopAsync(expectedSessionId = exitSessionId)
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -212,10 +212,10 @@ class TvVideoPlaybackStarter(
             val serverSourceStartPos = readyV3.plan.timeline.sourceStartSeconds
                 .takeIf { it.isFinite() && it >= 0.0 }
                 ?: resolved.position.coerceAtLeast(0.0)
-            val sourceStartPos = resolvePlaybackStartPosition(
-                overridePosition = request.resumePositionOverride,
-                sessionPosition = serverSourceStartPos,
-                detailPosition = startRequestPosition ?: playerStartPos,
+            val sourceStartPos = resolveTvSourceStartPosition(
+                startRequestPosition = startRequestPosition,
+                serverSourceStartPosition = serverSourceStartPos,
+                playerStartPosition = playerStartPos,
             )
 
             val adopted = sessionLifecycle.adoptActiveSessionIfCurrent(
@@ -322,6 +322,16 @@ class TvVideoPlaybackStarter(
         const val TAG = "TvVideoPlaybackStarter"
     }
 }
+
+internal fun resolveTvSourceStartPosition(
+    startRequestPosition: Double?,
+    serverSourceStartPosition: Double,
+    playerStartPosition: Double,
+): Double = resolvePlaybackStartPosition(
+    overridePosition = startRequestPosition,
+    sessionPosition = serverSourceStartPosition,
+    detailPosition = playerStartPosition,
+)
 
 /**
  * Resolves session-only episode intent after the target detail is available.

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -23,7 +23,9 @@ import org.siloserver.silo.common.settings.dolbyVisionPolicySnapshot
 import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.playback.applyResumeRewind
 import org.siloserver.silo.model.playback.buildPlaybackSubtitleChoices
+import org.siloserver.silo.model.playback.isExplicitStartOver
 import org.siloserver.silo.model.playback.resolvePlaybackStartRequestPosition
+import org.siloserver.silo.model.playback.resolvePlaybackStartPosition
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.playback.orNullIfBlank
 import org.siloserver.silo.playback.selectPlaybackVersion
@@ -195,13 +197,26 @@ class TvVideoPlaybackStarter(
             // The server may reanchor an HLS stream at a non-zero movie time
             // while exposing a player timeline that begins at zero. Preserve
             // both coordinates so Media3 and the UI each receive the right one.
-            val playerStartPos = readyV3.plan.timeline.playerStartSeconds
+            val serverPlayerStartPos = readyV3.plan.timeline.playerStartSeconds
                 .takeIf { it.isFinite() && it >= 0.0 }
                 ?: resolved.position.coerceAtLeast(0.0)
-            val sourceStartPos = readyV3.plan.timeline.sourceStartSeconds
+            val playerStartPos = resolvePlaybackStartPosition(
+                // A reanchored stream may legitimately expose player time 0
+                // for a non-zero source time. Only Start Over's explicit zero
+                // may override that server-defined player coordinate.
+                overridePosition = request.resumePositionOverride
+                    .takeIf(::isExplicitStartOver),
+                sessionPosition = serverPlayerStartPos,
+                detailPosition = null,
+            )
+            val serverSourceStartPos = readyV3.plan.timeline.sourceStartSeconds
                 .takeIf { it.isFinite() && it >= 0.0 }
-                ?: startRequestPosition
-                ?: playerStartPos
+                ?: resolved.position.coerceAtLeast(0.0)
+            val sourceStartPos = resolvePlaybackStartPosition(
+                overridePosition = request.resumePositionOverride,
+                sessionPosition = serverSourceStartPos,
+                detailPosition = startRequestPosition ?: playerStartPos,
+            )
 
             val adopted = sessionLifecycle.adoptActiveSessionIfCurrent(
                 params = StartParams(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -160,17 +160,17 @@ fun TvRecommendationsScreen(
     }
 
     LaunchedEffect(firstRecommendationRowFocused) {
-        while (firstRecommendationRowFocused) {
+        while (
+            firstRecommendationRowFocused &&
+            (recommendationsListState.firstVisibleItemIndex != 0 ||
+                recommendationsListState.firstVisibleItemScrollOffset != 0)
+        ) {
             // Focus-driven bring-into-view can run after the focus callback.
-            // Keep the top anchor armed until focus leaves this first row.
+            // Delay before re-anchoring so that relocation finishes first,
+            // then stop once the list reaches its true top.
             kotlinx.coroutines.delay(80)
             if (!firstRecommendationRowFocused) break
-            if (
-                recommendationsListState.firstVisibleItemIndex != 0 ||
-                recommendationsListState.firstVisibleItemScrollOffset != 0
-            ) {
-                runCatching { recommendationsListState.animateScrollToItem(0) }
-            }
+            runCatching { recommendationsListState.animateScrollToItem(0) }
         }
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -99,6 +99,7 @@ fun TvRecommendationsScreen(
     val recommendationsListState = rememberLazyListState()
     var savedListSelection by rememberSaveable { mutableStateOf(entryRequest.selection) }
     var lastAppliedEntrySequence by rememberSaveable { mutableIntStateOf(0) }
+    var firstRecommendationRowFocused by remember { mutableStateOf(false) }
     val moveIntoRecommendations: () -> Boolean = {
         if (
             !shouldBridgeRecommendationsDown(
@@ -155,6 +156,21 @@ fun TvRecommendationsScreen(
     LaunchedEffect(state.isLoading, state.error, visibleSections) {
         if (!state.isLoading && state.error == null && visibleSections.isEmpty() && savedListSelection == null) {
             savedListSelection = SavedListSelection.Watchlist
+        }
+    }
+
+    LaunchedEffect(firstRecommendationRowFocused) {
+        while (firstRecommendationRowFocused) {
+            // Focus-driven bring-into-view can run after the focus callback.
+            // Keep the top anchor armed until focus leaves this first row.
+            kotlinx.coroutines.delay(80)
+            if (!firstRecommendationRowFocused) break
+            if (
+                recommendationsListState.firstVisibleItemIndex != 0 ||
+                recommendationsListState.firstVisibleItemScrollOffset != 0
+            ) {
+                runCatching { recommendationsListState.animateScrollToItem(0) }
+            }
         }
     }
 
@@ -300,17 +316,8 @@ fun TvRecommendationsScreen(
                                 } else {
                                     null
                                 },
-                                onItemFocused = if (index == 0) {
-                                    {
-                                        if (
-                                            recommendationsListState.firstVisibleItemIndex != 0 ||
-                                            recommendationsListState.firstVisibleItemScrollOffset != 0
-                                        ) {
-                                            focusBridgeScope.launch {
-                                                recommendationsListState.animateScrollToItem(0)
-                                            }
-                                        }
-                                    }
+                                onRowFocusChanged = if (index == 0) {
+                                    { focused -> firstRecommendationRowFocused = focused }
                                 } else {
                                     null
                                 },

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -300,6 +300,20 @@ fun TvRecommendationsScreen(
                                 } else {
                                     null
                                 },
+                                onItemFocused = if (index == 0) {
+                                    {
+                                        if (
+                                            recommendationsListState.firstVisibleItemIndex != 0 ||
+                                            recommendationsListState.firstVisibleItemScrollOffset != 0
+                                        ) {
+                                            focusBridgeScope.launch {
+                                                recommendationsListState.animateScrollToItem(0)
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    null
+                                },
                             )
                         }
                         item { Spacer(modifier = Modifier.height(8.dp)) }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
@@ -485,7 +485,7 @@ private fun SettingsRail(
             onFocused = { railActionHasFocus = true },
         )
         Text(
-            text = "Silo ${BuildConfig.VERSION_NAME}",
+            text = "Silo ${BuildConfig.DISPLAY_VERSION}",
             style = MaterialTheme.typography.bodySmall.copy(
                 fontFamily = FontFamily.Monospace,
                 fontSize = 14.sp,
@@ -1388,7 +1388,7 @@ private fun TvServerSettingsPane(
         }
         item {
             SettingsGroup(title = "About") {
-                SettingsInfoRow(label = "Version", value = BuildConfig.VERSION_NAME)
+                SettingsInfoRow(label = "Version", value = BuildConfig.DISPLAY_VERSION)
             }
         }
     }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt
@@ -96,6 +96,23 @@ class TvTrackSelectionPersistenceTest {
     }
 
     @Test
+    fun playbackReturnPreservesPreviouslySelectedFileForUnknownExitFile() {
+        val contentId = "episode-playback-return-file"
+        TvDetailTrackSelectionSession.remember(contentId, fileId = 22, audio = 1, subtitle = 2)
+
+        TvDetailTrackSelectionSession.rememberPlaybackReturn(
+            contentId = contentId,
+            fileId = null,
+            audio = null,
+            subtitle = null,
+            positionSeconds = 37.0,
+            durationSeconds = 120.0,
+        )
+
+        assertEquals(22, TvDetailTrackSelectionSession.recall(contentId)?.fileId)
+    }
+
+    @Test
     fun playbackReturnProgressIsConsumedOnceWhileTrackChoicesRemain() {
         val contentId = "episode-playback-return-progress"
         TvDetailTrackSelectionSession.remember(contentId, fileId = 22, audio = 1, subtitle = 2)

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt
@@ -13,6 +13,7 @@ import org.siloserver.silo.repository.port.WriteOutcome
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class TvTrackSelectionPersistenceTest {
@@ -58,6 +59,46 @@ class TvTrackSelectionPersistenceTest {
 
         assertEquals(TvDetailTrackSelectionSession.Saved(22, 1, 0), TvDetailTrackSelectionSession.recall("episode-session-a"))
         assertEquals(TvDetailTrackSelectionSession.Saved(23, null, -1), TvDetailTrackSelectionSession.recall("episode-session-b"))
+    }
+
+    @Test
+    fun playbackReturnPreservesPreviouslySelectedAudio() {
+        val contentId = "episode-playback-return-audio"
+        TvDetailTrackSelectionSession.remember(contentId, fileId = 22, audio = 1, subtitle = 0)
+
+        TvDetailTrackSelectionSession.rememberPlaybackReturn(
+            contentId = contentId,
+            fileId = 22,
+            audio = null,
+            subtitle = 2,
+            positionSeconds = 37.0,
+            durationSeconds = 120.0,
+        )
+
+        assertEquals(1, TvDetailTrackSelectionSession.recall(contentId)?.audio)
+    }
+
+    @Test
+    fun playbackReturnProgressIsConsumedOnceWhileTrackChoicesRemain() {
+        val contentId = "episode-playback-return-progress"
+        TvDetailTrackSelectionSession.remember(contentId, fileId = 22, audio = 1, subtitle = 2)
+        TvDetailTrackSelectionSession.rememberPlaybackReturn(
+            contentId = contentId,
+            fileId = 22,
+            audio = null,
+            subtitle = 2,
+            positionSeconds = 37.0,
+            durationSeconds = 120.0,
+        )
+
+        val playbackReturn = TvDetailTrackSelectionSession.consumePlaybackReturn(contentId)
+
+        assertEquals(37.0, playbackReturn?.positionSeconds)
+        assertNull(TvDetailTrackSelectionSession.consumePlaybackReturn(contentId))
+        assertEquals(
+            TvDetailTrackSelectionSession.Saved(fileId = 22, audio = 1, subtitle = 2),
+            TvDetailTrackSelectionSession.recall(contentId),
+        )
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt
@@ -79,6 +79,23 @@ class TvTrackSelectionPersistenceTest {
     }
 
     @Test
+    fun playbackReturnPreservesPreviouslySelectedSubtitleForKeepCurrent() {
+        val contentId = "episode-playback-return-subtitle"
+        TvDetailTrackSelectionSession.remember(contentId, fileId = 22, audio = 1, subtitle = 2)
+
+        TvDetailTrackSelectionSession.rememberPlaybackReturn(
+            contentId = contentId,
+            fileId = 22,
+            audio = null,
+            subtitle = null,
+            positionSeconds = 37.0,
+            durationSeconds = 120.0,
+        )
+
+        assertEquals(2, TvDetailTrackSelectionSession.recall(contentId)?.subtitle)
+    }
+
+    @Test
     fun playbackReturnProgressIsConsumedOnceWhileTrackChoicesRemain() {
         val contentId = "episode-playback-return-progress"
         TvDetailTrackSelectionSession.remember(contentId, fileId = 22, audio = 1, subtitle = 2)

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvFireTvRcFeedbackOwnershipTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvFireTvRcFeedbackOwnershipTest.kt
@@ -2,7 +2,6 @@ package org.siloserver.silo.tv.ui.screens.player
 
 import java.io.File
 import kotlin.test.Test
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class TvFireTvRcFeedbackOwnershipTest {
@@ -11,111 +10,11 @@ class TvFireTvRcFeedbackOwnershipTest {
     fun `release display version keeps the complete tag`() {
         val gradle = source("build.gradle.kts")
         val workflow = source("../.github/workflows/release.yml")
-        val settings = source(
-            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt",
-        )
 
         assertTrue(gradle.contains("SILO_DISPLAY_VERSION"))
         assertTrue(gradle.contains("\"DISPLAY_VERSION\""))
         assertTrue(workflow.contains("SILO_DISPLAY_VERSION: \${{ needs.setup.outputs.version }}"))
-        assertTrue(settings.contains("BuildConfig.DISPLAY_VERSION"))
-    }
-
-    @Test
-    fun `focused selector rows request visibility without changing menu presentation`() {
-        val selector = source(
-            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt",
-        )
-
-        assertTrue(selector.contains("DropdownMenu("))
-        assertTrue(selector.contains("bringIntoViewRequester"))
-        assertTrue(selector.contains("bringIntoView()"))
-    }
-
-    @Test
-    fun `for you first row restores the true top after scrolling back up`() {
-        val recommendations = source(
-            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt",
-        )
-
-        assertTrue(recommendations.contains("recommendationsListState.animateScrollToItem(0)"))
-        assertTrue(recommendations.contains("onItemFocused"))
-    }
-
-    @Test
-    fun `phone confirmation card bounds legacy long codes`() {
-        val setup = source(
-            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt",
-        )
-        val card = setup.substringAfter("private fun MatchCodeCard(code: String)")
-            .substringBefore("private object TvServerSetupTextStyles")
-
-        assertTrue(card.contains("matchCodeTileWidthDp(code)"))
-        assertTrue(card.contains("MATCH_CODE_TILE_GAP_DP.dp"))
-    }
-
-    @Test
-    fun `explicit start position owns both player and source timeline resolution`() {
-        val starter = source(
-            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt",
-        )
-        val resolutionCount = Regex.escape("resolvePlaybackStartPosition(")
-            .toRegex()
-            .findAll(starter)
-            .count()
-
-        assertTrue(resolutionCount >= 2)
-        assertTrue(starter.contains("overridePosition = request.resumePositionOverride"))
-    }
-
-    @Test
-    fun `stop snapshots state and reserves durable subtitles before player teardown`() {
-        val screen = source(
-            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt",
-        )
-        val viewModel = source(
-            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt",
-        )
-        val stopBody = screen
-            .substringAfter("val stopPlaybackAndExit =")
-            .substringBefore("// A remote")
-        val asyncBody = viewModel
-            .substringAfter("fun stopSessionForExitAsync(")
-            .substringBefore("fun onExit()")
-
-        assertBefore(stopBody, "viewModel.stopSessionForExitAsync(", "controller.stop()")
-        assertBefore(
-            asyncBody,
-            "subtitleTransactions.reserveDurableFinalPersistence()",
-            "subtitleTransactions.invalidate()",
-        )
-        assertTrue(asyncBody.contains("subtitleTransactions::requestDurableFinalPersistence"))
-        assertTrue(asyncBody.contains("TvDetailTrackSelectionSession.remember"))
-        assertTrue(asyncBody.contains("positionSeconds = state.position"))
-        assertFalse(asyncBody.contains("viewModelScope.launch"))
-
-        val detail = source(
-            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt",
-        )
-        val refreshBody = detail
-            .substringAfter("fun refreshOnReturn()")
-            .substringBefore("fun onToggleFavorite()")
-        assertTrue(refreshBody.contains("TvDetailTrackSelectionSession.consumePlaybackReturn(contentId)"))
-        val returnOverlayCount = Regex.escape("withPlaybackReturn")
-            .toRegex()
-            .findAll(refreshBody)
-            .count()
-        assertTrue(returnOverlayCount >= 3)
-        assertTrue(detail.contains("saved.positionSeconds"))
     }
 
     private fun source(path: String): String = File(path).readText()
-
-    private fun assertBefore(source: String, first: String, second: String) {
-        val firstIndex = source.indexOf(first)
-        val secondIndex = source.indexOf(second)
-        assertTrue(firstIndex >= 0, "Missing `$first`")
-        assertTrue(secondIndex >= 0, "Missing `$second`")
-        assertTrue(firstIndex < secondIndex, "Expected `$first` before `$second`")
-    }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvFireTvRcFeedbackOwnershipTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvFireTvRcFeedbackOwnershipTest.kt
@@ -1,0 +1,121 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvFireTvRcFeedbackOwnershipTest {
+
+    @Test
+    fun `release display version keeps the complete tag`() {
+        val gradle = source("build.gradle.kts")
+        val workflow = source("../.github/workflows/release.yml")
+        val settings = source(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt",
+        )
+
+        assertTrue(gradle.contains("SILO_DISPLAY_VERSION"))
+        assertTrue(gradle.contains("\"DISPLAY_VERSION\""))
+        assertTrue(workflow.contains("SILO_DISPLAY_VERSION: \${{ needs.setup.outputs.version }}"))
+        assertTrue(settings.contains("BuildConfig.DISPLAY_VERSION"))
+    }
+
+    @Test
+    fun `focused selector rows request visibility without changing menu presentation`() {
+        val selector = source(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt",
+        )
+
+        assertTrue(selector.contains("DropdownMenu("))
+        assertTrue(selector.contains("bringIntoViewRequester"))
+        assertTrue(selector.contains("bringIntoView()"))
+    }
+
+    @Test
+    fun `for you first row restores the true top after scrolling back up`() {
+        val recommendations = source(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt",
+        )
+
+        assertTrue(recommendations.contains("recommendationsListState.animateScrollToItem(0)"))
+        assertTrue(recommendations.contains("onItemFocused"))
+    }
+
+    @Test
+    fun `phone confirmation card bounds legacy long codes`() {
+        val setup = source(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt",
+        )
+        val card = setup.substringAfter("private fun MatchCodeCard(code: String)")
+            .substringBefore("private object TvServerSetupTextStyles")
+
+        assertTrue(card.contains("matchCodeTileWidthDp(code)"))
+        assertTrue(card.contains("MATCH_CODE_TILE_GAP_DP.dp"))
+    }
+
+    @Test
+    fun `explicit start position owns both player and source timeline resolution`() {
+        val starter = source(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt",
+        )
+        val resolutionCount = Regex.escape("resolvePlaybackStartPosition(")
+            .toRegex()
+            .findAll(starter)
+            .count()
+
+        assertTrue(resolutionCount >= 2)
+        assertTrue(starter.contains("overridePosition = request.resumePositionOverride"))
+    }
+
+    @Test
+    fun `stop snapshots state and reserves durable subtitles before player teardown`() {
+        val screen = source(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt",
+        )
+        val viewModel = source(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt",
+        )
+        val stopBody = screen
+            .substringAfter("val stopPlaybackAndExit =")
+            .substringBefore("// A remote")
+        val asyncBody = viewModel
+            .substringAfter("fun stopSessionForExitAsync(")
+            .substringBefore("fun onExit()")
+
+        assertBefore(stopBody, "viewModel.stopSessionForExitAsync(", "controller.stop()")
+        assertBefore(
+            asyncBody,
+            "subtitleTransactions.reserveDurableFinalPersistence()",
+            "subtitleTransactions.invalidate()",
+        )
+        assertTrue(asyncBody.contains("subtitleTransactions::requestDurableFinalPersistence"))
+        assertTrue(asyncBody.contains("TvDetailTrackSelectionSession.remember"))
+        assertTrue(asyncBody.contains("positionSeconds = state.position"))
+        assertFalse(asyncBody.contains("viewModelScope.launch"))
+
+        val detail = source(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt",
+        )
+        val refreshBody = detail
+            .substringAfter("fun refreshOnReturn()")
+            .substringBefore("fun onToggleFavorite()")
+        assertTrue(refreshBody.contains("TvDetailTrackSelectionSession.consumePlaybackReturn(contentId)"))
+        val returnOverlayCount = Regex.escape("withPlaybackReturn")
+            .toRegex()
+            .findAll(refreshBody)
+            .count()
+        assertTrue(returnOverlayCount >= 3)
+        assertTrue(detail.contains("saved.positionSeconds"))
+    }
+
+    private fun source(path: String): String = File(path).readText()
+
+    private fun assertBefore(source: String, first: String, second: String) {
+        val firstIndex = source.indexOf(first)
+        val secondIndex = source.indexOf(second)
+        assertTrue(firstIndex >= 0, "Missing `$first`")
+        assertTrue(secondIndex >= 0, "Missing `$second`")
+        assertTrue(firstIndex < secondIndex, "Expected `$first` before `$second`")
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackExitSnapshotTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackExitSnapshotTest.kt
@@ -1,0 +1,49 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import org.siloserver.silo.model.playback.PlaybackTimeline
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TvPlaybackExitSnapshotTest {
+    @Test
+    fun suppliedFinalPlayerSampleReplacesStaleState() {
+        val snapshot = resolveTvPlaybackExitSnapshot(
+            currentPositionSeconds = 12.0,
+            currentDurationSeconds = 100.0,
+            positionMs = 37_000,
+            durationMs = 120_000,
+            timeline = null,
+            serverDurationSeconds = 0.0,
+        )
+
+        assertEquals(TvPlaybackExitSnapshot(37.0, 120.0), snapshot)
+    }
+
+    @Test
+    fun missingFinalSamplePreservesCurrentState() {
+        val snapshot = resolveTvPlaybackExitSnapshot(
+            currentPositionSeconds = 37.0,
+            currentDurationSeconds = 120.0,
+            positionMs = null,
+            durationMs = null,
+            timeline = null,
+            serverDurationSeconds = 0.0,
+        )
+
+        assertEquals(TvPlaybackExitSnapshot(37.0, 120.0), snapshot)
+    }
+
+    @Test
+    fun finalPlayerSampleRetainsReanchoredSourceCoordinates() {
+        val snapshot = resolveTvPlaybackExitSnapshot(
+            currentPositionSeconds = 3_001.0,
+            currentDurationSeconds = 3_600.0,
+            positionMs = 5_000,
+            durationMs = 600_000,
+            timeline = PlaybackTimeline(timelineOffsetSeconds = 3_000.0),
+            serverDurationSeconds = 3_600.0,
+        )
+
+        assertEquals(TvPlaybackExitSnapshot(3_005.0, 3_600.0), snapshot)
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackSourceStartTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackSourceStartTest.kt
@@ -1,0 +1,42 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TvPlaybackSourceStartTest {
+    @Test
+    fun adoptedSourceStartUsesTheRewoundServerRequest() {
+        assertEquals(
+            593.0,
+            resolveTvSourceStartPosition(
+                startRequestPosition = 593.0,
+                serverSourceStartPosition = 600.0,
+                playerStartPosition = 0.0,
+            ),
+        )
+    }
+
+    @Test
+    fun explicitStartOverKeepsZeroSourceStart() {
+        assertEquals(
+            0.0,
+            resolveTvSourceStartPosition(
+                startRequestPosition = 0.0,
+                serverSourceStartPosition = 600.0,
+                playerStartPosition = 0.0,
+            ),
+        )
+    }
+
+    @Test
+    fun serverSourceAnchorWinsWhenNoPositionWasRequested() {
+        assertEquals(
+            3_005.0,
+            resolveTvSourceStartPosition(
+                startRequestPosition = null,
+                serverSourceStartPosition = 3_005.0,
+                playerStartPosition = 5.0,
+            ),
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-08-03-firetv-rc-review-fixes.md
+++ b/docs/superpowers/plans/2026-08-03-firetv-rc-review-fixes.md
@@ -23,9 +23,9 @@
 - Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt`
 - Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvLoginMatchCodeLayoutTest.kt`
 
-- [ ] Verify `matchCodeTileWidthDp` budgets `MATCH_CODE_SEPARATOR_WIDTH_DP` while `MatchCodeCard` renders 12dp.
-- [ ] Render separators with `MATCH_CODE_SEPARATOR_WIDTH_DP.dp`.
-- [ ] Run the match-code layout tests.
+- [x] Verify `matchCodeTileWidthDp` budgets `MATCH_CODE_SEPARATOR_WIDTH_DP` while `MatchCodeCard` renders 12dp.
+- [x] Render separators with `MATCH_CODE_SEPARATOR_WIDTH_DP.dp`.
+- [x] Run the match-code layout tests.
 
 ### Task 2: Nullable track-selection persistence
 
@@ -33,9 +33,10 @@
 - Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt`
 - Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt`
 
-- [ ] Add a failing test proving a null keep-current subtitle retains the previous explicit selection.
-- [ ] Make `rememberPlaybackReturn` fall back to `previous?.subtitle` only for null; retain `-1` and nonnegative values.
-- [ ] Run the focused persistence tests.
+- [x] Add a failing test proving a null keep-current subtitle retains the previous explicit selection.
+- [x] Make `rememberPlaybackReturn` fall back to `previous?.subtitle` only for null; retain `-1` and nonnegative values.
+- [x] Preserve the previously selected file version when the exit snapshot has no reliable file identifier.
+- [x] Run the focused persistence tests.
 
 ### Task 3: Final Stop snapshot
 
@@ -43,10 +44,10 @@
 - Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt`
 - Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackExitSnapshotTest.kt`
 
-- [ ] Add failing behavioral tests for supplied final player position, missing samples, and reanchored timeline mapping.
-- [ ] Extract a pure exit-snapshot resolver that maps player time to source time and clamps to server duration.
-- [ ] Apply that snapshot directly to `_uiState` before persistence, without invoking seek/mount presentation gates.
-- [ ] Run the focused exit-snapshot tests.
+- [x] Add failing behavioral tests for supplied final player position, missing samples, and reanchored timeline mapping.
+- [x] Extract a pure exit-snapshot resolver that maps player time to source time and clamps to server duration.
+- [x] Apply that snapshot directly to `_uiState` before persistence, without invoking seek/mount presentation gates.
+- [x] Run the focused exit-snapshot tests.
 
 ### Task 4: Rewound source-start metadata
 
@@ -54,9 +55,9 @@
 - Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt`
 - Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackSourceStartTest.kt`
 
-- [ ] Add a failing behavioral test showing a 600-second resume rewound to 593 seconds must adopt 593 as source start.
-- [ ] Resolve source start from `startRequestPosition`, server source start, then player start.
-- [ ] Verify Start Over zero and no-request server anchors remain intact.
+- [x] Add a failing behavioral test showing a 600-second resume rewound to 593 seconds must adopt 593 as source start.
+- [x] Resolve source start from `startRequestPosition`, server source start, then player start.
+- [x] Verify Start Over zero and no-request server anchors remain intact.
 
 ### Task 5: Focus-scoped For You re-anchor
 
@@ -64,15 +65,15 @@
 - Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt`
 - Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt`
 
-- [ ] Add a row-level focus callback to `TvMediaRow`.
-- [ ] Track first-row focus and repeatedly re-anchor while focus relocation leaves the list below item zero, matching the existing library control-row pattern.
-- [ ] Keep an already-top list as a no-op and stop the loop immediately when row focus leaves.
+- [x] Add a row-level focus callback to `TvMediaRow`.
+- [x] Track first-row focus and repeatedly re-anchor while focus relocation leaves the list below item zero, matching the existing library control-row pattern.
+- [x] Keep an already-top list as a no-op and stop the loop immediately when row focus leaves.
 
 ### Task 6: Verification and PR update
 
 **Files:**
 - Modify: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvFireTvRcFeedbackOwnershipTest.kt`
 
-- [ ] Remove superseded source-text assertions for Kotlin behavior while retaining workflow/Gradle contract checks.
-- [ ] Run focused tests, then the complete shared/TV unit and APK build gate with `1.0.0-rc.1+4` display version.
-- [ ] Push the follow-up commit and reply to each review thread with the verification evidence.
+- [x] Remove superseded source-text assertions for Kotlin behavior while retaining workflow/Gradle contract checks.
+- [x] Run focused tests, then the complete shared/TV unit and APK build gate with `1.0.0-rc.1+4` display version.
+- [x] Push the follow-up commit and reply to each review thread with the verification evidence.

--- a/docs/superpowers/plans/2026-08-03-firetv-rc-review-fixes.md
+++ b/docs/superpowers/plans/2026-08-03-firetv-rc-review-fixes.md
@@ -1,0 +1,78 @@
+# Fire TV rc.1+4 Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve every actionable review finding on Android PR #161 without regressing reanchored playback, track persistence, or TV focus behavior.
+
+**Architecture:** Keep layout constants shared, model exit-position and source-start decisions as testable pure logic, and use the established focus-scoped re-anchor loop for Compose focus relocation. Preserve the existing player timeline mapping while bypassing only the transient presentation gates during final Stop capture.
+
+**Tech Stack:** Kotlin 2.1, Jetpack Compose for TV, Media3, Kotlin/JUnit tests, Gradle.
+
+## Global Constraints
+
+- Preserve compatibility with legacy long pairing codes and newly bounded server codes.
+- Preserve source/movie-time mapping for reanchored HLS playback.
+- Keep explicit subtitle Off (`-1`) distinct from unresolved/keep-current (`null`).
+- Do not alter phone behavior.
+
+---
+
+### Task 1: Pairing-code shared width
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt`
+- Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvLoginMatchCodeLayoutTest.kt`
+
+- [ ] Verify `matchCodeTileWidthDp` budgets `MATCH_CODE_SEPARATOR_WIDTH_DP` while `MatchCodeCard` renders 12dp.
+- [ ] Render separators with `MATCH_CODE_SEPARATOR_WIDTH_DP.dp`.
+- [ ] Run the match-code layout tests.
+
+### Task 2: Nullable track-selection persistence
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt`
+- Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvTrackSelectionPersistenceTest.kt`
+
+- [ ] Add a failing test proving a null keep-current subtitle retains the previous explicit selection.
+- [ ] Make `rememberPlaybackReturn` fall back to `previous?.subtitle` only for null; retain `-1` and nonnegative values.
+- [ ] Run the focused persistence tests.
+
+### Task 3: Final Stop snapshot
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt`
+- Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackExitSnapshotTest.kt`
+
+- [ ] Add failing behavioral tests for supplied final player position, missing samples, and reanchored timeline mapping.
+- [ ] Extract a pure exit-snapshot resolver that maps player time to source time and clamps to server duration.
+- [ ] Apply that snapshot directly to `_uiState` before persistence, without invoking seek/mount presentation gates.
+- [ ] Run the focused exit-snapshot tests.
+
+### Task 4: Rewound source-start metadata
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt`
+- Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackSourceStartTest.kt`
+
+- [ ] Add a failing behavioral test showing a 600-second resume rewound to 593 seconds must adopt 593 as source start.
+- [ ] Resolve source start from `startRequestPosition`, server source start, then player start.
+- [ ] Verify Start Over zero and no-request server anchors remain intact.
+
+### Task 5: Focus-scoped For You re-anchor
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt`
+
+- [ ] Add a row-level focus callback to `TvMediaRow`.
+- [ ] Track first-row focus and repeatedly re-anchor while focus relocation leaves the list below item zero, matching the existing library control-row pattern.
+- [ ] Keep an already-top list as a no-op and stop the loop immediately when row focus leaves.
+
+### Task 6: Verification and PR update
+
+**Files:**
+- Modify: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvFireTvRcFeedbackOwnershipTest.kt`
+
+- [ ] Remove superseded source-text assertions for Kotlin behavior while retaining workflow/Gradle contract checks.
+- [ ] Run focused tests, then the complete shared/TV unit and APK build gate with `1.0.0-rc.1+4` display version.
+- [ ] Push the follow-up commit and reply to each review thread with the verification evidence.


### PR DESCRIPTION
## Summary

Addresses the Fire TV rc.1+4 QA feedback reported on 2026-08-03:

- show the complete release version in Settings while retaining the base Android package version
- keep D-pad subtitle selection scrolling as focus reaches the last visible item
- snapshot Stop progress before Media3 teardown so Resume shows the correct time
- preserve selected subtitle and audio choices after Stop
- make Start Over honor an explicit zero position
- restore the For You row to the top when focus returns after partial scrolling
- fit legacy long phone-confirmation codes without clipping

The coordinated server change that limits newly generated pairing codes to eight letters is Silo-Server/silo-server#535. This client remains compatible with older long codes.

## Implementation notes

- Separates `BuildConfig.DISPLAY_VERSION` from `VERSION_NAME`; release builds receive the full tag through `SILO_DISPLAY_VERSION`.
- Brings focused anchored-selector rows into view for TV D-pad navigation.
- Preserves explicit zero start positions while retaining nonzero HLS timeline re-anchoring.
- Captures player-exit state synchronously, consumes the progress overlay once, and retains file/audio/subtitle session choices.
- Restores the For You recommendation list to item zero when it regains focus while partially scrolled.
- Uses adaptive match-code tile sizing for legacy codes.

## Testing

- `./gradlew :shared:testDebugUnitTest :androidTvApp:testDebugUnitTest :androidTvApp:assembleDebug -PsiloVersionName=1.0.0 -PsiloDisplayVersion=1.0.0-rc.1+4 --no-daemon`
- Result: `BUILD SUCCESSFUL` — 110 actionable tasks
- Added behavioral regression coverage for Stop audio preservation and one-shot resume-position consumption.
- Verified the release label as `1.0.0-rc.1+4` in the generated debug build.

## Related work

- Silo-Server/silo-android#160 changes the GitHub-release publication gate. This PR touches a separate release-workflow concern: passing the display version into APK builds.
- Silo-Server/silo-server#535 bounds newly generated phone-confirmation codes to eight letters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TV About and settings screens now show the complete display version, including prerelease details.
  * Playback position, duration, and track selections are better preserved when returning from video playback.
  * Start Over playback behavior now correctly respects the selected starting point.

* **Bug Fixes**
  * Focused dropdown and recommendation items are automatically brought into view.
  * Match-code tiles resize appropriately for different code lengths.
  * Improved playback exit and subtitle persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->