### PR TITLE
fix(tv): recover late For You focus relocation

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,9 +60,33 @@ import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
 import org.siloserver.silo.tv.ui.util.visibleOnTv
 import org.siloserver.silo.viewmodel.RecommendationsViewModel
 import org.koin.compose.viewmodel.koinViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 private val RecommendationsFilterBandHeight = 52.dp
+
+internal data class ForYouListPosition(
+    val firstVisibleItemIndex: Int,
+    val firstVisibleItemScrollOffset: Int,
+) {
+    val isAtTop: Boolean
+        get() = firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset == 0
+}
+
+internal suspend fun maintainForYouTopAnchor(
+    positionEvents: Flow<ForYouListPosition>,
+    isFirstRowFocused: () -> Boolean,
+    awaitRelocation: suspend () -> Unit,
+    currentPosition: () -> ForYouListPosition,
+    scrollToTop: suspend () -> Unit,
+) {
+    positionEvents.collect { observed ->
+        if (!isFirstRowFocused() || observed.isAtTop) return@collect
+        awaitRelocation()
+        if (isFirstRowFocused() && !currentPosition().isAtTop) scrollToTop()
+    }
+}
 
 /**
  * "For You" tab. Reuses the shared [RecommendationsViewModel] that drives
@@ -160,18 +185,21 @@ fun TvRecommendationsScreen(
     }
 
     LaunchedEffect(firstRecommendationRowFocused) {
-        while (
-            firstRecommendationRowFocused &&
-            (recommendationsListState.firstVisibleItemIndex != 0 ||
-                recommendationsListState.firstVisibleItemScrollOffset != 0)
-        ) {
-            // Focus-driven bring-into-view can run after the focus callback.
-            // Delay before re-anchoring so that relocation finishes first,
-            // then stop once the list reaches its true top.
-            kotlinx.coroutines.delay(80)
-            if (!firstRecommendationRowFocused) break
-            runCatching { recommendationsListState.animateScrollToItem(0) }
-        }
+        if (!firstRecommendationRowFocused) return@LaunchedEffect
+        fun currentPosition() = ForYouListPosition(
+            firstVisibleItemIndex = recommendationsListState.firstVisibleItemIndex,
+            firstVisibleItemScrollOffset = recommendationsListState.firstVisibleItemScrollOffset,
+        )
+        // Stay suspended while the list is correctly anchored. A delayed
+        // focus relocation can still move it after an initially-top sample;
+        // snapshotFlow observes that later displacement without polling.
+        maintainForYouTopAnchor(
+            positionEvents = snapshotFlow { currentPosition() },
+            isFirstRowFocused = { firstRecommendationRowFocused },
+            awaitRelocation = { kotlinx.coroutines.delay(80) },
+            currentPosition = ::currentPosition,
+            scrollToTop = { recommendationsListState.animateScrollToItem(0) },
+        )
     }
 
     // The saved-list shortcuts are the stable first row in every state. Focus

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsTopAnchorTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsTopAnchorTest.kt
@@ -1,0 +1,65 @@
+package org.siloserver.silo.tv.ui.screens.recommendations
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+
+class TvRecommendationsTopAnchorTest {
+
+    @Test
+    fun delayedRelocationAfterAnInitiallyCorrectTopIsReanchored() = runTest {
+        var current = ForYouListPosition(0, 0)
+        var corrections = 0
+
+        maintainForYouTopAnchor(
+            positionEvents = flow {
+                emit(current)
+                current = ForYouListPosition(1, 24)
+                emit(current)
+            },
+            isFirstRowFocused = { true },
+            awaitRelocation = {},
+            currentPosition = { current },
+            scrollToTop = {
+                corrections += 1
+                current = ForYouListPosition(0, 0)
+            },
+        )
+
+        assertEquals(1, corrections)
+    }
+
+    @Test
+    fun topOnlyPositionEventsDoNotScroll() = runTest {
+        var corrections = 0
+
+        maintainForYouTopAnchor(
+            positionEvents = flowOf(ForYouListPosition(0, 0)),
+            isFirstRowFocused = { true },
+            awaitRelocation = {},
+            currentPosition = { ForYouListPosition(0, 0) },
+            scrollToTop = { corrections += 1 },
+        )
+
+        assertEquals(0, corrections)
+    }
+
+    @Test
+    fun focusLossPreventsPendingCorrection() = runTest {
+        var focused = true
+        var corrections = 0
+        val displaced = ForYouListPosition(1, 24)
+
+        maintainForYouTopAnchor(
+            positionEvents = flowOf(displaced),
+            isFirstRowFocused = { focused },
+            awaitRelocation = { focused = false },
+            currentPosition = { displaced },
+            scrollToTop = { corrections += 1 },
+        )
+
+        assertEquals(0, corrections)
+    }
+}

--- a/docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
+++ b/docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
@@ -1,0 +1,159 @@
+# For You Late Focus-Relocation Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the For You list at its true top when a delayed focus-relocation pass moves it after the first recommendation row has already gained focus.
+
+**Architecture:** Convert the focus-scoped early-exit loop into an event-driven observer over `LazyListState` position changes. A small suspend helper owns the timing policy and is exercised with real coroutine flows so the delayed-displacement regression is testable without a Compose UI harness.
+
+**Tech Stack:** Kotlin, Jetpack Compose `snapshotFlow`, Kotlin coroutines `Flow`, `kotlinx-coroutines-test`, Gradle.
+
+## Global Constraints
+
+- Observe scroll changes only while the first recommendation row owns focus.
+- Do no work while the list remains at item zero with offset zero.
+- Re-check focus and position after the 80 ms relocation-settling delay.
+- Do not change the shared bring-into-view policy or other recommendation rows.
+- Preserve the full RC display version during verification.
+
+---
+
+### Task 1: Event-driven top-anchor recovery
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt`
+- Create: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsTopAnchorTest.kt`
+
+**Interfaces:**
+- Consumes: a `Flow<ForYouListPosition>`, focus/position readers, an 80 ms settling callback, and a suspend scroll callback.
+- Produces: `ForYouListPosition(firstVisibleItemIndex: Int, firstVisibleItemScrollOffset: Int)` and `maintainForYouTopAnchor(...)` for the screen effect and focused unit tests.
+
+- [ ] **Step 1: Write the failing delayed-displacement regression test**
+
+```kotlin
+@Test
+fun delayedRelocationAfterAnInitiallyCorrectTopIsReanchored() = runTest {
+    var current = ForYouListPosition(0, 0)
+    var corrections = 0
+
+    maintainForYouTopAnchor(
+        positionEvents = flow {
+            emit(current)
+            current = ForYouListPosition(1, 24)
+            emit(current)
+        },
+        isFirstRowFocused = { true },
+        awaitRelocation = {},
+        currentPosition = { current },
+        scrollToTop = {
+            corrections += 1
+            current = ForYouListPosition(0, 0)
+        },
+    )
+
+    assertEquals(1, corrections)
+}
+```
+
+Add two neighboring tests using `flowOf(...)`: a top-only sequence produces zero corrections, and focus becoming false inside `awaitRelocation` prevents a pending correction.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.tv.ui.screens.recommendations.TvRecommendationsTopAnchorTest' \
+  --no-daemon
+```
+
+Expected: compilation fails because `ForYouListPosition` and `maintainForYouTopAnchor` do not exist.
+
+- [ ] **Step 3: Implement the minimal event-driven helper**
+
+```kotlin
+internal data class ForYouListPosition(
+    val firstVisibleItemIndex: Int,
+    val firstVisibleItemScrollOffset: Int,
+) {
+    val isAtTop: Boolean
+        get() = firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset == 0
+}
+
+internal suspend fun maintainForYouTopAnchor(
+    positionEvents: Flow<ForYouListPosition>,
+    isFirstRowFocused: () -> Boolean,
+    awaitRelocation: suspend () -> Unit,
+    currentPosition: () -> ForYouListPosition,
+    scrollToTop: suspend () -> Unit,
+) {
+    positionEvents.collect { observed ->
+        if (!isFirstRowFocused() || observed.isAtTop) return@collect
+        awaitRelocation()
+        if (isFirstRowFocused() && !currentPosition().isAtTop) scrollToTop()
+    }
+}
+```
+
+In `LaunchedEffect(firstRecommendationRowFocused)`, return immediately when focus is false. Otherwise pass a `snapshotFlow` of the real lazy-list position to the helper, retain the existing 80 ms settling delay, and call `recommendationsListState.animateScrollToItem(0)` only from `scrollToTop`.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the Step 2 command.
+
+Expected: all three `TvRecommendationsTopAnchorTest` cases pass.
+
+- [ ] **Step 5: Commit the behavior and tests**
+
+```bash
+git add \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsTopAnchorTest.kt
+git commit -m "fix(tv): recover late For You focus relocation"
+```
+
+### Task 2: Full verification
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md`
+
+**Interfaces:**
+- Consumes: the Task 1 helper, integration, and regression suite.
+- Produces: a verified Android TV debug APK and completed plan checklist.
+
+- [ ] **Step 1: Run the complete TV verification gate**
+
+```bash
+./gradlew \
+  :shared:testDebugUnitTest \
+  :androidTvApp:testDebugUnitTest \
+  :androidTvApp:assembleDebug \
+  -PsiloVersionName=1.0.0 \
+  -PsiloDisplayVersion=1.0.0-rc.2+5 \
+  --no-daemon
+bash scripts/test-release-workflow.sh
+bash scripts/test-check-build-supply-chain.sh
+bash scripts/check-build-supply-chain.sh
+git diff --check
+```
+
+Expected: Gradle reports `BUILD SUCCESSFUL`, both workflow self-tests pass, the supply-chain check passes, and `git diff --check` emits no errors.
+
+- [ ] **Step 2: Mark the plan complete and commit verification metadata**
+
+Change every task checkbox in this plan from `[ ]` to `[x]`, then run:
+
+```bash
+git add docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
+git commit -m "docs(tv): complete For You relocation plan"
+```
+
+- [ ] **Step 3: Review branch scope**
+
+```bash
+git status --short
+git diff --stat upstream/main...HEAD
+git log --oneline upstream/main..HEAD
+```
+
+Expected: the worktree is clean and the branch contains only the approved design, focused implementation/tests, and completed implementation plan.

--- a/docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
+++ b/docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
@@ -28,7 +28,7 @@
 - Consumes: a `Flow<ForYouListPosition>`, focus/position readers, an 80 ms settling callback, and a suspend scroll callback.
 - Produces: `ForYouListPosition(firstVisibleItemIndex: Int, firstVisibleItemScrollOffset: Int)` and `maintainForYouTopAnchor(...)` for the screen effect and focused unit tests.
 
-- [ ] **Step 1: Write the failing delayed-displacement regression test**
+- [x] **Step 1: Write the failing delayed-displacement regression test**
 
 ```kotlin
 @Test
@@ -57,7 +57,7 @@ fun delayedRelocationAfterAnInitiallyCorrectTopIsReanchored() = runTest {
 
 Add two neighboring tests using `flowOf(...)`: a top-only sequence produces zero corrections, and focus becoming false inside `awaitRelocation` prevents a pending correction.
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run:
 
@@ -69,7 +69,7 @@ Run:
 
 Expected: compilation fails because `ForYouListPosition` and `maintainForYouTopAnchor` do not exist.
 
-- [ ] **Step 3: Implement the minimal event-driven helper**
+- [x] **Step 3: Implement the minimal event-driven helper**
 
 ```kotlin
 internal data class ForYouListPosition(
@@ -97,13 +97,13 @@ internal suspend fun maintainForYouTopAnchor(
 
 In `LaunchedEffect(firstRecommendationRowFocused)`, return immediately when focus is false. Otherwise pass a `snapshotFlow` of the real lazy-list position to the helper, retain the existing 80 ms settling delay, and call `recommendationsListState.animateScrollToItem(0)` only from `scrollToTop`.
 
-- [ ] **Step 4: Run the focused test and verify GREEN**
+- [x] **Step 4: Run the focused test and verify GREEN**
 
 Run the Step 2 command.
 
 Expected: all three `TvRecommendationsTopAnchorTest` cases pass.
 
-- [ ] **Step 5: Commit the behavior and tests**
+- [x] **Step 5: Commit the behavior and tests**
 
 ```bash
 git add \
@@ -121,7 +121,7 @@ git commit -m "fix(tv): recover late For You focus relocation"
 - Consumes: the Task 1 helper, integration, and regression suite.
 - Produces: a verified Android TV debug APK and completed plan checklist.
 
-- [ ] **Step 1: Run the complete TV verification gate**
+- [x] **Step 1: Run the complete TV verification gate**
 
 ```bash
 ./gradlew \
@@ -139,7 +139,7 @@ git diff --check
 
 Expected: Gradle reports `BUILD SUCCESSFUL`, both workflow self-tests pass, the supply-chain check passes, and `git diff --check` emits no errors.
 
-- [ ] **Step 2: Mark the plan complete and commit verification metadata**
+- [x] **Step 2: Mark the plan complete and commit verification metadata**
 
 Change every task checkbox in this plan from `[ ]` to `[x]`, then run:
 
@@ -148,7 +148,7 @@ git add docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
 git commit -m "docs(tv): complete For You relocation plan"
 ```
 
-- [ ] **Step 3: Review branch scope**
+- [x] **Step 3: Review branch scope**
 
 ```bash
 git status --short

--- a/docs/superpowers/specs/2026-08-03-for-you-late-focus-relocation-design.md
+++ b/docs/superpowers/specs/2026-08-03-for-you-late-focus-relocation-design.md
@@ -1,0 +1,45 @@
+# For You Late Focus-Relocation Recovery Design
+
+## Problem
+
+When focus enters the first recommendation row while the For You list is
+already at item zero, the current correction effect exits immediately. Compose
+can run the row's focus-driven bring-into-view relocation afterward and move the
+list below its intended top anchor. Moving down and back up re-enters the row and
+re-arms the correction, which is why the screen then recovers.
+
+## Design
+
+Keep a scroll-position observer active only while the first recommendation row
+owns focus. The observer remains suspended while the list is correctly anchored
+and reacts only when the list position changes. If a later focus-relocation pass
+moves the list away from item zero, wait for that relocation to settle, confirm
+the row still owns focus and the list is still displaced, then animate back to
+item zero. Leaving the row cancels the observer through the existing
+focus-keyed `LaunchedEffect`.
+
+The observer and correction loop will be extracted behind a small suspend
+helper that accepts position events and scroll callbacks. This keeps the
+timing policy testable without a Compose UI harness while production continues
+to obtain positions from `snapshotFlow` over the real `LazyListState`.
+
+## Alternatives Rejected
+
+- A fixed number of settling polls adds arbitrary timing and can still miss a
+  slower Fire TV relocation.
+- Changing the shared bring-into-view policy affects every recommendation row
+  and risks wider D-pad navigation regressions.
+- Continuous polling for the entire focus lifetime wakes unnecessarily even
+  when the list does not move; an event-driven observer has no such activity.
+
+## Verification
+
+Add a coroutine regression test that emits an initially correct top position,
+then emits a delayed displaced position while focus remains in the first row.
+The test must fail against the current early-exit behavior and pass only when
+the delayed displacement triggers one top-anchor correction. Also cover that a
+top-only sequence is a no-op and that focus loss prevents a pending correction.
+
+Run the focused test, the complete Android TV unit suite, release-workflow and
+supply-chain checks, and assemble the Android TV debug APK with the full RC
+display version.


### PR DESCRIPTION
## Summary

- keep an event-driven top-anchor observer active while the first For You recommendation row owns focus
- recover when Compose moves an initially-correct list after a delayed bring-into-view pass
- remain idle at the correct top and cancel correction when focus leaves
- add coroutine regression coverage for delayed displacement, top-only no-op, and focus loss

## Root cause

The previous focus-scoped loop checked whether the list was already at item zero before its first delay. When it started at the correct top it exited immediately, allowing a later focus-relocation pass to move the list with no observer left to recover it.

## Verification

- RED: focused suite failed before `ForYouListPosition` / `maintainForYouTopAnchor` existed
- GREEN: all three `TvRecommendationsTopAnchorTest` cases pass
- `./gradlew :shared:testDebugUnitTest :androidTvApp:testDebugUnitTest :androidTvApp:assembleDebug -PsiloVersionName=1.0.0 -PsiloDisplayVersion=1.0.0-rc.2+5 --no-daemon` — `BUILD SUCCESSFUL`, 110 tasks
- `scripts/test-release-workflow.sh` — passed
- supply-chain policy self-tests and check — passed
- `git diff --check` — clean