### PR TITLE
fix(tv): restore Shield focus navigation

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -22,6 +23,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.ExperimentalComposeUiApi
 import org.siloserver.silo.model.section.SectionItem
@@ -98,6 +100,12 @@ fun TvMediaRow(
      *  of card 0. Callers should only pass it while a restore is pending. */
     restoreFocusIndex: Int = -1,
     restoreFocusRequester: FocusRequester? = null,
+    /** Nonzero only while an exact-card return is pending. The row uses its
+     *  private horizontal state to compose [restoreFocusIndex] before focus is
+     *  requested; ordinary row rendering never changes horizontal position. */
+    restoreFocusRequest: Int = 0,
+    onRestoreFocusTargetPlaced: ((Int, Int) -> Unit)? = null,
+    onRestoreFocusTargetDisposed: ((Int, Int) -> Unit)? = null,
     /** Fired (on focus GAIN only) with whichever card the user focuses, so the
      *  Skyline marquee + backdrop can preview the focused item. */
     onItemFocused: ((SectionItem) -> Unit)? = null,
@@ -124,6 +132,16 @@ fun TvMediaRow(
                 contentType = "${cardLayout.name}:${style.name}:${item.type}",
             )
         }
+    }
+    val restoreFocusContentId = rowItems.getOrNull(restoreFocusIndex)?.item?.contentId
+
+    LaunchedEffect(restoreFocusRequest, restoreFocusIndex, restoreFocusContentId) {
+        prepareTvMediaRowFocusRestore(
+            requestId = restoreFocusRequest,
+            restoreFocusIndex = restoreFocusIndex,
+            itemCount = rowItems.size,
+            scrollToItem = rowState::scrollToItem,
+        )
     }
 
     LaunchedEffect(firstItemFocusRequest) {
@@ -189,6 +207,15 @@ fun TvMediaRow(
                 contentType = { _, rowItem -> rowItem.contentType },
             ) { index, rowItem ->
                 val item = rowItem.item
+                val isRestoreFocusTarget =
+                    restoreFocusRequest > 0 && index == restoreFocusIndex
+                if (isRestoreFocusTarget && onRestoreFocusTargetDisposed != null) {
+                    DisposableEffect(restoreFocusRequest, index) {
+                        onDispose {
+                            onRestoreFocusTargetDisposed(restoreFocusRequest, index)
+                        }
+                    }
+                }
                 // Always anchor firstItemFocusRequester to index 0 so it can
                 // serve as a stable fallback target for focusRestorer and for
                 // imperative requestFocus() calls from parent screens.
@@ -198,6 +225,14 @@ fun TvMediaRow(
                 ).then(
                     if (restoreFocusRequester != null && index == restoreFocusIndex) {
                         Modifier.focusRequester(restoreFocusRequester)
+                    } else {
+                        Modifier
+                    },
+                ).then(
+                    if (isRestoreFocusTarget && onRestoreFocusTargetPlaced != null) {
+                        Modifier.onGloballyPositioned {
+                            onRestoreFocusTargetPlaced(restoreFocusRequest, index)
+                        }
                     } else {
                         Modifier
                     },
@@ -283,6 +318,17 @@ fun TvMediaRow(
             }
         }
     }
+}
+
+internal suspend fun prepareTvMediaRowFocusRestore(
+    requestId: Int,
+    restoreFocusIndex: Int,
+    itemCount: Int,
+    scrollToItem: suspend (Int) -> Unit,
+): Boolean {
+    if (requestId <= 0 || restoreFocusIndex !in 0 until itemCount) return false
+    scrollToItem(restoreFocusIndex)
+    return true
 }
 
 /** Fraction [0..1] of item consumed for "continue watching" progress bars. */

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
@@ -182,8 +182,10 @@ fun TvCalendarScreen(
             kotlinx.coroutines.delay(120)
             runCatching { requester.requestFocus() }
             androidx.compose.runtime.withFrameNanos { }
-            lastAppliedFocusRequest = focusRequest
-            onInitialContentFocus()
+            if (lastAppliedFocusRequest != focusRequest) {
+                lastAppliedFocusRequest = focusRequest
+                onInitialContentFocus()
+            }
         }
     }
     // Focus hand-off for day selection: picking a day in the week strip scrolls
@@ -216,7 +218,7 @@ fun TvCalendarScreen(
                 modifier = Modifier.fillMaxSize(),
             )
 
-            val controls: @Composable () -> Unit = {
+            val controls: @Composable ((CalendarControlFocusZone) -> Unit) -> Unit = { onControlFocused ->
                 CalendarControls(
                     selectedFilter = state.filter,
                     weekDates = state.weekDates,
@@ -227,7 +229,7 @@ fun TvCalendarScreen(
                     firstSegmentFocusRequester = filterFocusRequester,
                     segmentFocusRequesters = filterFocusRequesters,
                     selectedDayFocusRequester = selectedDayFocusRequester,
-                    onControlFocused = snapControlsToInitialPosition,
+                    onControlFocused = onControlFocused,
                     includeTopInset = false,
                     onSelectFilter = viewModel::setFilter,
                     onSelectDay = { date ->
@@ -256,6 +258,14 @@ fun TvCalendarScreen(
                 state = state,
                 listState = listState,
                 controls = controls,
+                activeFilterFocusRequester = filterFocusRequesters[state.filter] ?: filterFocusRequester,
+                onControlFocused = snapControlsToInitialPosition,
+                onFocusRequestAcknowledged = {
+                    if (lastAppliedFocusRequest != focusRequest) {
+                        lastAppliedFocusRequest = focusRequest
+                        onInitialContentFocus()
+                    }
+                },
                 onRefresh = viewModel::refresh,
                 onShowEverything = { viewModel.setFilter(CalendarFilter.All) },
                 selectedDayFocusRequester = selectedDayFocusRequester,
@@ -283,7 +293,7 @@ private fun CalendarControls(
     firstSegmentFocusRequester: FocusRequester,
     segmentFocusRequesters: Map<String, FocusRequester>,
     selectedDayFocusRequester: FocusRequester,
-    onControlFocused: () -> Unit,
+    onControlFocused: (CalendarControlFocusZone) -> Unit,
     includeTopInset: Boolean,
     onSelectFilter: (String) -> Unit,
     onSelectDay: (String) -> Unit,
@@ -338,7 +348,7 @@ private fun CalendarControlRow(
     onSelectFilter: (String) -> Unit,
     firstSegmentFocusRequester: FocusRequester,
     segmentFocusRequesters: Map<String, FocusRequester>,
-    onControlFocused: () -> Unit,
+    onControlFocused: (CalendarControlFocusZone) -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -371,7 +381,7 @@ private fun FilterBar(
     onSelect: (String) -> Unit,
     firstSegmentFocusRequester: FocusRequester,
     segmentFocusRequesters: Map<String, FocusRequester>,
-    onControlFocused: () -> Unit,
+    onControlFocused: (CalendarControlFocusZone) -> Unit,
 ) {
     val presets = listOf(
         CalendarFilter.Following to "Following",
@@ -394,7 +404,7 @@ private fun FilterBar(
                 onClick = { onSelect(value) },
                 focusRequester = segmentFocusRequesters[value]
                     ?: if (index == 0) firstSegmentFocusRequester else null,
-                onFocused = onControlFocused,
+                onFocused = { onControlFocused(CalendarControlFocusZone.Filter) },
             )
         }
     }
@@ -457,7 +467,7 @@ private fun WeekStrip(
     isCurrentWeek: Boolean,
     hasEvents: (String) -> Boolean,
     selectedDayFocusRequester: FocusRequester,
-    onControlFocused: () -> Unit,
+    onControlFocused: (CalendarControlFocusZone) -> Unit,
     onSelectDay: (String) -> Unit,
     onPrevWeek: () -> Unit,
     onNextWeek: () -> Unit,
@@ -470,7 +480,11 @@ private fun WeekStrip(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Spacing.md),
     ) {
-        ChevronButton(arrow = NavArrow.Prev, onClick = onPrevWeek)
+        ChevronButton(
+            arrow = NavArrow.Prev,
+            onClick = onPrevWeek,
+            onFocused = { onControlFocused(CalendarControlFocusZone.WeekStrip) },
+        )
         Row(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -482,14 +496,21 @@ private fun WeekStrip(
                     isToday = date == today,
                     hasEvents = hasEvents(date),
                     focusRequester = if (date == selectedDay) selectedDayFocusRequester else null,
-                    onFocused = onControlFocused,
+                    onFocused = { onControlFocused(CalendarControlFocusZone.WeekStrip) },
                     onClick = { onSelectDay(date) },
                 )
             }
         }
-        ChevronButton(arrow = NavArrow.Next, onClick = onNextWeek)
+        ChevronButton(
+            arrow = NavArrow.Next,
+            onClick = onNextWeek,
+            onFocused = { onControlFocused(CalendarControlFocusZone.WeekStrip) },
+        )
         if (!isCurrentWeek) {
-            TodayButton(onClick = onToday)
+            TodayButton(
+                onClick = onToday,
+                onFocused = { onControlFocused(CalendarControlFocusZone.WeekStrip) },
+            )
         }
         Spacer(modifier = Modifier.weight(1f))
         Text(
@@ -508,7 +529,11 @@ private enum class NavArrow { Prev, Next }
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun ChevronButton(arrow: NavArrow, onClick: () -> Unit) {
+private fun ChevronButton(
+    arrow: NavArrow,
+    onClick: () -> Unit,
+    onFocused: () -> Unit,
+) {
     val shape = CircleShape
     Surface(
         onClick = onClick,
@@ -522,7 +547,9 @@ private fun ChevronButton(arrow: NavArrow, onClick: () -> Unit) {
             pressedContentColor = FocusedContent,
         ),
         scale = ClickableSurfaceDefaults.scale(focusedScale = 1.06f),
-        modifier = Modifier.size(28.dp),
+        modifier = Modifier
+            .onFocusChanged { if (it.isFocused) onFocused() }
+            .size(28.dp),
     ) {
         Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
             Icon(
@@ -541,7 +568,7 @@ private fun ChevronButton(arrow: NavArrow, onClick: () -> Unit) {
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun TodayButton(onClick: () -> Unit) {
+private fun TodayButton(onClick: () -> Unit, onFocused: () -> Unit) {
     val shape = RoundedCornerShape(100.dp)
     Surface(
         onClick = onClick,
@@ -555,6 +582,7 @@ private fun TodayButton(onClick: () -> Unit) {
             pressedContentColor = FocusedContent,
         ),
         scale = ClickableSurfaceDefaults.scale(focusedScale = 1.05f),
+        modifier = Modifier.onFocusChanged { if (it.isFocused) onFocused() },
     ) {
         Box(
             modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
@@ -677,8 +705,11 @@ internal fun shouldReturnCalendarFocusToControls(
     focusedShelfIndex == firstFocusableShelfIndex &&
     !isReturningToControls
 
+internal enum class CalendarControlFocusZone { Filter, WeekStrip }
+
 internal enum class CalendarUpFallbackAction {
     EnterMenu,
+    FocusFilter,
     ReturnToControls,
     StayInContent,
     MoveWithinContent,
@@ -688,6 +719,7 @@ internal fun calendarUpFallbackAction(
     focusedShelfIndex: Int?,
     firstFocusableShelfIndex: Int,
     isReturningToControls: Boolean,
+    focusedControlZone: CalendarControlFocusZone?,
     isRepeat: Boolean = false,
 ): CalendarUpFallbackAction = when {
     shouldReturnCalendarFocusToControls(
@@ -695,8 +727,9 @@ internal fun calendarUpFallbackAction(
         firstFocusableShelfIndex = firstFocusableShelfIndex,
         isReturningToControls = isReturningToControls,
     ) -> if (isRepeat) CalendarUpFallbackAction.StayInContent else CalendarUpFallbackAction.ReturnToControls
-    focusedShelfIndex == null && isRepeat -> CalendarUpFallbackAction.StayInContent
-    focusedShelfIndex == null -> CalendarUpFallbackAction.EnterMenu
+    isRepeat -> CalendarUpFallbackAction.StayInContent
+    focusedControlZone == CalendarControlFocusZone.WeekStrip -> CalendarUpFallbackAction.FocusFilter
+    focusedControlZone == CalendarControlFocusZone.Filter -> CalendarUpFallbackAction.EnterMenu
     else -> CalendarUpFallbackAction.MoveWithinContent
 }
 
@@ -709,7 +742,10 @@ private fun CalendarList(
     onMoveUpToMenu: () -> Unit = {},
     state: org.siloserver.silo.viewmodel.CalendarUiState,
     listState: LazyListState,
-    controls: @Composable () -> Unit,
+    controls: @Composable ((CalendarControlFocusZone) -> Unit) -> Unit,
+    activeFilterFocusRequester: FocusRequester,
+    onControlFocused: () -> Unit,
+    onFocusRequestAcknowledged: () -> Unit,
     onRefresh: () -> Unit,
     onShowEverything: () -> Unit,
     selectedDayFocusRequester: FocusRequester,
@@ -722,6 +758,7 @@ private fun CalendarList(
     val snapScope = rememberCoroutineScope()
     val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
     var isReturningToControls by remember { mutableStateOf(false) }
+    var focusedControlZone by remember { mutableStateOf<CalendarControlFocusZone?>(null) }
     val firstFocusableDayIndex = state.weekDates.indexOfFirst { state.itemsFor(it).isNotEmpty() }
     val onShelfFocused: (Int) -> Unit = { index ->
         // Item zero is the filter/week control shell.
@@ -758,17 +795,26 @@ private fun CalendarList(
     // when focus is already in the controls item, mirror the shell's default
     // (moveFocus within content; false -> shell hands off to the menu bar).
     var focusedShelfIndex by remember { mutableStateOf<Int?>(null) }
+    val onCalendarControlFocused: (CalendarControlFocusZone) -> Unit = { zone ->
+        focusedControlZone = zone
+        onControlFocused()
+        onFocusRequestAcknowledged()
+    }
     val currentCalendarUpFallback = rememberUpdatedState<(Boolean) -> Boolean> { isRepeat ->
             when (calendarUpFallbackAction(
                     focusedShelfIndex = focusedShelfIndex,
                     firstFocusableShelfIndex = firstFocusableDayIndex,
                     isReturningToControls = isReturningToControls,
+                    focusedControlZone = focusedControlZone,
                     isRepeat = isRepeat,
                 )
             ) {
                 CalendarUpFallbackAction.EnterMenu -> {
                     onMoveUpToMenu()
                     true
+                }
+                CalendarUpFallbackAction.FocusFilter -> {
+                    runCatching { activeFilterFocusRequester.requestFocus() }.getOrDefault(false)
                 }
                 CalendarUpFallbackAction.ReturnToControls -> {
                     onMoveUpToControls()
@@ -811,7 +857,7 @@ private fun CalendarList(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         item(key = "calendar-controls") {
-            controls()
+            controls(onCalendarControlFocused)
         }
 
         // Keep the control item in this same LazyColumn for every data state.
@@ -862,6 +908,7 @@ private fun CalendarList(
                 onShelfFocusChanged = { focused ->
                     if (focused) {
                         focusedShelfIndex = index
+                        focusedControlZone = null
                     } else if (focusedShelfIndex == index) {
                         focusedShelfIndex = null
                     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
@@ -727,7 +727,7 @@ internal fun calendarUpFallbackAction(
         firstFocusableShelfIndex = firstFocusableShelfIndex,
         isReturningToControls = isReturningToControls,
     ) -> if (isRepeat) CalendarUpFallbackAction.StayInContent else CalendarUpFallbackAction.ReturnToControls
-    isRepeat -> CalendarUpFallbackAction.StayInContent
+    focusedShelfIndex == null && isRepeat -> CalendarUpFallbackAction.StayInContent
     focusedControlZone == CalendarControlFocusZone.WeekStrip -> CalendarUpFallbackAction.FocusFilter
     focusedControlZone == CalendarControlFocusZone.Filter -> CalendarUpFallbackAction.EnterMenu
     else -> CalendarUpFallbackAction.MoveWithinContent

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
@@ -759,6 +759,7 @@ private fun CalendarList(
     val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
     var isReturningToControls by remember { mutableStateOf(false) }
     var focusedControlZone by remember { mutableStateOf<CalendarControlFocusZone?>(null) }
+    val clearControlFocusZone: () -> Unit = { focusedControlZone = null }
     val firstFocusableDayIndex = state.weekDates.indexOfFirst { state.itemsFor(it).isNotEmpty() }
     val onShelfFocused: (Int) -> Unit = { index ->
         // Item zero is the filter/week control shell.
@@ -872,6 +873,7 @@ private fun CalendarList(
                         title = state.error ?: "Failed to load calendar",
                         subtitle = "Press the week arrows to try another week.",
                         action = CalendarAction("Refresh", onRefresh),
+                        onActionFocused = clearControlFocusZone,
                     )
                 }
             }
@@ -886,6 +888,7 @@ private fun CalendarList(
                             CalendarAction("Refresh", onRefresh)
                         },
                         topAligned = true,
+                        onActionFocused = clearControlFocusZone,
                     )
                 }
             }
@@ -908,7 +911,7 @@ private fun CalendarList(
                 onShelfFocusChanged = { focused ->
                     if (focused) {
                         focusedShelfIndex = index
-                        focusedControlZone = null
+                        clearControlFocusZone()
                     } else if (focusedShelfIndex == index) {
                         focusedShelfIndex = null
                     }
@@ -1225,6 +1228,7 @@ private fun CalendarMessage(
     subtitle: String,
     action: CalendarAction,
     topAligned: Boolean = false,
+    onActionFocused: () -> Unit,
 ) {
     Box(
         modifier = Modifier
@@ -1273,6 +1277,7 @@ private fun CalendarMessage(
                     pressedContentColor = FocusedContent,
                 ),
                 scale = ClickableSurfaceDefaults.scale(focusedScale = 1.05f),
+                modifier = Modifier.onFocusChanged { if (it.isFocused) onActionFocused() },
             ) {
                 Box(
                     modifier = Modifier

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt
@@ -18,6 +18,31 @@ internal data class ResolvedForYouFocusTarget(
     val exact: Boolean,
 )
 
+internal data class ForYouDetailReturnState(
+    val requestId: Int,
+    val pending: Boolean,
+)
+
+internal data class ForYouReturnFocusLocation(
+    val requestId: Int,
+    val rowIndex: Int,
+    val cardIndex: Int,
+    val sectionId: String,
+    val contentId: String,
+)
+
+internal enum class ForYouReturnTargetState {
+    NotAttached,
+    Attached,
+    Disposed,
+}
+
+internal enum class ForYouReturnFocusResult {
+    Focused,
+    Exhausted,
+    Disposed,
+}
+
 internal fun shouldFallbackForYouReturnToFilter(
     resolved: ResolvedForYouFocusTarget?,
 ): Boolean = resolved == null
@@ -61,6 +86,72 @@ internal fun resolveForYouReturnTarget(
     val fallbackCards = rows[fallbackRowIndex].contentIds
     if (fallbackCards.isEmpty()) return null
     return ResolvedForYouFocusTarget(fallbackRowIndex, 0, false)
+}
+
+internal fun beginForYouDetailReturn(
+    previousRequestId: Int,
+): ForYouDetailReturnState = ForYouDetailReturnState(
+    requestId = previousRequestId + 1,
+    pending = true,
+)
+
+internal fun consumeForYouDetailReturn(
+    state: ForYouDetailReturnState,
+    completedRequestId: Int,
+): ForYouDetailReturnState = if (state.pending && state.requestId == completedRequestId) {
+    state.copy(pending = false)
+} else {
+    state
+}
+
+internal fun resolvePendingForYouReturnLocation(
+    state: ForYouDetailReturnState,
+    launchTarget: ForYouFocusTarget?,
+    rows: List<ForYouFocusRow>,
+): ForYouReturnFocusLocation? {
+    if (!state.pending || launchTarget == null) return null
+    val resolved = resolveForYouReturnTarget(launchTarget, rows) ?: return null
+    val row = rows.getOrNull(resolved.rowIndex) ?: return null
+    val contentId = row.contentIds.getOrNull(resolved.cardIndex) ?: return null
+    return ForYouReturnFocusLocation(
+        requestId = state.requestId,
+        rowIndex = resolved.rowIndex,
+        cardIndex = resolved.cardIndex,
+        sectionId = row.sectionId,
+        contentId = contentId,
+    )
+}
+
+internal suspend fun requestPendingForYouReturnFocus(
+    maxAttempts: Int,
+    awaitFrame: suspend () -> Unit,
+    targetState: () -> ForYouReturnTargetState,
+    requestRowContainer: () -> FocusRequestOutcome,
+    awaitRowFrame: suspend () -> Unit,
+    requestCard: () -> FocusRequestOutcome,
+): ForYouReturnFocusResult {
+    repeat(maxAttempts) {
+        awaitFrame()
+        when (targetState()) {
+            ForYouReturnTargetState.NotAttached -> Unit
+            ForYouReturnTargetState.Disposed -> return ForYouReturnFocusResult.Disposed
+            ForYouReturnTargetState.Attached -> {
+                when (requestRowContainer()) {
+                    FocusRequestOutcome.Rejected -> Unit
+                    FocusRequestOutcome.Disposed -> return ForYouReturnFocusResult.Disposed
+                    FocusRequestOutcome.Handled -> {
+                        awaitRowFrame()
+                        when (requestCard()) {
+                            FocusRequestOutcome.Handled -> return ForYouReturnFocusResult.Focused
+                            FocusRequestOutcome.Rejected -> Unit
+                            FocusRequestOutcome.Disposed -> return ForYouReturnFocusResult.Disposed
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return ForYouReturnFocusResult.Exhausted
 }
 
 internal suspend fun requestRecommendationRowFocus(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt
@@ -1,5 +1,49 @@
 package org.siloserver.silo.tv.ui.screens.recommendations
 
+internal data class ForYouFocusTarget(
+    val sectionId: String,
+    val contentId: String,
+    val rowIndex: Int,
+    val cardIndex: Int,
+)
+
+internal data class ForYouFocusRow(
+    val sectionId: String,
+    val contentIds: List<String>,
+)
+
+internal data class ResolvedForYouFocusTarget(
+    val rowIndex: Int,
+    val cardIndex: Int,
+    val exact: Boolean,
+)
+
+internal fun resolveForYouReturnTarget(
+    target: ForYouFocusTarget,
+    rows: List<ForYouFocusRow>,
+): ResolvedForYouFocusTarget? {
+    if (rows.isEmpty()) return null
+    val stableRowIndex = rows.indexOfFirst { it.sectionId == target.sectionId }
+    if (stableRowIndex >= 0) {
+        val cards = rows[stableRowIndex].contentIds
+        if (cards.isEmpty()) return null
+        val stableCardIndex = cards.indexOf(target.contentId)
+        return if (stableCardIndex >= 0) {
+            ResolvedForYouFocusTarget(stableRowIndex, stableCardIndex, true)
+        } else {
+            ResolvedForYouFocusTarget(
+                stableRowIndex,
+                target.cardIndex.coerceIn(cards.indices),
+                false,
+            )
+        }
+    }
+    val fallbackRowIndex = target.rowIndex.coerceIn(rows.indices)
+    val fallbackCards = rows[fallbackRowIndex].contentIds
+    if (fallbackCards.isEmpty()) return null
+    return ResolvedForYouFocusTarget(fallbackRowIndex, 0, false)
+}
+
 internal suspend fun requestRecommendationRowFocus(
     requestRowContainer: () -> Boolean,
     awaitFrame: suspend () -> Unit,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt
@@ -22,6 +22,21 @@ internal fun shouldFallbackForYouReturnToFilter(
     resolved: ResolvedForYouFocusTarget?,
 ): Boolean = resolved == null
 
+internal enum class FocusRequestOutcome {
+    Handled,
+    Rejected,
+    Disposed,
+}
+
+internal fun requestFocusSafely(
+    requestFocus: () -> Boolean,
+): FocusRequestOutcome = runCatching(requestFocus).fold(
+    onSuccess = { handled ->
+        if (handled) FocusRequestOutcome.Handled else FocusRequestOutcome.Rejected
+    },
+    onFailure = { FocusRequestOutcome.Disposed },
+)
+
 internal fun resolveForYouReturnTarget(
     target: ForYouFocusTarget,
     rows: List<ForYouFocusRow>,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt
@@ -18,6 +18,10 @@ internal data class ResolvedForYouFocusTarget(
     val exact: Boolean,
 )
 
+internal fun shouldFallbackForYouReturnToFilter(
+    resolved: ResolvedForYouFocusTarget?,
+): Boolean = resolved == null
+
 internal fun resolveForYouReturnTarget(
     target: ForYouFocusTarget,
     rows: List<ForYouFocusRow>,
@@ -51,8 +55,7 @@ internal suspend fun requestRecommendationRowFocus(
 ): Boolean {
     if (!requestRowContainer()) return false
     awaitFrame()
-    requestFirstCard()
-    return true
+    return requestFirstCard()
 }
 
 internal fun shouldBridgeRecommendationsDown(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt
@@ -95,6 +95,9 @@ internal fun beginForYouDetailReturn(
     pending = true,
 )
 
+internal fun resetForExplicitForYouSelection(): ForYouDetailReturnState =
+    ForYouDetailReturnState(requestId = 0, pending = false)
+
 internal fun consumeForYouDetailReturn(
     state: ForYouDetailReturnState,
     completedRequestId: Int,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -98,6 +99,10 @@ internal suspend fun maintainForYouTopAnchor(
 @Composable
 fun TvRecommendationsScreen(
     onItemClick: (contentId: String) -> Unit,
+    onRecommendationItemClick: (contentId: String) -> Unit,
+    detailReturnFocusRequest: Int,
+    detailReturnCardFocusRequester: FocusRequester,
+    onSolidTopBarChanged: (Boolean) -> Unit,
     onInitialContentFocus: () -> Unit = {},
     focusRequest: Int = 0,
     entryRequest: TvForYouEntryRequest = TvForYouEntryRequest(),
@@ -110,6 +115,7 @@ fun TvRecommendationsScreen(
     val favoritesFocusRequester = remember { FocusRequester() }
     val firstRecommendationRowFocusRequester = remember { FocusRequester() }
     val firstRecommendationCardFocusRequester = remember { FocusRequester() }
+    val detailReturnRowFocusRequester = remember { FocusRequester() }
     val focusBridgeScope = rememberCoroutineScope()
     // rememberSaveable, not remember: opening an item disposes this screen's
     // composition, and a plain remember would re-initialise from
@@ -124,7 +130,39 @@ fun TvRecommendationsScreen(
     val recommendationsListState = rememberLazyListState()
     var savedListSelection by rememberSaveable { mutableStateOf(entryRequest.selection) }
     var lastAppliedEntrySequence by rememberSaveable { mutableIntStateOf(0) }
+    var lastFocusedSectionId by rememberSaveable { mutableStateOf("") }
+    var lastFocusedContentId by rememberSaveable { mutableStateOf("") }
+    var lastFocusedRowIndex by rememberSaveable { mutableIntStateOf(0) }
+    var lastFocusedCardIndex by rememberSaveable { mutableIntStateOf(0) }
+    val lastFocusedTarget = if (
+        lastFocusedSectionId.isNotBlank() && lastFocusedContentId.isNotBlank()
+    ) {
+        ForYouFocusTarget(
+            sectionId = lastFocusedSectionId,
+            contentId = lastFocusedContentId,
+            rowIndex = lastFocusedRowIndex,
+            cardIndex = lastFocusedCardIndex,
+        )
+    } else {
+        null
+    }
+    val returnRows = remember(visibleSections) {
+        visibleSections.map { section ->
+            ForYouFocusRow(section.id, section.items.map { it.contentId })
+        }
+    }
+    val resolvedReturnTarget = lastFocusedTarget?.let {
+        resolveForYouReturnTarget(it, returnRows)
+    }
     var firstRecommendationRowFocused by remember { mutableStateOf(false) }
+    // The first row still owns the established filter-to-feed bridge. When it
+    // is also the detail return row, use the return requester so the LazyRow
+    // has only one row-container requester attached at a time.
+    val firstRowContainerFocusRequester = if (resolvedReturnTarget?.rowIndex == 0) {
+        detailReturnRowFocusRequester
+    } else {
+        firstRecommendationRowFocusRequester
+    }
     val moveIntoRecommendations: () -> Boolean = {
         if (
             !shouldBridgeRecommendationsDown(
@@ -137,7 +175,7 @@ fun TvRecommendationsScreen(
             focusBridgeScope.launch {
                 requestRecommendationRowFocus(
                     requestRowContainer = {
-                        runCatching { firstRecommendationRowFocusRequester.requestFocus() }
+                        runCatching { firstRowContainerFocusRequester.requestFocus() }
                             .getOrDefault(false)
                     },
                     awaitFrame = { withFrameNanos { } },
@@ -149,6 +187,11 @@ fun TvRecommendationsScreen(
             }
             true
         }
+    }
+
+    DisposableEffect(savedListSelection, onSolidTopBarChanged) {
+        onSolidTopBarChanged(savedListSelection == null)
+        onDispose { onSolidTopBarChanged(false) }
     }
 
     LaunchedEffect(entryRequest.sequence) {
@@ -173,6 +216,39 @@ fun TvRecommendationsScreen(
                     runCatching { favoritesFocusRequester.requestFocus() }.getOrDefault(false)
                 },
             )
+        }
+    }
+
+    LaunchedEffect(detailReturnFocusRequest, resolvedReturnTarget) {
+        if (detailReturnFocusRequest == 0) return@LaunchedEffect
+        val target = resolvedReturnTarget
+        if (shouldFallbackForYouReturnToFilter(target)) {
+            repeat(6) {
+                withFrameNanos { }
+                val handled = runCatching { forYouFocusRequester.requestFocus() }
+                    .getOrDefault(false)
+                if (handled) return@LaunchedEffect
+            }
+            return@LaunchedEffect
+        }
+        target ?: return@LaunchedEffect
+        val rowVisible = recommendationsListState.layoutInfo.visibleItemsInfo
+            .any { it.index == target.rowIndex }
+        if (!rowVisible) recommendationsListState.scrollToItem(target.rowIndex)
+        repeat(6) {
+            withFrameNanos { }
+            val handled = requestRecommendationRowFocus(
+                requestRowContainer = {
+                    runCatching { detailReturnRowFocusRequester.requestFocus() }
+                        .getOrDefault(false)
+                },
+                awaitFrame = { withFrameNanos { } },
+                requestFirstCard = {
+                    runCatching { detailReturnCardFocusRequester.requestFocus() }
+                        .getOrDefault(false)
+                },
+            )
+            if (handled) return@LaunchedEffect
         }
     }
 
@@ -330,12 +406,33 @@ fun TvRecommendationsScreen(
                             TvMediaRow(
                                 title = section.title,
                                 items = section.items,
-                                onItemClick = onItemClick,
+                                onItemClick = { contentId ->
+                                    lastFocusedSectionId = section.id
+                                    lastFocusedContentId = contentId
+                                    lastFocusedRowIndex = index
+                                    lastFocusedCardIndex = section.items.indexOfFirst {
+                                        it.contentId == contentId
+                                    }.coerceAtLeast(0)
+                                    onRecommendationItemClick(contentId)
+                                },
                                 style = TvRowStyle.Poster,
                                 firstItemFocusRequester = firstRecommendationCardFocusRequester
                                     .takeIf { index == 0 },
-                                rowContainerFocusRequester = firstRecommendationRowFocusRequester
-                                    .takeIf { index == 0 },
+                                rowContainerFocusRequester = when {
+                                    index == resolvedReturnTarget?.rowIndex ->
+                                        detailReturnRowFocusRequester
+                                    index == 0 -> firstRecommendationRowFocusRequester
+                                    else -> null
+                                },
+                                restoreFocusIndex = resolvedReturnTarget?.cardIndex ?: -1,
+                                restoreFocusRequester = detailReturnCardFocusRequester
+                                    .takeIf { index == resolvedReturnTarget?.rowIndex },
+                                onItemFocusedAtIndex = { item, cardIndex ->
+                                    lastFocusedSectionId = section.id
+                                    lastFocusedContentId = item.contentId
+                                    lastFocusedRowIndex = index
+                                    lastFocusedCardIndex = cardIndex
+                                },
                                 onDirectionUp = if (index == 0) {
                                     {
                                         runCatching { forYouFocusRequester.requestFocus() }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -225,9 +225,11 @@ fun TvRecommendationsScreen(
         if (shouldFallbackForYouReturnToFilter(target)) {
             repeat(6) {
                 withFrameNanos { }
-                val handled = runCatching { forYouFocusRequester.requestFocus() }
-                    .getOrDefault(false)
-                if (handled) return@LaunchedEffect
+                when (requestFocusSafely { forYouFocusRequester.requestFocus() }) {
+                    FocusRequestOutcome.Handled,
+                    FocusRequestOutcome.Disposed -> return@LaunchedEffect
+                    FocusRequestOutcome.Rejected -> Unit
+                }
             }
             return@LaunchedEffect
         }
@@ -237,18 +239,26 @@ fun TvRecommendationsScreen(
         if (!rowVisible) recommendationsListState.scrollToItem(target.rowIndex)
         repeat(6) {
             withFrameNanos { }
+            var requesterDisposed = false
+            fun requestFocus(request: () -> Boolean): Boolean =
+                when (requestFocusSafely(request)) {
+                    FocusRequestOutcome.Handled -> true
+                    FocusRequestOutcome.Rejected -> false
+                    FocusRequestOutcome.Disposed -> {
+                        requesterDisposed = true
+                        false
+                    }
+                }
             val handled = requestRecommendationRowFocus(
                 requestRowContainer = {
-                    runCatching { detailReturnRowFocusRequester.requestFocus() }
-                        .getOrDefault(false)
+                    requestFocus { detailReturnRowFocusRequester.requestFocus() }
                 },
                 awaitFrame = { withFrameNanos { } },
                 requestFirstCard = {
-                    runCatching { detailReturnCardFocusRequester.requestFocus() }
-                        .getOrDefault(false)
+                    requestFocus { detailReturnCardFocusRequester.requestFocus() }
                 },
             )
-            if (handled) return@LaunchedEffect
+            if (requesterDisposed || handled) return@LaunchedEffect
         }
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,9 +60,33 @@ import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
 import org.siloserver.silo.tv.ui.util.visibleOnTv
 import org.siloserver.silo.viewmodel.RecommendationsViewModel
 import org.koin.compose.viewmodel.koinViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 private val RecommendationsFilterBandHeight = 52.dp
+
+internal data class ForYouListPosition(
+    val firstVisibleItemIndex: Int,
+    val firstVisibleItemScrollOffset: Int,
+) {
+    val isAtTop: Boolean
+        get() = firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset == 0
+}
+
+internal suspend fun maintainForYouTopAnchor(
+    positionEvents: Flow<ForYouListPosition>,
+    isFirstRowFocused: () -> Boolean,
+    awaitRelocation: suspend () -> Unit,
+    currentPosition: () -> ForYouListPosition,
+    scrollToTop: suspend () -> Unit,
+) {
+    positionEvents.collect { observed ->
+        if (!isFirstRowFocused() || observed.isAtTop) return@collect
+        awaitRelocation()
+        if (isFirstRowFocused() && !currentPosition().isAtTop) scrollToTop()
+    }
+}
 
 /**
  * "For You" tab. Reuses the shared [RecommendationsViewModel] that drives
@@ -160,18 +185,21 @@ fun TvRecommendationsScreen(
     }
 
     LaunchedEffect(firstRecommendationRowFocused) {
-        while (
-            firstRecommendationRowFocused &&
-            (recommendationsListState.firstVisibleItemIndex != 0 ||
-                recommendationsListState.firstVisibleItemScrollOffset != 0)
-        ) {
-            // Focus-driven bring-into-view can run after the focus callback.
-            // Delay before re-anchoring so that relocation finishes first,
-            // then stop once the list reaches its true top.
-            kotlinx.coroutines.delay(80)
-            if (!firstRecommendationRowFocused) break
-            runCatching { recommendationsListState.animateScrollToItem(0) }
-        }
+        if (!firstRecommendationRowFocused) return@LaunchedEffect
+        fun currentPosition() = ForYouListPosition(
+            firstVisibleItemIndex = recommendationsListState.firstVisibleItemIndex,
+            firstVisibleItemScrollOffset = recommendationsListState.firstVisibleItemScrollOffset,
+        )
+        // Stay suspended while the list is correctly anchored. A delayed
+        // focus relocation can still move it after an initially-top sample;
+        // snapshotFlow observes that later displacement without polling.
+        maintainForYouTopAnchor(
+            positionEvents = snapshotFlow { currentPosition() },
+            isFirstRowFocused = { firstRecommendationRowFocused },
+            awaitRelocation = { kotlinx.coroutines.delay(80) },
+            currentPosition = ::currentPosition,
+            scrollToTop = { recommendationsListState.animateScrollToItem(0) },
+        )
     }
 
     // The saved-list shortcuts are the stable first row in every state. Focus

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -101,7 +102,9 @@ fun TvRecommendationsScreen(
     onItemClick: (contentId: String) -> Unit,
     onRecommendationItemClick: (contentId: String) -> Unit,
     detailReturnFocusRequest: Int,
+    detailReturnFocusPending: Boolean,
     detailReturnCardFocusRequester: FocusRequester,
+    onDetailReturnFocusConsumed: (Int) -> Unit,
     onSolidTopBarChanged: (Boolean) -> Unit,
     onInitialContentFocus: () -> Unit = {},
     focusRequest: Int = 0,
@@ -130,18 +133,22 @@ fun TvRecommendationsScreen(
     val recommendationsListState = rememberLazyListState()
     var savedListSelection by rememberSaveable { mutableStateOf(entryRequest.selection) }
     var lastAppliedEntrySequence by rememberSaveable { mutableIntStateOf(0) }
-    var lastFocusedSectionId by rememberSaveable { mutableStateOf("") }
-    var lastFocusedContentId by rememberSaveable { mutableStateOf("") }
-    var lastFocusedRowIndex by rememberSaveable { mutableIntStateOf(0) }
-    var lastFocusedCardIndex by rememberSaveable { mutableIntStateOf(0) }
-    val lastFocusedTarget = if (
-        lastFocusedSectionId.isNotBlank() && lastFocusedContentId.isNotBlank()
+    // This is the card that launched the pending detail route, not a rolling
+    // "currently focused" value. Keeping the launch snapshot separate prevents
+    // the row-container hop from retargeting restoration to whichever composed
+    // card temporarily receives focus while the exact card is being prepared.
+    var detailReturnSectionId by rememberSaveable { mutableStateOf("") }
+    var detailReturnContentId by rememberSaveable { mutableStateOf("") }
+    var detailReturnRowIndex by rememberSaveable { mutableIntStateOf(0) }
+    var detailReturnCardIndex by rememberSaveable { mutableIntStateOf(0) }
+    val detailReturnLaunchTarget = if (
+        detailReturnSectionId.isNotBlank() && detailReturnContentId.isNotBlank()
     ) {
         ForYouFocusTarget(
-            sectionId = lastFocusedSectionId,
-            contentId = lastFocusedContentId,
-            rowIndex = lastFocusedRowIndex,
-            cardIndex = lastFocusedCardIndex,
+            sectionId = detailReturnSectionId,
+            contentId = detailReturnContentId,
+            rowIndex = detailReturnRowIndex,
+            cardIndex = detailReturnCardIndex,
         )
     } else {
         null
@@ -151,14 +158,23 @@ fun TvRecommendationsScreen(
             ForYouFocusRow(section.id, section.items.map { it.contentId })
         }
     }
-    val resolvedReturnTarget = lastFocusedTarget?.let {
-        resolveForYouReturnTarget(it, returnRows)
-    }
+    val detailReturnState = ForYouDetailReturnState(
+        requestId = detailReturnFocusRequest,
+        pending = detailReturnFocusPending,
+    )
+    val pendingReturnLocation = resolvePendingForYouReturnLocation(
+        state = detailReturnState,
+        launchTarget = detailReturnLaunchTarget,
+        rows = returnRows,
+    )
+    var preparedReturnLocation by remember { mutableStateOf<ForYouReturnFocusLocation?>(null) }
+    var disposedReturnLocation by remember { mutableStateOf<ForYouReturnFocusLocation?>(null) }
+    val latestOnDetailReturnFocusConsumed by rememberUpdatedState(onDetailReturnFocusConsumed)
     var firstRecommendationRowFocused by remember { mutableStateOf(false) }
     // The first row still owns the established filter-to-feed bridge. When it
     // is also the detail return row, use the return requester so the LazyRow
     // has only one row-container requester attached at a time.
-    val firstRowContainerFocusRequester = if (resolvedReturnTarget?.rowIndex == 0) {
+    val firstRowContainerFocusRequester = if (pendingReturnLocation?.rowIndex == 0) {
         detailReturnRowFocusRequester
     } else {
         firstRecommendationRowFocusRequester
@@ -194,6 +210,14 @@ fun TvRecommendationsScreen(
         onDispose { onSolidTopBarChanged(false) }
     }
 
+    DisposableEffect(detailReturnFocusRequest, detailReturnFocusPending) {
+        onDispose {
+            if (detailReturnFocusPending) {
+                latestOnDetailReturnFocusConsumed(detailReturnFocusRequest)
+            }
+        }
+    }
+
     LaunchedEffect(entryRequest.sequence) {
         val applied = applyForYouEntryRequest(
             currentSelection = savedListSelection,
@@ -219,47 +243,56 @@ fun TvRecommendationsScreen(
         }
     }
 
-    LaunchedEffect(detailReturnFocusRequest, resolvedReturnTarget) {
-        if (detailReturnFocusRequest == 0) return@LaunchedEffect
-        val target = resolvedReturnTarget
-        if (shouldFallbackForYouReturnToFilter(target)) {
+    LaunchedEffect(
+        detailReturnFocusRequest,
+        detailReturnFocusPending,
+        pendingReturnLocation,
+        state.isLoading,
+    ) {
+        if (!detailReturnFocusPending || detailReturnFocusRequest == 0 || state.isLoading) {
+            return@LaunchedEffect
+        }
+        val target = pendingReturnLocation
+        if (target == null) {
             repeat(6) {
                 withFrameNanos { }
                 when (requestFocusSafely { forYouFocusRequester.requestFocus() }) {
                     FocusRequestOutcome.Handled,
-                    FocusRequestOutcome.Disposed -> return@LaunchedEffect
+                    FocusRequestOutcome.Disposed -> {
+                        latestOnDetailReturnFocusConsumed(detailReturnFocusRequest)
+                        return@LaunchedEffect
+                    }
                     FocusRequestOutcome.Rejected -> Unit
                 }
             }
+            latestOnDetailReturnFocusConsumed(detailReturnFocusRequest)
             return@LaunchedEffect
         }
-        target ?: return@LaunchedEffect
         val rowVisible = recommendationsListState.layoutInfo.visibleItemsInfo
             .any { it.index == target.rowIndex }
         if (!rowVisible) recommendationsListState.scrollToItem(target.rowIndex)
-        repeat(6) {
-            withFrameNanos { }
-            var requesterDisposed = false
-            fun requestFocus(request: () -> Boolean): Boolean =
-                when (requestFocusSafely(request)) {
-                    FocusRequestOutcome.Handled -> true
-                    FocusRequestOutcome.Rejected -> false
-                    FocusRequestOutcome.Disposed -> {
-                        requesterDisposed = true
-                        false
-                    }
+        val result = requestPendingForYouReturnFocus(
+            maxAttempts = 6,
+            awaitFrame = { withFrameNanos { } },
+            targetState = {
+                when {
+                    disposedReturnLocation == target -> ForYouReturnTargetState.Disposed
+                    preparedReturnLocation == target -> ForYouReturnTargetState.Attached
+                    else -> ForYouReturnTargetState.NotAttached
                 }
-            val handled = requestRecommendationRowFocus(
-                requestRowContainer = {
-                    requestFocus { detailReturnRowFocusRequester.requestFocus() }
-                },
-                awaitFrame = { withFrameNanos { } },
-                requestFirstCard = {
-                    requestFocus { detailReturnCardFocusRequester.requestFocus() }
-                },
-            )
-            if (requesterDisposed || handled) return@LaunchedEffect
+            },
+            requestRowContainer = {
+                requestFocusSafely { detailReturnRowFocusRequester.requestFocus() }
+            },
+            awaitRowFrame = { withFrameNanos { } },
+            requestCard = {
+                requestFocusSafely { detailReturnCardFocusRequester.requestFocus() }
+            },
+        )
+        if (result == ForYouReturnFocusResult.Exhausted) {
+            requestFocusSafely { forYouFocusRequester.requestFocus() }
         }
+        latestOnDetailReturnFocusConsumed(detailReturnFocusRequest)
     }
 
     // Match tvOS: recommendations remain the landing content when available;
@@ -413,14 +446,16 @@ fun TvRecommendationsScreen(
                             key = { _, section -> section.id },
                             contentType = { _, _ -> "recommendation-section-row" },
                         ) { index, section ->
+                            val rowReturnLocation = pendingReturnLocation
+                                ?.takeIf { it.rowIndex == index }
                             TvMediaRow(
                                 title = section.title,
                                 items = section.items,
                                 onItemClick = { contentId ->
-                                    lastFocusedSectionId = section.id
-                                    lastFocusedContentId = contentId
-                                    lastFocusedRowIndex = index
-                                    lastFocusedCardIndex = section.items.indexOfFirst {
+                                    detailReturnSectionId = section.id
+                                    detailReturnContentId = contentId
+                                    detailReturnRowIndex = index
+                                    detailReturnCardIndex = section.items.indexOfFirst {
                                         it.contentId == contentId
                                     }.coerceAtLeast(0)
                                     onRecommendationItemClick(contentId)
@@ -429,19 +464,40 @@ fun TvRecommendationsScreen(
                                 firstItemFocusRequester = firstRecommendationCardFocusRequester
                                     .takeIf { index == 0 },
                                 rowContainerFocusRequester = when {
-                                    index == resolvedReturnTarget?.rowIndex ->
-                                        detailReturnRowFocusRequester
+                                    rowReturnLocation != null -> detailReturnRowFocusRequester
                                     index == 0 -> firstRecommendationRowFocusRequester
                                     else -> null
                                 },
-                                restoreFocusIndex = resolvedReturnTarget?.cardIndex ?: -1,
+                                restoreFocusIndex = rowReturnLocation?.cardIndex ?: -1,
                                 restoreFocusRequester = detailReturnCardFocusRequester
-                                    .takeIf { index == resolvedReturnTarget?.rowIndex },
-                                onItemFocusedAtIndex = { item, cardIndex ->
-                                    lastFocusedSectionId = section.id
-                                    lastFocusedContentId = item.contentId
-                                    lastFocusedRowIndex = index
-                                    lastFocusedCardIndex = cardIndex
+                                    .takeIf { rowReturnLocation != null },
+                                restoreFocusRequest = detailReturnFocusRequest
+                                    .takeIf {
+                                        detailReturnFocusPending && rowReturnLocation != null
+                                    } ?: 0,
+                                onRestoreFocusTargetPlaced = if (rowReturnLocation != null) {
+                                    { requestId, cardIndex ->
+                                        if (
+                                            requestId == rowReturnLocation.requestId &&
+                                            cardIndex == rowReturnLocation.cardIndex
+                                        ) {
+                                            preparedReturnLocation = rowReturnLocation
+                                        }
+                                    }
+                                } else {
+                                    null
+                                },
+                                onRestoreFocusTargetDisposed = if (rowReturnLocation != null) {
+                                    { requestId, cardIndex ->
+                                        if (
+                                            requestId == rowReturnLocation.requestId &&
+                                            cardIndex == rowReturnLocation.cardIndex
+                                        ) {
+                                            disposedReturnLocation = rowReturnLocation
+                                        }
+                                    }
+                                } else {
+                                    null
                                 },
                                 onDirectionUp = if (index == 0) {
                                     {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt
@@ -72,10 +72,16 @@ fun TvDiagnosticsSettingsScreen(
         val target = initialTvDiagnosticsCrashFocus(state.consent)
         repeat(6) {
             withFrameNanos { }
-            val focused = runCatching {
-                crashFocusRequesters.getValue(target).requestFocus()
-            }.getOrDefault(false)
-            if (focused) return@LaunchedEffect
+            when (
+                tvDiagnosticsCrashFocusRequestResult(
+                    runCatching { crashFocusRequesters.getValue(target).requestFocus() },
+                )
+            ) {
+                TvDiagnosticsCrashFocusRequestResult.FOCUSED,
+                TvDiagnosticsCrashFocusRequestResult.DISPOSED,
+                -> return@LaunchedEffect
+                TvDiagnosticsCrashFocusRequestResult.RETRY -> Unit
+            }
         }
     }
     val model = tvDiagnosticsScreenModel(state)
@@ -220,6 +226,16 @@ fun TvDiagnosticsSettingsScreen(
 internal enum class TvDiagnosticsCrashFocus { ASK, ALWAYS, NEVER, DEBUG_LOGGING }
 
 internal enum class TvDiagnosticsFocusDirection { Up, Down }
+
+internal enum class TvDiagnosticsCrashFocusRequestResult { FOCUSED, RETRY, DISPOSED }
+
+internal fun tvDiagnosticsCrashFocusRequestResult(
+    result: Result<Boolean>,
+): TvDiagnosticsCrashFocusRequestResult = when {
+    result.isFailure -> TvDiagnosticsCrashFocusRequestResult.DISPOSED
+    result.getOrDefault(false) -> TvDiagnosticsCrashFocusRequestResult.FOCUSED
+    else -> TvDiagnosticsCrashFocusRequestResult.RETRY
+}
 
 internal fun initialTvDiagnosticsCrashFocus(mode: DiagnosticsConsentMode) = when (mode) {
     DiagnosticsConsentMode.ASK -> TvDiagnosticsCrashFocus.ASK

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt
@@ -77,9 +77,7 @@ fun TvDiagnosticsSettingsScreen(
                     runCatching { crashFocusRequesters.getValue(target).requestFocus() },
                 )
             ) {
-                TvDiagnosticsCrashFocusRequestResult.FOCUSED,
-                TvDiagnosticsCrashFocusRequestResult.DISPOSED,
-                -> return@LaunchedEffect
+                TvDiagnosticsCrashFocusRequestResult.FOCUSED -> return@LaunchedEffect
                 TvDiagnosticsCrashFocusRequestResult.RETRY -> Unit
             }
         }
@@ -235,14 +233,14 @@ internal data class TvDiagnosticsCrashFocusKeyResult(
     val consume: Boolean,
 )
 
-internal enum class TvDiagnosticsCrashFocusRequestResult { FOCUSED, RETRY, DISPOSED }
+internal enum class TvDiagnosticsCrashFocusRequestResult { FOCUSED, RETRY }
 
 internal fun tvDiagnosticsCrashFocusRequestResult(
     result: Result<Boolean>,
-): TvDiagnosticsCrashFocusRequestResult = when {
-    result.isFailure -> TvDiagnosticsCrashFocusRequestResult.DISPOSED
-    result.getOrDefault(false) -> TvDiagnosticsCrashFocusRequestResult.FOCUSED
-    else -> TvDiagnosticsCrashFocusRequestResult.RETRY
+): TvDiagnosticsCrashFocusRequestResult = if (result.getOrDefault(false)) {
+    TvDiagnosticsCrashFocusRequestResult.FOCUSED
+} else {
+    TvDiagnosticsCrashFocusRequestResult.RETRY
 }
 
 internal fun initialTvDiagnosticsCrashFocus(mode: DiagnosticsConsentMode) = when (mode) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt
@@ -94,17 +94,20 @@ fun TvDiagnosticsSettingsScreen(
                     event.key == Key.DirectionDown -> TvDiagnosticsFocusDirection.Down
                     else -> null
                 }
-                val target = direction?.let {
-                    nextTvDiagnosticsCrashFocus(
+                val keyResult = direction?.let {
+                    tvDiagnosticsCrashFocusKeyResult(
                         current = current,
                         direction = it,
                         debugLoggingEnabled = state.consent != DiagnosticsConsentMode.NEVER,
+                        isRepeat = event.nativeKeyEvent.repeatCount > 0,
                     )
                 }
-                if (target == null) {
+                if (keyResult == null || !keyResult.consume) {
                     false
                 } else {
-                    runCatching { crashFocusRequesters.getValue(target).requestFocus() }
+                    keyResult.target?.let { target ->
+                        runCatching { crashFocusRequesters.getValue(target).requestFocus() }
+                    }
                     true
                 }
             }
@@ -227,6 +230,11 @@ internal enum class TvDiagnosticsCrashFocus { ASK, ALWAYS, NEVER, DEBUG_LOGGING 
 
 internal enum class TvDiagnosticsFocusDirection { Up, Down }
 
+internal data class TvDiagnosticsCrashFocusKeyResult(
+    val target: TvDiagnosticsCrashFocus?,
+    val consume: Boolean,
+)
+
 internal enum class TvDiagnosticsCrashFocusRequestResult { FOCUSED, RETRY, DISPOSED }
 
 internal fun tvDiagnosticsCrashFocusRequestResult(
@@ -261,6 +269,17 @@ internal fun nextTvDiagnosticsCrashFocus(
         TvDiagnosticsFocusDirection.Up -> order[(index - 1).coerceAtLeast(0)]
         TvDiagnosticsFocusDirection.Down -> order.getOrNull(index + 1)
     }
+}
+
+internal fun tvDiagnosticsCrashFocusKeyResult(
+    current: TvDiagnosticsCrashFocus,
+    direction: TvDiagnosticsFocusDirection,
+    debugLoggingEnabled: Boolean,
+    isRepeat: Boolean,
+): TvDiagnosticsCrashFocusKeyResult {
+    if (isRepeat) return TvDiagnosticsCrashFocusKeyResult(target = null, consume = true)
+    val target = nextTvDiagnosticsCrashFocus(current, direction, debugLoggingEnabled)
+    return TvDiagnosticsCrashFocusKeyResult(target = target, consume = target != null)
 }
 
 @Composable

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt
@@ -22,11 +22,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -59,9 +65,43 @@ fun TvDiagnosticsSettingsScreen(
         return
     }
     var confirmAlways by remember { mutableStateOf(false) }
-    val firstFocus = remember { FocusRequester() }
-    LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+    val crashFocusRequesters = remember {
+        TvDiagnosticsCrashFocus.entries.associateWith { FocusRequester() }
+    }
+    LaunchedEffect(state.consent) {
+        val target = initialTvDiagnosticsCrashFocus(state.consent)
+        repeat(6) {
+            withFrameNanos { }
+            val focused = runCatching {
+                crashFocusRequesters.getValue(target).requestFocus()
+            }.getOrDefault(false)
+            if (focused) return@LaunchedEffect
+        }
+    }
     val model = tvDiagnosticsScreenModel(state)
+    fun Modifier.crashFocusControl(current: TvDiagnosticsCrashFocus): Modifier =
+        focusRequester(crashFocusRequesters.getValue(current))
+            .onPreviewKeyEvent { event ->
+                val direction = when {
+                    event.type != KeyEventType.KeyDown -> null
+                    event.key == Key.DirectionUp -> TvDiagnosticsFocusDirection.Up
+                    event.key == Key.DirectionDown -> TvDiagnosticsFocusDirection.Down
+                    else -> null
+                }
+                val target = direction?.let {
+                    nextTvDiagnosticsCrashFocus(
+                        current = current,
+                        direction = it,
+                        debugLoggingEnabled = state.consent != DiagnosticsConsentMode.NEVER,
+                    )
+                }
+                if (target == null) {
+                    false
+                } else {
+                    runCatching { crashFocusRequesters.getValue(target).requestFocus() }
+                    true
+                }
+            }
     TvDiagnosticsPage(title = "Diagnostics") {
         LazyColumn(
             contentPadding = PaddingValues(bottom = 40.dp),
@@ -81,7 +121,7 @@ fun TvDiagnosticsSettingsScreen(
             }
             item {
                 TvDiagnosticsSection("CRASH REPORTS") {
-                    DiagnosticsConsentMode.entries.forEachIndexed { index, mode ->
+                    DiagnosticsConsentMode.entries.forEach { mode ->
                         TvDiagnosticsAction(
                             label = when (mode) {
                                 DiagnosticsConsentMode.ASK -> "Ask before sending"
@@ -96,7 +136,9 @@ fun TvDiagnosticsSettingsScreen(
                                     viewModel.setConsent(mode)
                                 }
                             },
-                            modifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier,
+                            modifier = Modifier.crashFocusControl(
+                                initialTvDiagnosticsCrashFocus(mode),
+                            ),
                         )
                     }
                     TvDiagnosticsAction(
@@ -104,6 +146,7 @@ fun TvDiagnosticsSettingsScreen(
                         value = if (state.debugLogging) "On" else "Off",
                         enabled = state.consent != DiagnosticsConsentMode.NEVER,
                         onClick = { viewModel.setDebugLogging(!state.debugLogging) },
+                        modifier = Modifier.crashFocusControl(TvDiagnosticsCrashFocus.DEBUG_LOGGING),
                     )
                 }
             }
@@ -171,6 +214,36 @@ fun TvDiagnosticsSettingsScreen(
             },
             onDismiss = { confirmAlways = false },
         )
+    }
+}
+
+internal enum class TvDiagnosticsCrashFocus { ASK, ALWAYS, NEVER, DEBUG_LOGGING }
+
+internal enum class TvDiagnosticsFocusDirection { Up, Down }
+
+internal fun initialTvDiagnosticsCrashFocus(mode: DiagnosticsConsentMode) = when (mode) {
+    DiagnosticsConsentMode.ASK -> TvDiagnosticsCrashFocus.ASK
+    DiagnosticsConsentMode.ALWAYS -> TvDiagnosticsCrashFocus.ALWAYS
+    DiagnosticsConsentMode.NEVER -> TvDiagnosticsCrashFocus.NEVER
+}
+
+internal fun tvDiagnosticsCrashFocusOrder(debugLoggingEnabled: Boolean) = buildList {
+    add(TvDiagnosticsCrashFocus.ASK)
+    add(TvDiagnosticsCrashFocus.ALWAYS)
+    add(TvDiagnosticsCrashFocus.NEVER)
+    if (debugLoggingEnabled) add(TvDiagnosticsCrashFocus.DEBUG_LOGGING)
+}
+
+internal fun nextTvDiagnosticsCrashFocus(
+    current: TvDiagnosticsCrashFocus,
+    direction: TvDiagnosticsFocusDirection,
+    debugLoggingEnabled: Boolean,
+): TvDiagnosticsCrashFocus? {
+    val order = tvDiagnosticsCrashFocusOrder(debugLoggingEnabled)
+    val index = order.indexOf(current).coerceAtLeast(0)
+    return when (direction) {
+        TvDiagnosticsFocusDirection.Up -> order[(index - 1).coerceAtLeast(0)]
+        TvDiagnosticsFocusDirection.Down -> order.getOrNull(index + 1)
     }
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusState.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusState.kt
@@ -15,6 +15,19 @@ internal fun beginHomeDetailReturnRetry(
     fallbackPending = needsRetry,
 )
 
+internal fun beginHomeDetailReturnRetryIfHome(
+    previousState: HomeDetailReturnFocusState,
+    isHomeDetailReturn: Boolean,
+    needsRetry: Boolean,
+): HomeDetailReturnFocusState = if (isHomeDetailReturn) {
+    beginHomeDetailReturnRetry(
+        previousRequestId = previousState.requestId,
+        needsRetry = needsRetry,
+    )
+} else {
+    previousState
+}
+
 internal fun completeHomeDetailReturnRetry(
     state: HomeDetailReturnFocusState,
 ): HomeDetailReturnFocusState = state.copy(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusState.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusState.kt
@@ -1,0 +1,26 @@
+package org.siloserver.silo.tv.ui.shell
+
+internal data class HomeDetailReturnFocusState(
+    val requestId: Int = 0,
+    val needsRetry: Boolean = false,
+    val fallbackPending: Boolean = false,
+)
+
+internal fun beginHomeDetailReturnRetry(
+    previousRequestId: Int,
+    needsRetry: Boolean,
+): HomeDetailReturnFocusState = HomeDetailReturnFocusState(
+    requestId = previousRequestId + 1,
+    needsRetry = needsRetry,
+    fallbackPending = needsRetry,
+)
+
+internal fun completeHomeDetailReturnRetry(
+    state: HomeDetailReturnFocusState,
+): HomeDetailReturnFocusState = state.copy(
+    needsRetry = false,
+    fallbackPending = false,
+)
+
+internal fun resetHomeDetailReturnFocus(): HomeDetailReturnFocusState =
+    HomeDetailReturnFocusState()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -343,6 +343,8 @@ fun TvMainShell(
     var restoreForYouContentAfterDetail by rememberSaveable { mutableStateOf(false) }
     var suppressHomeRefreshAfterDetail by rememberSaveable { mutableStateOf(false) }
     var homeDetailReturnFocusState by remember { mutableStateOf(HomeDetailReturnFocusState()) }
+    var detailReturnFocusRequest by remember { mutableIntStateOf(0) }
+    var detailReturnNeedsRetry by remember { mutableStateOf(false) }
     var forYouDetailReturnFocusRequest by rememberSaveable { mutableIntStateOf(0) }
     var forYouDetailReturnFocusPending by rememberSaveable { mutableStateOf(false) }
     // Attached (by the Home feed) to the exact card a detail page was launched
@@ -368,19 +370,22 @@ fun TvMainShell(
     var contentHasFocus by remember { mutableStateOf(false) }
     LifecycleResumeEffect(Unit) {
         if (restoreContentAfterDetail) {
+            val isHomeDetailReturn = restoreHomeContentAfterDetail
             // Claim the content group synchronously during ON_RESUME, before
             // Compose's default search can briefly settle on the Home tab —
             // but only when the feed hasn't already claimed it. Claim BEFORE
             // clearing the flag so the restorer fallback still points at the
             // launch card for this claim.
-            val homeDetailReturnNeedsRetry = if (contentHasFocus) {
+            detailReturnNeedsRetry = if (contentHasFocus) {
                 false
             } else {
                 runCatching { !contentFocusRequester.requestFocus() }.getOrDefault(true)
             }
-            homeDetailReturnFocusState = beginHomeDetailReturnRetry(
-                previousRequestId = homeDetailReturnFocusState.requestId,
-                needsRetry = homeDetailReturnNeedsRetry,
+            detailReturnFocusRequest++
+            homeDetailReturnFocusState = beginHomeDetailReturnRetryIfHome(
+                previousState = homeDetailReturnFocusState,
+                isHomeDetailReturn = isHomeDetailReturn,
+                needsRetry = detailReturnNeedsRetry,
             )
             restoreContentAfterDetail = false
             restoreHomeContentAfterDetail = false
@@ -393,12 +398,12 @@ fun TvMainShell(
         }
         onPauseOrDispose { }
     }
-    LaunchedEffect(homeDetailReturnFocusState.requestId) {
-        if (homeDetailReturnFocusState.requestId == 0) return@LaunchedEffect
+    LaunchedEffect(detailReturnFocusRequest) {
+        if (detailReturnFocusRequest == 0) return@LaunchedEffect
         // One-frame fallback for the disposed/recreated case where the Home row
         // requester was not attached during the synchronous resume claim.
         withFrameNanos { }
-        if (homeDetailReturnFocusState.needsRetry) {
+        if (detailReturnNeedsRetry) {
             runCatching { contentFocusRequester.requestFocus() }
         }
         homeDetailReturnFocusState = completeHomeDetailReturnRetry(homeDetailReturnFocusState)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -156,6 +156,7 @@ import org.siloserver.silo.tv.ui.screens.recommendations.TvForYouEntryRequest
 import org.siloserver.silo.tv.ui.screens.recommendations.ForYouDetailReturnState
 import org.siloserver.silo.tv.ui.screens.recommendations.beginForYouDetailReturn
 import org.siloserver.silo.tv.ui.screens.recommendations.consumeForYouDetailReturn
+import org.siloserver.silo.tv.ui.screens.recommendations.resetForExplicitForYouSelection
 import org.siloserver.silo.tv.ui.screens.requests.TvMyRequestsScreen
 import org.siloserver.silo.tv.ui.screens.requests.TvRequestDetailScreen
 import org.siloserver.silo.tv.ui.screens.requests.TvRequestsScreen
@@ -612,6 +613,9 @@ fun TvMainShell(
     val onSelectRoot: (TvRootDestination) -> Unit = { dest ->
         val route = dest.toRoute()
         if (dest == TvRootDestination.ForYou) {
+            val reset = resetForExplicitForYouSelection()
+            forYouDetailReturnFocusRequest = reset.requestId
+            forYouDetailReturnFocusPending = reset.pending
             forYouEntryRequest = forYouEntryRequest.nextForTopLevelForYou()
         }
         if (dest == TvRootDestination.Home) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -342,10 +342,9 @@ fun TvMainShell(
     var restoreHomeContentAfterDetail by rememberSaveable { mutableStateOf(false) }
     var restoreForYouContentAfterDetail by rememberSaveable { mutableStateOf(false) }
     var suppressHomeRefreshAfterDetail by rememberSaveable { mutableStateOf(false) }
-    var homeDetailReturnFocusRequest by remember { mutableIntStateOf(0) }
+    var homeDetailReturnFocusState by remember { mutableStateOf(HomeDetailReturnFocusState()) }
     var forYouDetailReturnFocusRequest by rememberSaveable { mutableIntStateOf(0) }
     var forYouDetailReturnFocusPending by rememberSaveable { mutableStateOf(false) }
-    var homeDetailReturnNeedsRetry by remember { mutableStateOf(false) }
     // Attached (by the Home feed) to the exact card a detail page was launched
     // from, while that return is pending. Used as the content restorer's enter
     // fallback during the return resume so the synchronous claim below lands
@@ -355,7 +354,8 @@ fun TvMainShell(
     val homeDetailReturnCardFocusRequester = remember { FocusRequester() }
     val forYouDetailReturnCardFocusRequester = remember { FocusRequester() }
     val detailReturnFallback = when {
-        restoreHomeContentAfterDetail -> homeDetailReturnCardFocusRequester
+        restoreHomeContentAfterDetail || homeDetailReturnFocusState.fallbackPending ->
+            homeDetailReturnCardFocusRequester
         restoreForYouContentAfterDetail || forYouDetailReturnFocusPending ->
             forYouDetailReturnCardFocusRequester
         else -> FocusRequester.Default
@@ -373,11 +373,15 @@ fun TvMainShell(
             // but only when the feed hasn't already claimed it. Claim BEFORE
             // clearing the flag so the restorer fallback still points at the
             // launch card for this claim.
-            homeDetailReturnNeedsRetry = if (contentHasFocus) {
+            val homeDetailReturnNeedsRetry = if (contentHasFocus) {
                 false
             } else {
                 runCatching { !contentFocusRequester.requestFocus() }.getOrDefault(true)
             }
+            homeDetailReturnFocusState = beginHomeDetailReturnRetry(
+                previousRequestId = homeDetailReturnFocusState.requestId,
+                needsRetry = homeDetailReturnNeedsRetry,
+            )
             restoreContentAfterDetail = false
             restoreHomeContentAfterDetail = false
             if (restoreForYouContentAfterDetail) {
@@ -386,18 +390,18 @@ fun TvMainShell(
                 forYouDetailReturnFocusPending = started.pending
             }
             restoreForYouContentAfterDetail = false
-            homeDetailReturnFocusRequest++
         }
         onPauseOrDispose { }
     }
-    LaunchedEffect(homeDetailReturnFocusRequest) {
-        if (homeDetailReturnFocusRequest == 0) return@LaunchedEffect
+    LaunchedEffect(homeDetailReturnFocusState.requestId) {
+        if (homeDetailReturnFocusState.requestId == 0) return@LaunchedEffect
         // One-frame fallback for the disposed/recreated case where the Home row
         // requester was not attached during the synchronous resume claim.
         withFrameNanos { }
-        if (homeDetailReturnNeedsRetry) {
+        if (homeDetailReturnFocusState.needsRetry) {
             runCatching { contentFocusRequester.requestFocus() }
         }
+        homeDetailReturnFocusState = completeHomeDetailReturnRetry(homeDetailReturnFocusState)
         // The detail-return ON_RESUME event has now passed and Home is stable;
         // future real resumes (playback/background) should refresh normally.
         suppressHomeRefreshAfterDetail = false
@@ -611,8 +615,7 @@ fun TvMainShell(
             // explicitly selects Home from the bar. Otherwise its nonzero
             // token keeps suppressing Home's normal first-card focus request
             // for the rest of the shell session.
-            homeDetailReturnFocusRequest = 0
-            homeDetailReturnNeedsRetry = false
+            homeDetailReturnFocusState = resetHomeDetailReturnFocus()
         }
         if (dest == TvRootDestination.Calendar) {
             calendarFocusHandoffPending = true
@@ -941,7 +944,7 @@ fun TvMainShell(
                         },
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                         focusRequest = contentFocusRequest,
-                        detailReturnFocusRequest = homeDetailReturnFocusRequest,
+                        detailReturnFocusRequest = homeDetailReturnFocusState.requestId,
                         detailReturnCardFocusRequester = homeDetailReturnCardFocusRequester,
                         firstRowFocusRequester = homeFirstItemFocusRequester,
                         firstRowContainerFocusRequester = homeFirstRowContainerFocusRequester,
@@ -962,7 +965,7 @@ fun TvMainShell(
                         },
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                         focusRequest = contentFocusRequest,
-                        detailReturnFocusRequest = homeDetailReturnFocusRequest,
+                        detailReturnFocusRequest = homeDetailReturnFocusState.requestId,
                         detailReturnCardFocusRequester = homeDetailReturnCardFocusRequester,
                         firstRowFocusRequester = homeFirstItemFocusRequester,
                         firstRowContainerFocusRequester = homeFirstRowContainerFocusRequester,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -153,6 +153,9 @@ import org.siloserver.silo.tv.ui.screens.personal.TvWatchlistScreen
 import org.siloserver.silo.tv.ui.screens.recommendations.TvRecommendationsScreen
 import org.siloserver.silo.tv.ui.screens.recommendations.SavedListSelection
 import org.siloserver.silo.tv.ui.screens.recommendations.TvForYouEntryRequest
+import org.siloserver.silo.tv.ui.screens.recommendations.ForYouDetailReturnState
+import org.siloserver.silo.tv.ui.screens.recommendations.beginForYouDetailReturn
+import org.siloserver.silo.tv.ui.screens.recommendations.consumeForYouDetailReturn
 import org.siloserver.silo.tv.ui.screens.requests.TvMyRequestsScreen
 import org.siloserver.silo.tv.ui.screens.requests.TvRequestDetailScreen
 import org.siloserver.silo.tv.ui.screens.requests.TvRequestsScreen
@@ -340,7 +343,8 @@ fun TvMainShell(
     var restoreForYouContentAfterDetail by rememberSaveable { mutableStateOf(false) }
     var suppressHomeRefreshAfterDetail by rememberSaveable { mutableStateOf(false) }
     var homeDetailReturnFocusRequest by remember { mutableIntStateOf(0) }
-    var forYouDetailReturnFocusRequest by remember { mutableIntStateOf(0) }
+    var forYouDetailReturnFocusRequest by rememberSaveable { mutableIntStateOf(0) }
+    var forYouDetailReturnFocusPending by rememberSaveable { mutableStateOf(false) }
     var homeDetailReturnNeedsRetry by remember { mutableStateOf(false) }
     // Attached (by the Home feed) to the exact card a detail page was launched
     // from, while that return is pending. Used as the content restorer's enter
@@ -352,7 +356,8 @@ fun TvMainShell(
     val forYouDetailReturnCardFocusRequester = remember { FocusRequester() }
     val detailReturnFallback = when {
         restoreHomeContentAfterDetail -> homeDetailReturnCardFocusRequester
-        restoreForYouContentAfterDetail -> forYouDetailReturnCardFocusRequester
+        restoreForYouContentAfterDetail || forYouDetailReturnFocusPending ->
+            forYouDetailReturnCardFocusRequester
         else -> FocusRequester.Default
     }
     // Whether focus currently sits anywhere inside the content group. Gates
@@ -376,7 +381,9 @@ fun TvMainShell(
             restoreContentAfterDetail = false
             restoreHomeContentAfterDetail = false
             if (restoreForYouContentAfterDetail) {
-                forYouDetailReturnFocusRequest++
+                val started = beginForYouDetailReturn(forYouDetailReturnFocusRequest)
+                forYouDetailReturnFocusRequest = started.requestId
+                forYouDetailReturnFocusPending = started.pending
             }
             restoreForYouContentAfterDetail = false
             homeDetailReturnFocusRequest++
@@ -402,6 +409,7 @@ fun TvMainShell(
         onOpenItemDetail(contentId)
     }
     val openForYouItemDetail: (String) -> Unit = { contentId ->
+        forYouDetailReturnFocusPending = false
         restoreContentAfterDetail = true
         restoreForYouContentAfterDetail = true
         onOpenItemDetail(contentId)
@@ -1062,7 +1070,18 @@ fun TvMainShell(
                         onItemClick = openContentItemDetail,
                         onRecommendationItemClick = openForYouItemDetail,
                         detailReturnFocusRequest = forYouDetailReturnFocusRequest,
+                        detailReturnFocusPending = forYouDetailReturnFocusPending,
                         detailReturnCardFocusRequester = forYouDetailReturnCardFocusRequester,
+                        onDetailReturnFocusConsumed = { completedRequestId ->
+                            val consumed = consumeForYouDetailReturn(
+                                state = ForYouDetailReturnState(
+                                    requestId = forYouDetailReturnFocusRequest,
+                                    pending = forYouDetailReturnFocusPending,
+                                ),
+                                completedRequestId = completedRequestId,
+                            )
+                            forYouDetailReturnFocusPending = consumed.pending
+                        },
                         onSolidTopBarChanged = onForYouSolidTopBarChanged,
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                         focusRequest = contentFocusRequest,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -296,6 +296,12 @@ fun TvMainShell(
     val activeLibrary: (TvLibraryTabType) -> UserLibrary? = { type -> resolvedLibraries[type] }
 
     val currentRoute = currentEntry?.destination?.route ?: firstTvRoute()
+    var forYouRequestsSolidTopBar by remember { mutableStateOf(false) }
+    val onForYouSolidTopBarChanged = remember {
+        { requested: Boolean -> forYouRequestsSolidTopBar = requested }
+    }
+    val useSolidForYouTopBar =
+        currentRoute == TvMainRoute.ForYou.route && forYouRequestsSolidTopBar
     var calendarFocusHandoffPending by remember(currentRoute) {
         mutableStateOf(currentRoute == TvMainRoute.Calendar.route)
     }
@@ -323,18 +329,18 @@ fun TvMainShell(
     // Opening an outer item-detail route pauses/removes this shell. Remember the
     // pending hand-back in the Main back-stack entry so it survives either form,
     // then re-enter the existing content focusRestorer when Main resumes.
-    // Two flags, deliberately. `restoreContentAfterDetail` says a detail return
-    // is pending for ANY root, and gates the resume claim below so focus lands
-    // back inside content instead of Compose's default search picking the top
-    // bar. `restoreHomeContentAfterDetail` additionally says it was the Home
-    // feed, which is the only root that attaches
-    // homeDetailReturnCardFocusRequester to its launch card — using that
-    // requester as the restorer fallback for a root that never attached it
-    // would point the restorer at a detached node.
+    // `restoreContentAfterDetail` says a detail return is pending for ANY root
+    // and gates the resume claim below so focus lands back inside content
+    // instead of Compose's default search picking the top bar. The Home and
+    // For You flags select their route-specific launch-card requesters; using
+    // either requester for a root that never attached it would point the
+    // restorer at a detached node.
     var restoreContentAfterDetail by rememberSaveable { mutableStateOf(false) }
     var restoreHomeContentAfterDetail by rememberSaveable { mutableStateOf(false) }
+    var restoreForYouContentAfterDetail by rememberSaveable { mutableStateOf(false) }
     var suppressHomeRefreshAfterDetail by rememberSaveable { mutableStateOf(false) }
     var homeDetailReturnFocusRequest by remember { mutableIntStateOf(0) }
+    var forYouDetailReturnFocusRequest by remember { mutableIntStateOf(0) }
     var homeDetailReturnNeedsRetry by remember { mutableStateOf(false) }
     // Attached (by the Home feed) to the exact card a detail page was launched
     // from, while that return is pending. Used as the content restorer's enter
@@ -343,6 +349,12 @@ fun TvMainShell(
     // survive the shell being removed for the outer detail route, and its
     // default enter could land a row below the launch card for a few frames.
     val homeDetailReturnCardFocusRequester = remember { FocusRequester() }
+    val forYouDetailReturnCardFocusRequester = remember { FocusRequester() }
+    val detailReturnFallback = when {
+        restoreHomeContentAfterDetail -> homeDetailReturnCardFocusRequester
+        restoreForYouContentAfterDetail -> forYouDetailReturnCardFocusRequester
+        else -> FocusRequester.Default
+    }
     // Whether focus currently sits anywhere inside the content group. Gates
     // the detail-return resume claim below: the Home feed's early restore
     // ladder usually re-focuses the launch card during the pop transition, and
@@ -363,6 +375,10 @@ fun TvMainShell(
             }
             restoreContentAfterDetail = false
             restoreHomeContentAfterDetail = false
+            if (restoreForYouContentAfterDetail) {
+                forYouDetailReturnFocusRequest++
+            }
+            restoreForYouContentAfterDetail = false
             homeDetailReturnFocusRequest++
         }
         onPauseOrDispose { }
@@ -385,8 +401,13 @@ fun TvMainShell(
         suppressHomeRefreshAfterDetail = true
         onOpenItemDetail(contentId)
     }
-    // Same hand-back for roots that render inside the shell but do not attach a
-    // launch-card requester (For You). Without this the shell never claims
+    val openForYouItemDetail: (String) -> Unit = { contentId ->
+        restoreContentAfterDetail = true
+        restoreForYouContentAfterDetail = true
+        onOpenItemDetail(contentId)
+    }
+    // Same generic hand-back for roots that render inside the shell but do not
+    // attach a launch-card requester. Without this the shell never claims
     // content focus on the return resume, so focus settles wherever Compose's
     // default search lands — in practice the top bar — and the D-pad no longer
     // drives the rows the viewer was just in.
@@ -828,15 +849,9 @@ fun TvMainShell(
                 .onFocusChanged { contentHasFocus = it.hasFocus }
                 .focusRequester(contentFocusRequester)
                 // During a detail-return resume the restorer's saved child is
-                // gone (the shell left composition), so fall back to the Home
-                // feed's launch-card requester; Default otherwise.
-                .focusRestorer(
-                    if (restoreHomeContentAfterDetail) {
-                        homeDetailReturnCardFocusRequester
-                    } else {
-                        FocusRequester.Default
-                    },
-                )
+                // gone (the shell left composition), so fall back to the
+                // active feed's launch-card requester; Default otherwise.
+                .focusRestorer(detailReturnFallback)
                 // Block any GEOMETRIC focus escape upward out of the content
                 // group. Without this, moveFocus(Up) from the top content row
                 // does a 2D search into the sibling top bar and lands on the
@@ -1045,6 +1060,10 @@ fun TvMainShell(
                 shellComposable(TvMainRoute.ForYou.route) {
                     TvRecommendationsScreen(
                         onItemClick = openContentItemDetail,
+                        onRecommendationItemClick = openForYouItemDetail,
+                        detailReturnFocusRequest = forYouDetailReturnFocusRequest,
+                        detailReturnCardFocusRequester = forYouDetailReturnCardFocusRequester,
+                        onSolidTopBarChanged = onForYouSolidTopBarChanged,
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                         focusRequest = contentFocusRequest,
                         entryRequest = forYouEntryRequest,
@@ -1207,23 +1226,29 @@ fun TvMainShell(
         // The bar deliberately has no background band of its own ("the SHELL
         // draws a fixed top scrim behind the bar", QA 2026-07-08); without it
         // the labels sat directly on whatever scrolled underneath, which on
-        // For You is a poster row and is unreadable. A gradient rather than a
-        // solid band keeps the tvOS look this shell asks for — content stays
-        // visible behind the bar, just no longer competing with the labels.
+        // For You is a poster row and is unreadable. Recommendation rows ask
+        // for the opaque treatment; saved lists and every other route retain
+        // the gradient so content remains visible behind the bar.
         if (currentRoute != TvMainRoute.Settings.route) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(TvTopMenuLayout.contentTopInset)
                     .align(Alignment.TopCenter)
-                    .background(
-                        Brush.verticalGradient(
-                            listOf(
-                                MaterialTheme.colorScheme.background.copy(alpha = 0.92f),
-                                MaterialTheme.colorScheme.background.copy(alpha = 0.72f),
-                                MaterialTheme.colorScheme.background.copy(alpha = 0f),
-                            ),
-                        ),
+                    .then(
+                        if (useSolidForYouTopBar) {
+                            Modifier.background(MaterialTheme.colorScheme.background)
+                        } else {
+                            Modifier.background(
+                                Brush.verticalGradient(
+                                    listOf(
+                                        MaterialTheme.colorScheme.background.copy(alpha = 0.92f),
+                                        MaterialTheme.colorScheme.background.copy(alpha = 0.72f),
+                                        MaterialTheme.colorScheme.background.copy(alpha = 0f),
+                                    ),
+                                ),
+                            )
+                        }
                     ),
             )
         }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRowFocusRestoreTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRowFocusRestoreTest.kt
@@ -1,0 +1,39 @@
+package org.siloserver.silo.tv.ui.components
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvMediaRowFocusRestoreTest {
+    @Test
+    fun pendingOffscreenReturnScrollsToResolvedCardIndex() = runTest {
+        var scrolledTo: Int? = null
+
+        val prepared = prepareTvMediaRowFocusRestore(
+            requestId = 3,
+            restoreFocusIndex = 8,
+            itemCount = 10,
+            scrollToItem = { scrolledTo = it },
+        )
+
+        assertTrue(prepared)
+        assertEquals(8, scrolledTo)
+    }
+
+    @Test
+    fun ordinaryRowRenderingPreservesHorizontalPosition() = runTest {
+        var scrollCalls = 0
+
+        val prepared = prepareTvMediaRowFocusRestore(
+            requestId = 0,
+            restoreFocusIndex = 8,
+            itemCount = 10,
+            scrollToItem = { scrollCalls++ },
+        )
+
+        assertFalse(prepared)
+        assertEquals(0, scrollCalls)
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
@@ -58,4 +58,18 @@ class TvCalendarFocusRoutingTest {
             ),
         )
     }
+
+    @Test
+    fun heldUpBelowFirstShelfContinuesContentMovement() {
+        assertEquals(
+            CalendarUpFallbackAction.MoveWithinContent,
+            calendarUpFallbackAction(
+                focusedShelfIndex = 4,
+                firstFocusableShelfIndex = 2,
+                isReturningToControls = false,
+                focusedControlZone = null,
+                isRepeat = true,
+            ),
+        )
+    }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
@@ -17,19 +17,10 @@ class TvCalendarFocusRoutingTest {
     }
 
     @Test
-    fun controlsUseNormalUpMovement() {
-        assertFalse(shouldReturnCalendarFocusToControls(null, 2, false))
-    }
-
-    @Test
-    fun controlsReturnToShellMenuTarget() {
+    fun weekStripMovesUpToActiveFilter() {
         assertEquals(
-            CalendarUpFallbackAction.EnterMenu,
-            calendarUpFallbackAction(
-                focusedShelfIndex = null,
-                firstFocusableShelfIndex = 2,
-                isReturningToControls = false,
-            ),
+            CalendarUpFallbackAction.FocusFilter,
+            calendarUpFallbackAction(null, 0, false, CalendarControlFocusZone.WeekStrip),
         )
     }
 
@@ -39,13 +30,22 @@ class TvCalendarFocusRoutingTest {
     }
 
     @Test
-    fun heldUpOnCalendarControlsStaysInContent() {
+    fun filterMovesUpToCalendarMenuTab() {
+        assertEquals(
+            CalendarUpFallbackAction.EnterMenu,
+            calendarUpFallbackAction(null, 0, false, CalendarControlFocusZone.Filter),
+        )
+    }
+
+    @Test
+    fun heldUpOnControlsDoesNotSkipALayer() {
         assertEquals(
             CalendarUpFallbackAction.StayInContent,
             calendarUpFallbackAction(
-                focusedShelfIndex = null,
-                firstFocusableShelfIndex = 2,
-                isReturningToControls = false,
+                null,
+                0,
+                false,
+                CalendarControlFocusZone.WeekStrip,
                 isRepeat = true,
             ),
         )

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
@@ -38,6 +38,14 @@ class TvCalendarFocusRoutingTest {
     }
 
     @Test
+    fun nullControlZoneUsesNormalContentMovement() {
+        assertEquals(
+            CalendarUpFallbackAction.MoveWithinContent,
+            calendarUpFallbackAction(null, 0, false, null),
+        )
+    }
+
+    @Test
     fun heldUpOnControlsDoesNotSkipALayer() {
         assertEquals(
             CalendarUpFallbackAction.StayInContent,

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
@@ -1,9 +1,11 @@
 package org.siloserver.silo.tv.ui.screens.recommendations
 
 import kotlinx.coroutines.test.runTest
+import org.siloserver.silo.tv.ui.components.prepareTvMediaRowFocusRestore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class TvRecommendationsFocusBridgeTest {
@@ -140,5 +142,144 @@ class TvRecommendationsFocusBridgeTest {
                 hasVisibleRecommendations = false,
             ),
         )
+    }
+
+    @Test
+    fun successfulReturnIsConsumedUntilANewDetailReturnBegins() {
+        val pending = beginForYouDetailReturn(previousRequestId = 4)
+        val rows = listOf(
+            ForYouFocusRow("because-you-watched", listOf("movie-a", "movie-b")),
+        )
+
+        assertEquals(
+            ForYouReturnFocusLocation(
+                requestId = 5,
+                rowIndex = 0,
+                cardIndex = 1,
+                sectionId = "because-you-watched",
+                contentId = "movie-b",
+            ),
+            resolvePendingForYouReturnLocation(pending, target, rows),
+        )
+
+        val consumed = consumeForYouDetailReturn(pending, completedRequestId = 5)
+        assertFalse(consumed.pending)
+        val ordinaryFocusTarget = ForYouFocusTarget("trending", "movie-z", 1, 0)
+        val refreshedRows = listOf(
+            ForYouFocusRow("inserted", listOf("movie-new")),
+            ForYouFocusRow("trending", listOf("movie-z")),
+            rows.single(),
+        )
+        assertNull(
+            resolvePendingForYouReturnLocation(
+                consumed,
+                ordinaryFocusTarget,
+                refreshedRows,
+            ),
+        )
+        assertEquals(consumed, consumeForYouDetailReturn(consumed, completedRequestId = 5))
+
+        val nextReturn = beginForYouDetailReturn(previousRequestId = consumed.requestId)
+        assertTrue(nextReturn.pending)
+        assertEquals(6, nextReturn.requestId)
+    }
+
+    @Test
+    fun staleCompletionCannotConsumeANewerReturn() {
+        val newer = beginForYouDetailReturn(previousRequestId = 8)
+
+        assertEquals(
+            newer,
+            consumeForYouDetailReturn(newer, completedRequestId = 8),
+        )
+    }
+
+    @Test
+    fun offscreenReorderedTargetWaitsForAttachmentThenFocuses() = runTest {
+        val reorderedRows = listOf(
+            ForYouFocusRow(
+                "because-you-watched",
+                listOf(
+                    "movie-a",
+                    "movie-c",
+                    "movie-d",
+                    "movie-e",
+                    "movie-f",
+                    "movie-g",
+                    "movie-h",
+                    "movie-i",
+                    "movie-b",
+                ),
+            ),
+        )
+        val location = resolvePendingForYouReturnLocation(
+            beginForYouDetailReturn(previousRequestId = 0),
+            target,
+            reorderedRows,
+        )
+        assertEquals(8, location?.cardIndex)
+
+        val events = mutableListOf<String>()
+        val prepared = prepareTvMediaRowFocusRestore(
+            requestId = location?.requestId ?: 0,
+            restoreFocusIndex = location?.cardIndex ?: -1,
+            itemCount = reorderedRows.single().contentIds.size,
+            scrollToItem = { index -> events += "scroll:$index" },
+        )
+        assertTrue(prepared)
+
+        var frames = 0
+        var rowRequests = 0
+        var cardRequests = 0
+        val result = requestPendingForYouReturnFocus(
+            maxAttempts = 6,
+            awaitFrame = { frames++ },
+            targetState = {
+                if (frames < 3) ForYouReturnTargetState.NotAttached
+                else ForYouReturnTargetState.Attached
+            },
+            requestRowContainer = {
+                rowRequests++
+                events += "row"
+                FocusRequestOutcome.Handled
+            },
+            awaitRowFrame = { events += "row-frame" },
+            requestCard = {
+                cardRequests++
+                events += "card"
+                FocusRequestOutcome.Handled
+            },
+        )
+
+        assertEquals(ForYouReturnFocusResult.Focused, result)
+        assertEquals(3, frames)
+        assertEquals(1, rowRequests)
+        assertEquals(1, cardRequests)
+        assertEquals(listOf("scroll:8", "row", "row-frame", "card"), events)
+    }
+
+    @Test
+    fun genuineTargetDisposalStopsBoundedRetries() = runTest {
+        var frames = 0
+        var focusRequests = 0
+
+        val result = requestPendingForYouReturnFocus(
+            maxAttempts = 6,
+            awaitFrame = { frames++ },
+            targetState = { ForYouReturnTargetState.Disposed },
+            requestRowContainer = {
+                focusRequests++
+                FocusRequestOutcome.Handled
+            },
+            awaitRowFrame = {},
+            requestCard = {
+                focusRequests++
+                FocusRequestOutcome.Handled
+            },
+        )
+
+        assertEquals(ForYouReturnFocusResult.Disposed, result)
+        assertEquals(1, frames)
+        assertEquals(0, focusRequests)
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
@@ -195,6 +195,14 @@ class TvRecommendationsFocusBridgeTest {
     }
 
     @Test
+    fun explicitForYouSelectionClearsStaleReturnState() {
+        assertEquals(
+            ForYouDetailReturnState(requestId = 0, pending = false),
+            resetForExplicitForYouSelection(),
+        )
+    }
+
+    @Test
     fun offscreenReorderedTargetWaitsForAttachmentThenFocuses() = runTest {
         val reorderedRows = listOf(
             ForYouFocusRow(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
@@ -8,6 +8,49 @@ import kotlin.test.assertTrue
 
 class TvRecommendationsFocusBridgeTest {
 
+    private val target = ForYouFocusTarget("because-you-watched", "movie-b", 1, 2)
+
+    @Test
+    fun exactReturnTargetUsesStableIdsAfterReorder() {
+        val resolved = resolveForYouReturnTarget(
+            target,
+            listOf(
+                ForYouFocusRow("because-you-watched", listOf("movie-c", "movie-b", "movie-a")),
+                ForYouFocusRow("trending", listOf("movie-d")),
+            ),
+        )
+
+        assertEquals(ResolvedForYouFocusTarget(0, 1, true), resolved)
+    }
+
+    @Test
+    fun missingCardUsesClosestIndexInSameSection() {
+        val resolved = resolveForYouReturnTarget(
+            target,
+            listOf(ForYouFocusRow("because-you-watched", listOf("movie-a", "movie-c"))),
+        )
+
+        assertEquals(ResolvedForYouFocusTarget(0, 1, false), resolved)
+    }
+
+    @Test
+    fun missingSectionUsesClosestRowFirstCard() {
+        val resolved = resolveForYouReturnTarget(
+            target,
+            listOf(
+                ForYouFocusRow("row-a", listOf("a")),
+                ForYouFocusRow("row-b", listOf("b")),
+            ),
+        )
+
+        assertEquals(ResolvedForYouFocusTarget(1, 0, false), resolved)
+    }
+
+    @Test
+    fun emptyFeedHasNoCardReturnTarget() {
+        assertEquals(null, resolveForYouReturnTarget(target, emptyList()))
+    }
+
     @Test
     fun handoffCrossesRowRestorerBeforeTargetingFirstCard() = runTest {
         val events = mutableListOf<String>()

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
@@ -52,6 +52,16 @@ class TvRecommendationsFocusBridgeTest {
     }
 
     @Test
+    fun emptyFeedFallsBackToForYouFilter() {
+        assertTrue(shouldFallbackForYouReturnToFilter(resolveForYouReturnTarget(target, emptyList())))
+        assertFalse(
+            shouldFallbackForYouReturnToFilter(
+                ResolvedForYouFocusTarget(rowIndex = 0, cardIndex = 0, exact = true),
+            ),
+        )
+    }
+
+    @Test
     fun handoffCrossesRowRestorerBeforeTargetingFirstCard() = runTest {
         val events = mutableListOf<String>()
 
@@ -77,6 +87,16 @@ class TvRecommendationsFocusBridgeTest {
 
         assertFalse(handled)
         assertEquals(listOf("row"), events)
+    }
+
+    @Test
+    fun rejectedCardRequestCanBeRetried() = runTest {
+        val handled = requestRecommendationRowFocus(
+            requestRowContainer = { true },
+            awaitFrame = {},
+            requestFirstCard = { false },
+        )
+        assertFalse(handled)
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
@@ -100,6 +100,19 @@ class TvRecommendationsFocusBridgeTest {
     }
 
     @Test
+    fun rejectedFocusRequestRemainsRetryable() {
+        assertEquals(FocusRequestOutcome.Rejected, requestFocusSafely { false })
+    }
+
+    @Test
+    fun focusRequesterExceptionStopsRetries() {
+        assertEquals(
+            FocusRequestOutcome.Disposed,
+            requestFocusSafely { error("FocusRequester is not initialized") },
+        )
+    }
+
+    @Test
     fun forYouWithVisibleRowsUsesTheBridge() {
         assertTrue(
             shouldBridgeRecommendationsDown(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsTopAnchorTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsTopAnchorTest.kt
@@ -1,0 +1,65 @@
+package org.siloserver.silo.tv.ui.screens.recommendations
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+
+class TvRecommendationsTopAnchorTest {
+
+    @Test
+    fun delayedRelocationAfterAnInitiallyCorrectTopIsReanchored() = runTest {
+        var current = ForYouListPosition(0, 0)
+        var corrections = 0
+
+        maintainForYouTopAnchor(
+            positionEvents = flow {
+                emit(current)
+                current = ForYouListPosition(1, 24)
+                emit(current)
+            },
+            isFirstRowFocused = { true },
+            awaitRelocation = {},
+            currentPosition = { current },
+            scrollToTop = {
+                corrections += 1
+                current = ForYouListPosition(0, 0)
+            },
+        )
+
+        assertEquals(1, corrections)
+    }
+
+    @Test
+    fun topOnlyPositionEventsDoNotScroll() = runTest {
+        var corrections = 0
+
+        maintainForYouTopAnchor(
+            positionEvents = flowOf(ForYouListPosition(0, 0)),
+            isFirstRowFocused = { true },
+            awaitRelocation = {},
+            currentPosition = { ForYouListPosition(0, 0) },
+            scrollToTop = { corrections += 1 },
+        )
+
+        assertEquals(0, corrections)
+    }
+
+    @Test
+    fun focusLossPreventsPendingCorrection() = runTest {
+        var focused = true
+        var corrections = 0
+        val displaced = ForYouListPosition(1, 24)
+
+        maintainForYouTopAnchor(
+            positionEvents = flowOf(displaced),
+            isFirstRowFocused = { focused },
+            awaitRelocation = { focused = false },
+            currentPosition = { displaced },
+            scrollToTop = { corrections += 1 },
+        )
+
+        assertEquals(0, corrections)
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
@@ -16,6 +16,24 @@ import kotlin.test.assertTrue
 
 class TvDiagnosticsStateTest {
     @Test
+    fun unsuccessfulFocusRequestIsRetryable() {
+        assertEquals(
+            TvDiagnosticsCrashFocusRequestResult.RETRY,
+            tvDiagnosticsCrashFocusRequestResult(Result.success(false)),
+        )
+    }
+
+    @Test
+    fun failedFocusRequestIsTerminalBecauseTheScreenWasDisposed() {
+        assertEquals(
+            TvDiagnosticsCrashFocusRequestResult.DISPOSED,
+            tvDiagnosticsCrashFocusRequestResult(
+                Result.failure(IllegalStateException("Focus requester is detached")),
+            ),
+        )
+    }
+
+    @Test
     fun selectedConsentIsTheInitialCrashReportFocus() {
         assertEquals(
             TvDiagnosticsCrashFocus.ALWAYS,

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
@@ -24,9 +24,9 @@ class TvDiagnosticsStateTest {
     }
 
     @Test
-    fun failedFocusRequestIsTerminalBecauseTheScreenWasDisposed() {
+    fun detachedFocusRequesterFailureIsRetryable() {
         assertEquals(
-            TvDiagnosticsCrashFocusRequestResult.DISPOSED,
+            TvDiagnosticsCrashFocusRequestResult.RETRY,
             tvDiagnosticsCrashFocusRequestResult(
                 Result.failure(IllegalStateException("Focus requester is detached")),
             ),

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
@@ -90,6 +90,32 @@ class TvDiagnosticsStateTest {
     }
 
     @Test
+    fun repeatedDownIsConsumedWithoutMovingToAnotherLayer() {
+        assertEquals(
+            TvDiagnosticsCrashFocusKeyResult(target = null, consume = true),
+            tvDiagnosticsCrashFocusKeyResult(
+                current = TvDiagnosticsCrashFocus.DEBUG_LOGGING,
+                direction = TvDiagnosticsFocusDirection.Down,
+                debugLoggingEnabled = true,
+                isRepeat = true,
+            ),
+        )
+    }
+
+    @Test
+    fun freshDownFromLastEnabledChoiceStillFallsThrough() {
+        assertEquals(
+            TvDiagnosticsCrashFocusKeyResult(target = null, consume = false),
+            tvDiagnosticsCrashFocusKeyResult(
+                current = TvDiagnosticsCrashFocus.DEBUG_LOGGING,
+                direction = TvDiagnosticsFocusDirection.Down,
+                debugLoggingEnabled = true,
+                isRepeat = false,
+            ),
+        )
+    }
+
+    @Test
     fun promptDefaultsToDontSend() {
         val model = tvDiagnosticsPromptModel(
             DiagnosticsPrompt("report-1", DiagnosticsReportType.CRASH, "2026-07-22T00:00:00Z"),

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
@@ -16,6 +16,62 @@ import kotlin.test.assertTrue
 
 class TvDiagnosticsStateTest {
     @Test
+    fun selectedConsentIsTheInitialCrashReportFocus() {
+        assertEquals(
+            TvDiagnosticsCrashFocus.ALWAYS,
+            initialTvDiagnosticsCrashFocus(DiagnosticsConsentMode.ALWAYS),
+        )
+    }
+
+    @Test
+    fun downTraversesConsentChoicesThenDebugLogging() {
+        assertEquals(
+            TvDiagnosticsCrashFocus.DEBUG_LOGGING,
+            nextTvDiagnosticsCrashFocus(
+                current = TvDiagnosticsCrashFocus.NEVER,
+                direction = TvDiagnosticsFocusDirection.Down,
+                debugLoggingEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun disabledDebugLoggingIsSkipped() {
+        assertEquals(
+            null,
+            nextTvDiagnosticsCrashFocus(
+                current = TvDiagnosticsCrashFocus.NEVER,
+                direction = TvDiagnosticsFocusDirection.Down,
+                debugLoggingEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun firstChoiceHoldsAtUpperBoundary() {
+        assertEquals(
+            TvDiagnosticsCrashFocus.ASK,
+            nextTvDiagnosticsCrashFocus(
+                current = TvDiagnosticsCrashFocus.ASK,
+                direction = TvDiagnosticsFocusDirection.Up,
+                debugLoggingEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun downFromLastEnabledChoiceFallsThroughToCaptureSection() {
+        assertEquals(
+            null,
+            nextTvDiagnosticsCrashFocus(
+                current = TvDiagnosticsCrashFocus.DEBUG_LOGGING,
+                direction = TvDiagnosticsFocusDirection.Down,
+                debugLoggingEnabled = true,
+            ),
+        )
+    }
+
+    @Test
     fun promptDefaultsToDontSend() {
         val model = tvDiagnosticsPromptModel(
             DiagnosticsPrompt("report-1", DiagnosticsReportType.CRASH, "2026-07-22T00:00:00Z"),

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusStateTest.kt
@@ -1,0 +1,36 @@
+package org.siloserver.silo.tv.ui.shell
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvDetailReturnFocusStateTest {
+    @Test
+    fun requestedHomeRetryKeepsCardFallbackPending() {
+        val state = beginHomeDetailReturnRetry(previousRequestId = 7, needsRetry = true)
+
+        assertEquals(8, state.requestId)
+        assertTrue(state.needsRetry)
+        assertTrue(state.fallbackPending)
+    }
+
+    @Test
+    fun completedHomeRetryClearsRetryAndFallback() {
+        val completed = completeHomeDetailReturnRetry(
+            HomeDetailReturnFocusState(requestId = 8, needsRetry = true, fallbackPending = true),
+        )
+
+        assertEquals(8, completed.requestId)
+        assertFalse(completed.needsRetry)
+        assertFalse(completed.fallbackPending)
+    }
+
+    @Test
+    fun explicitHomeSelectionResetsReturnState() {
+        assertEquals(
+            HomeDetailReturnFocusState(),
+            resetHomeDetailReturnFocus(),
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusStateTest.kt
@@ -46,4 +46,34 @@ class TvDetailReturnFocusStateTest {
         assertFalse(state.needsRetry)
         assertFalse(state.fallbackPending)
     }
+
+    @Test
+    fun homeRetryArmsCardFallbackUntilRetryCompletes() {
+        val state = beginHomeDetailReturnRetryIfHome(
+            previousState = HomeDetailReturnFocusState(requestId = 7),
+            isHomeDetailReturn = true,
+            needsRetry = true,
+        )
+
+        assertEquals(8, state.requestId)
+        assertTrue(state.needsRetry)
+        assertTrue(state.fallbackPending)
+    }
+
+    @Test
+    fun successfulHomeResumeDoesNotLeaveRetryOrFallbackPending() {
+        val state = beginHomeDetailReturnRetryIfHome(
+            previousState = HomeDetailReturnFocusState(
+                requestId = 7,
+                needsRetry = true,
+                fallbackPending = true,
+            ),
+            isHomeDetailReturn = true,
+            needsRetry = false,
+        )
+
+        assertEquals(8, state.requestId)
+        assertFalse(state.needsRetry)
+        assertFalse(state.fallbackPending)
+    }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusStateTest.kt
@@ -33,4 +33,17 @@ class TvDetailReturnFocusStateTest {
             resetHomeDetailReturnFocus(),
         )
     }
+
+    @Test
+    fun nonHomeRetryDoesNotArmHomeFallback() {
+        val state = beginHomeDetailReturnRetryIfHome(
+            previousState = HomeDetailReturnFocusState(),
+            isHomeDetailReturn = false,
+            needsRetry = true,
+        )
+
+        assertEquals(0, state.requestId)
+        assertFalse(state.needsRetry)
+        assertFalse(state.fallbackPending)
+    }
 }

--- a/docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
+++ b/docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
@@ -1,0 +1,159 @@
+# For You Late Focus-Relocation Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the For You list at its true top when a delayed focus-relocation pass moves it after the first recommendation row has already gained focus.
+
+**Architecture:** Convert the focus-scoped early-exit loop into an event-driven observer over `LazyListState` position changes. A small suspend helper owns the timing policy and is exercised with real coroutine flows so the delayed-displacement regression is testable without a Compose UI harness.
+
+**Tech Stack:** Kotlin, Jetpack Compose `snapshotFlow`, Kotlin coroutines `Flow`, `kotlinx-coroutines-test`, Gradle.
+
+## Global Constraints
+
+- Observe scroll changes only while the first recommendation row owns focus.
+- Do no work while the list remains at item zero with offset zero.
+- Re-check focus and position after the 80 ms relocation-settling delay.
+- Do not change the shared bring-into-view policy or other recommendation rows.
+- Preserve the full RC display version during verification.
+
+---
+
+### Task 1: Event-driven top-anchor recovery
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt`
+- Create: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsTopAnchorTest.kt`
+
+**Interfaces:**
+- Consumes: a `Flow<ForYouListPosition>`, focus/position readers, an 80 ms settling callback, and a suspend scroll callback.
+- Produces: `ForYouListPosition(firstVisibleItemIndex: Int, firstVisibleItemScrollOffset: Int)` and `maintainForYouTopAnchor(...)` for the screen effect and focused unit tests.
+
+- [ ] **Step 1: Write the failing delayed-displacement regression test**
+
+```kotlin
+@Test
+fun delayedRelocationAfterAnInitiallyCorrectTopIsReanchored() = runTest {
+    var current = ForYouListPosition(0, 0)
+    var corrections = 0
+
+    maintainForYouTopAnchor(
+        positionEvents = flow {
+            emit(current)
+            current = ForYouListPosition(1, 24)
+            emit(current)
+        },
+        isFirstRowFocused = { true },
+        awaitRelocation = {},
+        currentPosition = { current },
+        scrollToTop = {
+            corrections += 1
+            current = ForYouListPosition(0, 0)
+        },
+    )
+
+    assertEquals(1, corrections)
+}
+```
+
+Add two neighboring tests using `flowOf(...)`: a top-only sequence produces zero corrections, and focus becoming false inside `awaitRelocation` prevents a pending correction.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests 'org.siloserver.silo.tv.ui.screens.recommendations.TvRecommendationsTopAnchorTest' \
+  --no-daemon
+```
+
+Expected: compilation fails because `ForYouListPosition` and `maintainForYouTopAnchor` do not exist.
+
+- [ ] **Step 3: Implement the minimal event-driven helper**
+
+```kotlin
+internal data class ForYouListPosition(
+    val firstVisibleItemIndex: Int,
+    val firstVisibleItemScrollOffset: Int,
+) {
+    val isAtTop: Boolean
+        get() = firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset == 0
+}
+
+internal suspend fun maintainForYouTopAnchor(
+    positionEvents: Flow<ForYouListPosition>,
+    isFirstRowFocused: () -> Boolean,
+    awaitRelocation: suspend () -> Unit,
+    currentPosition: () -> ForYouListPosition,
+    scrollToTop: suspend () -> Unit,
+) {
+    positionEvents.collect { observed ->
+        if (!isFirstRowFocused() || observed.isAtTop) return@collect
+        awaitRelocation()
+        if (isFirstRowFocused() && !currentPosition().isAtTop) scrollToTop()
+    }
+}
+```
+
+In `LaunchedEffect(firstRecommendationRowFocused)`, return immediately when focus is false. Otherwise pass a `snapshotFlow` of the real lazy-list position to the helper, retain the existing 80 ms settling delay, and call `recommendationsListState.animateScrollToItem(0)` only from `scrollToTop`.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the Step 2 command.
+
+Expected: all three `TvRecommendationsTopAnchorTest` cases pass.
+
+- [ ] **Step 5: Commit the behavior and tests**
+
+```bash
+git add \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt \
+  androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsTopAnchorTest.kt
+git commit -m "fix(tv): recover late For You focus relocation"
+```
+
+### Task 2: Full verification
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md`
+
+**Interfaces:**
+- Consumes: the Task 1 helper, integration, and regression suite.
+- Produces: a verified Android TV debug APK and completed plan checklist.
+
+- [ ] **Step 1: Run the complete TV verification gate**
+
+```bash
+./gradlew \
+  :shared:testDebugUnitTest \
+  :androidTvApp:testDebugUnitTest \
+  :androidTvApp:assembleDebug \
+  -PsiloVersionName=1.0.0 \
+  -PsiloDisplayVersion=1.0.0-rc.2+5 \
+  --no-daemon
+bash scripts/test-release-workflow.sh
+bash scripts/test-check-build-supply-chain.sh
+bash scripts/check-build-supply-chain.sh
+git diff --check
+```
+
+Expected: Gradle reports `BUILD SUCCESSFUL`, both workflow self-tests pass, the supply-chain check passes, and `git diff --check` emits no errors.
+
+- [ ] **Step 2: Mark the plan complete and commit verification metadata**
+
+Change every task checkbox in this plan from `[ ]` to `[x]`, then run:
+
+```bash
+git add docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
+git commit -m "docs(tv): complete For You relocation plan"
+```
+
+- [ ] **Step 3: Review branch scope**
+
+```bash
+git status --short
+git diff --stat upstream/main...HEAD
+git log --oneline upstream/main..HEAD
+```
+
+Expected: the worktree is clean and the branch contains only the approved design, focused implementation/tests, and completed implementation plan.

--- a/docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
+++ b/docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
@@ -28,7 +28,7 @@
 - Consumes: a `Flow<ForYouListPosition>`, focus/position readers, an 80 ms settling callback, and a suspend scroll callback.
 - Produces: `ForYouListPosition(firstVisibleItemIndex: Int, firstVisibleItemScrollOffset: Int)` and `maintainForYouTopAnchor(...)` for the screen effect and focused unit tests.
 
-- [ ] **Step 1: Write the failing delayed-displacement regression test**
+- [x] **Step 1: Write the failing delayed-displacement regression test**
 
 ```kotlin
 @Test
@@ -57,7 +57,7 @@ fun delayedRelocationAfterAnInitiallyCorrectTopIsReanchored() = runTest {
 
 Add two neighboring tests using `flowOf(...)`: a top-only sequence produces zero corrections, and focus becoming false inside `awaitRelocation` prevents a pending correction.
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run:
 
@@ -69,7 +69,7 @@ Run:
 
 Expected: compilation fails because `ForYouListPosition` and `maintainForYouTopAnchor` do not exist.
 
-- [ ] **Step 3: Implement the minimal event-driven helper**
+- [x] **Step 3: Implement the minimal event-driven helper**
 
 ```kotlin
 internal data class ForYouListPosition(
@@ -97,13 +97,13 @@ internal suspend fun maintainForYouTopAnchor(
 
 In `LaunchedEffect(firstRecommendationRowFocused)`, return immediately when focus is false. Otherwise pass a `snapshotFlow` of the real lazy-list position to the helper, retain the existing 80 ms settling delay, and call `recommendationsListState.animateScrollToItem(0)` only from `scrollToTop`.
 
-- [ ] **Step 4: Run the focused test and verify GREEN**
+- [x] **Step 4: Run the focused test and verify GREEN**
 
 Run the Step 2 command.
 
 Expected: all three `TvRecommendationsTopAnchorTest` cases pass.
 
-- [ ] **Step 5: Commit the behavior and tests**
+- [x] **Step 5: Commit the behavior and tests**
 
 ```bash
 git add \
@@ -121,7 +121,7 @@ git commit -m "fix(tv): recover late For You focus relocation"
 - Consumes: the Task 1 helper, integration, and regression suite.
 - Produces: a verified Android TV debug APK and completed plan checklist.
 
-- [ ] **Step 1: Run the complete TV verification gate**
+- [x] **Step 1: Run the complete TV verification gate**
 
 ```bash
 ./gradlew \
@@ -139,7 +139,7 @@ git diff --check
 
 Expected: Gradle reports `BUILD SUCCESSFUL`, both workflow self-tests pass, the supply-chain check passes, and `git diff --check` emits no errors.
 
-- [ ] **Step 2: Mark the plan complete and commit verification metadata**
+- [x] **Step 2: Mark the plan complete and commit verification metadata**
 
 Change every task checkbox in this plan from `[ ]` to `[x]`, then run:
 
@@ -148,7 +148,7 @@ git add docs/superpowers/plans/2026-08-03-for-you-late-focus-relocation.md
 git commit -m "docs(tv): complete For You relocation plan"
 ```
 
-- [ ] **Step 3: Review branch scope**
+- [x] **Step 3: Review branch scope**
 
 ```bash
 git status --short

--- a/docs/superpowers/plans/2026-08-03-shield-focus-restoration.md
+++ b/docs/superpowers/plans/2026-08-03-shield-focus-restoration.md
@@ -1,0 +1,651 @@
+# Shield Focus Restoration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore deterministic D-pad focus on For You, Calendar, and Diagnostics on Shield Pro, and make only For You use the solid top-bar treatment already seen in Watchlist/Favorites.
+
+**Architecture:** Keep the existing Navigation Compose and TV shell structure. Add small pure routing/resolution functions with unit coverage, then wire stable `FocusRequester`s and bounded frame-based handoffs into the three affected screens. For You reuses `TvMediaRow`'s exact-card restore interface; Calendar and Diagnostics make their local focus zones explicit.
+
+**Tech Stack:** Kotlin 2.1, Jetpack Compose for TV, Navigation Compose, coroutines, Kotlin test/JUnit, Gradle, Android Debug Bridge.
+
+## Global Constraints
+
+- Do not promote Watchlist to a top-level tab.
+- Do not alter Watchlist or Favorites behavior, navigation, layout, or rendering.
+- Do not redesign For You, Calendar, Diagnostics, or the global shell.
+- Keep PR #162's event-driven first-row top-anchor correction.
+- Use stable IDs before indices when resolving refreshed recommendation content.
+- Bound every frame-based focus retry and stop immediately on success or disposal.
+- Preserve the existing one-layer-per-press behavior for repeated D-pad events.
+- Installation on the Shield and opening the app are separate explicit delivery steps after verification.
+
+---
+
+## File Map
+
+- `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt`: pure For You focus-target resolution and the existing row-to-card focus bridge.
+- `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt`: save the focused recommendation identity, attach exact return requesters, perform post-return handoff, and report For You's top-bar treatment.
+- `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt`: distinguish For You detail returns from Home, expose the return token/requester, and draw a solid scrim only for the recommendations selection.
+- `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt`: track filter/week-strip zones, route Up deterministically, and acknowledge any successful Calendar control focus.
+- `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt`: model and wire deterministic crash-report focus order and reliable initial focus.
+- Existing unit-test files beside each feature validate the pure decisions without introducing UI instrumentation.
+
+---
+
+### Task 1: Resolve For You return targets by stable identity
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt`
+- Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt`
+
+**Interfaces:**
+- Produces: `ForYouFocusTarget`, `ForYouFocusRow`, `ResolvedForYouFocusTarget`, and `resolveForYouReturnTarget(target, rows)`.
+- Consumed by: Task 2's recommendation-screen focus restoration.
+
+- [ ] **Step 1: Write failing stable-ID and fallback tests**
+
+Add tests that exercise exact resolution, reorder handling, missing-card fallback, missing-section fallback, and an empty feed:
+
+```kotlin
+private val target = ForYouFocusTarget("because-you-watched", "movie-b", 1, 2)
+
+@Test
+fun exactReturnTargetUsesStableIdsAfterReorder() {
+    val resolved = resolveForYouReturnTarget(
+        target,
+        listOf(
+            ForYouFocusRow("because-you-watched", listOf("movie-c", "movie-b", "movie-a")),
+            ForYouFocusRow("trending", listOf("movie-d")),
+        ),
+    )
+    assertEquals(ResolvedForYouFocusTarget(0, 1, true), resolved)
+}
+
+@Test
+fun missingCardUsesClosestIndexInSameSection() {
+    val resolved = resolveForYouReturnTarget(
+        target,
+        listOf(ForYouFocusRow("because-you-watched", listOf("movie-a", "movie-c"))),
+    )
+    assertEquals(ResolvedForYouFocusTarget(0, 1, false), resolved)
+}
+
+@Test
+fun missingSectionUsesClosestRowFirstCard() {
+    val resolved = resolveForYouReturnTarget(
+        target,
+        listOf(
+            ForYouFocusRow("row-a", listOf("a")),
+            ForYouFocusRow("row-b", listOf("b")),
+        ),
+    )
+    assertEquals(ResolvedForYouFocusTarget(1, 0, false), resolved)
+}
+
+@Test
+fun emptyFeedHasNoCardReturnTarget() {
+    assertEquals(null, resolveForYouReturnTarget(target, emptyList()))
+}
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvRecommendationsFocusBridgeTest'
+```
+
+Expected: compilation fails because the new target types and resolver do not exist.
+
+- [ ] **Step 3: Implement the minimal resolver**
+
+Add the following pure models and algorithm:
+
+```kotlin
+internal data class ForYouFocusTarget(
+    val sectionId: String,
+    val contentId: String,
+    val rowIndex: Int,
+    val cardIndex: Int,
+)
+
+internal data class ForYouFocusRow(
+    val sectionId: String,
+    val contentIds: List<String>,
+)
+
+internal data class ResolvedForYouFocusTarget(
+    val rowIndex: Int,
+    val cardIndex: Int,
+    val exact: Boolean,
+)
+
+internal fun resolveForYouReturnTarget(
+    target: ForYouFocusTarget,
+    rows: List<ForYouFocusRow>,
+): ResolvedForYouFocusTarget? {
+    if (rows.isEmpty()) return null
+    val stableRowIndex = rows.indexOfFirst { it.sectionId == target.sectionId }
+    if (stableRowIndex >= 0) {
+        val cards = rows[stableRowIndex].contentIds
+        if (cards.isEmpty()) return null
+        val stableCardIndex = cards.indexOf(target.contentId)
+        return if (stableCardIndex >= 0) {
+            ResolvedForYouFocusTarget(stableRowIndex, stableCardIndex, true)
+        } else {
+            ResolvedForYouFocusTarget(
+                stableRowIndex,
+                target.cardIndex.coerceIn(cards.indices),
+                false,
+            )
+        }
+    }
+    val fallbackRowIndex = target.rowIndex.coerceIn(rows.indices)
+    val fallbackCards = rows[fallbackRowIndex].contentIds
+    if (fallbackCards.isEmpty()) return null
+    return ResolvedForYouFocusTarget(fallbackRowIndex, 0, false)
+}
+```
+
+- [ ] **Step 4: Run the focused tests**
+
+Run the command from Step 2. Expected: all `TvRecommendationsFocusBridgeTest` tests pass. PR #162's separate `TvRecommendationsTopAnchorTest` remains covered by the full TV test task in Task 2 and Task 5.
+
+- [ ] **Step 5: Commit the resolver**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
+git commit -m "fix(tv): resolve For You return targets"
+```
+
+---
+
+### Task 2: Restore For You to the launch card and solidify only its top bar
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt`
+- Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1's `resolveForYouReturnTarget` and existing `requestRecommendationRowFocus`.
+- Adds to `TvRecommendationsScreen`: `onRecommendationItemClick: (String) -> Unit`, `detailReturnFocusRequest: Int`, `detailReturnCardFocusRequester: FocusRequester`, and `onSolidTopBarChanged: (Boolean) -> Unit`. The existing `onItemClick` remains the unchanged saved-list callback.
+- Produces in the shell: a For You-specific pending flag, requester, and return token; Home's existing path remains unchanged.
+
+- [ ] **Step 1: Add a failing bridge test for the filter fallback**
+
+Extend the focus-bridge tests to make both the no-row contract and a failed card request explicit:
+
+```kotlin
+@Test
+fun emptyFeedFallsBackToForYouFilter() {
+    assertTrue(shouldFallbackForYouReturnToFilter(resolveForYouReturnTarget(target, emptyList())))
+    assertFalse(
+        shouldFallbackForYouReturnToFilter(
+            ResolvedForYouFocusTarget(rowIndex = 0, cardIndex = 0, exact = true),
+        ),
+    )
+}
+
+@Test
+fun rejectedCardRequestCanBeRetried() = runTest {
+    val handled = requestRecommendationRowFocus(
+        requestRowContainer = { true },
+        awaitFrame = {},
+        requestFirstCard = { false },
+    )
+    assertFalse(handled)
+}
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvRecommendationsFocusBridgeTest'
+```
+
+Expected: compilation fails because `shouldFallbackForYouReturnToFilter` is undefined; after that symbol is introduced, the new card-rejection assertion still fails against the old bridge semantics.
+
+- [ ] **Step 3: Add the minimal fallback predicate**
+
+```kotlin
+internal fun shouldFallbackForYouReturnToFilter(
+    resolved: ResolvedForYouFocusTarget?,
+): Boolean = resolved == null
+```
+
+Also make `requestRecommendationRowFocus` return the card request result after the row hop and frame:
+
+```kotlin
+if (!requestRowContainer()) return false
+awaitFrame()
+return requestFirstCard()
+```
+
+- [ ] **Step 4: Wire saveable focus identity and exact requesters in For You**
+
+In `TvRecommendationsScreen`, add saveable primitive fields for the last focused section/content IDs and indices. Construct `ForYouFocusTarget` only when both IDs are nonblank, and map `visibleSections` to `ForYouFocusRow` before calling the resolver.
+
+Use one row requester and the shell-provided card requester:
+
+```kotlin
+val detailReturnRowFocusRequester = remember { FocusRequester() }
+val returnRows = remember(visibleSections) {
+    visibleSections.map { section ->
+        ForYouFocusRow(section.id, section.items.map { it.contentId })
+    }
+}
+val resolvedReturnTarget = lastFocusedTarget?.let { resolveForYouReturnTarget(it, returnRows) }
+```
+
+For each `TvMediaRow`, set:
+
+```kotlin
+rowContainerFocusRequester = detailReturnRowFocusRequester
+    .takeIf { index == resolvedReturnTarget?.rowIndex },
+restoreFocusIndex = resolvedReturnTarget?.cardIndex ?: -1,
+restoreFocusRequester = detailReturnCardFocusRequester
+    .takeIf { index == resolvedReturnTarget?.rowIndex },
+onItemFocusedAtIndex = { item, cardIndex ->
+    lastFocusedSectionId = section.id
+    lastFocusedContentId = item.contentId
+    lastFocusedRowIndex = index
+    lastFocusedCardIndex = cardIndex
+},
+```
+
+Wrap only recommendation-row clicks with `onRecommendationItemClick` so the focus identity is saved before navigation. Continue passing the existing `onItemClick` unchanged to `TvWatchlistInline` and `TvFavoritesInline`; this keeps saved-list detail returns on their current generic path. Do not reset `recommendationsListState` or a row's horizontal state.
+
+- [ ] **Step 5: Add the bounded post-return handoff**
+
+On a nonzero `detailReturnFocusRequest`, resolve the current target. If the row is not in `recommendationsListState.layoutInfo.visibleItemsInfo`, bring only that row into composition. Await frames, request the row container, await one more frame, then request the card through `requestRecommendationRowFocus`. If resolution returns null, request `forYouFocusRequester`. Retry for at most six frames and stop after the first success.
+
+```kotlin
+LaunchedEffect(detailReturnFocusRequest, resolvedReturnTarget) {
+    if (detailReturnFocusRequest == 0) return@LaunchedEffect
+    val target = resolvedReturnTarget
+    if (target == null) {
+        repeat(6) {
+            withFrameNanos { }
+            if (forYouFocusRequester.requestFocus()) return@LaunchedEffect
+        }
+        return@LaunchedEffect
+    }
+    val rowVisible = recommendationsListState.layoutInfo.visibleItemsInfo
+        .any { it.index == target.rowIndex }
+    if (!rowVisible) recommendationsListState.scrollToItem(target.rowIndex)
+    repeat(6) {
+        withFrameNanos { }
+        val handled = requestRecommendationRowFocus(
+            requestRowContainer = { detailReturnRowFocusRequester.requestFocus() },
+            awaitFrame = { withFrameNanos { } },
+            requestFirstCard = { detailReturnCardFocusRequester.requestFocus() },
+        )
+        if (handled) return@LaunchedEffect
+    }
+}
+```
+
+Use `runCatching` around requester calls in production so a disposed node ends the attempt safely rather than crashing.
+
+- [ ] **Step 6: Add the For You-specific shell return path**
+
+In `TvMainShell`, add `restoreForYouContentAfterDetail`, `forYouDetailReturnCardFocusRequester`, and `forYouDetailReturnFocusRequest`. A new recommendation-only click callback sets the pending flags before opening detail. Keep the existing generic `openContentItemDetail` callback for Watchlist/Favorites. On resume, use the For You requester as the content restorer fallback while its flag is set, increment the For You token, then clear the pending flag. Pass both click callbacks plus the token/requester into `TvRecommendationsScreen`.
+
+Keep the fallback priority explicit:
+
+```kotlin
+val detailReturnFallback = when {
+    restoreHomeContentAfterDetail -> homeDetailReturnCardFocusRequester
+    restoreForYouContentAfterDetail -> forYouDetailReturnCardFocusRequester
+    else -> FocusRequester.Default
+}
+```
+
+Do not change `openHomeItemDetail`, Home's request token, or Home's requester attachment.
+
+- [ ] **Step 7: Make only recommendations request a solid top scrim**
+
+Have `TvRecommendationsScreen` report `savedListSelection == null` through `onSolidTopBarChanged`, and reset the signal on disposal. In the shell, use an opaque theme-background scrim only when the current route is For You and that signal is true; otherwise retain the existing gradient.
+
+```kotlin
+val useSolidForYouTopBar =
+    currentRoute == TvMainRoute.ForYou.route && forYouRequestsSolidTopBar
+```
+
+Do not edit `TvWatchlistInline`, `TvFavoritesInline`, or `TvPersonalScreens.kt`.
+
+- [ ] **Step 8: Run focused and full TV tests**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvRecommendationsFocusBridgeTest'
+./gradlew :androidTvApp:testDebugUnitTest
+```
+
+Expected: both commands succeed with no failures.
+
+- [ ] **Step 9: Commit the For You restoration**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
+git commit -m "fix(tv): restore For You focus after detail"
+```
+
+---
+
+### Task 3: Route Calendar Up through explicit control zones
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt`
+- Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt`
+
+**Interfaces:**
+- Produces: `CalendarControlFocusZone` and an expanded `calendarUpFallbackAction` that distinguishes filters from the week strip.
+- Preserves: the shell's existing `onMoveUpToMenu` and content-up fallback registration protocol.
+
+- [ ] **Step 1: Replace the ambiguous control tests with failing zone tests**
+
+```kotlin
+@Test
+fun weekStripMovesUpToActiveFilter() {
+    assertEquals(
+        CalendarUpFallbackAction.FocusFilter,
+        calendarUpFallbackAction(null, 0, false, CalendarControlFocusZone.WeekStrip),
+    )
+}
+
+@Test
+fun filterMovesUpToCalendarMenuTab() {
+    assertEquals(
+        CalendarUpFallbackAction.EnterMenu,
+        calendarUpFallbackAction(null, 0, false, CalendarControlFocusZone.Filter),
+    )
+}
+
+@Test
+fun heldUpOnControlsDoesNotSkipALayer() {
+    assertEquals(
+        CalendarUpFallbackAction.StayInContent,
+        calendarUpFallbackAction(
+            null,
+            0,
+            false,
+            CalendarControlFocusZone.WeekStrip,
+            isRepeat = true,
+        ),
+    )
+}
+```
+
+- [ ] **Step 2: Run the Calendar test and confirm it fails**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvCalendarFocusRoutingTest'
+```
+
+Expected: compilation fails because the zone and `FocusFilter` action do not exist.
+
+- [ ] **Step 3: Implement the pure zone routing**
+
+```kotlin
+internal enum class CalendarControlFocusZone { Filter, WeekStrip }
+
+internal enum class CalendarUpFallbackAction {
+    EnterMenu,
+    FocusFilter,
+    ReturnToControls,
+    StayInContent,
+    MoveWithinContent,
+}
+```
+
+Extend `calendarUpFallbackAction` with `focusedControlZone: CalendarControlFocusZone?`. Preserve the shelf cases first, return `StayInContent` for repeats, then map `WeekStrip -> FocusFilter`, `Filter -> EnterMenu`, and null to the existing content movement behavior. Clear the control zone when a shelf gains focus so stale control state cannot affect shelf routing.
+
+- [ ] **Step 4: Track and acknowledge Calendar control focus**
+
+Maintain `focusedControlZone` in `CalendarList`. Pass zone-aware callbacks into `FilterSegment`, every `DayCell`, both chevrons, and `TodayButton`. When a control gains focus:
+
+1. Update the zone.
+2. Run the existing snap-to-controls callback.
+3. If the current `focusRequest` has not been acknowledged, record it and call `onInitialContentFocus()`.
+
+This makes a successful default weekday focus release `calendarFocusHandoffPending` even if the earlier imperative filter request returned false.
+
+- [ ] **Step 5: Wire the active filter requester into the Up fallback**
+
+Pass `filterFocusRequesters[state.filter] ?: filterFocusRequester` into `CalendarList`. Handle the new action with a safe direct request:
+
+```kotlin
+CalendarUpFallbackAction.FocusFilter -> {
+    runCatching { activeFilterFocusRequester.requestFocus() }.getOrDefault(false)
+}
+```
+
+Keep `EnterMenu` routed through `onMoveUpToMenu`, and keep the existing shelf-to-selected-day choreography unchanged.
+
+- [ ] **Step 6: Run focused and full TV tests**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvCalendarFocusRoutingTest'
+./gradlew :androidTvApp:testDebugUnitTest
+```
+
+Expected: both commands succeed.
+
+- [ ] **Step 7: Commit Calendar routing**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
+git commit -m "fix(tv): route Calendar focus back to menu"
+```
+
+---
+
+### Task 4: Make Diagnostics crash-report focus deterministic
+
+**Files:**
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt`
+- Test: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt`
+
+**Interfaces:**
+- Produces: `TvDiagnosticsCrashFocus`, `tvDiagnosticsCrashFocusOrder`, and `nextTvDiagnosticsCrashFocus`.
+- Consumes: `DiagnosticsConsentMode` and the existing `TvDiagnosticsAction` modifier hook.
+
+- [ ] **Step 1: Add failing focus-order tests**
+
+```kotlin
+@Test
+fun selectedConsentIsTheInitialCrashReportFocus() {
+    assertEquals(
+        TvDiagnosticsCrashFocus.ALWAYS,
+        initialTvDiagnosticsCrashFocus(DiagnosticsConsentMode.ALWAYS),
+    )
+}
+
+@Test
+fun downTraversesConsentChoicesThenDebugLogging() {
+    assertEquals(
+        TvDiagnosticsCrashFocus.DEBUG_LOGGING,
+        nextTvDiagnosticsCrashFocus(
+            current = TvDiagnosticsCrashFocus.NEVER,
+            direction = TvDiagnosticsFocusDirection.Down,
+            debugLoggingEnabled = true,
+        ),
+    )
+}
+
+@Test
+fun disabledDebugLoggingIsSkipped() {
+    assertEquals(
+        null,
+        nextTvDiagnosticsCrashFocus(
+            current = TvDiagnosticsCrashFocus.NEVER,
+            direction = TvDiagnosticsFocusDirection.Down,
+            debugLoggingEnabled = false,
+        ),
+    )
+}
+
+@Test
+fun firstChoiceHoldsAtUpperBoundary() {
+    assertEquals(
+        TvDiagnosticsCrashFocus.ASK,
+        nextTvDiagnosticsCrashFocus(
+            current = TvDiagnosticsCrashFocus.ASK,
+            direction = TvDiagnosticsFocusDirection.Up,
+            debugLoggingEnabled = true,
+        ),
+    )
+}
+
+@Test
+fun downFromLastEnabledChoiceFallsThroughToCaptureSection() {
+    assertEquals(
+        null,
+        nextTvDiagnosticsCrashFocus(
+            current = TvDiagnosticsCrashFocus.DEBUG_LOGGING,
+            direction = TvDiagnosticsFocusDirection.Down,
+            debugLoggingEnabled = true,
+        ),
+    )
+}
+```
+
+- [ ] **Step 2: Run the Diagnostics test and confirm it fails**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvDiagnosticsStateTest'
+```
+
+Expected: compilation fails because the crash-focus types and functions do not exist.
+
+- [ ] **Step 3: Implement the pure focus order**
+
+```kotlin
+internal enum class TvDiagnosticsCrashFocus { ASK, ALWAYS, NEVER, DEBUG_LOGGING }
+internal enum class TvDiagnosticsFocusDirection { Up, Down }
+
+internal fun initialTvDiagnosticsCrashFocus(mode: DiagnosticsConsentMode) = when (mode) {
+    DiagnosticsConsentMode.ASK -> TvDiagnosticsCrashFocus.ASK
+    DiagnosticsConsentMode.ALWAYS -> TvDiagnosticsCrashFocus.ALWAYS
+    DiagnosticsConsentMode.NEVER -> TvDiagnosticsCrashFocus.NEVER
+}
+
+internal fun tvDiagnosticsCrashFocusOrder(debugLoggingEnabled: Boolean) = buildList {
+    add(TvDiagnosticsCrashFocus.ASK)
+    add(TvDiagnosticsCrashFocus.ALWAYS)
+    add(TvDiagnosticsCrashFocus.NEVER)
+    if (debugLoggingEnabled) add(TvDiagnosticsCrashFocus.DEBUG_LOGGING)
+}
+
+internal fun nextTvDiagnosticsCrashFocus(
+    current: TvDiagnosticsCrashFocus,
+    direction: TvDiagnosticsFocusDirection,
+    debugLoggingEnabled: Boolean,
+): TvDiagnosticsCrashFocus? {
+    val order = tvDiagnosticsCrashFocusOrder(debugLoggingEnabled)
+    val index = order.indexOf(current).coerceAtLeast(0)
+    return when (direction) {
+        TvDiagnosticsFocusDirection.Up -> order[(index - 1).coerceAtLeast(0)]
+        TvDiagnosticsFocusDirection.Down -> order.getOrNull(index + 1)
+    }
+}
+```
+
+- [ ] **Step 4: Attach stable requesters and key routing**
+
+Create a stable requester for each `TvDiagnosticsCrashFocus`. Map each consent mode to its focus target. Give each consent action and Debug logging its requester plus an `onPreviewKeyEvent` handler that:
+
+1. Handles only `KeyDown` Up/Down.
+2. Calls `nextTvDiagnosticsCrashFocus` with `debugLoggingEnabled = state.consent != DiagnosticsConsentMode.NEVER`.
+3. Requests the returned enabled target when nonnull.
+4. Consumes the event only when a request was attempted. A null Down result from the last enabled crash-report action returns `false`, allowing normal focus search to enter the Capture section.
+
+Do not alter labels, consent callbacks, enabled state, sizes, or colors.
+
+- [ ] **Step 5: Replace the one-shot initial request with a bounded frame handoff**
+
+Key the effect by the selected consent mode. Await one frame, then request the selected option for at most six frames:
+
+```kotlin
+LaunchedEffect(state.consent) {
+    val target = initialTvDiagnosticsCrashFocus(state.consent)
+    repeat(6) {
+        withFrameNanos { }
+        val focused = runCatching {
+            crashFocusRequesters.getValue(target).requestFocus()
+        }.getOrDefault(false)
+        if (focused) return@LaunchedEffect
+    }
+}
+```
+
+Remove the old `firstFocus` requester and its unchecked `LaunchedEffect(Unit)`.
+
+- [ ] **Step 6: Run focused and full TV tests**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvDiagnosticsStateTest'
+./gradlew :androidTvApp:testDebugUnitTest
+```
+
+Expected: both commands succeed.
+
+- [ ] **Step 7: Commit Diagnostics routing**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
+git commit -m "fix(tv): focus Diagnostics crash-report controls"
+```
+
+---
+
+### Task 5: Verify the integrated TV build
+
+**Files:**
+- Verify only; no production files should change.
+
+**Interfaces:**
+- Consumes: all prior tasks.
+- Produces: a tested TV debug APK ready for an explicitly requested Shield installation.
+
+- [ ] **Step 1: Confirm Watchlist/Favorites were not edited**
+
+```bash
+git diff 8a4bdb9c...HEAD -- androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Run whitespace and complete TV unit-test gates**
+
+```bash
+git diff --check
+./gradlew :androidTvApp:testDebugUnitTest
+```
+
+Expected: no whitespace errors and `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Assemble the TV debug APK**
+
+```bash
+./gradlew :androidTvApp:assembleDebug
+```
+
+Expected: `BUILD SUCCESSFUL` and an APK under `androidTvApp/build/outputs/apk/debug/`.
+
+- [ ] **Step 4: Inspect the final branch**
+
+```bash
+git status --short --branch
+git log --oneline --decorate 8a4bdb9c..HEAD
+```
+
+Expected: a clean `fix/shield-focus-restoration` branch containing the design, plan, and four focused implementation commits.
+
+- [ ] **Step 5: Stop before device mutation**
+
+Report the verified APK path and ask for explicit authorization before installing it on `192.168.1.128:5555`. Do not launch Silo after installation unless separately requested.

--- a/docs/superpowers/plans/2026-08-04-pr-164-review-remediation.md
+++ b/docs/superpowers/plans/2026-08-04-pr-164-review-remediation.md
@@ -1,0 +1,391 @@
+# PR #164 Review Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correct the four verified Android TV focus-state defects blocking PR #164 without broadening its navigation behavior.
+
+**Architecture:** Keep Calendar and Diagnostics corrections inside their existing pure policy helpers. Move Home retry lifetime into a small immutable shell state model, and extend the existing For You return-state helper with an explicit-selection reset so both flows are deterministic and unit-testable without Compose instrumentation.
+
+**Tech Stack:** Kotlin 2.1, Jetpack Compose for TV, Kotlin test/JUnit, Gradle, Java 21
+
+## Global Constraints
+
+- Android TV only; do not change phone behavior.
+- Preserve one-layer-per-press behavior for repeated D-pad events.
+- Focus requests remain bounded and best-effort.
+- Coroutine cancellation is authoritative for composable disposal.
+- Explicit top-menu navigation overrides stale detail-return state.
+- Do not redesign recommendation identities or perform unrelated focus refactors.
+- A physical Shield D-pad smoke test remains the release gate.
+
+---
+
+### Task 1: Restore Calendar held-Up movement below the boundary
+
+**Files:**
+- Modify: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt:714-734`
+
+**Interfaces:**
+- Consumes: `calendarUpFallbackAction(focusedShelfIndex, firstFocusableShelfIndex, isReturningToControls, focusedControlZone, isRepeat)`
+- Produces: the existing `CalendarUpFallbackAction.MoveWithinContent` result for repeated Up below the first focusable shelf
+
+- [ ] **Step 1: Add the failing regression test**
+
+Add this test to `TvCalendarFocusRoutingTest`:
+
+```kotlin
+@Test
+fun heldUpBelowFirstShelfContinuesContentMovement() {
+    assertEquals(
+        CalendarUpFallbackAction.MoveWithinContent,
+        calendarUpFallbackAction(
+            focusedShelfIndex = 4,
+            firstFocusableShelfIndex = 2,
+            isReturningToControls = false,
+            focusedControlZone = null,
+            isRepeat = true,
+        ),
+    )
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvCalendarFocusRoutingTest'
+```
+
+Expected: `heldUpBelowFirstShelfContinuesContentMovement` fails because the current unconditional `isRepeat` branch returns `StayInContent`.
+
+- [ ] **Step 3: Restore the content-aware repeat guard**
+
+Change the broad repeat branch in `calendarUpFallbackAction` to:
+
+```kotlin
+focusedShelfIndex == null && isRepeat -> CalendarUpFallbackAction.StayInContent
+```
+
+Keep the first-shelf boundary branch above it unchanged so a held event cannot skip from the first shelf into controls.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the Task 1 command again. Expected: all `TvCalendarFocusRoutingTest` tests pass.
+
+- [ ] **Step 5: Commit the Calendar correction**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
+git commit -m "fix(tv): preserve held Calendar shelf movement"
+```
+
+### Task 2: Retry transient Diagnostics focus-request failures
+
+**Files:**
+- Modify: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt:18-34`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt:71-85,238-246`
+
+**Interfaces:**
+- Consumes: `tvDiagnosticsCrashFocusRequestResult(Result<Boolean>)`
+- Produces: `FOCUSED` for `true`; `RETRY` for `false` and caught exceptions
+
+- [ ] **Step 1: Change the failure test to the required behavior**
+
+Replace `failedFocusRequestIsTerminalBecauseTheScreenWasDisposed` with:
+
+```kotlin
+@Test
+fun detachedFocusRequesterFailureIsRetryable() {
+    assertEquals(
+        TvDiagnosticsCrashFocusRequestResult.RETRY,
+        tvDiagnosticsCrashFocusRequestResult(
+            Result.failure(IllegalStateException("Focus requester is detached")),
+        ),
+    )
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvDiagnosticsStateTest'
+```
+
+Expected: `detachedFocusRequesterFailureIsRetryable` fails because the current function returns `DISPOSED`.
+
+- [ ] **Step 3: Remove synthetic disposal classification**
+
+Reduce the enum and classifier to:
+
+```kotlin
+internal enum class TvDiagnosticsCrashFocusRequestResult { FOCUSED, RETRY }
+
+internal fun tvDiagnosticsCrashFocusRequestResult(
+    result: Result<Boolean>,
+): TvDiagnosticsCrashFocusRequestResult = if (result.getOrDefault(false)) {
+    TvDiagnosticsCrashFocusRequestResult.FOCUSED
+} else {
+    TvDiagnosticsCrashFocusRequestResult.RETRY
+}
+```
+
+Update the `LaunchedEffect` `when` so only `FOCUSED` exits and `RETRY` continues to the next bounded frame. Disposal continues to cancel the effect through structured concurrency.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the Task 2 command again. Expected: all `TvDiagnosticsStateTest` tests pass.
+
+- [ ] **Step 5: Commit the Diagnostics correction**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
+git commit -m "fix(tv): retry detached Diagnostics focus"
+```
+
+### Task 3: Preserve Home’s card fallback through deferred retry
+
+**Files:**
+- Create: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusState.kt`
+- Create: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusStateTest.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt:341-404,609-616`
+
+**Interfaces:**
+- Produces: `HomeDetailReturnFocusState(requestId: Int, needsRetry: Boolean, fallbackPending: Boolean)`
+- Produces: `beginHomeDetailReturnRetry(previousRequestId: Int, needsRetry: Boolean): HomeDetailReturnFocusState`
+- Produces: `completeHomeDetailReturnRetry(state: HomeDetailReturnFocusState): HomeDetailReturnFocusState`
+- Produces: `resetHomeDetailReturnFocus(): HomeDetailReturnFocusState`
+
+- [ ] **Step 1: Add failing tests for the Home retry lifetime**
+
+Create `TvDetailReturnFocusStateTest.kt`:
+
+```kotlin
+package org.siloserver.silo.tv.ui.shell
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvDetailReturnFocusStateTest {
+    @Test
+    fun requestedHomeRetryKeepsCardFallbackPending() {
+        val state = beginHomeDetailReturnRetry(previousRequestId = 7, needsRetry = true)
+
+        assertEquals(8, state.requestId)
+        assertTrue(state.needsRetry)
+        assertTrue(state.fallbackPending)
+    }
+
+    @Test
+    fun completedHomeRetryClearsRetryAndFallback() {
+        val completed = completeHomeDetailReturnRetry(
+            HomeDetailReturnFocusState(requestId = 8, needsRetry = true, fallbackPending = true),
+        )
+
+        assertEquals(8, completed.requestId)
+        assertFalse(completed.needsRetry)
+        assertFalse(completed.fallbackPending)
+    }
+
+    @Test
+    fun explicitHomeSelectionResetsReturnState() {
+        assertEquals(
+            HomeDetailReturnFocusState(),
+            resetHomeDetailReturnFocus(),
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvDetailReturnFocusStateTest'
+```
+
+Expected: compilation fails because the Home state type and transition functions do not exist.
+
+- [ ] **Step 3: Add the minimal immutable state model**
+
+Create `TvDetailReturnFocusState.kt`:
+
+```kotlin
+package org.siloserver.silo.tv.ui.shell
+
+internal data class HomeDetailReturnFocusState(
+    val requestId: Int = 0,
+    val needsRetry: Boolean = false,
+    val fallbackPending: Boolean = false,
+)
+
+internal fun beginHomeDetailReturnRetry(
+    previousRequestId: Int,
+    needsRetry: Boolean,
+): HomeDetailReturnFocusState = HomeDetailReturnFocusState(
+    requestId = previousRequestId + 1,
+    needsRetry = needsRetry,
+    fallbackPending = needsRetry,
+)
+
+internal fun completeHomeDetailReturnRetry(
+    state: HomeDetailReturnFocusState,
+): HomeDetailReturnFocusState = state.copy(
+    needsRetry = false,
+    fallbackPending = false,
+)
+
+internal fun resetHomeDetailReturnFocus(): HomeDetailReturnFocusState =
+    HomeDetailReturnFocusState()
+```
+
+- [ ] **Step 4: Wire the state model into `TvMainShell`**
+
+Replace `homeDetailReturnFocusRequest` and `homeDetailReturnNeedsRetry` with one remembered `HomeDetailReturnFocusState`. Include `homeDetailReturnFocusState.fallbackPending` in the Home branch of `detailReturnFallback`. After the synchronous resume request, call `beginHomeDetailReturnRetry`; after the optional deferred request, call `completeHomeDetailReturnRetry`. On explicit Home selection, assign `resetHomeDetailReturnFocus()`.
+
+Pass `homeDetailReturnFocusState.requestId` to both Home screen call sites. Do not change the For You flow in this task.
+
+- [ ] **Step 5: Run focused shell and Home tests and verify GREEN**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvDetailReturnFocusStateTest' --tests '*TvShellFocusStateTest'
+```
+
+Expected: both test classes pass.
+
+- [ ] **Step 6: Commit the Home correction**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusState.kt androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusStateTest.kt
+git commit -m "fix(tv): retain Home detail fallback through retry"
+```
+
+### Task 4: Reset stale For You return state on explicit selection
+
+**Files:**
+- Modify: `androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt:21-25,91-105`
+- Modify: `androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt:600-620`
+
+**Interfaces:**
+- Consumes: `ForYouDetailReturnState(requestId: Int, pending: Boolean)`
+- Produces: `resetForExplicitForYouSelection(): ForYouDetailReturnState`
+
+- [ ] **Step 1: Add the failing explicit-reset test**
+
+Add to `TvRecommendationsFocusBridgeTest`:
+
+```kotlin
+@Test
+fun explicitForYouSelectionClearsStaleReturnState() {
+    assertEquals(
+        ForYouDetailReturnState(requestId = 0, pending = false),
+        resetForExplicitForYouSelection(),
+    )
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest --tests '*TvRecommendationsFocusBridgeTest'
+```
+
+Expected: compilation fails because `resetForExplicitForYouSelection` does not exist.
+
+- [ ] **Step 3: Add and wire the explicit reset**
+
+Add to `TvRecommendationsFocusBridge.kt`:
+
+```kotlin
+internal fun resetForExplicitForYouSelection(): ForYouDetailReturnState =
+    ForYouDetailReturnState(requestId = 0, pending = false)
+```
+
+In the `TvRootDestination.ForYou` branch of `onSelectRoot`, call the helper and assign both `forYouDetailReturnFocusRequest` and `forYouDetailReturnFocusPending` from the returned state before creating the top-level For You entry request.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the Task 4 command again. Expected: all `TvRecommendationsFocusBridgeTest` tests pass.
+
+- [ ] **Step 5: Commit the For You correction**
+
+```bash
+git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
+git commit -m "fix(tv): reset stale For You detail return"
+```
+
+### Task 5: Verify the complete PR remediation
+
+**Files:**
+- Verify only: all files changed in Tasks 1-4
+
+**Interfaces:**
+- Consumes: all four independently passing fixes
+- Produces: a review-ready PR #164 branch with focused and full validation evidence
+
+- [ ] **Step 1: Run all focused regression classes together**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest \
+  --tests '*TvCalendarFocusRoutingTest' \
+  --tests '*TvDiagnosticsStateTest' \
+  --tests '*TvDetailReturnFocusStateTest' \
+  --tests '*TvRecommendationsFocusBridgeTest' \
+  --tests '*TvShellFocusStateTest'
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run the full Android TV unit suite**
+
+```bash
+./gradlew :androidTvApp:testDebugUnitTest
+```
+
+Expected: zero failures.
+
+- [ ] **Step 3: Assemble the Android TV debug APK**
+
+```bash
+./gradlew :androidTvApp:assembleDebug
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Run repository hygiene checks**
+
+```bash
+git diff --check origin/main...HEAD
+git status --short
+```
+
+Expected: no whitespace errors and no uncommitted files.
+
+- [ ] **Step 5: Review the final diff against the approved scope**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusState.kt \
+  androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+```
+
+Confirm the diff implements only the four approved corrections and their regression coverage.
+
+- [ ] **Step 6: Record the remaining device gate**
+
+Report that automated validation is complete while Shield smoke checks remain required for held Calendar movement, Diagnostics initial focus, and Home/For You detail-return restoration.

--- a/docs/superpowers/plans/2026-08-04-pr-164-review-remediation.md
+++ b/docs/superpowers/plans/2026-08-04-pr-164-review-remediation.md
@@ -30,7 +30,7 @@
 - Consumes: `calendarUpFallbackAction(focusedShelfIndex, firstFocusableShelfIndex, isReturningToControls, focusedControlZone, isRepeat)`
 - Produces: the existing `CalendarUpFallbackAction.MoveWithinContent` result for repeated Up below the first focusable shelf
 
-- [ ] **Step 1: Add the failing regression test**
+- [x] **Step 1: Add the failing regression test**
 
 Add this test to `TvCalendarFocusRoutingTest`:
 
@@ -50,7 +50,7 @@ fun heldUpBelowFirstShelfContinuesContentMovement() {
 }
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run:
 
@@ -60,7 +60,7 @@ Run:
 
 Expected: `heldUpBelowFirstShelfContinuesContentMovement` fails because the current unconditional `isRepeat` branch returns `StayInContent`.
 
-- [ ] **Step 3: Restore the content-aware repeat guard**
+- [x] **Step 3: Restore the content-aware repeat guard**
 
 Change the broad repeat branch in `calendarUpFallbackAction` to:
 
@@ -70,11 +70,11 @@ focusedShelfIndex == null && isRepeat -> CalendarUpFallbackAction.StayInContent
 
 Keep the first-shelf boundary branch above it unchanged so a held event cannot skip from the first shelf into controls.
 
-- [ ] **Step 4: Run the focused test and verify GREEN**
+- [x] **Step 4: Run the focused test and verify GREEN**
 
 Run the Task 1 command again. Expected: all `TvCalendarFocusRoutingTest` tests pass.
 
-- [ ] **Step 5: Commit the Calendar correction**
+- [x] **Step 5: Commit the Calendar correction**
 
 ```bash
 git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
@@ -91,7 +91,7 @@ git commit -m "fix(tv): preserve held Calendar shelf movement"
 - Consumes: `tvDiagnosticsCrashFocusRequestResult(Result<Boolean>)`
 - Produces: `FOCUSED` for `true`; `RETRY` for `false` and caught exceptions
 
-- [ ] **Step 1: Change the failure test to the required behavior**
+- [x] **Step 1: Change the failure test to the required behavior**
 
 Replace `failedFocusRequestIsTerminalBecauseTheScreenWasDisposed` with:
 
@@ -107,7 +107,7 @@ fun detachedFocusRequesterFailureIsRetryable() {
 }
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run:
 
@@ -117,7 +117,7 @@ Run:
 
 Expected: `detachedFocusRequesterFailureIsRetryable` fails because the current function returns `DISPOSED`.
 
-- [ ] **Step 3: Remove synthetic disposal classification**
+- [x] **Step 3: Remove synthetic disposal classification**
 
 Reduce the enum and classifier to:
 
@@ -135,11 +135,11 @@ internal fun tvDiagnosticsCrashFocusRequestResult(
 
 Update the `LaunchedEffect` `when` so only `FOCUSED` exits and `RETRY` continues to the next bounded frame. Disposal continues to cancel the effect through structured concurrency.
 
-- [ ] **Step 4: Run the focused test and verify GREEN**
+- [x] **Step 4: Run the focused test and verify GREEN**
 
 Run the Task 2 command again. Expected: all `TvDiagnosticsStateTest` tests pass.
 
-- [ ] **Step 5: Commit the Diagnostics correction**
+- [x] **Step 5: Commit the Diagnostics correction**
 
 ```bash
 git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsStateTest.kt
@@ -159,7 +159,7 @@ git commit -m "fix(tv): retry detached Diagnostics focus"
 - Produces: `completeHomeDetailReturnRetry(state: HomeDetailReturnFocusState): HomeDetailReturnFocusState`
 - Produces: `resetHomeDetailReturnFocus(): HomeDetailReturnFocusState`
 
-- [ ] **Step 1: Add failing tests for the Home retry lifetime**
+- [x] **Step 1: Add failing tests for the Home retry lifetime**
 
 Create `TvDetailReturnFocusStateTest.kt`:
 
@@ -202,7 +202,7 @@ class TvDetailReturnFocusStateTest {
 }
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run:
 
@@ -212,7 +212,7 @@ Run:
 
 Expected: compilation fails because the Home state type and transition functions do not exist.
 
-- [ ] **Step 3: Add the minimal immutable state model**
+- [x] **Step 3: Add the minimal immutable state model**
 
 Create `TvDetailReturnFocusState.kt`:
 
@@ -245,13 +245,13 @@ internal fun resetHomeDetailReturnFocus(): HomeDetailReturnFocusState =
     HomeDetailReturnFocusState()
 ```
 
-- [ ] **Step 4: Wire the state model into `TvMainShell`**
+- [x] **Step 4: Wire the state model into `TvMainShell`**
 
 Replace `homeDetailReturnFocusRequest` and `homeDetailReturnNeedsRetry` with one remembered `HomeDetailReturnFocusState`. Include `homeDetailReturnFocusState.fallbackPending` in the Home branch of `detailReturnFallback`. After the synchronous resume request, call `beginHomeDetailReturnRetry`; after the optional deferred request, call `completeHomeDetailReturnRetry`. On explicit Home selection, assign `resetHomeDetailReturnFocus()`.
 
 Pass `homeDetailReturnFocusState.requestId` to both Home screen call sites. Do not change the For You flow in this task.
 
-- [ ] **Step 5: Run focused shell and Home tests and verify GREEN**
+- [x] **Step 5: Run focused shell and Home tests and verify GREEN**
 
 Run:
 
@@ -261,7 +261,7 @@ Run:
 
 Expected: both test classes pass.
 
-- [ ] **Step 6: Commit the Home correction**
+- [x] **Step 6: Commit the Home correction**
 
 ```bash
 git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusState.kt androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvDetailReturnFocusStateTest.kt
@@ -279,7 +279,7 @@ git commit -m "fix(tv): retain Home detail fallback through retry"
 - Consumes: `ForYouDetailReturnState(requestId: Int, pending: Boolean)`
 - Produces: `resetForExplicitForYouSelection(): ForYouDetailReturnState`
 
-- [ ] **Step 1: Add the failing explicit-reset test**
+- [x] **Step 1: Add the failing explicit-reset test**
 
 Add to `TvRecommendationsFocusBridgeTest`:
 
@@ -293,7 +293,7 @@ fun explicitForYouSelectionClearsStaleReturnState() {
 }
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run:
 
@@ -303,7 +303,7 @@ Run:
 
 Expected: compilation fails because `resetForExplicitForYouSelection` does not exist.
 
-- [ ] **Step 3: Add and wire the explicit reset**
+- [x] **Step 3: Add and wire the explicit reset**
 
 Add to `TvRecommendationsFocusBridge.kt`:
 
@@ -314,11 +314,11 @@ internal fun resetForExplicitForYouSelection(): ForYouDetailReturnState =
 
 In the `TvRootDestination.ForYou` branch of `onSelectRoot`, call the helper and assign both `forYouDetailReturnFocusRequest` and `forYouDetailReturnFocusPending` from the returned state before creating the top-level For You entry request.
 
-- [ ] **Step 4: Run the focused test and verify GREEN**
+- [x] **Step 4: Run the focused test and verify GREEN**
 
 Run the Task 4 command again. Expected: all `TvRecommendationsFocusBridgeTest` tests pass.
 
-- [ ] **Step 5: Commit the For You correction**
+- [x] **Step 5: Commit the For You correction**
 
 ```bash
 git add androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridge.kt androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsFocusBridgeTest.kt
@@ -334,7 +334,7 @@ git commit -m "fix(tv): reset stale For You detail return"
 - Consumes: all four independently passing fixes
 - Produces: a review-ready PR #164 branch with focused and full validation evidence
 
-- [ ] **Step 1: Run all focused regression classes together**
+- [x] **Step 1: Run all focused regression classes together**
 
 ```bash
 ./gradlew :androidTvApp:testDebugUnitTest \
@@ -347,7 +347,7 @@ git commit -m "fix(tv): reset stale For You detail return"
 
 Expected: all focused tests pass.
 
-- [ ] **Step 2: Run the full Android TV unit suite**
+- [x] **Step 2: Run the full Android TV unit suite**
 
 ```bash
 ./gradlew :androidTvApp:testDebugUnitTest
@@ -355,7 +355,7 @@ Expected: all focused tests pass.
 
 Expected: zero failures.
 
-- [ ] **Step 3: Assemble the Android TV debug APK**
+- [x] **Step 3: Assemble the Android TV debug APK**
 
 ```bash
 ./gradlew :androidTvApp:assembleDebug
@@ -363,7 +363,7 @@ Expected: zero failures.
 
 Expected: `BUILD SUCCESSFUL`.
 
-- [ ] **Step 4: Run repository hygiene checks**
+- [x] **Step 4: Run repository hygiene checks**
 
 ```bash
 git diff --check origin/main...HEAD
@@ -372,7 +372,7 @@ git status --short
 
 Expected: no whitespace errors and no uncommitted files.
 
-- [ ] **Step 5: Review the final diff against the approved scope**
+- [x] **Step 5: Review the final diff against the approved scope**
 
 ```bash
 git diff --stat origin/main...HEAD
@@ -386,6 +386,6 @@ git diff origin/main...HEAD -- \
 
 Confirm the diff implements only the four approved corrections and their regression coverage.
 
-- [ ] **Step 6: Record the remaining device gate**
+- [x] **Step 6: Record the remaining device gate**
 
 Report that automated validation is complete while Shield smoke checks remain required for held Calendar movement, Diagnostics initial focus, and Home/For You detail-return restoration.

--- a/docs/superpowers/specs/2026-08-03-for-you-late-focus-relocation-design.md
+++ b/docs/superpowers/specs/2026-08-03-for-you-late-focus-relocation-design.md
@@ -1,0 +1,45 @@
+# For You Late Focus-Relocation Recovery Design
+
+## Problem
+
+When focus enters the first recommendation row while the For You list is
+already at item zero, the current correction effect exits immediately. Compose
+can run the row's focus-driven bring-into-view relocation afterward and move the
+list below its intended top anchor. Moving down and back up re-enters the row and
+re-arms the correction, which is why the screen then recovers.
+
+## Design
+
+Keep a scroll-position observer active only while the first recommendation row
+owns focus. The observer remains suspended while the list is correctly anchored
+and reacts only when the list position changes. If a later focus-relocation pass
+moves the list away from item zero, wait for that relocation to settle, confirm
+the row still owns focus and the list is still displaced, then animate back to
+item zero. Leaving the row cancels the observer through the existing
+focus-keyed `LaunchedEffect`.
+
+The observer and correction loop will be extracted behind a small suspend
+helper that accepts position events and scroll callbacks. This keeps the
+timing policy testable without a Compose UI harness while production continues
+to obtain positions from `snapshotFlow` over the real `LazyListState`.
+
+## Alternatives Rejected
+
+- A fixed number of settling polls adds arbitrary timing and can still miss a
+  slower Fire TV relocation.
+- Changing the shared bring-into-view policy affects every recommendation row
+  and risks wider D-pad navigation regressions.
+- Continuous polling for the entire focus lifetime wakes unnecessarily even
+  when the list does not move; an event-driven observer has no such activity.
+
+## Verification
+
+Add a coroutine regression test that emits an initially correct top position,
+then emits a delayed displaced position while focus remains in the first row.
+The test must fail against the current early-exit behavior and pass only when
+the delayed displacement triggers one top-anchor correction. Also cover that a
+top-only sequence is a no-op and that focus loss prevents a pending correction.
+
+Run the focused test, the complete Android TV unit suite, release-workflow and
+supply-chain checks, and assemble the Android TV debug APK with the full RC
+display version.

--- a/docs/superpowers/specs/2026-08-03-shield-focus-restoration-design.md
+++ b/docs/superpowers/specs/2026-08-03-shield-focus-restoration-design.md
@@ -1,0 +1,113 @@
+# Shield Focus Restoration Design
+
+## Purpose
+
+Fix the remaining Android TV focus failures reported on Shield Pro without changing Watchlist placement, behavior, navigation, or rendering:
+
+- Returning from a For You item detail must preserve the feed position and restore D-pad focus to the card that launched the detail screen.
+- The For You top chrome must use the same solid visual foundation already visible in Watchlist and Favorites, without editing those saved-list views.
+- Calendar must allow Up navigation from the weekday row through its controls and back to the selected Calendar tab.
+- The Diagnostics page's crash-report choices must reliably receive and move focus with a remote.
+
+This branch is based on the head of PR #162, so the event-driven first-row top-anchor correction remains part of the resulting change.
+
+## Non-goals
+
+- Do not promote Watchlist to a top-level tab.
+- Do not alter Watchlist or Favorites behavior, navigation, layout, or rendering.
+- Do not redesign For You, Calendar, Diagnostics, or the global shell.
+- Do not retain every nested route in composition or replace Navigation Compose.
+- Do not add touch or keyboard-specific interaction models unrelated to TV D-pad navigation.
+
+## Root Causes
+
+### For You detail return
+
+The For You vertical `LazyListState` is retained, but the shell restores only the generic content focus group after the outer detail route disposes and recreates the shell. Unlike Home, For You does not attach the shell's return requester to the exact launch card. The generic restorer therefore has no durable descendant target and can select a filter, a different card, or no usable row focus after recreation. A subsequent focus-driven bring-into-view pass can make the retained list appear to have lost its position.
+
+### Calendar exit
+
+The shell suppresses the top menu while Calendar performs its initial content handoff. Calendar clears that suppression only when one imperative filter request reports success. If that request misses during route composition but Android's default search still focuses a weekday, the screen looks usable while the menu remains suppressed indefinitely. The shell also treats every control as the same focus zone, so Up from a weekday has no deterministic intermediate target.
+
+### Diagnostics crash-report controls
+
+The Diagnostics page performs one immediate request to the first consent action and discards the result. A request that races route layout is never retried. The consent actions also rely on geometric focus search, so there is no deterministic Up/Down path through the crash-report choices when the page enters without a focused descendant.
+
+### For You top chrome
+
+Watchlist and Favorites render on an opaque full-page saved-list surface. For You relies on the shell gradient and its scrolling feed, producing visibly different top chrome. The inconsistency belongs to For You; changing the saved-list views would expand the visual impact unnecessarily.
+
+## Design
+
+### 1. Exact For You return target
+
+For You will maintain a saveable return target containing stable section and content identities, plus the most recent row/card indices as fallbacks. `TvMediaRow` already supports an indexed item-focus callback and an exact-card restore requester; the screen will use those existing interfaces instead of creating a second card component.
+
+When a recommendation card gains focus, For You records its section ID, content ID, row index, and card index. When that card opens detail, the screen marks the recorded target as pending before delegating navigation to the shell. While pending, the matching `TvMediaRow` attaches a dedicated return `FocusRequester` to the exact card and uses it as that row's restorer fallback.
+
+The shell will distinguish a For You detail return from Home and generic content returns. During resume it will enter the content group using the For You return requester as the fallback, following the existing Home pattern. A screen-level post-composition handoff will ensure the saved vertical row is composed before retrying the exact card request.
+
+Resolution order on return:
+
+1. The same section and content ID.
+2. The same section and the closest valid card index.
+3. The closest surviving recommendation row's first card.
+4. The For You filter pill if the recommendation feed is now empty.
+
+The existing saved vertical list state and each row's saved horizontal list state remain authoritative. Focus restoration must not reset either list to zero. PR #162's first-row anchor watcher remains limited to the case where the first recommendation row itself has focus.
+
+### 2. Calendar focus zones and suppression acknowledgement
+
+Calendar will explicitly identify focus in two control zones: filter segments and week-strip controls. The shell's Up fallback will route based on the active zone:
+
+- From a poster shelf, preserve the existing return-to-week-strip behavior.
+- From the weekday/week-strip zone, request the active filter segment.
+- From the filter zone, request the selected Calendar tab in the top menu.
+- Preserve the existing held-key repeat guard so one long press cannot skip multiple layers.
+
+Any successful focus gain inside Calendar's controls will acknowledge that Calendar content owns focus. This acknowledgement clears `calendarFocusHandoffPending` even when the original imperative filter request failed. The shell can then accept the next Up request. The imperative initial request remains useful, but it is no longer the sole authority allowed to release menu suppression.
+
+### 3. Diagnostics crash-report focus routing
+
+The crash-report consent actions will receive stable requesters. On page entry, Diagnostics will target the currently selected consent mode, rather than always targeting `Ask`, after at least one layout frame. A bounded retry handles route-transition timing; success ends the retry immediately.
+
+Up and Down will route explicitly through the enabled crash-report actions in visual order. The last consent choice routes Down to Debug logging when that action is enabled; disabled actions are skipped. At the upper boundary, focus remains on the first crash-report choice instead of escaping to a non-focusable status block. Navigation from the end of the crash-report section into the existing Capture actions remains available through normal focus search.
+
+No consent values, upload behavior, report data, or diagnostics visuals change.
+
+### 4. For You-only top underlay
+
+For You will paint an opaque background under the top-menu region before drawing its feed. The color will be the existing TV theme background, matching the solid foundation visible in Watchlist and Favorites. This underlay is conditional on the recommendations selection only. Watchlist and Favorites remain byte-for-byte unchanged.
+
+The global shell gradient remains in place for other routes. No button, typography, spacing, or focus styling changes.
+
+## State and Failure Handling
+
+- Return targets use stable IDs first because recommendation refreshes can reorder rows and cards.
+- Missing or filtered content follows the explicit fallback order and never loops indefinitely.
+- Focus retries are bounded and frame-based; they stop on success, disposal, or target removal.
+- A failed Calendar initial request cannot leave the menu permanently suppressed once any Calendar control receives focus.
+- Disabled Diagnostics actions are never requested as focus destinations.
+- Repeated D-pad key events retain the existing one-layer-per-press policy.
+
+## Testing
+
+Add focused unit tests for pure routing and resolution logic:
+
+- For You exact target, reordered target, missing-card fallback, missing-row fallback, and empty-feed fallback.
+- Calendar shelf-to-week-strip, week-strip-to-filter, filter-to-menu, and repeat-event behavior.
+- Diagnostics selected-consent entry, Up/Down ordering, disabled Debug logging, and boundary behavior.
+- Preserve PR #162's delayed first-row relocation tests.
+
+Run the complete Android TV unit-test task and assemble the TV debug APK. On Shield Pro, manually verify:
+
+1. Scroll several For You rows, open a non-first card, return, and confirm the same card and both scroll axes are restored.
+2. Repeat after a recommendations refresh or reorder and confirm the stable-ID/fallback behavior.
+3. Focus the first For You row and confirm a delayed bring-into-view cannot displace it from the top.
+4. Move from a Calendar shelf to weekdays, Up to filters, then Up to the Calendar top-menu tab.
+5. Enter Diagnostics and confirm the selected crash-report consent choice is focused; traverse every enabled choice with Up/Down.
+6. Compare For You top chrome with Watchlist/Favorites and confirm only For You changed.
+
+## Delivery
+
+The implementation stays on the isolated `fix/shield-focus-restoration` branch. It will not modify or rewrite the separate unpushed episode-selector branch. Installation on the Shield and opening the app remain separate explicit delivery steps after the build passes.

--- a/docs/superpowers/specs/2026-08-04-pr-164-review-remediation-design.md
+++ b/docs/superpowers/specs/2026-08-04-pr-164-review-remediation-design.md
@@ -1,0 +1,75 @@
+# PR #164 Review Remediation Design
+
+## Goal
+
+Make PR #164 safe to merge by correcting four verified Android TV focus-state defects without broadening the feature or changing unrelated navigation behavior.
+
+## Scope
+
+The remediation covers:
+
+1. Calendar held-Up navigation from a non-boundary shelf.
+2. Diagnostics initial-focus retries when a `FocusRequester` is temporarily detached.
+3. Home detail-return fallback lifetime across its deferred retry.
+4. Stale For You detail-return state after an explicit top-menu selection.
+
+The following review observations are intentionally outside this change:
+
+- Diagnostics Up at the first crash-report option remains a consumed boundary because the STATUS section above it has no focusable control.
+- Keyless recommendation section kinds remain stable singleton identities under the current server contract.
+- Legacy-server duplicate fallback identities are a separate compatibility-hardening concern.
+- The unused `shouldFallbackForYouReturnToFilter` predicate is cleanup rather than a behavioral blocker.
+
+## Design
+
+### Calendar repeat routing
+
+`calendarUpFallbackAction` will distinguish content from control boundaries. A repeated Up event with no focused shelf may remain within the current control layer, and a repeated Up event at the first focusable shelf may remain in content. A repeated Up event from any deeper shelf must return `MoveWithinContent`, matching the pre-PR behavior and allowing held D-pad movement to continue one shelf at a time.
+
+The existing action enum and event pipeline remain unchanged. The correction is limited to the predicate ordering and a regression test combining `isRepeat = true` with a non-null, non-boundary shelf index.
+
+### Diagnostics focus retry
+
+`FocusRequester.requestFocus()` returning `false` or throwing while the target is not attached will both map to `RETRY`. The existing six-frame bound prevents an infinite loop. Actual screen disposal is represented by cancellation of the `LaunchedEffect`, so no synthetic `DISPOSED` result is needed for caught focus-request exceptions.
+
+The result enum may retain `DISPOSED` only if another production path still produces it; otherwise it will be removed with the now-unreachable branch. A regression test will require a failed `Result<Boolean>` to map to `RETRY`.
+
+### Home detail-return fallback lifetime
+
+Home will gain an explicit pending lifetime for its card-specific detail-return fallback, parallel in purpose to the For You pending state but limited to the existing one-frame Home retry flow. The fallback must remain the Home launch-card requester through the synchronous resume attempt and, when needed, through the deferred frame retry. It will be cleared after the retry flow finishes, or immediately when no retry is required.
+
+Explicit Home selection will continue clearing the Home return token and retry state. The state transition logic will be extracted or represented by a small pure helper only where needed to make the lifetime regression test deterministic; no generalized focus coordinator will be introduced.
+
+### For You explicit-selection reset
+
+Selecting the For You root from the top menu will clear both `forYouDetailReturnFocusRequest` and `forYouDetailReturnFocusPending` before issuing the normal top-level entry request. This prevents an interrupted detail-return request from suppressing or redirecting the explicit first-content focus handoff.
+
+The reset will apply to explicit root selection only. Returning naturally from item detail will preserve the pending request until the recommendation screen consumes the matching request ID.
+
+## Error and lifecycle behavior
+
+- Focus requests remain best-effort and bounded; failures do not escape the composing coroutine.
+- Coroutine cancellation remains authoritative for disposal.
+- A stale completion ID cannot consume a newer For You request.
+- Explicit menu navigation takes precedence over stale detail-return state.
+- No persisted server, profile, or media state changes.
+
+## Testing
+
+Each production change will follow a separate red-green cycle:
+
+1. Add a Calendar test proving repeated Up from a deeper shelf returns `MoveWithinContent`.
+2. Change the Diagnostics failure test to require `RETRY` and confirm it fails before implementation.
+3. Add a Home state-transition test proving the launch-card fallback remains active through a requested retry and clears afterward.
+4. Add a For You explicit-selection reset test proving both request ID and pending state clear together.
+
+After the focused tests pass, run:
+
+- `./gradlew :androidTvApp:testDebugUnitTest --tests '*TvCalendarFocusRoutingTest'`
+- `./gradlew :androidTvApp:testDebugUnitTest --tests '*TvDiagnosticsStateTest'`
+- the focused shell/recommendation state tests introduced or updated by this remediation
+- `./gradlew :androidTvApp:testDebugUnitTest`
+- `./gradlew :androidTvApp:assembleDebug`
+- `git diff --check`
+
+A physical Shield D-pad smoke test remains the release gate for Calendar held-Up movement, Diagnostics initial focus, and Home/For You detail-return restoration.

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/recommendation/RecommendationModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/recommendation/RecommendationModels.kt
@@ -8,6 +8,8 @@ import kotlinx.serialization.Serializable
 data class DiscoverRow(
     val type: String,
     val label: String,
+    @SerialName("section_kind") val sectionKind: String? = null,
+    @SerialName("section_key") val sectionKey: String? = null,
     val items: List<SectionItem> = emptyList(),
 )
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/RecommendationsViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/RecommendationsViewModel.kt
@@ -64,10 +64,7 @@ class RecommendationsViewModel(
 
         when (discoverResult) {
             is ApiResult.Success -> {
-                val sections = discoverResult.data.rows
-                    .mapIndexed { index, row -> row.toResolvedSection(index) }
-                    .filter { it.items.isNotEmpty() }
-                    .sortedByDescending { it.title.equals("For You", ignoreCase = true) }
+                val sections = discoverResult.data.rows.toResolvedSections()
 
                 _uiState.update {
                     it.copy(
@@ -103,12 +100,23 @@ class RecommendationsViewModel(
         }
     }
 
-    private fun DiscoverRow.toResolvedSection(index: Int): ResolvedSection = ResolvedSection(
-        id = "discover_${index}_${type}",
-        sectionType = type,
-        title = label,
-        itemLimit = items.size,
-        totalCount = items.size,
-        items = items,
-    )
 }
+
+internal fun List<DiscoverRow>.toResolvedSections(): List<ResolvedSection> =
+    map(DiscoverRow::toResolvedSection)
+        .filter { it.items.isNotEmpty() }
+        .sortedByDescending { it.title.equals("For You", ignoreCase = true) }
+
+private fun DiscoverRow.toResolvedSection(): ResolvedSection = ResolvedSection(
+    id = stableSectionId(),
+    sectionType = type,
+    title = label,
+    itemLimit = items.size,
+    totalCount = items.size,
+    items = items,
+)
+
+private fun DiscoverRow.stableSectionId(): String =
+    sectionKind?.takeIf { it.isNotBlank() }?.let { kind ->
+        "discover:kind=$kind:key=${sectionKey.orEmpty()}"
+    } ?: "discover:type=$type:label=$label"

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/RecommendationsSectionIdentityTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/RecommendationsSectionIdentityTest.kt
@@ -1,0 +1,72 @@
+package org.siloserver.silo.viewmodel
+
+import org.siloserver.silo.model.recommendation.DiscoverRow
+import org.siloserver.silo.model.section.SectionItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class RecommendationsSectionIdentityTest {
+    @Test
+    fun productionSectionIdsSurviveRowInsertionAndReorder() {
+        val returnedFrom = row(
+            type = "cluster",
+            label = "Because you enjoy Drama",
+            sectionKind = "cluster",
+            sectionKey = "2",
+            contentId = "movie-b",
+        )
+        val popular = row(
+            type = "popular",
+            label = "Popular on This Server",
+            sectionKind = "popular",
+            contentId = "movie-popular",
+        )
+
+        val beforeRefresh = listOf(returnedFrom, popular).toResolvedSections()
+        val afterRefresh = listOf(
+            row(
+                type = "cluster",
+                label = "Because you enjoy Comedy",
+                sectionKind = "cluster",
+                sectionKey = "7",
+                contentId = "movie-new",
+            ),
+            popular,
+            returnedFrom,
+        ).toResolvedSections()
+
+        val originalId = beforeRefresh.single { section ->
+            section.items.any { it.contentId == "movie-b" }
+        }.id
+        val refreshedId = afterRefresh.single { section ->
+            section.items.any { it.contentId == "movie-b" }
+        }.id
+        val insertedId = afterRefresh.single { section ->
+            section.items.any { it.contentId == "movie-new" }
+        }.id
+
+        assertEquals(originalId, refreshedId)
+        assertNotEquals(insertedId, refreshedId)
+    }
+
+    private fun row(
+        type: String,
+        label: String,
+        sectionKind: String,
+        sectionKey: String? = null,
+        contentId: String,
+    ) = DiscoverRow(
+        type = type,
+        label = label,
+        sectionKind = sectionKind,
+        sectionKey = sectionKey,
+        items = listOf(
+            SectionItem(
+                contentId = contentId,
+                type = "movie",
+                title = contentId,
+            ),
+        ),
+    )
+}


### PR DESCRIPTION
## Summary

- preserve and restore the exact For You recommendation card after returning from detail, including reordered and horizontally offscreen targets
- retain PR #162 late first-row anchor recovery and make only the For You recommendations view use the solid top treatment already shown by Watchlist/Favorites
- route Calendar focus from shelves to weekdays to filters to the Calendar tab, including empty/error states
- make Diagnostics crash-report controls reliably focusable and prevent held D-pad repeats from skipping layers

Watchlist remains inside For You. Its behavior, navigation, layout, rendering, and generic detail callback are unchanged.

This PR includes and supersedes #162.

## Verification

- shared recommendation identity test: passed
- focused For You resolver, lifecycle, offscreen-row, and top-anchor tests: passed
- focused Diagnostics tests: passed
- full Android TV unit suite: 794 tests, 0 failures
- androidTvApp debug APK assembly: passed
- final whole-branch review and scoped fix re-review: ready to merge
- TvPersonalScreens.kt protected-file diff: empty

## Device follow-up

The APK was built but was not installed or launched during this branch pass. Shield Pro focus and visual smoke checks remain the post-PR release gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Restores focus to previously selected recommendations after returning from details, including reordered or temporarily unavailable content.
  * Improves D-pad navigation across Calendar filters, week controls, menus, and content.
  * Enhances Diagnostics settings focus order, retries, and directional navigation.
  * Preserves the For You list’s top position after delayed focus changes.
  * Displays a solid top-bar background when needed for For You navigation.

* **Tests**
  * Added coverage for focus restoration, navigation boundaries, delayed scrolling, and diagnostics controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->