### PR TITLE
Add synced navigation and card customization

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/network/AndroidDeviceMetadataProvider.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/network/AndroidDeviceMetadataProvider.kt
@@ -21,6 +21,7 @@ class AndroidDeviceMetadataProvider(
     private val context: Context,
     private val platform: String,
     private val buildIdentity: SiloClientBuildIdentity,
+    private val clientFamily: String? = null,
 ) : DeviceMetadataProvider {
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val cachedClientName: String by lazy { clientNameFor(platform) }
@@ -39,6 +40,10 @@ class AndroidDeviceMetadataProvider(
             id = deviceId,
             name = model,
             platform = platform,
+            clientFamily = clientFamily ?: androidClientFamily(
+                platform = platform,
+                smallestScreenWidthDp = context.resources.configuration.smallestScreenWidthDp,
+            ),
             clientName = cachedClientName,
             clientVersion = cachedClientVersion,
             clientBuild = buildIdentity.reportedBuildNumber,
@@ -67,3 +72,10 @@ class AndroidDeviceMetadataProvider(
         const val KEY_DEVICE_ID = "device_id"
     }
 }
+
+fun androidClientFamily(platform: String, smallestScreenWidthDp: Int): String =
+    when {
+        platform == "android-tv" -> "tv"
+        smallestScreenWidthDp >= 600 -> "tablet"
+        else -> "mobile"
+    }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/UiCustomizationStore.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/UiCustomizationStore.kt
@@ -1,0 +1,1453 @@
+package org.siloserver.silo.common.settings
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.put
+import java.security.MessageDigest
+import org.siloserver.silo.common.diagnostics.SiloLog
+import org.siloserver.silo.model.diagnostics.DiagnosticsLogCategory
+import org.siloserver.silo.model.settings.CardPresentation
+import org.siloserver.silo.model.settings.NavigationShortcuts
+import org.siloserver.silo.model.settings.PrimaryMenu
+import org.siloserver.silo.model.settings.PrimaryMenuItem
+import org.siloserver.silo.model.settings.SettingKeys
+import org.siloserver.silo.model.settings.SettingScope
+import org.siloserver.silo.model.settings.SiloClientFamily
+import org.siloserver.silo.model.settings.UiCustomizationCodec
+import org.siloserver.silo.model.settings.supportsUiCustomization
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionPhase
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.api.newSettingMutationId
+import org.siloserver.silo.network.api.SettingsCapabilitiesResult
+import org.siloserver.silo.repository.SettingsRepository
+
+/**
+ * Cached, server-synchronized navigation and card preferences.
+ *
+ * Family-scoped values are shared by Android and Apple devices in the same
+ * family through `profile_client`; shortcuts remain profile-wide. Every edit
+ * is cached before its best-effort network write. A failed write is marked
+ * pending and retried on the next foreground refresh, so airplane mode and an
+ * older server never make the app forget a usable local layout.
+ */
+interface UiCustomizationStore {
+    val family: SiloClientFamily
+    /** true=supported, false=confirmed incompatible, null=unknown/transiently offline. */
+    val uiCustomizationSupported: StateFlow<Boolean?>
+    val primaryMenu: StateFlow<PrimaryMenu?>
+    val shortcuts: StateFlow<NavigationShortcuts>
+    val cardPresentation: StateFlow<CardPresentation>
+    /** Raw effective source scope, retained for forward-compatible UI. */
+    val primaryMenuSource: StateFlow<String?>
+    val cardPresentationSource: StateFlow<String?>
+
+    suspend fun refresh()
+    fun setPrimaryMenu(value: PrimaryMenu)
+    fun updatePrimaryMenu(
+        fallback: PrimaryMenu,
+        transform: (PrimaryMenu) -> PrimaryMenu,
+    )
+    fun resetPrimaryMenu()
+    fun setShortcutPresent(item: PrimaryMenuItem, present: Boolean)
+    /** Durably author both halves of one menu pin/unpin before either request starts. */
+    fun setPrimaryMenuAndShortcut(
+        value: PrimaryMenu,
+        item: PrimaryMenuItem,
+        present: Boolean,
+    )
+    fun updatePrimaryMenuAndShortcut(
+        fallback: PrimaryMenu,
+        item: PrimaryMenuItem,
+        present: Boolean,
+        /** `null` rejects both halves of the compound mutation atomically. */
+        transform: (PrimaryMenu) -> PrimaryMenu?,
+    )
+    fun setCardPresentation(value: CardPresentation)
+    fun updateCardPresentation(transform: (CardPresentation) -> CardPresentation)
+    /** Clear higher-precedence device rows and inherit this family's values. */
+    fun useFamilySettings()
+    /**
+     * Synchronously crosses a runtime client-family boundary, invalidating
+     * queued authoring work and painting the new family's durable cache.
+     */
+    fun reclassifyClientFamily()
+    fun clear()
+}
+
+class DefaultUiCustomizationStore(
+    family: SiloClientFamily,
+    private val repository: SettingsRepository,
+    private val tokenManager: TokenManager,
+    private val cache: AndroidServerSettingsCache,
+    private val scope: CoroutineScope,
+    private val identityTransitions: IdentityTransitionBarrier =
+        DefaultIdentityTransitionBarrier(),
+    private val familyProvider: () -> SiloClientFamily = { family },
+) : UiCustomizationStore {
+    override val family: SiloClientFamily
+        get() = familyProvider()
+
+    private val _uiCustomizationSupported = MutableStateFlow<Boolean?>(null)
+    private val _primaryMenu = MutableStateFlow<PrimaryMenu?>(null)
+    private val _shortcuts = MutableStateFlow(NavigationShortcuts.EMPTY)
+    private val _cardPresentation = MutableStateFlow(CardPresentation.DEFAULT)
+    private val _primaryMenuSource = MutableStateFlow<String?>(null)
+    private val _cardPresentationSource = MutableStateFlow<String?>(null)
+
+    override val uiCustomizationSupported: StateFlow<Boolean?> =
+        _uiCustomizationSupported.asStateFlow()
+    override val primaryMenu: StateFlow<PrimaryMenu?> = _primaryMenu.asStateFlow()
+    override val shortcuts: StateFlow<NavigationShortcuts> = _shortcuts.asStateFlow()
+    override val cardPresentation: StateFlow<CardPresentation> =
+        _cardPresentation.asStateFlow()
+    override val primaryMenuSource: StateFlow<String?> = _primaryMenuSource.asStateFlow()
+    override val cardPresentationSource: StateFlow<String?> =
+        _cardPresentationSource.asStateFlow()
+
+    private val refreshMutex = Mutex()
+    private val mutationMutex = Mutex()
+    private val authoringMutex = Mutex()
+    private val authoringStateLock = Any()
+    private val generationLock = Any()
+    private val navigationOutboxLock = Any()
+    private val authoringCommands = Channel<AuthoringCommand>(Channel.UNLIMITED)
+    private val generations = mutableMapOf<String, Long>()
+    private var authoringEpoch = 0L
+    private var observedFamily = family
+
+    @Volatile
+    private var activeIdentity: CacheIdentity? = null
+
+    init {
+        // Clear synchronously at the privacy boundary, before the new identity
+        // becomes visible. Registry-derived UI keys cannot see temporary cast
+        // scopes, so the store owns this complete identity lifecycle itself.
+        identityTransitions.installGate { transition ->
+            if (transition.phase == IdentityTransitionPhase.WILL_CHANGE) clear()
+        }
+        // Start undispatched so no transition can fall between construction and
+        // SharedFlow subscription. DID_CHANGE always resolves one atomic auth
+        // snapshot before activating and refreshing the replacement owner.
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            identityTransitions.transitions.collect { transition ->
+                if (transition.phase == IdentityTransitionPhase.DID_CHANGE) refresh()
+            }
+        }
+        scope.launch {
+            for (command in authoringCommands) {
+                executeAuthoringCommand(command)
+            }
+        }
+    }
+
+    override suspend fun refresh() {
+        reclassifyClientFamily()
+        val requestedEpoch = synchronized(authoringStateLock) { authoringEpoch }
+        // Identity activation is deliberately outside the serialized network
+        // lane. If server A has a slow GET in flight, switching to server B
+        // must paint B's cache/defaults immediately instead of leaving A's
+        // presentation visible until that request times out.
+        val binding = authoringMutex.withLock author@{
+            val current = currentBinding() ?: return@author null
+            synchronized(authoringStateLock) {
+                if (requestedEpoch != authoringEpoch) {
+                    null
+                } else {
+                    activateIdentity(current.identity)
+                    current
+                }
+            }
+        } ?: return
+
+        refreshMutex.withLock {
+            // This particular refresh belongs to the identity and clear epoch
+            // captured above. A later lifecycle refresh owns any newer scope.
+            if (synchronized(authoringStateLock) { requestedEpoch != authoringEpoch } ||
+                activeIdentity != binding.identity || !currentOwnerMatches(binding)
+            ) return@withLock
+            val support = when (val result = repository.contractCapabilities()) {
+                is SettingsCapabilitiesResult.Available ->
+                    result.capabilities.supportsUiCustomization
+                SettingsCapabilitiesResult.ServerUpgradeRequired -> false
+                is SettingsCapabilitiesResult.Error,
+                is SettingsCapabilitiesResult.NetworkError -> null
+            }
+            if (synchronized(authoringStateLock) { requestedEpoch != authoringEpoch } ||
+                activeIdentity != binding.identity || !currentOwnerMatches(binding)
+            ) return@withLock
+            _uiCustomizationSupported.value = support
+            // A confirmed old/partial server cannot accept this contract. A
+            // transiently unknown server keeps cached presentation for offline
+            // use, but avoids speculative revision-5 writes until re-probed.
+            if (support == true) refreshBinding(binding, requestedEpoch)
+        }
+    }
+
+    private suspend fun refreshBinding(binding: RequestBinding, requestedEpoch: Long) {
+        val identity = binding.identity
+
+        val pendingDeviceDeletes = flushPendingDeviceDeletes(binding)
+        val pending = flushPending(binding)
+        val shortcutOpsPending = flushPendingShortcutOps(binding)
+        if (synchronized(authoringStateLock) { requestedEpoch != authoringEpoch } ||
+            activeIdentity != identity || !currentOwnerMatches(binding)
+        ) return
+        // A GET can begin before a local edit, then return after that edit's
+        // PUT/DELETE has already cleared its pending marker. Pending state
+        // alone therefore cannot identify a stale response: retain the
+        // per-key generations that this request was made against as well.
+        val requestedGenerations = snapshotGenerations(ALL_KEYS)
+        when (
+            val result = repository.getEffectiveValues(
+                listOf(
+                    SettingKeys.NAV_PRIMARY_MENU,
+                    SettingKeys.NAV_SHORTCUTS,
+                    SettingKeys.UI_CARD_PRESENTATION,
+                ),
+                profileId = identity.profileId,
+                authScope = binding.authScope,
+            )
+        ) {
+            is ApiResult.Success -> {
+                // A logout/server switch can clear this singleton while the
+                // request is in flight. Never publish the previous profile's
+                // response into the newly active UI.
+                if (synchronized(authoringStateLock) { requestedEpoch != authoringEpoch } ||
+                    activeIdentity != identity || !currentOwnerMatches(binding)
+                ) return
+                // Authoring and response application share one short critical
+                // section. A local edit can therefore only happen entirely
+                // before this generation check (and make it fail), or after
+                // this paint (and overwrite it with the optimistic value).
+                synchronized(authoringStateLock) {
+                    if (activeIdentity != identity) return@synchronized
+                    if (SettingKeys.NAV_PRIMARY_MENU !in pending &&
+                        SettingKeys.NAV_PRIMARY_MENU !in pendingDeviceDeletes &&
+                        !isPending(identity, SettingKeys.NAV_PRIMARY_MENU)
+                        && !isPendingDeviceDelete(identity, SettingKeys.NAV_PRIMARY_MENU)
+                        && isCurrent(
+                            SettingKeys.NAV_PRIMARY_MENU,
+                            requestedGenerations.getValue(SettingKeys.NAV_PRIMARY_MENU),
+                        )
+                    ) {
+                        result.data[SettingKeys.NAV_PRIMARY_MENU]?.let { row ->
+                            val value = row.value
+                            if (value is JsonNull) {
+                                _primaryMenu.value = null
+                                cacheValue(identity, SettingKeys.NAV_PRIMARY_MENU, JsonNull)
+                            } else {
+                                UiCustomizationCodec.parsePrimaryMenu(value)?.let { parsed ->
+                                    _primaryMenu.value = parsed
+                                    cacheValue(identity, SettingKeys.NAV_PRIMARY_MENU, value)
+                                }
+                            }
+                            effectiveSource(row.source, row.scope).let { source ->
+                                _primaryMenuSource.value = source
+                                cacheSource(identity, SettingKeys.NAV_PRIMARY_MENU, source)
+                            }
+                        }
+                    }
+                    if (!shortcutOpsPending &&
+                        !hasPendingShortcutOps(identity) &&
+                        isCurrent(
+                            SettingKeys.NAV_SHORTCUTS,
+                            requestedGenerations.getValue(SettingKeys.NAV_SHORTCUTS),
+                        )
+                    ) {
+                        result.data[SettingKeys.NAV_SHORTCUTS]?.value?.let { value ->
+                            UiCustomizationCodec.parseShortcuts(value)?.let { parsed ->
+                                _shortcuts.value = parsed
+                                cacheValue(identity, SettingKeys.NAV_SHORTCUTS, value)
+                            }
+                        }
+                    }
+                    if (SettingKeys.UI_CARD_PRESENTATION !in pending &&
+                        SettingKeys.UI_CARD_PRESENTATION !in pendingDeviceDeletes &&
+                        !isPending(identity, SettingKeys.UI_CARD_PRESENTATION)
+                        && !isPendingDeviceDelete(identity, SettingKeys.UI_CARD_PRESENTATION)
+                        && isCurrent(
+                            SettingKeys.UI_CARD_PRESENTATION,
+                            requestedGenerations.getValue(SettingKeys.UI_CARD_PRESENTATION),
+                        )
+                    ) {
+                        result.data[SettingKeys.UI_CARD_PRESENTATION]?.let { row ->
+                            val value = row.value
+                            UiCustomizationCodec.parseCardPresentation(value)?.let { parsed ->
+                                _cardPresentation.value = parsed
+                                cacheValue(identity, SettingKeys.UI_CARD_PRESENTATION, value)
+                            }
+                            effectiveSource(row.source, row.scope).let { source ->
+                                _cardPresentationSource.value = source
+                                cacheSource(identity, SettingKeys.UI_CARD_PRESENTATION, source)
+                            }
+                        }
+                    }
+                }
+            }
+            is ApiResult.Error, is ApiResult.NetworkError -> Unit
+        }
+    }
+
+    override fun setPrimaryMenu(value: PrimaryMenu) {
+        authorPrimaryMenu { value }
+    }
+
+    override fun updatePrimaryMenu(
+        fallback: PrimaryMenu,
+        transform: (PrimaryMenu) -> PrimaryMenu,
+    ) {
+        authorPrimaryMenu { current -> transform(current ?: fallback) }
+    }
+
+    private fun authorPrimaryMenu(resolve: (PrimaryMenu?) -> PrimaryMenu) {
+        authorMutation { binding ->
+            val identity = binding.identity
+            val value = resolve(_primaryMenu.value)
+            val encoded = UiCustomizationCodec.encodePrimaryMenu(value)
+            if (UiCustomizationCodec.parsePrimaryMenu(encoded) == null) return@authorMutation
+            enqueue(
+                binding = binding,
+                key = SettingKeys.NAV_PRIMARY_MENU,
+                value = encoded,
+            )
+            _primaryMenu.value = value
+            setFamilySourceUnlessDeviceOverride(
+                identity = identity,
+                key = SettingKeys.NAV_PRIMARY_MENU,
+                source = _primaryMenuSource,
+            )
+        }
+    }
+
+    override fun resetPrimaryMenu() {
+        authorMutation { binding ->
+            val identity = binding.identity
+            cachePendingMutation(
+                identity,
+                SettingKeys.NAV_PRIMARY_MENU,
+                PendingMutation(JsonNull, mutationId = null),
+            )
+            cacheValue(identity, SettingKeys.NAV_PRIMARY_MENU, JsonNull)
+            cacheSource(identity, SettingKeys.NAV_PRIMARY_MENU, null)
+            markPending(identity, SettingKeys.NAV_PRIMARY_MENU, true)
+            val generation = nextGeneration(SettingKeys.NAV_PRIMARY_MENU)
+            _primaryMenu.value = null
+            _primaryMenuSource.value = null
+            scope.launch {
+                mutationMutex.withLock {
+                    if (!isCurrent(SettingKeys.NAV_PRIMARY_MENU, generation) ||
+                        activeIdentity != identity || !currentOwnerMatches(binding)
+                    ) return@withLock
+                    val result = repository.clearProfileClientValue(
+                            SettingKeys.NAV_PRIMARY_MENU,
+                            profileId = identity.profileId,
+                            authScope = binding.authScope,
+                            clientFamily = identity.family,
+                        )
+                    val identityStillCurrent = currentOwnerMatches(binding)
+                    if (result is ApiResult.Success && identityStillCurrent) {
+                        synchronized(authoringStateLock) {
+                            if (isCurrent(SettingKeys.NAV_PRIMARY_MENU, generation) &&
+                                activeIdentity == identity
+                            ) {
+                                markPending(identity, SettingKeys.NAV_PRIMARY_MENU, false)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun setShortcutPresent(item: PrimaryMenuItem, present: Boolean) {
+        if (UiCustomizationCodec.encodeShortcutItem(item) == null) return
+        authorMutation { binding ->
+            val identity = binding.identity
+            val operation = PendingShortcutOperation(
+                item = item,
+                present = present,
+                mutationId = newSettingMutationId(),
+            )
+            val accepted = synchronized(navigationOutboxLock) {
+                val optimistic = applyShortcutOperation(_shortcuts.value, operation)
+                val encoded = UiCustomizationCodec.encodeShortcuts(optimistic)
+                if (UiCustomizationCodec.parseShortcuts(encoded) == null) {
+                    false
+                } else {
+                    // The outbox is the durable source of intent; write it before
+                    // painting the optimistic document so a process death can
+                    // reconstruct the same membership change from trusted cache.
+                    val semanticIdentity = UiCustomizationCodec.identity(operation.item)
+                    val state = readPendingNavigationState(identity)
+                    val next = state.shortcutOperations.filterNot {
+                        UiCustomizationCodec.identity(it.item) == semanticIdentity
+                    } + operation
+                    writePendingNavigationState(
+                        identity,
+                        state.copy(shortcutOperations = next),
+                    )
+                    nextGeneration(SettingKeys.NAV_SHORTCUTS)
+                    _shortcuts.value = optimistic
+                    cacheValue(identity, SettingKeys.NAV_SHORTCUTS, encoded)
+                    true
+                }
+            }
+            if (accepted) scope.launch { flushPendingShortcutOps(binding) }
+        }
+    }
+
+    override fun setPrimaryMenuAndShortcut(
+        value: PrimaryMenu,
+        item: PrimaryMenuItem,
+        present: Boolean,
+    ) {
+        authorPrimaryMenuAndShortcut(item, present) { value }
+    }
+
+    override fun updatePrimaryMenuAndShortcut(
+        fallback: PrimaryMenu,
+        item: PrimaryMenuItem,
+        present: Boolean,
+        transform: (PrimaryMenu) -> PrimaryMenu?,
+    ) {
+        authorPrimaryMenuAndShortcut(item, present) { current ->
+            transform(current ?: fallback)
+        }
+    }
+
+    private fun authorPrimaryMenuAndShortcut(
+        item: PrimaryMenuItem,
+        present: Boolean,
+        resolve: (PrimaryMenu?) -> PrimaryMenu?,
+    ) {
+        authorMutation { binding ->
+            val identity = binding.identity
+            val value = resolve(_primaryMenu.value) ?: return@authorMutation
+            val encodedMenu = UiCustomizationCodec.encodePrimaryMenu(value)
+            if (UiCustomizationCodec.parsePrimaryMenu(encodedMenu) == null ||
+                UiCustomizationCodec.encodeShortcutItem(item) == null
+            ) return@authorMutation
+            val menuMutation = PendingMutation(encodedMenu, newSettingMutationId())
+            val shortcutOperation = PendingShortcutOperation(
+                item = item,
+                present = present,
+                mutationId = newSettingMutationId(),
+            )
+            val accepted = synchronized(navigationOutboxLock) {
+                val optimisticShortcuts = applyShortcutOperation(
+                    _shortcuts.value,
+                    shortcutOperation,
+                )
+                val encodedShortcuts = UiCustomizationCodec.encodeShortcuts(optimisticShortcuts)
+                if (UiCustomizationCodec.parseShortcuts(encodedShortcuts) == null) {
+                    false
+                } else {
+                    val semanticIdentity = UiCustomizationCodec.identity(item)
+                    val state = readPendingNavigationState(identity)
+                    val nextShortcuts = state.shortcutOperations.filterNot {
+                        UiCustomizationCodec.identity(it.item) == semanticIdentity
+                    } + shortcutOperation
+                    // One cache record is the transaction boundary: after
+                    // this write, a restart can always finish both stable-id
+                    // substeps, even if the process dies before either UI
+                    // cache write or request begins.
+                    writePendingNavigationState(
+                        identity,
+                        state.copy(
+                            menuMutations = state.menuMutations +
+                                (identity.family.wire to menuMutation),
+                            shortcutOperations = nextShortcuts,
+                        ),
+                    )
+                    markPendingFlag(identity, SettingKeys.NAV_PRIMARY_MENU, true)
+                    nextGeneration(SettingKeys.NAV_PRIMARY_MENU)
+                    nextGeneration(SettingKeys.NAV_SHORTCUTS)
+                    cacheValue(identity, SettingKeys.NAV_PRIMARY_MENU, encodedMenu)
+                    cacheValue(identity, SettingKeys.NAV_SHORTCUTS, encodedShortcuts)
+                    _primaryMenu.value = value
+                    _shortcuts.value = optimisticShortcuts
+                    true
+                }
+            }
+            if (!accepted) return@authorMutation
+            setFamilySourceUnlessDeviceOverride(
+                identity = identity,
+                key = SettingKeys.NAV_PRIMARY_MENU,
+                source = _primaryMenuSource,
+            )
+            scope.launch {
+                flushPending(binding)
+                flushPendingShortcutOps(binding)
+            }
+        }
+    }
+
+    override fun setCardPresentation(value: CardPresentation) {
+        authorCardPresentation { value }
+    }
+
+    override fun updateCardPresentation(
+        transform: (CardPresentation) -> CardPresentation,
+    ) {
+        authorCardPresentation(transform)
+    }
+
+    private fun authorCardPresentation(
+        resolve: (CardPresentation) -> CardPresentation,
+    ) {
+        authorMutation { binding ->
+            val identity = binding.identity
+            val value = resolve(_cardPresentation.value)
+            val encoded = UiCustomizationCodec.encodeCardPresentation(value)
+            if (UiCustomizationCodec.parseCardPresentation(encoded) == null) {
+                return@authorMutation
+            }
+            enqueue(
+                binding = binding,
+                key = SettingKeys.UI_CARD_PRESENTATION,
+                value = encoded,
+            )
+            _cardPresentation.value = value
+            setFamilySourceUnlessDeviceOverride(
+                identity = identity,
+                key = SettingKeys.UI_CARD_PRESENTATION,
+                source = _cardPresentationSource,
+            )
+        }
+    }
+
+    override fun useFamilySettings() {
+        authorMutation { binding ->
+            val identity = binding.identity
+            val keys = buildList {
+                if (_primaryMenuSource.value == SettingScope.PROFILE_DEVICE.wire) {
+                    add(SettingKeys.NAV_PRIMARY_MENU)
+                }
+                if (_cardPresentationSource.value == SettingScope.PROFILE_DEVICE.wire) {
+                    add(SettingKeys.UI_CARD_PRESENTATION)
+                }
+            }
+            if (keys.isEmpty()) return@authorMutation
+            // Persist each idempotent device-row delete before starting I/O. A
+            // partial failure or process death must not strand the remaining
+            // higher-precedence row forever.
+            keys.forEach { key ->
+                markPendingDeviceDelete(identity, key, true)
+                nextGeneration(key)
+            }
+            scope.launch { refresh() }
+        }
+    }
+
+    override fun clear() {
+        synchronized(authoringStateLock) {
+            authoringEpoch += 1
+            activeIdentity = null
+            resetVisibleState()
+            invalidateAllGenerations()
+        }
+    }
+
+    override fun reclassifyClientFamily() {
+        val nextFamily = familyProvider()
+        synchronized(authoringStateLock) {
+            val currentIdentity = activeIdentity
+            if (
+                observedFamily == nextFamily &&
+                (currentIdentity == null || currentIdentity.family == nextFamily)
+            ) {
+                return@synchronized
+            }
+
+            observedFamily = nextFamily
+            authoringEpoch += 1
+            invalidateAllGenerations()
+            if (currentIdentity == null) {
+                resetVisibleState()
+            } else {
+                // Cache keys and pending menu outbox entries are family-scoped.
+                // Re-key from the stable auth identity without waiting for I/O.
+                activateIdentity(currentIdentity.copy(family = nextFamily))
+            }
+        }
+    }
+
+    private fun resetVisibleState() {
+        _uiCustomizationSupported.value = null
+        _primaryMenu.value = null
+        _shortcuts.value = NavigationShortcuts.EMPTY
+        _cardPresentation.value = CardPresentation.DEFAULT
+        _primaryMenuSource.value = null
+        _cardPresentationSource.value = null
+    }
+
+    private fun invalidateAllGenerations() {
+        synchronized(generationLock) {
+            ALL_KEYS.forEach { key ->
+                generations[key] = (generations[key] ?: 0) + 1
+            }
+        }
+    }
+
+    private fun enqueue(binding: RequestBinding, key: String, value: JsonElement) {
+        val identity = binding.identity
+        val mutationId = newSettingMutationId()
+        val pendingMutation = PendingMutation(value, mutationId)
+        // Persist value + id as one atomic record before the async request can
+        // start. A process death can never pair a newer value with an older
+        // idempotency receipt.
+        cachePendingMutation(identity, key, pendingMutation)
+        cacheValue(identity, key, value)
+        markPending(identity, key, true)
+        val generation = nextGeneration(key)
+        scope.launch {
+            mutationMutex.withLock {
+                if (!isCurrent(key, generation) || activeIdentity != identity ||
+                    !currentOwnerMatches(binding)
+                ) return@withLock
+                val result = repository.setProfileClientValue(
+                    key,
+                    value,
+                    mutationId = mutationId,
+                    profileId = identity.profileId,
+                    authScope = binding.authScope,
+                    clientFamily = identity.family,
+                )
+                val identityStillCurrent = currentOwnerMatches(binding)
+                if (result is ApiResult.Success && identityStillCurrent) {
+                    synchronized(authoringStateLock) {
+                        if (activeIdentity == identity && isCurrent(key, generation) &&
+                            cachedPendingMutation(identity, key) == pendingMutation
+                        ) {
+                            markPending(identity, key, false)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /** Returns keys that still have a local write the server has not accepted. */
+    private suspend fun flushPending(binding: RequestBinding): Set<String> =
+        mutationMutex.withLock {
+            val identity = binding.identity
+            val stillPending = mutableSetOf<String>()
+            for (key in PENDING_VALUE_KEYS) {
+                if (!isPending(identity, key)) continue
+                if (activeIdentity != identity || !currentOwnerMatches(binding)) {
+                    stillPending += key
+                    continue
+                }
+                val persisted = cachedPendingMutation(identity, key)
+                val value = persisted?.value ?: cachedJson(identity, key)
+                val mutationId = if (value != null && value !is JsonNull) {
+                    persisted?.mutationId ?: cachedLegacyMutationId(identity, key)
+                        ?: newSettingMutationId().also { generated ->
+                        // Upgrade pending writes created by an older app build
+                        // exactly once, then retain the id for every retry.
+                        cachePendingMutation(
+                            identity,
+                            key,
+                            PendingMutation(value, generated),
+                        )
+                    }
+                } else {
+                    null
+                }
+                val sent = PendingMutation(value ?: JsonNull, mutationId)
+                if (persisted == null) cachePendingMutation(identity, key, sent)
+                val result = when {
+                    key == SettingKeys.NAV_PRIMARY_MENU && value is JsonNull ->
+                        repository.clearProfileClientValue(
+                            key,
+                            profileId = identity.profileId,
+                            authScope = binding.authScope,
+                            clientFamily = identity.family,
+                        )
+                    value == null -> null
+                    else -> repository.setProfileClientValue(
+                        key,
+                        value,
+                        mutationId = checkNotNull(mutationId),
+                        profileId = identity.profileId,
+                        authScope = binding.authScope,
+                        clientFamily = identity.family,
+                    )
+                }
+                // A picker can author a newer cached value while this retry is in
+                // flight. Only clear the pending bit when the successful request
+                // still represents the cache contents we just sent.
+                val identityStillCurrent = currentOwnerMatches(binding)
+                val accepted = result is ApiResult.Success && identityStillCurrent &&
+                    synchronized(authoringStateLock) {
+                        if (activeIdentity != identity ||
+                            cachedPendingMutation(identity, key) != sent
+                        ) {
+                            false
+                        } else {
+                            // The atomic pending record is authoritative.
+                            // Repaint the ordinary cache here as well, covering
+                            // a process death between its durable write and the
+                            // original display-cache write.
+                            cacheValue(identity, key, sent.value)
+                            markPending(identity, key, false)
+                            true
+                        }
+                    }
+                if (!accepted) {
+                    stillPending += key
+                }
+            }
+            stillPending
+        }
+
+    /** Drains atomic shortcut membership operations in authored order. */
+    private suspend fun flushPendingShortcutOps(binding: RequestBinding): Boolean =
+        mutationMutex.withLock {
+            val identity = binding.identity
+            var couldNotDrain = false
+            var rejectedAnyOperation = false
+            // One id rotation per item per pass. The rotated id is durable, so
+            // a genuinely fresh id cannot collide again; a second conflict in
+            // the same pass is treated as retryable rather than spun on.
+            val rotatedIdentities = mutableSetOf<String>()
+            drain@ while (true) {
+                val operation = pendingShortcutOperations(identity).firstOrNull()
+                    ?: break
+                if (activeIdentity != identity || !currentOwnerMatches(binding)) {
+                    couldNotDrain = true
+                    break
+                }
+                when (
+                    val result = repository.setNavigationShortcutPresent(
+                        item = operation.item,
+                        present = operation.present,
+                        mutationId = operation.mutationId,
+                        profileId = identity.profileId,
+                        authScope = binding.authScope,
+                    )
+                ) {
+                    is ApiResult.Success -> {
+                        // The request may have completed after sign-out or a
+                        // server/profile switch. Keep the durable operation
+                        // for an idempotent retry, but never repaint another
+                        // identity with this response.
+                        if (activeIdentity != identity || !currentOwnerMatches(binding)) {
+                            couldNotDrain = true
+                            break@drain
+                        }
+                        if (!acceptShortcutOperationSuccess(identity, operation, result.data.value)) {
+                            couldNotDrain = true
+                            break@drain
+                        }
+                    }
+                    is ApiResult.Error -> {
+                        val semanticIdentity = UiCustomizationCodec.identity(operation.item)
+                        if (result.code == HTTP_CONFLICT) {
+                            // The id, not the intent, is what this refuses:
+                            // the server already recorded different content
+                            // under it, so every replay of the same id fails
+                            // identically and would wedge the whole outbox.
+                            // Desired-presence writes are declarative, so
+                            // re-issuing this operation under a fresh id
+                            // cannot double-apply anything.
+                            if (rotatedIdentities.add(semanticIdentity)) {
+                                shortcutFailed(
+                                    operation,
+                                    "${result.code} ${result.error}: ${result.message}",
+                                    disposition = "retried with a new mutation id",
+                                )
+                                if (!rotateShortcutMutationId(identity, operation)) {
+                                    couldNotDrain = true
+                                    break@drain
+                                }
+                                continue@drain
+                            }
+                            // A freshly minted id conflicted as well: some
+                            // other writer owns it. Retry later rather than
+                            // spinning here or discarding the user's intent.
+                            shortcutFailed(
+                                operation,
+                                "${result.code} ${result.error}: ${result.message}",
+                                disposition = "kept queued for retry",
+                            )
+                            couldNotDrain = true
+                            break@drain
+                        }
+                        if (isRetryableHttp(result.code)) {
+                            shortcutFailed(
+                                operation,
+                                "${result.code} ${result.error}: ${result.message}",
+                                disposition = "kept queued for retry",
+                            )
+                            couldNotDrain = true
+                            break@drain
+                        }
+                        // Definitive: this operation can never land as
+                        // authored (deleted library, malformed item, a
+                        // validation rule the server has since tightened).
+                        // Retrying it forever would block every later pin and
+                        // keep the local document from ever reconciling.
+                        shortcutFailed(
+                            operation,
+                            "${result.code} ${result.error}: ${result.message}",
+                            disposition = "dropped",
+                        )
+                        if (!rejectShortcutOperation(identity, operation)) {
+                            couldNotDrain = true
+                            break@drain
+                        }
+                        rejectedAnyOperation = true
+                    }
+                    is ApiResult.NetworkError -> {
+                        shortcutFailed(
+                            operation,
+                            "network error: ${result.exception}",
+                            disposition = "kept queued for retry",
+                        )
+                        couldNotDrain = true
+                        break@drain
+                    }
+                }
+            }
+            // A dropped operation leaves the local document holding an intent
+            // the server never accepted. Its pending marker is gone now, so a
+            // fetch can finally adopt the authoritative shortcut document.
+            if (rejectedAnyOperation) scope.launch { refresh() }
+            couldNotDrain
+        }
+
+    /**
+     * Drops a definitively rejected operation and reverts only its own
+     * optimistic effect, leaving every sibling operation queued and painted.
+     *
+     * Returns false when the identity moved on mid-request, in which case the
+     * durable operation is left untouched for the owner that authored it.
+     */
+    private fun rejectShortcutOperation(
+        identity: CacheIdentity,
+        operation: PendingShortcutOperation,
+    ): Boolean {
+        synchronized(authoringStateLock) {
+            if (activeIdentity != identity) return false
+            synchronized(navigationOutboxLock) {
+                val state = readPendingNavigationState(identity)
+                // A newer intent for this same item replaced the rejected one
+                // while it was in flight. That newer intent owns the item's
+                // optimistic membership; only the response is stale here.
+                if (state.shortcutOperations.none { it == operation }) return true
+                val remaining = state.shortcutOperations.filterNot { it == operation }
+                writePendingNavigationState(
+                    identity,
+                    state.copy(shortcutOperations = remaining),
+                )
+                // The outbox holds at most one operation per item identity, so
+                // undoing this one's membership change cannot disturb a
+                // sibling's optimistic state, and no remaining operation
+                // re-applies it. The exact pre-edit membership is not
+                // recorded: re-pinning an already pinned item is the only case
+                // this can revert too far, and dropping the operation clears
+                // the pending marker, so the effective fetch that follows
+                // repaints the authoritative document either way.
+                val reverted = applyShortcutOperation(
+                    _shortcuts.value,
+                    operation.copy(present = !operation.present),
+                )
+                _shortcuts.value = reverted
+                cacheValue(
+                    identity,
+                    SettingKeys.NAV_SHORTCUTS,
+                    UiCustomizationCodec.encodeShortcuts(reverted),
+                )
+            }
+        }
+        return true
+    }
+
+    /**
+     * Re-mints the head operation's idempotency key in place, so the retry is
+     * the same declarative intent under an id the server has never seen.
+     */
+    private fun rotateShortcutMutationId(
+        identity: CacheIdentity,
+        operation: PendingShortcutOperation,
+    ): Boolean {
+        synchronized(authoringStateLock) {
+            if (activeIdentity != identity) return false
+            synchronized(navigationOutboxLock) {
+                val state = readPendingNavigationState(identity)
+                val index = state.shortcutOperations.indexOf(operation)
+                // Superseded while in flight: the newer operation at the head
+                // carries its own id and needs no rotation.
+                if (index < 0) return true
+                val rotated = state.shortcutOperations.toMutableList()
+                rotated[index] = operation.copy(mutationId = newSettingMutationId())
+                writePendingNavigationState(
+                    identity,
+                    state.copy(shortcutOperations = rotated),
+                )
+            }
+        }
+        return true
+    }
+
+    private fun shortcutFailed(
+        operation: PendingShortcutOperation,
+        detail: String,
+        disposition: String,
+    ) {
+        SiloLog.w(
+            CATEGORY,
+            TAG,
+            "shortcut ${if (operation.present) "pin" else "unpin"} " +
+                "${UiCustomizationCodec.identity(operation.item)} failed ($detail); $disposition",
+        )
+    }
+
+    /** Returns device overrides that could not yet be cleared. */
+    private suspend fun flushPendingDeviceDeletes(binding: RequestBinding): Set<String> =
+        mutationMutex.withLock {
+            val identity = binding.identity
+            val stillPending = mutableSetOf<String>()
+            for (key in DEVICE_OVERRIDE_KEYS) {
+                if (!isPendingDeviceDelete(identity, key)) continue
+                if (activeIdentity != identity || !currentOwnerMatches(binding)) {
+                    stillPending += key
+                    continue
+                }
+                val result = repository.clearProfileDeviceValue(
+                    key,
+                    profileId = identity.profileId,
+                    authScope = binding.authScope,
+                    clientFamily = identity.family,
+                )
+                if (result is ApiResult.Success && activeIdentity == identity &&
+                    currentOwnerMatches(binding)
+                ) {
+                    markPendingDeviceDelete(identity, key, false)
+                } else {
+                    stillPending += key
+                }
+            }
+            stillPending
+        }
+
+    private suspend fun currentBinding(): RequestBinding? {
+        val currentFamily = familyProvider()
+        tokenManager.snapshotCurrentScope()?.let { snapshot ->
+            val profileId = snapshot.profileId?.takeIf { it.isNotBlank() }
+                ?: return null
+            val serverUrl = snapshot.serverUrl.trimEnd('/').takeIf { it.isNotBlank() }
+                ?: return null
+            return RequestBinding(
+                identity = CacheIdentity(
+                    serverUrl = serverUrl,
+                    profileId = profileId,
+                    serverId = snapshot.serverId,
+                    credentialOwnerKey = credentialOwnerKey(snapshot),
+                    family = currentFamily,
+                ),
+                authScope = snapshot,
+            )
+        }
+        // Common/test token managers may not implement scoped snapshots. The
+        // production Android manager always does, so live multi-server state
+        // takes the atomic path above rather than pairing two separate reads.
+        val profileId = tokenManager.getProfileId()?.takeIf { it.isNotBlank() } ?: return null
+        val serverUrl = tokenManager.getServerUrl().trimEnd('/').takeIf { it.isNotBlank() }
+            ?: return null
+        return RequestBinding(
+            identity = CacheIdentity(
+                serverUrl = serverUrl,
+                profileId = profileId,
+                serverId = null,
+                credentialOwnerKey = LEGACY_CREDENTIAL_OWNER,
+                family = currentFamily,
+            ),
+            authScope = null,
+        )
+    }
+
+    /**
+     * Snapshot fields such as identity generation may rotate while a pinned
+     * request is in flight. A successful receipt still belongs to the same
+     * durable operation when its stable credential owner is active.
+     */
+    private suspend fun currentOwnerMatches(binding: RequestBinding): Boolean =
+        currentBinding()?.identity == binding.identity
+
+    // credentialOwnerId is stable across PIN-token rotation, server switches,
+    // and process death, but is replaced on sign-out/re-login. Older/custom
+    // token managers fall back to the captured epoch when available; only
+    // hand-built epoch-zero scopes retain the legacy server/profile owner.
+    private fun credentialOwnerKey(snapshot: AuthScopeSnapshot): String =
+        snapshot.credentialGenerationId
+            ?.takeIf { it.isNotBlank() }
+            ?.let { "overlay:$it" }
+            ?: snapshot.credentialOwnerId
+                ?.takeIf { it.isNotBlank() }
+                ?.let { "persistent:${sha256(it)}" }
+            ?: snapshot.credentialEpoch
+                .takeIf { it != 0L }
+                ?.let { "persistent_epoch:$it" }
+            ?: LEGACY_CREDENTIAL_OWNER
+
+    private fun sha256(value: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString(separator = "") { byte -> "%02x".format(byte) }
+
+    /**
+     * Resolve and activate the current atomic auth identity inside the
+     * serialized authoring lane before any local mutation is persisted or
+     * painted. This closes the window where the registry has switched to B
+     * while [activeIdentity] still points at A awaiting lifecycle refresh.
+     */
+    private fun authorMutation(action: (RequestBinding) -> Unit) {
+        reclassifyClientFamily()
+        val requestedEpoch = synchronized(authoringStateLock) { authoringEpoch }
+        authoringCommands.trySend(AuthoringCommand(requestedEpoch, action))
+    }
+
+    private suspend fun executeAuthoringCommand(command: AuthoringCommand) {
+        authoringMutex.withLock {
+            val binding = currentBinding() ?: return@withLock
+            synchronized(authoringStateLock) {
+                if (command.epoch != authoringEpoch) return@synchronized
+                activateIdentity(binding.identity)
+                command.action(binding)
+            }
+        }
+    }
+
+    private fun activateIdentity(identity: CacheIdentity) {
+        if (activeIdentity == identity) return
+        activeIdentity = identity
+        _uiCustomizationSupported.value = null
+        loadCached(identity)
+    }
+
+    private fun loadCached(identity: CacheIdentity) {
+        // Never let one profile's last in-memory selection bleed into another
+        // profile when the new identity has no cached value (for example while
+        // offline on first use).
+        _primaryMenu.value = null
+        _shortcuts.value = NavigationShortcuts.EMPTY
+        _cardPresentation.value = CardPresentation.DEFAULT
+        _primaryMenuSource.value = null
+        _cardPresentationSource.value = null
+
+        cachedUiJson(identity, SettingKeys.NAV_PRIMARY_MENU)?.let { value ->
+            _primaryMenu.value = if (value is JsonNull) null else
+                UiCustomizationCodec.parsePrimaryMenu(value) ?: _primaryMenu.value
+        }
+        val cachedShortcuts = cachedJson(identity, SettingKeys.NAV_SHORTCUTS)
+            ?.let(UiCustomizationCodec::parseShortcuts)
+            ?: NavigationShortcuts.EMPTY
+        _shortcuts.value = applyShortcutOperations(
+            cachedShortcuts,
+            pendingShortcutOperations(identity),
+        )
+        cachedUiJson(identity, SettingKeys.UI_CARD_PRESENTATION)?.let { value ->
+            UiCustomizationCodec.parseCardPresentation(value)?.let { _cardPresentation.value = it }
+        }
+        _primaryMenuSource.value = cachedSource(identity, SettingKeys.NAV_PRIMARY_MENU)
+        _cardPresentationSource.value = cachedSource(identity, SettingKeys.UI_CARD_PRESENTATION)
+        if (cachedPendingMutation(identity, SettingKeys.NAV_PRIMARY_MENU) != null &&
+            _primaryMenuSource.value != SettingScope.PROFILE_DEVICE.wire
+        ) {
+            _primaryMenuSource.value = SettingScope.PROFILE_CLIENT.wire
+        }
+    }
+
+    private fun cachedJson(identity: CacheIdentity, key: String): JsonElement? {
+        val raw = cache.getString(identity.serverUrl, storageKey(identity, key))
+        if (raw.isBlank()) return null
+        return runCatching { JSON.parseToJsonElement(raw) }.getOrNull()
+    }
+
+    private fun cacheValue(identity: CacheIdentity, key: String, value: JsonElement) {
+        cache.putString(identity.serverUrl, storageKey(identity, key), value.toString())
+    }
+
+    private fun cachedUiJson(identity: CacheIdentity, key: String): JsonElement? =
+        cachedPendingMutation(identity, key)?.value ?: cachedJson(identity, key)
+
+    private fun isPending(identity: CacheIdentity, key: String): Boolean =
+        cachedPendingMutation(identity, key) != null ||
+            cache.getBoolean(identity.serverUrl, pendingKey(identity, key), false)
+
+    private fun markPending(identity: CacheIdentity, key: String, pending: Boolean) {
+        markPendingFlag(identity, key, pending)
+        if (!pending) {
+            cachePendingMutation(identity, key, null)
+            cacheLegacyMutationId(identity, key, null)
+        }
+    }
+
+    private fun markPendingFlag(identity: CacheIdentity, key: String, pending: Boolean) {
+        cache.putBoolean(identity.serverUrl, pendingKey(identity, key), pending)
+    }
+
+    private fun cachedPendingMutation(identity: CacheIdentity, key: String): PendingMutation? {
+        if (key == SettingKeys.NAV_PRIMARY_MENU) {
+            return synchronized(navigationOutboxLock) {
+                readPendingNavigationState(identity).menuMutations[identity.family.wire]
+            }
+        }
+        val raw = cache.getString(identity.serverUrl, pendingMutationKey(identity, key))
+        if (raw.isBlank()) return null
+        val element = runCatching { JSON.parseToJsonElement(raw) }.getOrNull() ?: return null
+        return parsePendingMutation(element)
+    }
+
+    private fun cachePendingMutation(
+        identity: CacheIdentity,
+        key: String,
+        pending: PendingMutation?,
+    ) {
+        if (key == SettingKeys.NAV_PRIMARY_MENU) {
+            synchronized(navigationOutboxLock) {
+                val state = readPendingNavigationState(identity)
+                val nextMenus = if (pending == null) {
+                    state.menuMutations - identity.family.wire
+                } else {
+                    state.menuMutations + (identity.family.wire to pending)
+                }
+                writePendingNavigationState(
+                    identity,
+                    state.copy(menuMutations = nextMenus),
+                )
+            }
+            return
+        }
+        val raw = pending?.let(::encodePendingMutation)?.toString().orEmpty()
+        cache.putString(identity.serverUrl, pendingMutationKey(identity, key), raw)
+    }
+
+    private fun parsePendingMutation(element: JsonElement): PendingMutation? {
+        val objectValue = element as? JsonObject ?: return null
+        if (objectValue.keys != setOf("value", "mutation_id")) return null
+        val value = objectValue["value"] ?: return null
+        val mutationIdValue = objectValue["mutation_id"]
+        val mutationId = when (mutationIdValue) {
+            is JsonNull -> null
+            is JsonPrimitive -> mutationIdValue.takeIf { it.isString }?.contentOrNull
+            else -> null
+        }
+        if (mutationIdValue !is JsonNull && mutationId.isNullOrBlank()) return null
+        return PendingMutation(value, mutationId)
+    }
+
+    private fun encodePendingMutation(mutation: PendingMutation): JsonObject = buildJsonObject {
+        put("value", mutation.value)
+        put("mutation_id", mutation.mutationId?.let(::JsonPrimitive) ?: JsonNull)
+    }
+
+    private fun cachedLegacyMutationId(identity: CacheIdentity, key: String): String? =
+        cache.getString(identity.serverUrl, mutationIdKey(identity, key))
+            .takeIf { it.isNotBlank() }
+
+    private fun cacheLegacyMutationId(identity: CacheIdentity, key: String, mutationId: String?) {
+        cache.putString(identity.serverUrl, mutationIdKey(identity, key), mutationId.orEmpty())
+    }
+
+    private fun cachedSource(identity: CacheIdentity, key: String): String? =
+        cache.getString(identity.serverUrl, sourceKey(identity, key)).takeIf { it.isNotBlank() }
+
+    private fun cacheSource(identity: CacheIdentity, key: String, source: String?) {
+        cache.putString(identity.serverUrl, sourceKey(identity, key), source.orEmpty())
+    }
+
+    private fun setFamilySourceUnlessDeviceOverride(
+        identity: CacheIdentity,
+        key: String,
+        source: MutableStateFlow<String?>,
+    ) {
+        if (source.value == SettingScope.PROFILE_DEVICE.wire) return
+        source.value = SettingScope.PROFILE_CLIENT.wire
+        cacheSource(identity, key, source.value)
+    }
+
+    private fun effectiveSource(source: String, scope: String?): String? =
+        (scope ?: source).takeUnless { it == "default" }
+
+    private fun storageKey(identity: CacheIdentity, key: String): String =
+        "$CACHE_PREFIX.${identity.serverId ?: LEGACY_SERVER_ID}.${identity.profileId}." +
+            "${identity.credentialOwnerKey}." +
+            "${if (key == SettingKeys.NAV_SHORTCUTS) PROFILE_WIDE else identity.family.wire}.$key"
+
+    private fun pendingKey(identity: CacheIdentity, key: String): String =
+        "${storageKey(identity, key)}.pending"
+
+    private fun mutationIdKey(identity: CacheIdentity, key: String): String =
+        "${storageKey(identity, key)}.mutation_id"
+
+    private fun pendingMutationKey(identity: CacheIdentity, key: String): String =
+        "${storageKey(identity, key)}.pending_mutation"
+
+    private fun sourceKey(identity: CacheIdentity, key: String): String =
+        "${storageKey(identity, key)}.source"
+
+    private fun pendingDeviceDeleteKey(identity: CacheIdentity, key: String): String =
+        "${storageKey(identity, key)}.pending_device_delete"
+
+    private fun isPendingDeviceDelete(identity: CacheIdentity, key: String): Boolean =
+        cache.getBoolean(identity.serverUrl, pendingDeviceDeleteKey(identity, key), false)
+
+    private fun markPendingDeviceDelete(identity: CacheIdentity, key: String, pending: Boolean) {
+        cache.putBoolean(identity.serverUrl, pendingDeviceDeleteKey(identity, key), pending)
+    }
+
+    private fun pendingShortcutOperations(identity: CacheIdentity): List<PendingShortcutOperation> =
+        synchronized(navigationOutboxLock) {
+            readPendingNavigationState(identity).shortcutOperations
+        }
+
+    private fun hasPendingShortcutOps(identity: CacheIdentity): Boolean =
+        synchronized(navigationOutboxLock) {
+            readPendingNavigationState(identity).shortcutOperations.isNotEmpty()
+        }
+
+    private fun acceptShortcutOperationSuccess(
+        identity: CacheIdentity,
+        operation: PendingShortcutOperation,
+        serverValue: JsonElement,
+    ): Boolean {
+        val remote = UiCustomizationCodec.parseShortcuts(serverValue) ?: return false
+        synchronized(authoringStateLock) {
+            if (activeIdentity != identity) return false
+            synchronized(navigationOutboxLock) {
+                val state = readPendingNavigationState(identity)
+                val remaining = state.shortcutOperations.filterNot { it == operation }
+                writePendingNavigationState(
+                    identity,
+                    state.copy(shortcutOperations = remaining),
+                )
+                val optimistic = applyShortcutOperations(remote, remaining)
+                _shortcuts.value = optimistic
+                cacheValue(
+                    identity,
+                    SettingKeys.NAV_SHORTCUTS,
+                    UiCustomizationCodec.encodeShortcuts(optimistic),
+                )
+            }
+        }
+        return true
+    }
+
+    private fun readPendingNavigationState(
+        identity: CacheIdentity,
+    ): PendingNavigationState {
+        val raw = cache.getString(identity.serverUrl, navigationOutboxKey(identity))
+        if (raw.isBlank()) return PendingNavigationState()
+        val root = runCatching { JSON.parseToJsonElement(raw) as? JsonObject }.getOrNull()
+            ?: return PendingNavigationState()
+        val menus: Map<String, PendingMutation> = when (root.keys) {
+            setOf("menus", "shortcut_operations") -> {
+                val menuObject = root["menus"] as? JsonObject
+                    ?: return PendingNavigationState()
+                buildMap {
+                    menuObject.forEach { (familyWire, element) ->
+                        val mutation = parsePendingMutation(element)
+                            ?: return PendingNavigationState()
+                        put(familyWire, mutation)
+                    }
+                }
+            }
+            // A pre-map development build did not record which family owned
+            // its menu. Never guess after a phone/tablet reclassification;
+            // discard that ambiguous menu while retaining the independently
+            // profile-wide shortcut operations below.
+            setOf("menu", "shortcut_operations") -> emptyMap()
+            else -> return PendingNavigationState()
+        }
+        val operations = root["shortcut_operations"] as? JsonArray
+            ?: return PendingNavigationState()
+        val parsedOperations = operations.map { element ->
+            val value = element as? JsonObject ?: return PendingNavigationState()
+            if (value.keys != setOf("identity", "item", "present", "mutation_id")) {
+                return PendingNavigationState()
+            }
+            val item = UiCustomizationCodec.parseShortcutItem(value["item"])
+                ?: return PendingNavigationState()
+            val semanticIdentity = (value["identity"] as? JsonPrimitive)
+                ?.takeIf { it.isString }
+                ?.contentOrNull
+                ?: return PendingNavigationState()
+            if (semanticIdentity != UiCustomizationCodec.identity(item)) {
+                return PendingNavigationState()
+            }
+            val present = (value["present"] as? JsonPrimitive)?.booleanOrNull
+                ?: return PendingNavigationState()
+            val mutationId = (value["mutation_id"] as? JsonPrimitive)
+                ?.takeIf { it.isString }
+                ?.contentOrNull
+                ?.takeIf { it.isNotBlank() }
+                ?: return PendingNavigationState()
+            PendingShortcutOperation(item, present, mutationId)
+        }
+        return PendingNavigationState(menus, parsedOperations)
+    }
+
+    private fun writePendingNavigationState(
+        identity: CacheIdentity,
+        state: PendingNavigationState,
+    ) {
+        val raw = if (state.menuMutations.isEmpty() && state.shortcutOperations.isEmpty()) {
+            ""
+        } else {
+            buildJsonObject {
+                put("menus", buildJsonObject {
+                    state.menuMutations.forEach { (familyWire, mutation) ->
+                        put(familyWire, encodePendingMutation(mutation))
+                    }
+                })
+                put("shortcut_operations", buildJsonArray {
+                    state.shortcutOperations.forEach { operation ->
+                        add(buildJsonObject {
+                            put("identity", UiCustomizationCodec.identity(operation.item))
+                            put("item", checkNotNull(
+                                UiCustomizationCodec.encodeShortcutItem(operation.item),
+                            ))
+                            put("present", operation.present)
+                            put("mutation_id", operation.mutationId)
+                        })
+                    }
+                })
+            }.toString()
+        }
+        cache.putString(identity.serverUrl, navigationOutboxKey(identity), raw)
+    }
+
+    private fun applyShortcutOperations(
+        base: NavigationShortcuts,
+        operations: List<PendingShortcutOperation>,
+    ): NavigationShortcuts = operations.fold(base, ::applyShortcutOperation)
+
+    private fun applyShortcutOperation(
+        base: NavigationShortcuts,
+        operation: PendingShortcutOperation,
+    ): NavigationShortcuts {
+        val identity = UiCustomizationCodec.identity(operation.item)
+        val existing = base.items.firstOrNull { UiCustomizationCodec.identity(it) == identity }
+        if (operation.present && existing != null) return base
+        val withoutItem = base.items.filterNot { UiCustomizationCodec.identity(it) == identity }
+        return if (operation.present) {
+            NavigationShortcuts(withoutItem + operation.item)
+        } else {
+            NavigationShortcuts(withoutItem)
+        }
+    }
+
+    private fun navigationOutboxKey(identity: CacheIdentity): String =
+        "$CACHE_PREFIX.${identity.serverId ?: LEGACY_SERVER_ID}.${identity.profileId}." +
+            "${identity.credentialOwnerKey}.navigation_outbox"
+
+    private fun nextGeneration(key: String): Long = synchronized(generationLock) {
+        ((generations[key] ?: 0L) + 1L).also { generations[key] = it }
+    }
+
+    private fun isCurrent(key: String, generation: Long): Boolean = synchronized(generationLock) {
+        (generations[key] ?: 0L) == generation
+    }
+
+    private fun snapshotGenerations(keys: List<String>): Map<String, Long> =
+        synchronized(generationLock) {
+            keys.associateWith { key -> generations[key] ?: 0L }
+        }
+
+    private data class CacheIdentity(
+        val serverUrl: String,
+        val profileId: String,
+        val serverId: String?,
+        val credentialOwnerKey: String,
+        val family: SiloClientFamily,
+    )
+
+    private data class RequestBinding(
+        val identity: CacheIdentity,
+        val authScope: AuthScopeSnapshot?,
+    )
+
+    private data class AuthoringCommand(
+        val epoch: Long,
+        val action: (RequestBinding) -> Unit,
+    )
+
+    private data class PendingMutation(
+        val value: JsonElement,
+        val mutationId: String?,
+    )
+
+    private data class PendingShortcutOperation(
+        val item: PrimaryMenuItem,
+        val present: Boolean,
+        val mutationId: String,
+    )
+
+    private data class PendingNavigationState(
+        val menuMutations: Map<String, PendingMutation> = emptyMap(),
+        val shortcutOperations: List<PendingShortcutOperation> = emptyList(),
+    )
+
+    private companion object {
+        const val TAG = "UiCustomizationStore"
+        val CATEGORY = DiagnosticsLogCategory.NETWORK
+        val JSON = Json { ignoreUnknownKeys = false }
+        const val CACHE_PREFIX = "ui_customization.v1"
+        const val LEGACY_SERVER_ID = "single_server"
+        const val LEGACY_CREDENTIAL_OWNER = "legacy_owner"
+        const val PROFILE_WIDE = "profile"
+        val ALL_KEYS = listOf(
+            SettingKeys.NAV_PRIMARY_MENU,
+            SettingKeys.NAV_SHORTCUTS,
+            SettingKeys.UI_CARD_PRESENTATION,
+        )
+        val PENDING_VALUE_KEYS = listOf(
+            SettingKeys.NAV_PRIMARY_MENU,
+            SettingKeys.UI_CARD_PRESENTATION,
+        )
+        val DEVICE_OVERRIDE_KEYS = listOf(
+            SettingKeys.NAV_PRIMARY_MENU,
+            SettingKeys.UI_CARD_PRESENTATION,
+        )
+
+        /** `mutation_id_conflict`: this id, not this intent, was refused. */
+        const val HTTP_CONFLICT = 409
+
+        /**
+         * Retrying can help: the server fell over, throttled us, timed out, or
+         * the session token was mid refresh. Every other 4xx is the contract
+         * refusing this membership change — an item the server will not store,
+         * a scope it will not accept — where the identical retry fails forever.
+         * Mirrors [ServerSettingsFlusher]'s classification, minus 409, which
+         * this outbox recovers from by re-minting the id rather than dropping
+         * the operation.
+         */
+        fun isRetryableHttp(code: Int): Boolean =
+            code >= 500 || code == 408 || code == 429 || code == 401
+    }
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/ui/components/CardPresentationLocals.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/ui/components/CardPresentationLocals.kt
@@ -1,0 +1,22 @@
+package org.siloserver.silo.common.ui.components
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import org.siloserver.silo.model.settings.CardPresentation
+import org.siloserver.silo.model.settings.PosterSizePreset
+
+/** Current family-synchronized card presentation, with safe native defaults. */
+val LocalCardPresentation = staticCompositionLocalOf { CardPresentation.DEFAULT }
+
+fun Dp.forPosterPreset(preset: PosterSizePreset): Dp = when (preset) {
+    PosterSizePreset.COMPACT -> this * 0.84f
+    PosterSizePreset.STANDARD -> this
+    PosterSizePreset.LARGE -> this * 1.22f
+}
+
+/** Maps a fixed poster grid to an adjacent density without platform pixels. */
+fun Int.forPosterPreset(preset: PosterSizePreset): Int = when (preset) {
+    PosterSizePreset.COMPACT -> this + 1
+    PosterSizePreset.STANDARD -> this
+    PosterSizePreset.LARGE -> (this - 1).coerceAtLeast(1)
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/network/AndroidClientFamilyTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/network/AndroidClientFamilyTest.kt
@@ -1,0 +1,26 @@
+package org.siloserver.silo.common.network
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AndroidClientFamilyTest {
+    @Test
+    fun mapsTvPhoneAndTabletToCanonicalFamilies() {
+        assertEquals("tv", androidClientFamily("android-tv", smallestScreenWidthDp = 0))
+        assertEquals("mobile", androidClientFamily("android", smallestScreenWidthDp = 599))
+        assertEquals("tablet", androidClientFamily("android", smallestScreenWidthDp = 600))
+    }
+
+    @Test
+    fun foldableCanReclassifyBetweenMobileAndTabletAcrossRestarts() {
+        assertEquals("mobile", androidClientFamily("android", smallestScreenWidthDp = 420))
+        assertEquals("tablet", androidClientFamily("android", smallestScreenWidthDp = 720))
+        assertEquals("mobile", androidClientFamily("android", smallestScreenWidthDp = 420))
+    }
+
+    @Test
+    fun unknownAndroidPlatformStillReturnsACanonicalMobileFamily() {
+        assertEquals("mobile", androidClientFamily("future-android", smallestScreenWidthDp = 420))
+        assertEquals("tablet", androidClientFamily("future-android", smallestScreenWidthDp = 700))
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
@@ -15,6 +15,7 @@ import org.siloserver.silo.network.IdentityTransitionKind
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -310,5 +311,82 @@ class RegistryPairingAuthPortTest {
         assertFalse(
             prefs.all.keys.any { key -> key.startsWith(AndroidServerRegistry.serverScopedKey(serverB, "")) },
         )
+    }
+
+    /**
+     * Disk-level proof that the durable credential owner rotates INSIDE the same
+     * atomic commit as the replacement credentials: the post-commit callback is
+     * killed, so the only state anyone can observe is what the single editor
+     * transaction wrote. A reconstruction that found account B's tokens under
+     * account A's owner id would mean an owner-keyed cache (UiCustomizationStore,
+     * TvLibraryScopeStore) could adopt the previous account's local data.
+     */
+    @Test
+    fun processDeathAfterAtomicCommitReconstructsTheRotatedCredentialOwnerWithTheNewTokens() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("pairing-credential-owner-rotation", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+        val registry = AndroidServerRegistry(prefs)
+        val serverId = registry.addOrUpdate("https://silo.example")
+        registry.switchTo(serverId)
+        val tokens = EncryptedTokenManagerImpl(prefs, registry)
+        tokens.saveTokens("old-access", "old-refresh", 3600)
+        tokens.setProfileIdentity("old-profile", "old-profile-token")
+        val ownerKey = AndroidServerRegistry.serverScopedKey(serverId, "credential_owner_id")
+        val oldOwner = checkNotNull(tokens.snapshotCurrentScope()?.credentialOwnerId)
+        assertEquals(oldOwner, prefs.getString(ownerKey, null))
+
+        val simulatedDeath = EncryptedTokenManagerImpl(
+            prefs = prefs,
+            registry = AndroidServerRegistry(prefs),
+            afterAccountSessionCommit = { error("simulated process death") },
+        )
+        assertFailsWith<IllegalStateException> {
+            simulatedDeath.replaceAccountSession(
+                serverId = serverId,
+                accessToken = "new-access",
+                refreshToken = "new-refresh",
+                expiresIn = 7200,
+                profileId = "new-profile",
+                profileToken = "new-profile-token",
+            )
+        }
+
+        val reconstructedRegistry = AndroidServerRegistry(prefs)
+        val reconstructedTokens = EncryptedTokenManagerImpl(prefs, reconstructedRegistry)
+        val reconstructed = checkNotNull(reconstructedTokens.snapshotCurrentScope())
+        assertEquals("new-access", reconstructedTokens.getAccessToken())
+        assertEquals("new-refresh", reconstructedTokens.getRefreshToken())
+        assertNotEquals(oldOwner, reconstructed.credentialOwnerId)
+        assertEquals(reconstructed.credentialOwnerId, prefs.getString(ownerKey, null))
+    }
+
+    /** Sign-out must not leave the previous account's durable owner id on disk. */
+    @Test
+    fun processDeathAfterAtomicSignOutReconstructsNoDurableCredentialOwner() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("pairing-credential-owner-sign-out", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+        val registry = AndroidServerRegistry(prefs)
+        val serverId = registry.addOrUpdate("https://signed-in.example")
+        registry.switchTo(serverId)
+        val tokens = EncryptedTokenManagerImpl(prefs, registry)
+        tokens.saveTokens("old-access", "old-refresh", 3600)
+        tokens.setProfileIdentity("old-profile", "old-profile-token")
+        val ownerKey = AndroidServerRegistry.serverScopedKey(serverId, "credential_owner_id")
+        val oldOwner = checkNotNull(tokens.snapshotCurrentScope()?.credentialOwnerId)
+        assertEquals(oldOwner, prefs.getString(ownerKey, null))
+
+        val simulatedDeath = EncryptedTokenManagerImpl(
+            prefs = prefs,
+            registry = AndroidServerRegistry(prefs),
+            afterAccountSignOutCommit = { error("simulated process death") },
+        )
+        assertFailsWith<IllegalStateException> { simulatedDeath.signOutCurrentServer() }
+
+        assertNull(prefs.getString(ownerKey, null))
+        val reconstructedTokens = EncryptedTokenManagerImpl(prefs, AndroidServerRegistry(prefs))
+        assertNull(reconstructedTokens.getAccessToken())
+        assertNotEquals(oldOwner, reconstructedTokens.snapshotCurrentScope()?.credentialOwnerId)
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStoreTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/AndroidPlayerSettingsStoreTest.kt
@@ -783,6 +783,8 @@ private class FakeSettingsApi(
         keys: List<String>,
         libraryIds: List<Int>,
         seriesIds: List<String>,
+        profileId: String?,
+        authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
     ): ApiResult<EffectiveSettingValuesResponse> {
         requestedKeys = keys
         // Like the server: answer only the keys this contract knows.

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/OverlayPrefsStoreTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/OverlayPrefsStoreTest.kt
@@ -346,6 +346,8 @@ private class RecordingOverlaySettingsApi(
         keys: List<String>,
         libraryIds: List<Int>,
         seriesIds: List<String>,
+        profileId: String?,
+        authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
     ): ApiResult<EffectiveSettingValuesResponse> {
         effectiveRequests += keys
         val value = storedValue
@@ -379,6 +381,7 @@ private class RecordingOverlaySettingsApi(
         value: JsonElement,
         mutationId: String,
         profileId: String?,
+        authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
     ): ApiResult<StoredSettingValue> {
         puts += Put(key, scope, value)
         nextPutGate?.also { gate ->
@@ -402,6 +405,7 @@ private class RecordingOverlaySettingsApi(
         key: String,
         scope: SettingScopeIdentity,
         profileId: String?,
+        authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
     ): ApiResult<Unit> {
         deleteCount += 1
         assertEquals(SettingKeys.UI_CARD_OVERLAYS, key)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/ServerSettingsFlusherTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/ServerSettingsFlusherTest.kt
@@ -532,6 +532,7 @@ private class RecordingSettingsApi : SettingsApi(HttpClient()) {
         value: JsonElement,
         mutationId: String,
         profileId: String?,
+        authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
     ): ApiResult<StoredSettingValue> {
         val call = Call(Call.Kind.PUT, key, value, profileId, mutationId, scope)
         calls.add(call)
@@ -549,6 +550,7 @@ private class RecordingSettingsApi : SettingsApi(HttpClient()) {
         key: String,
         scope: SettingScopeIdentity,
         profileId: String?,
+        authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
     ): ApiResult<Unit> {
         val call = Call(Call.Kind.DELETE, key, null, profileId, null, scope)
         calls.add(call)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/UiCustomizationStoreTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/UiCustomizationStoreTest.kt
@@ -1,0 +1,2476 @@
+package org.siloserver.silo.common.settings
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.ktor.client.HttpClient
+import java.io.IOException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonElement
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.siloserver.silo.model.settings.CardCaptionPreset
+import org.siloserver.silo.model.settings.CardPresentation
+import org.siloserver.silo.model.settings.EffectiveSettingValue
+import org.siloserver.silo.model.settings.EffectiveSettingValuesResponse
+import org.siloserver.silo.model.settings.NavigationShortcuts
+import org.siloserver.silo.model.settings.PosterSizePreset
+import org.siloserver.silo.model.settings.PrimaryMenu
+import org.siloserver.silo.model.settings.PrimaryMenuBuiltin
+import org.siloserver.silo.model.settings.PrimaryMenuItem
+import org.siloserver.silo.model.settings.SettingKeys
+import org.siloserver.silo.model.settings.SettingScope
+import org.siloserver.silo.model.settings.SettingScopeIdentity
+import org.siloserver.silo.model.settings.SettingsContractCapabilities
+import org.siloserver.silo.model.settings.SiloClientFamily
+import org.siloserver.silo.model.settings.StoredSettingValue
+import org.siloserver.silo.model.settings.UiCustomizationCodec
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionKind
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.TokenManagerImpl
+import org.siloserver.silo.network.api.SettingsApi
+import org.siloserver.silo.network.api.SettingsCapabilitiesResult
+import org.siloserver.silo.repository.SettingsRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class UiCustomizationStoreTest {
+    @Test
+    fun capabilityStateDistinguishesConfirmedUnsupportedFromTransientFailure() = runTest {
+        val api = FakeSettingsApi(
+            capabilityResult = SettingsCapabilitiesResult.ServerUpgradeRequired,
+        )
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            assertEquals(false, store.uiCustomizationSupported.value)
+            assertEquals(0, api.gets.size)
+
+            api.capabilityResult = SettingsCapabilitiesResult.NetworkError(IOException("offline"))
+            store.refresh()
+            assertEquals(null, store.uiCustomizationSupported.value)
+            assertEquals(0, api.gets.size)
+
+            api.capabilityResult = SettingsCapabilitiesResult.Available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsBatchedEffective = true,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            )
+            store.refresh()
+            assertEquals(true, store.uiCustomizationSupported.value)
+            assertEquals(1, api.gets.size)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun pendingWriteWaitsForCapabilityRecoveryThenDrainsWithSameMutation() = runTest {
+        val api = FakeSettingsApi(online = false)
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setCardPresentation(
+                CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK),
+            )
+            advanceUntilIdle()
+            assertEquals(1, api.puts.size)
+
+            api.online = true
+            api.capabilityResult = SettingsCapabilitiesResult.NetworkError(IOException("offline probe"))
+            store.refresh()
+            assertEquals(1, api.puts.size)
+
+            api.capabilityResult = SettingsCapabilitiesResult.Available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsBatchedEffective = true,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            )
+            store.refresh()
+            assertEquals(2, api.puts.size)
+            assertEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+
+            store.refresh()
+            assertEquals(2, api.puts.size)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun familyValuesWriteProfileClientWhileShortcutsUseAtomicProfileEndpoint() = runTest {
+        val api = FakeSettingsApi(
+            effective = mapOf(
+                SettingKeys.UI_CARD_PRESENTATION to EffectiveSettingValue(
+                    key = SettingKeys.UI_CARD_PRESENTATION,
+                    value = UiCustomizationCodec.encodeCardPresentation(
+                        CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK),
+                    ),
+                    source = SettingScope.PROFILE_CLIENT.wire,
+                ),
+            ),
+        )
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            assertEquals(PosterSizePreset.LARGE, store.cardPresentation.value.posterSize)
+
+            store.setCardPresentation(CardPresentation.DEFAULT)
+            store.setShortcutPresent(PrimaryMenuItem.Library(7, "Movies"), present = true)
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(SettingScope.PROFILE_CLIENT),
+                api.puts.map { it.scope.scope },
+            )
+            assertEquals(SiloClientFamily.TV, api.puts.single().scope.clientFamily)
+            assertEquals(1, api.shortcutPuts.size)
+            assertEquals(true, api.shortcutPuts.single().present)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun offlineCacheIsIsolatedByProfileAndRestoredOnReturn() = runTest {
+        val api = FakeSettingsApi(online = false)
+        val tokenManager = TokenManagerImpl().apply {
+            setServerUrl("https://silo.example")
+            setProfileId("profile-one")
+        }
+        val (store, storeScope) = store(api, tokenManager)
+        try {
+            store.refresh()
+            val offlineChoice = CardPresentation(
+                PosterSizePreset.LARGE,
+                CardCaptionPreset.TITLE,
+            )
+            store.setCardPresentation(offlineChoice)
+            advanceUntilIdle()
+            assertEquals(offlineChoice, store.cardPresentation.value)
+
+            tokenManager.setProfileId("profile-two")
+            store.refresh()
+            assertEquals(CardPresentation.DEFAULT, store.cardPresentation.value)
+
+            tokenManager.setProfileId("profile-one")
+            store.refresh()
+            assertEquals(offlineChoice, store.cardPresentation.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun editsAfterProfileSwitchBindToNewIdentityBeforeRefresh() = runTest {
+        val api = FakeSettingsApi(online = false)
+        val cache = InMemoryCache()
+        val tokenManager = SnapshotTokenManager(
+            AuthScopeSnapshot(
+                serverId = "server-1",
+                profileId = "profile-a",
+                serverUrl = "https://silo.example",
+                profileToken = null,
+                identityGeneration = 1,
+            ),
+        )
+        val (store, storeScope) = store(api, tokenManager, cache)
+        val menu = PrimaryMenu(listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME)))
+        val card = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        val shortcut = PrimaryMenuItem.Library(7, "Movies")
+        try {
+            store.refresh()
+            tokenManager.snapshot = tokenManager.snapshot.copy(
+                profileId = "profile-b",
+                identityGeneration = 2,
+            )
+
+            // No B refresh has happened yet: activeIdentity still points at A.
+            store.setPrimaryMenu(menu)
+            store.setCardPresentation(card)
+            store.setShortcutPresent(shortcut, present = true)
+            advanceUntilIdle()
+
+            assertEquals(listOf("profile-b", "profile-b"), api.puts.map { it.profileId })
+            assertEquals("profile-b", api.shortcutPuts.single().profileId)
+            assertEquals(menu, store.primaryMenu.value)
+            assertEquals(card, store.cardPresentation.value)
+            assertEquals(NavigationShortcuts(listOf(shortcut)), store.shortcuts.value)
+
+            tokenManager.snapshot = tokenManager.snapshot.copy(
+                profileId = "profile-a",
+                identityGeneration = 3,
+            )
+            store.refresh()
+            assertEquals(null, store.primaryMenu.value)
+            assertEquals(CardPresentation.DEFAULT, store.cardPresentation.value)
+            assertEquals(NavigationShortcuts.EMPTY, store.shortcuts.value)
+
+            tokenManager.snapshot = tokenManager.snapshot.copy(
+                profileId = "profile-b",
+                identityGeneration = 4,
+            )
+            store.refresh()
+            assertEquals(menu, store.primaryMenu.value)
+            assertEquals(card, store.cardPresentation.value)
+            assertEquals(NavigationShortcuts(listOf(shortcut)), store.shortcuts.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun anInFlightRefreshCannotOverwriteANewerLocalChoice() = runTest {
+        val remote = CardPresentation.DEFAULT
+        val local = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        val api = FakeSettingsApi(
+            effective = mapOf(
+                SettingKeys.UI_CARD_PRESENTATION to EffectiveSettingValue(
+                    key = SettingKeys.UI_CARD_PRESENTATION,
+                    value = UiCustomizationCodec.encodeCardPresentation(remote),
+                ),
+            ),
+        ).apply {
+            getGate = CompletableDeferred()
+            putGate = CompletableDeferred()
+        }
+        val (store, storeScope) = store(api)
+        try {
+            val refresh = launch { store.refresh() }
+            runCurrent()
+
+            store.setCardPresentation(local)
+            api.getGate?.complete(Unit)
+            refresh.join()
+
+            assertEquals(local, store.cardPresentation.value)
+            api.putGate?.complete(Unit)
+            advanceUntilIdle()
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun aSuccessfulEditDuringGetCannotBeOverwrittenAfterPendingClears() = runTest {
+        val remote = CardPresentation.DEFAULT
+        val local = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        val cache = InMemoryCache()
+        val api = FakeSettingsApi(
+            effective = mapOf(
+                SettingKeys.UI_CARD_PRESENTATION to EffectiveSettingValue(
+                    key = SettingKeys.UI_CARD_PRESENTATION,
+                    value = UiCustomizationCodec.encodeCardPresentation(remote),
+                ),
+            ),
+        ).apply { getGate = CompletableDeferred() }
+        val (store, storeScope) = store(api, cache = cache)
+        try {
+            val refresh = launch { store.refresh() }
+            runCurrent()
+
+            store.setCardPresentation(local)
+            runCurrent()
+            assertEquals(1, api.puts.size)
+
+            api.getGate?.complete(Unit)
+            refresh.join()
+            assertEquals(local, store.cardPresentation.value)
+
+            // The stale GET must not have replaced the durable cache either.
+            storeScope.cancel()
+            api.online = false
+            val (restartedStore, restartedScope) = store(api, cache = cache)
+            try {
+                restartedStore.refresh()
+                assertEquals(local, restartedStore.cardPresentation.value)
+            } finally {
+                restartedScope.cancel()
+            }
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun aSuccessfulResetDuringGetCannotBeOverwrittenAfterPendingClears() = runTest {
+        val remoteMenu = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES),
+            ),
+        )
+        val cache = InMemoryCache()
+        val api = FakeSettingsApi(
+            effective = mapOf(
+                SettingKeys.NAV_PRIMARY_MENU to EffectiveSettingValue(
+                    key = SettingKeys.NAV_PRIMARY_MENU,
+                    value = UiCustomizationCodec.encodePrimaryMenu(remoteMenu),
+                ),
+            ),
+        )
+        val (store, storeScope) = store(api, cache = cache)
+        try {
+            store.refresh()
+            assertEquals(remoteMenu, store.primaryMenu.value)
+
+            api.getGate = CompletableDeferred()
+            val refresh = launch { store.refresh() }
+            runCurrent()
+
+            store.resetPrimaryMenu()
+            runCurrent()
+            assertEquals(1, api.deletes.size)
+
+            api.getGate?.complete(Unit)
+            refresh.join()
+            assertEquals(null, store.primaryMenu.value)
+
+            storeScope.cancel()
+            api.online = false
+            val (restartedStore, restartedScope) = store(api, cache = cache)
+            try {
+                restartedStore.refresh()
+                assertEquals(null, restartedStore.primaryMenu.value)
+            } finally {
+                restartedScope.cancel()
+            }
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun pendingRetryAndNewEditAreSerializedSoTheNewEditLandsLast() = runTest {
+        val cached = CardPresentation(PosterSizePreset.COMPACT, CardCaptionPreset.TITLE)
+        val newer = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        val api = FakeSettingsApi(online = false)
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setCardPresentation(cached)
+            advanceUntilIdle()
+            assertEquals(1, api.puts.size)
+
+            api.online = true
+            api.putGate = CompletableDeferred()
+            val refresh = launch { store.refresh() }
+            runCurrent()
+            assertEquals(2, api.puts.size)
+
+            store.setCardPresentation(newer)
+            runCurrent()
+            // The new edit is cached synchronously, but its PUT must wait for
+            // the older retry's wire turn instead of racing and finishing first.
+            assertEquals(2, api.puts.size)
+
+            api.putGate?.complete(Unit)
+            refresh.join()
+            advanceUntilIdle()
+
+            assertEquals(3, api.puts.size)
+            assertEquals(
+                UiCustomizationCodec.encodeCardPresentation(newer),
+                api.puts.last().value,
+            )
+            assertEquals(newer, store.cardPresentation.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun ambiguousWriteRetryReusesItsPersistedMutationId() = runTest {
+        val api = FakeSettingsApi(online = false)
+        val cache = InMemoryCache()
+        val tokenManager = TokenManagerImpl().apply {
+            setServerUrl("https://silo.example")
+            setProfileId("profile-one")
+        }
+        val desired = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        val (firstStore, firstScope) = store(api, tokenManager, cache)
+        try {
+            firstStore.refresh()
+            firstStore.setCardPresentation(desired)
+            advanceUntilIdle()
+            assertEquals(1, api.puts.size)
+
+            // Model an app restart after the server may have accepted the PUT
+            // but the response never reached this client.
+            firstScope.cancel()
+            api.online = true
+            val (restartedStore, restartedScope) = store(api, tokenManager, cache)
+            try {
+                restartedStore.refresh()
+                advanceUntilIdle()
+
+                assertEquals(2, api.puts.size)
+                assertEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+                assertEquals(desired, restartedStore.cardPresentation.value)
+            } finally {
+                restartedScope.cancel()
+            }
+        } finally {
+            firstScope.cancel()
+        }
+    }
+
+    @Test
+    fun ambiguousSuccessReplayCannotOverwriteANewerRemoteEdit() = runTest {
+        val cachedEdit = CardPresentation(PosterSizePreset.COMPACT, CardCaptionPreset.TITLE)
+        val newerRemoteEdit = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        var firstMutationId: String? = null
+        val api = FakeSettingsApi().apply {
+            onPut = { put ->
+                val originalId = firstMutationId
+                if (originalId == null) {
+                    // The server applied this logical write, but the response
+                    // was lost. Retain its idempotency receipt.
+                    firstMutationId = put.mutationId
+                    ApiResult.NetworkError(IOException("response lost"))
+                } else {
+                    // A repeated receipt is a no-op. A new id would replay the
+                    // stale cached value over the other TV's newer edit.
+                    if (put.mutationId != originalId) {
+                        effective = effective + (
+                            put.key to EffectiveSettingValue(
+                                key = put.key,
+                                value = put.value,
+                                source = SettingScope.PROFILE_CLIENT.wire,
+                            )
+                        )
+                    }
+                    ApiResult.Success(
+                        StoredSettingValue(
+                            key = put.key,
+                            scope = put.scope.scope.wire,
+                            value = put.value,
+                        ),
+                    )
+                }
+            }
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setCardPresentation(cachedEdit)
+            advanceUntilIdle()
+
+            api.effective = mapOf(
+                SettingKeys.UI_CARD_PRESENTATION to EffectiveSettingValue(
+                    key = SettingKeys.UI_CARD_PRESENTATION,
+                    value = UiCustomizationCodec.encodeCardPresentation(newerRemoteEdit),
+                    source = SettingScope.PROFILE_CLIENT.wire,
+                ),
+            )
+            store.refresh()
+
+            assertEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+            assertEquals(newerRemoteEdit, store.cardPresentation.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun aNewLogicalEditGetsANewMutationId() = runTest {
+        val api = FakeSettingsApi()
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setCardPresentation(
+                CardPresentation(PosterSizePreset.COMPACT, CardCaptionPreset.TITLE),
+            )
+            advanceUntilIdle()
+            store.setCardPresentation(
+                CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK),
+            )
+            advanceUntilIdle()
+
+            assertEquals(2, api.puts.size)
+            assertNotEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun offlineShortcutOperationSurvivesRestartAndReusesExactMutation() = runTest {
+        val item = PrimaryMenuItem.Library(7, "Movies")
+        val cache = InMemoryCache()
+        val api = FakeSettingsApi(online = false)
+        val (firstStore, firstScope) = store(api, cache = cache)
+        try {
+            firstStore.refresh()
+            firstStore.setShortcutPresent(item, present = true)
+            advanceUntilIdle()
+
+            assertEquals(NavigationShortcuts(listOf(item)), firstStore.shortcuts.value)
+            assertEquals(1, api.shortcutPuts.size)
+
+            firstScope.cancel()
+            api.online = true
+            val (restartedStore, restartedScope) = store(api, cache = cache)
+            try {
+                restartedStore.refresh()
+
+                assertEquals(2, api.shortcutPuts.size)
+                assertEquals(api.shortcutPuts.first(), api.shortcutPuts.last())
+                assertEquals(NavigationShortcuts(listOf(item)), restartedStore.shortcuts.value)
+            } finally {
+                restartedScope.cancel()
+            }
+        } finally {
+            firstScope.cancel()
+        }
+    }
+
+    @Test
+    fun ambiguousShortcutRetryReusesBodyAndMutationId() = runTest {
+        val item = PrimaryMenuItem.Section(7, "recent", "Recently Added")
+        var receipt: StoredSettingValue? = null
+        val api = FakeSettingsApi().apply {
+            onShortcutPut = { put ->
+                if (receipt == null) {
+                    receipt = applyShortcutPut(put)
+                    ApiResult.NetworkError(IOException("response lost"))
+                } else {
+                    ApiResult.Success(checkNotNull(receipt))
+                }
+            }
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setShortcutPresent(item, present = true)
+            advanceUntilIdle()
+            store.refresh()
+
+            assertEquals(2, api.shortcutPuts.size)
+            assertEquals(api.shortcutPuts.first(), api.shortcutPuts.last())
+            assertEquals(NavigationShortcuts(listOf(item)), store.shortcuts.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun newerOppositeShortcutIntentIsNotClearedByOlderSuccess() = runTest {
+        val item = PrimaryMenuItem.Collection("favorites", "Favorites", libraryId = 7)
+        val firstPutGate = CompletableDeferred<Unit>()
+        val api = FakeSettingsApi().apply {
+            shortcutPutGate = firstPutGate
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setShortcutPresent(item, present = true)
+            runCurrent()
+
+            store.setShortcutPresent(item, present = false)
+            runCurrent()
+            assertEquals(NavigationShortcuts.EMPTY, store.shortcuts.value)
+
+            firstPutGate.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(listOf(true, false), api.shortcutPuts.map { it.present })
+            assertNotEquals(
+                api.shortcutPuts.first().mutationId,
+                api.shortcutPuts.last().mutationId,
+            )
+            assertEquals(NavigationShortcuts.EMPTY, store.shortcuts.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun newerEquivalentShortcutIntentIsNotClearedByOlderSuccess() = runTest {
+        val item = PrimaryMenuItem.Collection("favorites", "Favorites", libraryId = 7)
+        val firstPutGate = CompletableDeferred<Unit>()
+        val api = FakeSettingsApi().apply {
+            shortcutPutGate = firstPutGate
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setShortcutPresent(item, present = true)
+            runCurrent()
+
+            store.setShortcutPresent(item, present = true)
+            runCurrent()
+
+            firstPutGate.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(listOf(true, true), api.shortcutPuts.map { it.present })
+            assertNotEquals(
+                api.shortcutPuts.first().mutationId,
+                api.shortcutPuts.last().mutationId,
+            )
+            assertEquals(NavigationShortcuts(listOf(item)), store.shortcuts.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun definitiveShortcutRejectionDropsOnlyThatOperationAndKeepsDraining() = runTest {
+        val rejected = PrimaryMenuItem.Library(7, "Deleted")
+        val second = PrimaryMenuItem.Section(8, "recent", "Recently Added")
+        val third = PrimaryMenuItem.Collection("favorites", "Favorites", libraryId = 8)
+        val rejectedItem = checkNotNull(UiCustomizationCodec.encodeShortcutItem(rejected))
+        val api = FakeSettingsApi().apply {
+            onShortcutPut = { put ->
+                if (put.item == rejectedItem) {
+                    ApiResult.Error(
+                        code = 404,
+                        error = "not_found",
+                        message = "Library 7 no longer exists",
+                    )
+                } else {
+                    ApiResult.Success(applyShortcutPut(put))
+                }
+            }
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setShortcutPresent(rejected, present = true)
+            store.setShortcutPresent(second, present = true)
+            store.setShortcutPresent(third, present = true)
+            advanceUntilIdle()
+
+            // The rejected head is attempted once, then dropped: it neither
+            // repeats nor blocks the operations authored behind it.
+            assertEquals(1, api.shortcutPuts.count { it.item == rejectedItem })
+            assertEquals(3, api.shortcutPuts.size)
+            assertEquals(
+                NavigationShortcuts(listOf(second, third)),
+                store.shortcuts.value,
+            )
+
+            // Pending cleared, so a later refresh adopts the server document
+            // instead of replaying the rejection forever.
+            val putsAfterDrain = api.shortcutPuts.size
+            store.refresh()
+            advanceUntilIdle()
+
+            assertEquals(putsAfterDrain, api.shortcutPuts.size)
+            assertEquals(
+                NavigationShortcuts(listOf(second, third)),
+                store.shortcuts.value,
+            )
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun definitiveRejectionRevertsOnlyItsOwnPinWhilePendingSiblingSurvives() = runTest {
+        val rejected = PrimaryMenuItem.Library(7, "Deleted")
+        val sibling = PrimaryMenuItem.Section(8, "recent", "Recently Added")
+        val rejectedItem = checkNotNull(UiCustomizationCodec.encodeShortcutItem(rejected))
+        val api = FakeSettingsApi().apply {
+            onShortcutPut = { put ->
+                if (put.item == rejectedItem) {
+                    ApiResult.Error(
+                        code = 400,
+                        error = "invalid_value",
+                        message = "Shortcut item is not storable",
+                    )
+                } else {
+                    ApiResult.NetworkError(IOException("offline"))
+                }
+            }
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setShortcutPresent(rejected, present = true)
+            store.setShortcutPresent(sibling, present = true)
+            advanceUntilIdle()
+
+            // The sibling never reached the server, so nothing but the local
+            // rollback can have removed the rejected pin.
+            assertEquals(
+                NavigationShortcuts(listOf(sibling)),
+                store.shortcuts.value,
+            )
+
+            api.onShortcutPut = null
+            store.refresh()
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(sibling),
+                api.shortcutPuts.filter { it.item != rejectedItem }
+                    .map { checkNotNull(UiCustomizationCodec.parseShortcutItem(it.item)) }
+                    .distinct(),
+            )
+            assertEquals(
+                NavigationShortcuts(listOf(sibling)),
+                store.shortcuts.value,
+            )
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun definitivelyRejectedUnpinRestoresOnlyThatShortcut() = runTest {
+        val rejected = PrimaryMenuItem.Library(7, "Movies")
+        val untouched = PrimaryMenuItem.Section(8, "recent", "Recently Added")
+        val rejectedItem = checkNotNull(UiCustomizationCodec.encodeShortcutItem(rejected))
+        val api = FakeSettingsApi(
+            effective = shortcutEffective(NavigationShortcuts(listOf(rejected, untouched))),
+        ).apply {
+            onShortcutPut = { put ->
+                if (put.item == rejectedItem) {
+                    ApiResult.Error(
+                        code = 403,
+                        error = "scope_not_allowed",
+                        message = "This profile cannot edit that shortcut",
+                    )
+                } else {
+                    ApiResult.NetworkError(IOException("offline"))
+                }
+            }
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            advanceUntilIdle()
+            assertEquals(
+                NavigationShortcuts(listOf(rejected, untouched)),
+                store.shortcuts.value,
+            )
+
+            store.setShortcutPresent(rejected, present = false)
+            store.setShortcutPresent(untouched, present = false)
+            advanceUntilIdle()
+
+            // The rejected removal is undone; the still-pending sibling
+            // removal keeps its optimistic effect.
+            assertEquals(listOf(rejected), store.shortcuts.value.items)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun shortcutNetworkFailureStopsTheDrainAndRetriesTheWholeQueueLater() = runTest {
+        val first = PrimaryMenuItem.Library(7, "Movies")
+        val second = PrimaryMenuItem.Section(8, "recent", "Recently Added")
+        val firstItem = checkNotNull(UiCustomizationCodec.encodeShortcutItem(first))
+        val api = FakeSettingsApi(online = false)
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setShortcutPresent(first, present = true)
+            store.setShortcutPresent(second, present = true)
+            advanceUntilIdle()
+
+            // The head stays at the front of the outbox and nothing behind it
+            // is sent while it is still retryable.
+            assertEquals(listOf(firstItem), api.shortcutPuts.map { it.item }.distinct())
+            assertEquals(
+                NavigationShortcuts(listOf(first, second)),
+                store.shortcuts.value,
+            )
+
+            api.online = true
+            store.refresh()
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(first, second),
+                api.shortcutPuts.takeLast(2)
+                    .map { checkNotNull(UiCustomizationCodec.parseShortcutItem(it.item)) },
+            )
+            assertEquals(
+                NavigationShortcuts(listOf(first, second)),
+                store.shortcuts.value,
+            )
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun mutationIdConflictRetriesTheSameIntentUnderAFreshId() = runTest {
+        val item = PrimaryMenuItem.Library(7, "Movies")
+        var conflicted = false
+        val api = FakeSettingsApi().apply {
+            onShortcutPut = { put ->
+                if (!conflicted) {
+                    conflicted = true
+                    ApiResult.Error(
+                        code = 409,
+                        error = "mutation_id_conflict",
+                        message = "Mutation id already used for different content",
+                    )
+                } else {
+                    ApiResult.Success(applyShortcutPut(put))
+                }
+            }
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setShortcutPresent(item, present = true)
+            advanceUntilIdle()
+
+            // The intent is replayed verbatim under an id the server has never
+            // seen, rather than rolled back or retried into the same conflict.
+            assertEquals(2, api.shortcutPuts.size)
+            assertEquals(
+                api.shortcutPuts.first().copy(mutationId = ""),
+                api.shortcutPuts.last().copy(mutationId = ""),
+            )
+            assertNotEquals(
+                api.shortcutPuts.first().mutationId,
+                api.shortcutPuts.last().mutationId,
+            )
+            assertEquals(NavigationShortcuts(listOf(item)), store.shortcuts.value)
+
+            store.refresh()
+            advanceUntilIdle()
+
+            assertEquals(2, api.shortcutPuts.size)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun compoundNavigationIntentSurvivesDeathAfterItsSingleDurableWrite() = runTest {
+        val cache = InMemoryCache()
+        val api = FakeSettingsApi()
+        val menuItem = PrimaryMenuItem.Library(7, "Movies")
+        val menu = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                menuItem,
+            ),
+        )
+        val (firstStore, firstScope) = store(api, cache = cache)
+        try {
+            firstStore.refresh()
+            var interrupt = true
+            cache.afterPutString = { key ->
+                if (interrupt && key.endsWith(".navigation_outbox")) {
+                    interrupt = false
+                    throw CancellationException("simulated process death")
+                }
+            }
+
+            firstStore.setPrimaryMenuAndShortcut(menu, menuItem, present = true)
+            advanceUntilIdle()
+
+            assertEquals(0, api.puts.size)
+            assertEquals(0, api.shortcutPuts.size)
+
+            firstScope.cancel()
+            cache.afterPutString = null
+            val (restartedStore, restartedScope) = store(api, cache = cache)
+            try {
+                restartedStore.refresh()
+
+                assertEquals(menu, restartedStore.primaryMenu.value)
+                assertEquals(
+                    NavigationShortcuts(listOf(menuItem)),
+                    restartedStore.shortcuts.value,
+                )
+                assertEquals(1, api.puts.size)
+                assertEquals(1, api.shortcutPuts.size)
+                assertEquals("profile-one", api.puts.single().profileId)
+                assertEquals("profile-one", api.shortcutPuts.single().profileId)
+            } finally {
+                restartedScope.cancel()
+            }
+        } finally {
+            firstScope.cancel()
+        }
+    }
+
+    @Test
+    fun compoundMenuFailureRetriesOnlyMenuAfterShortcutCompletes() = runTest {
+        val cache = InMemoryCache()
+        val item = PrimaryMenuItem.Library(7, "Movies")
+        val menu = PrimaryMenu(listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME), item))
+        var failMenu = true
+        val api = FakeSettingsApi().apply {
+            onPut = { put ->
+                if (put.key == SettingKeys.NAV_PRIMARY_MENU && failMenu) {
+                    failMenu = false
+                    ApiResult.NetworkError(IOException("menu response lost"))
+                } else {
+                    ApiResult.Success(
+                        StoredSettingValue(put.key, put.scope.scope.wire, value = put.value),
+                    )
+                }
+            }
+        }
+        val (firstStore, firstScope) = store(api, cache = cache)
+        try {
+            firstStore.refresh()
+            firstStore.setPrimaryMenuAndShortcut(menu, item, present = true)
+            advanceUntilIdle()
+
+            assertEquals(1, api.puts.size)
+            assertEquals(1, api.shortcutPuts.size)
+
+            firstScope.cancel()
+            val (restartedStore, restartedScope) = store(api, cache = cache)
+            try {
+                restartedStore.refresh()
+
+                assertEquals(2, api.puts.size)
+                assertEquals(api.puts.first(), api.puts.last())
+                assertEquals(1, api.shortcutPuts.size)
+                assertEquals(menu, restartedStore.primaryMenu.value)
+                assertEquals(NavigationShortcuts(listOf(item)), restartedStore.shortcuts.value)
+            } finally {
+                restartedScope.cancel()
+            }
+        } finally {
+            firstScope.cancel()
+        }
+    }
+
+    @Test
+    fun compoundShortcutFailureRetriesOnlyShortcutAfterMenuCompletes() = runTest {
+        val cache = InMemoryCache()
+        val item = PrimaryMenuItem.Library(7, "Movies")
+        val menu = PrimaryMenu(listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME), item))
+        var receipt: StoredSettingValue? = null
+        val api = FakeSettingsApi().apply {
+            onShortcutPut = { put ->
+                if (receipt == null) {
+                    receipt = applyShortcutPut(put)
+                    ApiResult.NetworkError(IOException("shortcut response lost"))
+                } else {
+                    ApiResult.Success(checkNotNull(receipt))
+                }
+            }
+        }
+        val (firstStore, firstScope) = store(api, cache = cache)
+        try {
+            firstStore.refresh()
+            firstStore.setPrimaryMenuAndShortcut(menu, item, present = true)
+            advanceUntilIdle()
+
+            assertEquals(1, api.puts.size)
+            assertEquals(1, api.shortcutPuts.size)
+
+            firstScope.cancel()
+            val (restartedStore, restartedScope) = store(api, cache = cache)
+            try {
+                restartedStore.refresh()
+
+                assertEquals(1, api.puts.size)
+                assertEquals(2, api.shortcutPuts.size)
+                assertEquals(api.shortcutPuts.first(), api.shortcutPuts.last())
+                assertEquals(menu, restartedStore.primaryMenu.value)
+                assertEquals(NavigationShortcuts(listOf(item)), restartedStore.shortcuts.value)
+            } finally {
+                restartedScope.cancel()
+            }
+        } finally {
+            firstScope.cancel()
+        }
+    }
+
+    @Test
+    fun newerMenuEditWinsWhenCompoundMenuRequestWasAlreadyInFlight() = runTest {
+        val item = PrimaryMenuItem.Library(7, "Movies")
+        val compoundMenu = PrimaryMenu(
+            listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME), item),
+        )
+        val newerMenu = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+            ),
+        )
+        val menuPutGate = CompletableDeferred<Unit>()
+        val api = FakeSettingsApi().apply { putGate = menuPutGate }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setPrimaryMenuAndShortcut(compoundMenu, item, present = true)
+            runCurrent()
+            assertEquals(compoundMenu, store.primaryMenu.value)
+            assertEquals(1, api.puts.size)
+
+            store.setPrimaryMenu(newerMenu)
+            runCurrent()
+            assertEquals(newerMenu, store.primaryMenu.value)
+
+            menuPutGate.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(2, api.puts.size)
+            assertEquals(
+                listOf(compoundMenu, newerMenu),
+                api.puts.map { checkNotNull(UiCustomizationCodec.parsePrimaryMenu(it.value)) },
+            )
+            assertNotEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+            assertEquals(newerMenu, store.primaryMenu.value)
+            assertEquals(NavigationShortcuts(listOf(item)), store.shortcuts.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun shortcutSuccessAfterClearCannotRepaintTheSignedOutUi() = runTest {
+        val item = PrimaryMenuItem.Library(7, "Movies")
+        val firstPutGate = CompletableDeferred<Unit>()
+        val api = FakeSettingsApi().apply {
+            shortcutPutGate = firstPutGate
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setShortcutPresent(item, present = true)
+            runCurrent()
+
+            store.clear()
+            firstPutGate.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(NavigationShortcuts.EMPTY, store.shortcuts.value)
+            assertEquals(1, api.shortcutPuts.size)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun effectiveGetCannotOverwriteOptimisticShortcutWhileOperationIsPending() = runTest {
+        val item = PrimaryMenuItem.Library(7, "Movies")
+        val api = FakeSettingsApi().apply {
+            onShortcutPut = { ApiResult.NetworkError(IOException("offline shortcut endpoint")) }
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            store.setShortcutPresent(item, present = true)
+            advanceUntilIdle()
+            assertEquals(NavigationShortcuts(listOf(item)), store.shortcuts.value)
+
+            // GET remains online and still reports the empty server document.
+            // The pending atomic intent must remain painted instead.
+            store.refresh()
+            assertEquals(NavigationShortcuts(listOf(item)), store.shortcuts.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun deviceOverrideSourceIsPreservedUntilUseFamilySettingsClearsExactDevice() = runTest {
+        val deviceValue = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        val familyValue = CardPresentation.DEFAULT
+        val deviceMenu = org.siloserver.silo.model.settings.PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(
+                    org.siloserver.silo.model.settings.PrimaryMenuBuiltin.HOME,
+                ),
+                PrimaryMenuItem.Builtin(
+                    org.siloserver.silo.model.settings.PrimaryMenuBuiltin.MOVIES,
+                ),
+            ),
+        )
+        val familyMenu = org.siloserver.silo.model.settings.PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(
+                    org.siloserver.silo.model.settings.PrimaryMenuBuiltin.HOME,
+                ),
+            ),
+        )
+        val api = FakeSettingsApi(
+            effective = mapOf(
+                SettingKeys.NAV_PRIMARY_MENU to EffectiveSettingValue(
+                    key = SettingKeys.NAV_PRIMARY_MENU,
+                    value = UiCustomizationCodec.encodePrimaryMenu(deviceMenu),
+                    source = SettingScope.PROFILE_DEVICE.wire,
+                    scope = SettingScope.PROFILE_DEVICE.wire,
+                ),
+                SettingKeys.UI_CARD_PRESENTATION to EffectiveSettingValue(
+                    key = SettingKeys.UI_CARD_PRESENTATION,
+                    value = UiCustomizationCodec.encodeCardPresentation(deviceValue),
+                    source = SettingScope.PROFILE_DEVICE.wire,
+                    scope = SettingScope.PROFILE_DEVICE.wire,
+                ),
+            ),
+        ).apply {
+            onDelete = { key, scope ->
+                if (scope.scope == SettingScope.PROFILE_DEVICE) {
+                    val inherited = when (key) {
+                        SettingKeys.NAV_PRIMARY_MENU -> EffectiveSettingValue(
+                            key = key,
+                            value = UiCustomizationCodec.encodePrimaryMenu(familyMenu),
+                            source = SettingScope.PROFILE_CLIENT.wire,
+                            scope = SettingScope.PROFILE_CLIENT.wire,
+                        )
+                        SettingKeys.UI_CARD_PRESENTATION -> EffectiveSettingValue(
+                            key = key,
+                            value = UiCustomizationCodec.encodeCardPresentation(familyValue),
+                            source = SettingScope.PROFILE_CLIENT.wire,
+                            scope = SettingScope.PROFILE_CLIENT.wire,
+                        )
+                        else -> null
+                    }
+                    if (inherited != null) effective = effective + (key to inherited)
+                }
+            }
+        }
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+            assertEquals(SettingScope.PROFILE_DEVICE.wire, store.primaryMenuSource.value)
+            assertEquals(SettingScope.PROFILE_DEVICE.wire, store.cardPresentationSource.value)
+            assertEquals(deviceValue, store.cardPresentation.value)
+
+            store.useFamilySettings()
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(SettingScope.PROFILE_DEVICE, SettingScope.PROFILE_DEVICE),
+                api.deletes.map { it.scope.scope },
+            )
+            assertEquals(
+                listOf(SiloClientFamily.TV, SiloClientFamily.TV),
+                api.deletes.map { it.scope.clientFamily },
+            )
+            assertEquals(SettingScope.PROFILE_CLIENT.wire, store.primaryMenuSource.value)
+            assertEquals(SettingScope.PROFILE_CLIENT.wire, store.cardPresentationSource.value)
+            assertEquals(familyMenu, store.primaryMenu.value)
+            assertEquals(familyValue, store.cardPresentation.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun offlineDeviceDeleteSurvivesRestartAndRetriesBeforeEffectiveFetch() = runTest {
+        val deviceValue = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        val familyValue = CardPresentation.DEFAULT
+        val cache = InMemoryCache()
+        val api = FakeSettingsApi(
+            effective = mapOf(
+                SettingKeys.UI_CARD_PRESENTATION to EffectiveSettingValue(
+                    key = SettingKeys.UI_CARD_PRESENTATION,
+                    value = UiCustomizationCodec.encodeCardPresentation(deviceValue),
+                    source = SettingScope.PROFILE_DEVICE.wire,
+                    scope = SettingScope.PROFILE_DEVICE.wire,
+                ),
+            ),
+        )
+        val (firstStore, firstScope) = store(api, cache = cache)
+        try {
+            firstStore.refresh()
+            api.online = false
+            firstStore.useFamilySettings()
+            advanceUntilIdle()
+
+            assertEquals(1, api.deletes.size)
+            assertEquals(deviceValue, firstStore.cardPresentation.value)
+
+            firstScope.cancel()
+            api.online = true
+            api.onDelete = { key, scope ->
+                if (key == SettingKeys.UI_CARD_PRESENTATION &&
+                    scope.scope == SettingScope.PROFILE_DEVICE
+                ) {
+                    api.effective = api.effective + (
+                        key to EffectiveSettingValue(
+                            key = key,
+                            value = UiCustomizationCodec.encodeCardPresentation(familyValue),
+                            source = SettingScope.PROFILE_CLIENT.wire,
+                            scope = SettingScope.PROFILE_CLIENT.wire,
+                        )
+                    )
+                }
+            }
+            val (restartedStore, restartedScope) = store(api, cache = cache)
+            try {
+                restartedStore.refresh()
+
+                assertEquals(2, api.deletes.size)
+                assertEquals(familyValue, restartedStore.cardPresentation.value)
+                assertEquals(
+                    SettingScope.PROFILE_CLIENT.wire,
+                    restartedStore.cardPresentationSource.value,
+                )
+            } finally {
+                restartedScope.cancel()
+            }
+        } finally {
+            firstScope.cancel()
+        }
+    }
+
+    @Test
+    fun partialDeviceDeleteRetriesOnlyUnresolvedKeyAndSuppressesItsStaleGet() = runTest {
+        val deviceMenu = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES),
+            ),
+        )
+        val familyMenu = PrimaryMenu(
+            listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME)),
+        )
+        val deviceCard = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        val staleCard = CardPresentation(PosterSizePreset.COMPACT, CardCaptionPreset.TITLE)
+        val familyCard = CardPresentation.DEFAULT
+        val cache = InMemoryCache()
+        var failCardDelete = true
+        val api = FakeSettingsApi(
+            effective = mapOf(
+                SettingKeys.NAV_PRIMARY_MENU to EffectiveSettingValue(
+                    key = SettingKeys.NAV_PRIMARY_MENU,
+                    value = UiCustomizationCodec.encodePrimaryMenu(deviceMenu),
+                    source = SettingScope.PROFILE_DEVICE.wire,
+                    scope = SettingScope.PROFILE_DEVICE.wire,
+                ),
+                SettingKeys.UI_CARD_PRESENTATION to EffectiveSettingValue(
+                    key = SettingKeys.UI_CARD_PRESENTATION,
+                    value = UiCustomizationCodec.encodeCardPresentation(deviceCard),
+                    source = SettingScope.PROFILE_DEVICE.wire,
+                    scope = SettingScope.PROFILE_DEVICE.wire,
+                ),
+            ),
+        ).apply {
+            onDeleteResult = { key, _ ->
+                if (key == SettingKeys.UI_CARD_PRESENTATION && failCardDelete) {
+                    failCardDelete = false
+                    effective = effective + (
+                        key to EffectiveSettingValue(
+                            key = key,
+                            value = UiCustomizationCodec.encodeCardPresentation(staleCard),
+                            source = SettingScope.PROFILE_DEVICE.wire,
+                            scope = SettingScope.PROFILE_DEVICE.wire,
+                        )
+                    )
+                    ApiResult.NetworkError(IOException("offline during card delete"))
+                } else {
+                    null
+                }
+            }
+            onDelete = { key, scope ->
+                if (scope.scope == SettingScope.PROFILE_DEVICE) {
+                    val inherited = when (key) {
+                        SettingKeys.NAV_PRIMARY_MENU -> EffectiveSettingValue(
+                            key = key,
+                            value = UiCustomizationCodec.encodePrimaryMenu(familyMenu),
+                            source = SettingScope.PROFILE_CLIENT.wire,
+                            scope = SettingScope.PROFILE_CLIENT.wire,
+                        )
+                        SettingKeys.UI_CARD_PRESENTATION -> EffectiveSettingValue(
+                            key = key,
+                            value = UiCustomizationCodec.encodeCardPresentation(familyCard),
+                            source = SettingScope.PROFILE_CLIENT.wire,
+                            scope = SettingScope.PROFILE_CLIENT.wire,
+                        )
+                        else -> null
+                    }
+                    if (inherited != null) effective = effective + (key to inherited)
+                }
+            }
+        }
+        val (firstStore, firstScope) = store(api, cache = cache)
+        try {
+            firstStore.refresh()
+            firstStore.useFamilySettings()
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(SettingKeys.NAV_PRIMARY_MENU, SettingKeys.UI_CARD_PRESENTATION),
+                api.deletes.map { it.key },
+            )
+            assertEquals(familyMenu, firstStore.primaryMenu.value)
+            // The GET returned staleCard, but the unresolved durable delete
+            // keeps the last trusted device value painted until it can retry.
+            assertEquals(deviceCard, firstStore.cardPresentation.value)
+
+            firstScope.cancel()
+            val (restartedStore, restartedScope) = store(api, cache = cache)
+            try {
+                restartedStore.refresh()
+
+                assertEquals(
+                    listOf(
+                        SettingKeys.NAV_PRIMARY_MENU,
+                        SettingKeys.UI_CARD_PRESENTATION,
+                        SettingKeys.UI_CARD_PRESENTATION,
+                    ),
+                    api.deletes.map { it.key },
+                )
+                assertEquals(familyMenu, restartedStore.primaryMenu.value)
+                assertEquals(familyCard, restartedStore.cardPresentation.value)
+            } finally {
+                restartedScope.cancel()
+            }
+        } finally {
+            firstScope.cancel()
+        }
+    }
+
+    @Test
+    fun rapidCardTransformsComposeInAuthoredOrder() = runTest {
+        val api = FakeSettingsApi()
+        val (store, storeScope) = store(api)
+        try {
+            store.refresh()
+
+            store.updateCardPresentation { it.copy(posterSize = PosterSizePreset.LARGE) }
+            store.updateCardPresentation { it.copy(caption = CardCaptionPreset.ARTWORK) }
+            advanceUntilIdle()
+
+            val expected = CardPresentation(
+                PosterSizePreset.LARGE,
+                CardCaptionPreset.ARTWORK,
+            )
+            assertEquals(expected, store.cardPresentation.value)
+            assertEquals(
+                UiCustomizationCodec.encodeCardPresentation(expected),
+                api.puts.last().value,
+            )
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun rapidMenuTransformsComposeAcrossACompoundShortcutWrite() = runTest {
+        val api = FakeSettingsApi()
+        val (store, storeScope) = store(api)
+        val home = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME)
+        val movies = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES)
+        val library = PrimaryMenuItem.Library(7, "Movies Library")
+        val fallback = PrimaryMenu(listOf(home, movies))
+        try {
+            store.refresh()
+
+            store.updatePrimaryMenuAndShortcut(
+                fallback = fallback,
+                item = library,
+                present = true,
+            ) { current -> PrimaryMenu(current.items + library) }
+            store.updatePrimaryMenu(fallback) { current ->
+                PrimaryMenu(listOf(movies) + current.items.filterNot { it == movies })
+            }
+            advanceUntilIdle()
+
+            assertEquals(PrimaryMenu(listOf(movies, home, library)), store.primaryMenu.value)
+            assertEquals(NavigationShortcuts(listOf(library)), store.shortcuts.value)
+            assertEquals(
+                PrimaryMenu(listOf(movies, home, library)),
+                UiCustomizationCodec.parsePrimaryMenu(api.puts.last().value),
+            )
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun rejectedCompoundTransformDoesNotPersistAnOrphanShortcut() = runTest {
+        val api = FakeSettingsApi()
+        val (store, storeScope) = store(api)
+        val home = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME)
+        val library = PrimaryMenuItem.Library(7, "Movies Library")
+        val fallback = PrimaryMenu(listOf(home))
+        try {
+            store.refresh()
+            val putsBeforeMutation = api.puts.size
+            val menuBeforeMutation = store.primaryMenu.value
+
+            store.updatePrimaryMenuAndShortcut(
+                fallback = fallback,
+                item = library,
+                present = true,
+            ) { null }
+            advanceUntilIdle()
+
+            assertEquals(putsBeforeMutation, api.puts.size)
+            assertEquals(menuBeforeMutation, store.primaryMenu.value)
+            assertEquals(NavigationShortcuts.EMPTY, store.shortcuts.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun shortcutUnpinAndMenuHideRemainIndependent() = runTest {
+        val api = FakeSettingsApi()
+        val (store, storeScope) = store(api)
+        val home = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME)
+        val library = PrimaryMenuItem.Library(7, "Movies")
+        val menu = PrimaryMenu(listOf(home, library))
+        try {
+            store.refresh()
+            store.setPrimaryMenuAndShortcut(menu, library, present = true)
+            advanceUntilIdle()
+
+            store.setShortcutPresent(library, present = false)
+            advanceUntilIdle()
+            assertEquals(menu, store.primaryMenu.value)
+            assertEquals(NavigationShortcuts.EMPTY, store.shortcuts.value)
+
+            store.setShortcutPresent(library, present = true)
+            advanceUntilIdle()
+            store.updatePrimaryMenu(menu) { PrimaryMenu(it.items.filterNot { item -> item == library }) }
+            advanceUntilIdle()
+            assertEquals(PrimaryMenu(listOf(home)), store.primaryMenu.value)
+            assertEquals(NavigationShortcuts(listOf(library)), store.shortcuts.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun successfulPutIsAcknowledgedAcrossSameOwnerIdentityGenerationChange() = runTest {
+        val api = FakeSettingsApi()
+        val original = authScope("server-a", "https://server-a.example", generation = 1)
+        val tokenManager = SnapshotTokenManager(original)
+        val (store, storeScope) = store(api, tokenManager)
+        try {
+            store.refresh()
+            api.putGate = CompletableDeferred()
+            store.setCardPresentation(
+                CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK),
+            )
+            runCurrent()
+            assertEquals(1, api.puts.size)
+
+            tokenManager.snapshot = original.copy(
+                identityGeneration = 2,
+            )
+            api.putGate?.complete(Unit)
+            advanceUntilIdle()
+
+            store.refresh()
+            assertEquals(1, api.puts.size)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun profileTokenRotationDoesNotStrandSameOwnerDelete() = runTest {
+        val api = FakeSettingsApi()
+        val original = authScope("server-a", "https://server-a.example", generation = 1)
+        val tokenManager = SnapshotTokenManager(original)
+        val (store, storeScope) = store(api, tokenManager)
+        try {
+            store.refresh()
+            api.onDelete = { _, _ ->
+                tokenManager.snapshot = original.copy(
+                    profileToken = "rotated-pin-profile-token",
+                    identityGeneration = 2,
+                )
+            }
+            store.resetPrimaryMenu()
+            advanceUntilIdle()
+            assertEquals(1, api.deletes.size)
+
+            store.refresh()
+            assertEquals(1, api.deletes.size)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun replacementCredentialOwnerCannotAcknowledgeOrDrainTheOldOwnersWrite() = runTest {
+        val api = FakeSettingsApi()
+        val oldOwner = authScope("server-a", "https://server-a.example", generation = 1)
+        val tokenManager = SnapshotTokenManager(oldOwner)
+        val (store, storeScope) = store(api, tokenManager)
+        try {
+            store.refresh()
+            api.putGate = CompletableDeferred()
+            store.setCardPresentation(
+                CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK),
+            )
+            runCurrent()
+            assertEquals(1, api.puts.size)
+
+            tokenManager.snapshot = oldOwner.copy(
+                profileToken = null,
+                credentialOwnerId = "replacement-account-owner",
+                identityGeneration = 2,
+                credentialEpoch = 2,
+            )
+            api.putGate?.complete(Unit)
+            advanceUntilIdle()
+
+            store.refresh()
+            assertEquals(1, api.puts.size)
+
+            tokenManager.snapshot = oldOwner.copy(identityGeneration = 3)
+            store.refresh()
+            assertEquals(2, api.puts.size)
+            assertEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun epochFallbackSeparatesReplacementLoginWhenDurableOwnerIdIsUnavailable() = runTest {
+        val api = FakeSettingsApi()
+        val oldLogin = authScope("server-a", "https://server-a.example", generation = 1).copy(
+            profileToken = null,
+            credentialOwnerId = null,
+            credentialEpoch = 1,
+        )
+        val tokenManager = SnapshotTokenManager(oldLogin)
+        val (store, storeScope) = store(api, tokenManager)
+        try {
+            store.refresh()
+            api.putGate = CompletableDeferred()
+            store.setCardPresentation(
+                CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK),
+            )
+            runCurrent()
+            assertEquals(1, api.puts.size)
+
+            tokenManager.snapshot = oldLogin.copy(
+                identityGeneration = 2,
+                credentialEpoch = 2,
+            )
+            api.putGate?.complete(Unit)
+            advanceUntilIdle()
+
+            store.refresh()
+            assertEquals(1, api.puts.size)
+
+            tokenManager.snapshot = oldLogin.copy(identityGeneration = 3)
+            store.refresh()
+            assertEquals(2, api.puts.size)
+            assertEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun temporaryCredentialGenerationSeparatesOverlayOwners() = runTest {
+        val api = FakeSettingsApi()
+        val firstOverlay = authScope(
+            "server-a",
+            "https://server-a.example",
+            generation = 1,
+        ).copy(
+            credentialGenerationId = "temporary-owner-a",
+            credentialOwnerId = null,
+            credentialEpoch = 0,
+        )
+        val tokenManager = SnapshotTokenManager(firstOverlay)
+        val (store, storeScope) = store(api, tokenManager)
+        try {
+            store.refresh()
+            api.putGate = CompletableDeferred()
+            store.setCardPresentation(
+                CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK),
+            )
+            runCurrent()
+            assertEquals(1, api.puts.size)
+
+            tokenManager.snapshot = firstOverlay.copy(
+                credentialGenerationId = "temporary-owner-b",
+                identityGeneration = 2,
+            )
+            api.putGate?.complete(Unit)
+            advanceUntilIdle()
+
+            store.refresh()
+            assertEquals(1, api.puts.size)
+
+            tokenManager.snapshot = firstOverlay.copy(identityGeneration = 3)
+            store.refresh()
+            assertEquals(2, api.puts.size)
+            assertEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun putUsesCapturedServerScopeAndRecoversOnlyWhenThatServerReturns() = runTest {
+        val api = FakeSettingsApi()
+        val cache = InMemoryCache()
+        val scopeA = authScope("server-a", "https://server-a.example", generation = 1)
+        val scopeB = authScope("server-b", "https://server-b.example", generation = 2)
+        val tokenManager = SnapshotTokenManager(scopeA)
+        val (store, storeScope) = store(api, tokenManager, cache)
+        val desired = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        try {
+            store.refresh()
+            val gate = api.pauseNextPutConstruction()
+            store.setCardPresentation(desired)
+            gate.started.await()
+
+            tokenManager.snapshot = scopeB
+            gate.release.complete(Unit)
+            advanceUntilIdle()
+            assertEquals(scopeA, api.puts.single().authScope)
+
+            store.refresh()
+            assertEquals(1, api.puts.size)
+
+            val returnedA = scopeA.copy(identityGeneration = 3)
+            tokenManager.snapshot = returnedA
+            store.refresh()
+            assertEquals(2, api.puts.size)
+            assertEquals(returnedA, api.puts.last().authScope)
+            assertEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+            assertEquals(api.puts.first().value, api.puts.last().value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun deleteUsesCapturedServerScopeAndDoesNotDrainOnAnotherServer() = runTest {
+        val api = FakeSettingsApi()
+        val scopeA = authScope("server-a", "https://server-a.example", generation = 1)
+        val scopeB = authScope("server-b", "https://server-b.example", generation = 2)
+        val tokenManager = SnapshotTokenManager(scopeA)
+        val (store, storeScope) = store(api, tokenManager)
+        try {
+            store.refresh()
+            val gate = api.pauseNextDeleteConstruction()
+            store.resetPrimaryMenu()
+            gate.started.await()
+
+            tokenManager.snapshot = scopeB
+            gate.release.complete(Unit)
+            advanceUntilIdle()
+            assertEquals(scopeA, api.deletes.single().authScope)
+
+            store.refresh()
+            assertEquals(1, api.deletes.size)
+
+            val returnedA = scopeA.copy(identityGeneration = 3)
+            tokenManager.snapshot = returnedA
+            store.refresh()
+            assertEquals(listOf(scopeA, returnedA), api.deletes.map { it.authScope })
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun shortcutUsesCapturedServerScopeAndDoesNotDrainOnAnotherServer() = runTest {
+        val api = FakeSettingsApi()
+        val scopeA = authScope("server-a", "https://server-a.example", generation = 1)
+        val scopeB = authScope("server-b", "https://server-b.example", generation = 2)
+        val tokenManager = SnapshotTokenManager(scopeA)
+        val (store, storeScope) = store(api, tokenManager)
+        val library = PrimaryMenuItem.Library(7, "Movies")
+        try {
+            store.refresh()
+            val gate = api.pauseNextShortcutConstruction()
+            store.setShortcutPresent(library, present = true)
+            gate.started.await()
+
+            tokenManager.snapshot = scopeB
+            gate.release.complete(Unit)
+            advanceUntilIdle()
+            assertEquals(scopeA, api.shortcutPuts.single().authScope)
+
+            store.refresh()
+            assertEquals(1, api.shortcutPuts.size)
+
+            val returnedA = scopeA.copy(identityGeneration = 3)
+            tokenManager.snapshot = returnedA
+            store.refresh()
+            assertEquals(listOf(scopeA, returnedA), api.shortcutPuts.map { it.authScope })
+            assertEquals(
+                api.shortcutPuts.first().mutationId,
+                api.shortcutPuts.last().mutationId,
+            )
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun compoundIntentPinsFirstAttemptAndRecoversBothHalvesOnOriginalServer() = runTest {
+        val api = FakeSettingsApi()
+        val scopeA = authScope("server-a", "https://server-a.example", generation = 1)
+        val scopeB = authScope("server-b", "https://server-b.example", generation = 2)
+        val tokenManager = SnapshotTokenManager(scopeA)
+        val (store, storeScope) = store(api, tokenManager)
+        val library = PrimaryMenuItem.Library(7, "Movies")
+        val menu = PrimaryMenu(
+            listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME), library),
+        )
+        try {
+            store.refresh()
+            val gate = api.pauseNextPutConstruction()
+            store.setPrimaryMenuAndShortcut(menu, library, present = true)
+            gate.started.await()
+
+            tokenManager.snapshot = scopeB
+            gate.release.complete(Unit)
+            advanceUntilIdle()
+            assertEquals(scopeA, api.puts.single().authScope)
+            assertEquals(0, api.shortcutPuts.size)
+
+            store.refresh()
+            assertEquals(1, api.puts.size)
+            assertEquals(0, api.shortcutPuts.size)
+
+            val returnedA = scopeA.copy(identityGeneration = 3)
+            tokenManager.snapshot = returnedA
+            store.refresh()
+            assertEquals(2, api.puts.size)
+            assertEquals(returnedA, api.puts.last().authScope)
+            assertEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+            assertEquals(api.puts.first().value, api.puts.last().value)
+            assertEquals(listOf(returnedA), api.shortcutPuts.map { it.authScope })
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun clearRejectsOldGetEvenAfterSameIdentityReactivates() = runTest {
+        val stale = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        val fresh = CardPresentation.DEFAULT
+        val api = FakeSettingsApi(
+            effective = cardEffective(stale),
+        )
+        val (store, storeScope) = store(api)
+        try {
+            val staleGate = api.pauseNextGet()
+            val staleRefresh = launch { store.refresh() }
+            staleGate.started.await()
+
+            store.clear()
+            api.effective = cardEffective(fresh)
+            val freshGate = api.pauseNextGet()
+            val freshRefresh = launch { store.refresh() }
+            runCurrent()
+            assertEquals(fresh, store.cardPresentation.value)
+
+            staleGate.release.complete(Unit)
+            freshGate.started.await()
+            // The old response has returned while the fresh response remains
+            // blocked. It must not repaint the same logical identity.
+            assertEquals(fresh, store.cardPresentation.value)
+
+            freshGate.release.complete(Unit)
+            staleRefresh.join()
+            freshRefresh.join()
+            assertEquals(fresh, store.cardPresentation.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun serverSwitchPaintsNewCacheBeforeSlowOldRefreshCompletes() = runTest {
+        val api = FakeSettingsApi(online = false)
+        val scopeB = authScope("server-b", "https://server-b.example", generation = 1)
+        val scopeA = authScope("server-a", "https://server-a.example", generation = 2)
+        val tokenManager = SnapshotTokenManager(scopeB)
+        val (store, storeScope) = store(api, tokenManager)
+        val cachedB = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+        try {
+            store.refresh()
+            store.setCardPresentation(cachedB)
+            advanceUntilIdle()
+
+            tokenManager.snapshot = scopeA
+            api.online = true
+            val gate = api.pauseNextGet()
+            val refreshA = launch { store.refresh() }
+            gate.started.await()
+            assertEquals(CardPresentation.DEFAULT, store.cardPresentation.value)
+
+            tokenManager.snapshot = scopeB.copy(identityGeneration = 3)
+            val refreshB = launch { store.refresh() }
+            runCurrent()
+            // B activation is not serialized behind A's network request.
+            assertEquals(cachedB, store.cardPresentation.value)
+
+            api.online = false
+            gate.release.complete(Unit)
+            refreshA.join()
+            refreshB.join()
+            assertEquals(cachedB, store.cardPresentation.value)
+            assertEquals(
+                listOf(scopeA, scopeB.copy(identityGeneration = 3)),
+                api.gets.takeLast(2).map { it.authScope },
+            )
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun foldableRestartFromMobileToTabletDoesNotReplayMobileMenu() = runTest {
+        verifyFamilyReclassification(
+            originalFamily = SiloClientFamily.MOBILE,
+            reclassifiedFamily = SiloClientFamily.TABLET,
+        )
+    }
+
+    @Test
+    fun foldableRestartFromTabletToMobileKeepsShortcutProfileWide() = runTest {
+        verifyFamilyReclassification(
+            originalFamily = SiloClientFamily.TABLET,
+            reclassifiedFamily = SiloClientFamily.MOBILE,
+        )
+    }
+
+    @Test
+    fun liveFoldableReclassificationRekeysStoreWithoutReplayingTheOtherFamilyMenu() = runTest {
+        var currentFamily = SiloClientFamily.MOBILE
+        val cache = InMemoryCache()
+        val api = FakeSettingsApi(online = false)
+        val tokenManager = TokenManagerImpl().also {
+            it.setServerUrl("https://silo.example")
+            it.setProfileId("profile-one")
+        }
+        val library = PrimaryMenuItem.Library(7, "Movies")
+        val mobileMenu = PrimaryMenu(
+            listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME), library),
+        )
+        val (store, storeScope) = store(
+            api = api,
+            tokenManager = tokenManager,
+            cache = cache,
+            family = currentFamily,
+            familyProvider = { currentFamily },
+        )
+        try {
+            store.refresh()
+            store.setPrimaryMenuAndShortcut(mobileMenu, library, present = true)
+            advanceUntilIdle()
+            assertEquals(SiloClientFamily.MOBILE, store.family)
+            assertEquals(1, api.puts.size)
+            assertEquals(SiloClientFamily.MOBILE, api.puts.single().scope.clientFamily)
+            assertEquals(1, api.shortcutPuts.size)
+
+            currentFamily = SiloClientFamily.TABLET
+            store.reclassifyClientFamily()
+
+            // The lifecycle callback re-keys synchronously, before its async
+            // refresh can start, so no mobile-family presentation leaks across.
+            assertEquals(SiloClientFamily.TABLET, store.family)
+            assertEquals(null, store.primaryMenu.value)
+            assertEquals(NavigationShortcuts(listOf(library)), store.shortcuts.value)
+
+            api.online = true
+            store.refresh()
+
+            // The mobile menu stays queued while its profile-wide shortcut drains.
+            assertEquals(1, api.puts.size)
+            assertEquals(2, api.shortcutPuts.size)
+
+            currentFamily = SiloClientFamily.MOBILE
+            store.reclassifyClientFamily()
+
+            // Returning also paints the durable mobile cache synchronously.
+            assertEquals(mobileMenu, store.primaryMenu.value)
+            store.refresh()
+
+            assertEquals(mobileMenu, store.primaryMenu.value)
+            assertEquals(NavigationShortcuts(listOf(library)), store.shortcuts.value)
+            assertEquals(2, api.puts.size)
+            assertEquals(SiloClientFamily.MOBILE, api.puts.last().scope.clientFamily)
+            assertEquals(2, api.shortcutPuts.size)
+            assertEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+            assertEquals(api.puts.first().value, api.puts.last().value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun familyBoundaryRejectsAnOldQueuedEditBeforeItCanReachNewFamilyStorage() = runTest {
+        var currentFamily = SiloClientFamily.MOBILE
+        val api = FakeSettingsApi()
+        val (store, storeScope) = store(
+            api = api,
+            family = currentFamily,
+            familyProvider = { currentFamily },
+        )
+        val firstMenu = PrimaryMenu(
+            listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME)),
+        )
+        val queuedMenu = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+        )
+        try {
+            store.refresh()
+            store.setPrimaryMenu(firstMenu)
+            advanceUntilIdle()
+            assertEquals(1, api.puts.size)
+
+            // Leave this command in the authoring channel, then cross the
+            // family boundary before its binding or cache key is resolved.
+            store.setPrimaryMenu(queuedMenu)
+            currentFamily = SiloClientFamily.TABLET
+            store.reclassifyClientFamily()
+            assertEquals(null, store.primaryMenu.value)
+
+            advanceUntilIdle()
+            assertEquals(1, api.puts.size, "the stale command must be rejected")
+            assertEquals(null, store.primaryMenu.value)
+
+            currentFamily = SiloClientFamily.MOBILE
+            store.reclassifyClientFamily()
+            assertEquals(firstMenu, store.primaryMenu.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun inFlightOldFamilyEditKeepsItsBindingAndCannotRepaintNewFamily() = runTest {
+        var currentFamily = SiloClientFamily.MOBILE
+        val api = FakeSettingsApi()
+        val (store, storeScope) = store(
+            api = api,
+            family = currentFamily,
+            familyProvider = { currentFamily },
+        )
+        val mobileMenu = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+        )
+        try {
+            store.refresh()
+            val gate = api.pauseNextPutConstruction()
+            store.setPrimaryMenu(mobileMenu)
+            gate.started.await()
+
+            currentFamily = SiloClientFamily.TABLET
+            store.reclassifyClientFamily()
+            assertEquals(null, store.primaryMenu.value)
+
+            gate.release.complete(Unit)
+            advanceUntilIdle()
+            assertEquals(SiloClientFamily.MOBILE, api.puts.single().scope.clientFamily)
+            assertEquals(null, store.primaryMenu.value)
+
+            currentFamily = SiloClientFamily.MOBILE
+            store.reclassifyClientFamily()
+            assertEquals(mobileMenu, store.primaryMenu.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun offlineCacheIsIsolatedByServerWhenProfileIdsMatch() = runTest {
+        val api = FakeSettingsApi(online = false)
+        val tokenManager = TokenManagerImpl().apply {
+            setServerUrl("https://server-a.example")
+            setProfileId("same-profile")
+        }
+        val (store, storeScope) = store(api, tokenManager)
+        try {
+            store.refresh()
+            val serverAChoice = CardPresentation(
+                PosterSizePreset.LARGE,
+                CardCaptionPreset.ARTWORK,
+            )
+            store.setCardPresentation(serverAChoice)
+            advanceUntilIdle()
+
+            tokenManager.setServerUrl("https://server-b.example")
+            store.refresh()
+            assertEquals(CardPresentation.DEFAULT, store.cardPresentation.value)
+
+            tokenManager.setServerUrl("https://server-a.example")
+            store.refresh()
+            assertEquals(serverAChoice, store.cardPresentation.value)
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    @Test
+    fun temporaryScopeTransitionsClearInlineAndRehydrateEachAtomicOwner() = runTest {
+        val savedPresentation = CardPresentation(
+            PosterSizePreset.LARGE,
+            CardCaptionPreset.ARTWORK,
+        )
+        val guestPresentation = CardPresentation(
+            PosterSizePreset.COMPACT,
+            CardCaptionPreset.TITLE,
+        )
+        val api = FakeSettingsApi(effective = cardEffective(savedPresentation))
+        val savedScope = authScope(
+            "saved-server",
+            "https://saved.example",
+            generation = 1,
+        )
+        val guestScope = AuthScopeSnapshot(
+            serverId = "guest-server",
+            profileId = "guest-profile",
+            serverUrl = "https://guest.example",
+            profileToken = "guest-profile-token",
+            credentialGenerationId = "guest-generation",
+            identityGeneration = 2,
+        )
+        val tokenManager = SnapshotTokenManager(savedScope)
+        val identityTransitions = DefaultIdentityTransitionBarrier()
+        val (store, storeScope) = store(
+            api = api,
+            tokenManager = tokenManager,
+            identityTransitions = identityTransitions,
+        )
+        try {
+            store.refresh()
+            assertEquals(savedPresentation, store.cardPresentation.value)
+
+            api.effective = cardEffective(guestPresentation)
+            identityTransitions.changing(IdentityTransitionKind.TEMPORARY_SCOPE_BEGIN) {
+                assertEquals(CardPresentation.DEFAULT, store.cardPresentation.value)
+                tokenManager.snapshot = guestScope
+            }
+            advanceUntilIdle()
+
+            assertEquals(guestPresentation, store.cardPresentation.value)
+            assertEquals("guest-profile", api.gets.last().profileId)
+            assertEquals(
+                "guest-generation",
+                api.gets.last().authScope?.credentialGenerationId,
+            )
+
+            api.effective = cardEffective(savedPresentation)
+            identityTransitions.changing(IdentityTransitionKind.TEMPORARY_SCOPE_END) {
+                assertEquals(CardPresentation.DEFAULT, store.cardPresentation.value)
+                tokenManager.snapshot = savedScope.copy(identityGeneration = 3)
+            }
+            advanceUntilIdle()
+
+            assertEquals(savedPresentation, store.cardPresentation.value)
+            assertEquals("same-profile", api.gets.last().profileId)
+            assertEquals(
+                savedScope.credentialOwnerId,
+                api.gets.last().authScope?.credentialOwnerId,
+            )
+        } finally {
+            storeScope.cancel()
+        }
+    }
+
+    private suspend fun kotlinx.coroutines.test.TestScope.store(
+        api: FakeSettingsApi,
+        tokenManager: TokenManager? = null,
+        cache: InMemoryCache = InMemoryCache(),
+        family: SiloClientFamily = SiloClientFamily.TV,
+        familyProvider: () -> SiloClientFamily = { family },
+        identityTransitions: IdentityTransitionBarrier = DefaultIdentityTransitionBarrier(),
+    ): Pair<DefaultUiCustomizationStore, CoroutineScope> {
+        val resolvedTokenManager = tokenManager ?: TokenManagerImpl().also {
+            it.setServerUrl("https://silo.example")
+            it.setProfileId("profile-one")
+        }
+        val scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+        return DefaultUiCustomizationStore(
+            family = family,
+            repository = SettingsRepository(api),
+            tokenManager = resolvedTokenManager,
+            cache = cache,
+            scope = scope,
+            identityTransitions = identityTransitions,
+            familyProvider = familyProvider,
+        ) to scope
+    }
+
+    private suspend fun kotlinx.coroutines.test.TestScope.verifyFamilyReclassification(
+        originalFamily: SiloClientFamily,
+        reclassifiedFamily: SiloClientFamily,
+    ) {
+        val cache = InMemoryCache()
+        val api = FakeSettingsApi(online = false)
+        val tokenManager = TokenManagerImpl().also {
+            it.setServerUrl("https://silo.example")
+            it.setProfileId("profile-one")
+        }
+        val library = PrimaryMenuItem.Library(7, "Movies")
+        val originalMenu = PrimaryMenu(
+            listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME), library),
+        )
+        val (originalStore, originalScope) = store(
+            api = api,
+            tokenManager = tokenManager,
+            cache = cache,
+            family = originalFamily,
+        )
+        try {
+            originalStore.refresh()
+            originalStore.setPrimaryMenuAndShortcut(
+                originalMenu,
+                library,
+                present = true,
+            )
+            advanceUntilIdle()
+            assertEquals(1, api.puts.size)
+            assertEquals(originalFamily, api.puts.single().scope.clientFamily)
+            assertEquals(1, api.shortcutPuts.size)
+
+            originalScope.cancel()
+            api.online = true
+            val (reclassifiedStore, reclassifiedScope) = store(
+                api = api,
+                tokenManager = tokenManager,
+                cache = cache,
+                family = reclassifiedFamily,
+            )
+            try {
+                reclassifiedStore.refresh()
+
+                // The menu belongs to the original family and stays queued;
+                // the shortcut is profile-wide and recovers immediately.
+                assertEquals(null, reclassifiedStore.primaryMenu.value)
+                assertEquals(NavigationShortcuts(listOf(library)), reclassifiedStore.shortcuts.value)
+                assertEquals(1, api.puts.size)
+                assertEquals(2, api.shortcutPuts.size)
+            } finally {
+                reclassifiedScope.cancel()
+            }
+
+            val (returnedStore, returnedScope) = store(
+                api = api,
+                tokenManager = tokenManager,
+                cache = cache,
+                family = originalFamily,
+            )
+            try {
+                returnedStore.refresh()
+
+                assertEquals(originalMenu, returnedStore.primaryMenu.value)
+                assertEquals(NavigationShortcuts(listOf(library)), returnedStore.shortcuts.value)
+                assertEquals(2, api.puts.size)
+                assertEquals(originalFamily, api.puts.last().scope.clientFamily)
+                assertEquals(2, api.shortcutPuts.size)
+                assertEquals(api.puts.first().mutationId, api.puts.last().mutationId)
+                assertEquals(api.puts.first().value, api.puts.last().value)
+            } finally {
+                returnedScope.cancel()
+            }
+        } finally {
+            originalScope.cancel()
+        }
+    }
+
+    private fun authScope(serverId: String, serverUrl: String, generation: Long) =
+        AuthScopeSnapshot(
+            serverId = serverId,
+            profileId = "same-profile",
+            serverUrl = serverUrl,
+            profileToken = "fake-" + serverId,
+            identityGeneration = generation,
+            credentialOwnerId = "owner-" + serverId,
+            credentialEpoch = 1,
+        )
+
+    private fun shortcutEffective(
+        value: NavigationShortcuts,
+    ): Map<String, EffectiveSettingValue> =
+        mapOf(
+            SettingKeys.NAV_SHORTCUTS to EffectiveSettingValue(
+                key = SettingKeys.NAV_SHORTCUTS,
+                value = UiCustomizationCodec.encodeShortcuts(value),
+                source = SettingScope.PROFILE.wire,
+                scope = SettingScope.PROFILE.wire,
+            ),
+        )
+
+    private fun cardEffective(value: CardPresentation): Map<String, EffectiveSettingValue> =
+        mapOf(
+            SettingKeys.UI_CARD_PRESENTATION to EffectiveSettingValue(
+                key = SettingKeys.UI_CARD_PRESENTATION,
+                value = UiCustomizationCodec.encodeCardPresentation(value),
+                source = SettingScope.PROFILE_CLIENT.wire,
+                scope = SettingScope.PROFILE_CLIENT.wire,
+            ),
+        )
+
+    private class SnapshotTokenManager(
+        var snapshot: AuthScopeSnapshot,
+        private val delegate: TokenManager = TokenManagerImpl(),
+    ) : TokenManager by delegate {
+        override suspend fun snapshotCurrentScope(): AuthScopeSnapshot = snapshot
+    }
+
+    private class CallGate {
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+    }
+
+    private class FakeSettingsApi(
+        var effective: Map<String, EffectiveSettingValue> = emptyMap(),
+        var online: Boolean = true,
+        var capabilityResult: SettingsCapabilitiesResult =
+            SettingsCapabilitiesResult.Available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsBatchedEffective = true,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            ),
+    ) : SettingsApi(HttpClient()) {
+        data class Get(
+            val profileId: String?,
+            val authScope: AuthScopeSnapshot?,
+        )
+        data class Put(
+            val key: String,
+            val scope: SettingScopeIdentity,
+            val value: JsonElement,
+            val mutationId: String,
+            val profileId: String?,
+            val authScope: AuthScopeSnapshot?,
+        )
+        data class ShortcutPut(
+            val item: JsonElement,
+            val present: Boolean,
+            val mutationId: String,
+            val profileId: String?,
+            val authScope: AuthScopeSnapshot?,
+        )
+        data class Delete(
+            val key: String,
+            val scope: SettingScopeIdentity,
+            val authScope: AuthScopeSnapshot?,
+        )
+
+        val gets = mutableListOf<Get>()
+        val puts = mutableListOf<Put>()
+        val shortcutPuts = mutableListOf<ShortcutPut>()
+        val deletes = mutableListOf<Delete>()
+        var getGate: CompletableDeferred<Unit>? = null
+        var putGate: CompletableDeferred<Unit>? = null
+        var shortcutPutGate: CompletableDeferred<Unit>? = null
+        private val getCallGates = ArrayDeque<CallGate>()
+        var putConstructionGate: CallGate? = null
+        var shortcutConstructionGate: CallGate? = null
+        var deleteConstructionGate: CallGate? = null
+        var onPut: ((Put) -> ApiResult<StoredSettingValue>)? = null
+        var onShortcutPut: ((ShortcutPut) -> ApiResult<StoredSettingValue>)? = null
+        var onDelete: ((String, SettingScopeIdentity) -> Unit)? = null
+        var onDeleteResult: ((String, SettingScopeIdentity) -> ApiResult<Unit>?)? = null
+
+        fun pauseNextGet(): CallGate = CallGate().also(getCallGates::addLast)
+
+        fun pauseNextPutConstruction(): CallGate = CallGate().also {
+            check(putConstructionGate == null)
+            putConstructionGate = it
+        }
+
+        fun pauseNextShortcutConstruction(): CallGate = CallGate().also {
+            check(shortcutConstructionGate == null)
+            shortcutConstructionGate = it
+        }
+
+        fun pauseNextDeleteConstruction(): CallGate = CallGate().also {
+            check(deleteConstructionGate == null)
+            deleteConstructionGate = it
+        }
+
+        override suspend fun getContractCapabilities(): SettingsCapabilitiesResult =
+            capabilityResult
+
+        override suspend fun getEffectiveValues(
+            keys: List<String>,
+            libraryIds: List<Int>,
+            seriesIds: List<String>,
+            profileId: String?,
+            authScope: AuthScopeSnapshot?,
+        ): ApiResult<EffectiveSettingValuesResponse> {
+            val responseValues = effective
+            getCallGates.removeFirstOrNull()?.let { gate ->
+                gate.started.complete(Unit)
+                gate.release.await()
+            }
+            getGate?.await()
+            gets += Get(profileId, authScope)
+            return if (online) {
+                ApiResult.Success(
+                    EffectiveSettingValuesResponse(
+                        settings = keys.mapNotNull(responseValues::get),
+                        revision = SettingKeys.REVISION,
+                    ),
+                )
+            } else {
+                ApiResult.NetworkError(IOException("offline"))
+            }
+        }
+
+        override suspend fun putValue(
+            key: String,
+            scope: SettingScopeIdentity,
+            value: JsonElement,
+            mutationId: String,
+            profileId: String?,
+            authScope: AuthScopeSnapshot?,
+        ): ApiResult<StoredSettingValue> {
+            putConstructionGate?.also { gate ->
+                putConstructionGate = null
+                gate.started.complete(Unit)
+                gate.release.await()
+            }
+            val put = Put(key, scope, value, mutationId, profileId, authScope)
+            puts += put
+            putGate?.await()
+            onPut?.let { return it(put) }
+            return if (online) {
+                ApiResult.Success(
+                    StoredSettingValue(key = key, scope = scope.scope.wire, value = value),
+                )
+            } else {
+                ApiResult.NetworkError(IOException("offline"))
+            }
+        }
+
+        override suspend fun putNavigationShortcutItem(
+            item: JsonElement,
+            present: Boolean,
+            mutationId: String,
+            profileId: String?,
+            authScope: AuthScopeSnapshot?,
+        ): ApiResult<StoredSettingValue> {
+            shortcutConstructionGate?.also { gate ->
+                shortcutConstructionGate = null
+                gate.started.complete(Unit)
+                gate.release.await()
+            }
+            val put = ShortcutPut(item, present, mutationId, profileId, authScope)
+            shortcutPuts += put
+            val gate = shortcutPutGate
+            shortcutPutGate = null
+            gate?.await()
+            onShortcutPut?.let { return it(put) }
+            return if (online) {
+                ApiResult.Success(applyShortcutPut(put))
+            } else {
+                ApiResult.NetworkError(IOException("offline"))
+            }
+        }
+
+        fun applyShortcutPut(put: ShortcutPut): StoredSettingValue {
+            val item = checkNotNull(UiCustomizationCodec.parseShortcutItem(put.item))
+            val current = effective[SettingKeys.NAV_SHORTCUTS]?.value
+                ?.let(UiCustomizationCodec::parseShortcuts)
+                ?: NavigationShortcuts.EMPTY
+            val identity = UiCustomizationCodec.identity(item)
+            val withoutItem = current.items.filterNot {
+                UiCustomizationCodec.identity(it) == identity
+            }
+            val next = if (put.present && current.items.any {
+                    UiCustomizationCodec.identity(it) == identity
+                }
+            ) {
+                current
+            } else if (put.present) {
+                NavigationShortcuts(withoutItem + item)
+            } else {
+                NavigationShortcuts(withoutItem)
+            }
+            val encoded = UiCustomizationCodec.encodeShortcuts(next)
+            effective = effective + (
+                SettingKeys.NAV_SHORTCUTS to EffectiveSettingValue(
+                    key = SettingKeys.NAV_SHORTCUTS,
+                    value = encoded,
+                    source = SettingScope.PROFILE.wire,
+                    scope = SettingScope.PROFILE.wire,
+                )
+            )
+            return StoredSettingValue(
+                key = SettingKeys.NAV_SHORTCUTS,
+                scope = SettingScope.PROFILE.wire,
+                value = encoded,
+            )
+        }
+
+        override suspend fun deleteValue(
+            key: String,
+            scope: SettingScopeIdentity,
+            profileId: String?,
+            authScope: AuthScopeSnapshot?,
+        ): ApiResult<Unit> {
+            deleteConstructionGate?.also { gate ->
+                deleteConstructionGate = null
+                gate.started.complete(Unit)
+                gate.release.await()
+            }
+            deletes += Delete(key, scope, authScope)
+            return if (online) {
+                onDeleteResult?.invoke(key, scope)?.let { return it }
+                onDelete?.invoke(key, scope)
+                ApiResult.Success(Unit)
+            } else {
+                ApiResult.NetworkError(IOException("offline"))
+            }
+        }
+    }
+
+    private class InMemoryCache : AndroidServerSettingsCache(
+        ApplicationProvider.getApplicationContext<Context>(),
+    ) {
+        private val values = mutableMapOf<String, String>()
+        var afterPutString: ((String) -> Unit)? = null
+        private fun key(serverUrl: String, name: String) = "${serverUrl.trimEnd('/')}|$name"
+
+        override fun getString(serverUrl: String, key: String, defaultValue: String): String =
+            values[key(serverUrl, key)] ?: defaultValue
+
+        override fun putString(serverUrl: String, key: String, value: String) {
+            values[key(serverUrl, key)] = value
+            afterPutString?.invoke(key)
+        }
+
+        override fun getBoolean(serverUrl: String, key: String, defaultValue: Boolean): Boolean =
+            values[key(serverUrl, key)]?.toBooleanStrictOrNull() ?: defaultValue
+
+        override fun putBoolean(serverUrl: String, key: String, value: Boolean) {
+            values[key(serverUrl, key)] = value.toString()
+        }
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/ui/components/CardPresentationSizingTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/ui/components/CardPresentationSizingTest.kt
@@ -1,0 +1,15 @@
+package org.siloserver.silo.common.ui.components
+
+import org.siloserver.silo.model.settings.PosterSizePreset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CardPresentationSizingTest {
+    @Test
+    fun fixedPosterGridsMoveOneDensityStepPerPreset() {
+        assertEquals(7, 6.forPosterPreset(PosterSizePreset.COMPACT))
+        assertEquals(6, 6.forPosterPreset(PosterSizePreset.STANDARD))
+        assertEquals(5, 6.forPosterPreset(PosterSizePreset.LARGE))
+        assertEquals(1, 1.forPosterPreset(PosterSizePreset.LARGE))
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MainActivity.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MainActivity.kt
@@ -52,6 +52,7 @@ import org.siloserver.silo.common.pip.SiloPictureInPictureCoordinator
 import org.siloserver.silo.common.pip.SiloPictureInPictureSurface
 import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.common.settings.ServerDrivenConfigRefresher
+import org.siloserver.silo.common.settings.UiCustomizationStore
 import org.siloserver.silo.common.startup.StartupArtworkPlan
 import org.siloserver.silo.common.startup.warmAuthenticatedStartup
 import org.siloserver.silo.common.startup.warmProfileSelectionStartup
@@ -64,6 +65,7 @@ import org.siloserver.silo.repository.PersonalDataRepository
 import org.siloserver.silo.repository.ProfileRepository
 import org.siloserver.silo.repository.SectionRepository
 import org.siloserver.silo.repository.port.HomeCachePort
+import org.siloserver.silo.model.settings.SiloClientFamily
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -107,6 +109,7 @@ class MainActivity : ComponentActivity() {
     // example while an existing top Activity is being resumed by onNewIntent).
     // A replay-free SharedFlow can silently drop exactly that warm delivery.
     private val pendingExternalRouteRequests = MutableStateFlow<ExternalRouteRequest?>(null)
+    private var uiCustomizationFamily: SiloClientFamily? = null
 
     /**
      * The external route already delivered for the Intent this Activity was
@@ -127,6 +130,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         consumedExternalRoute = savedInstanceState?.getString(STATE_CONSUMED_EXTERNAL_ROUTE)
+        uiCustomizationFamily = mobileUiCustomizationFamily(applicationContext)
         enableEdgeToEdge()
         maybeRequestNotificationPermission()
         maybeRequestLegacyPublicDownloadPermission()
@@ -229,6 +233,24 @@ class MainActivity : ComponentActivity() {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         consumedExternalRoute?.let { outState.putString(STATE_CONSUMED_EXTERNAL_ROUTE, it) }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        val previousFamily = uiCustomizationFamily
+        // [newConfig] is deliberately unused here: it is this Activity's
+        // configuration, which in multi-window can differ from the
+        // application's. The UiCustomizationStore's familyProvider reads the
+        // application configuration on every write, so classifying from
+        // anything else would fire reclassifyClientFamily() for a change the
+        // store cannot observe (a no-op) and skip one it can.
+        val currentFamily = mobileUiCustomizationFamily(applicationContext)
+        uiCustomizationFamily = currentFamily
+        if (previousFamily != null && previousFamily != currentFamily) {
+            val store = get<UiCustomizationStore>(UiCustomizationStore::class.java)
+            store.reclassifyClientFamily()
+            lifecycleScope.launch(Dispatchers.IO) { store.refresh() }
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MobileUiCustomizationFamily.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MobileUiCustomizationFamily.kt
@@ -1,0 +1,25 @@
+package org.siloserver.silo.android
+
+import android.content.Context
+import org.siloserver.silo.common.network.androidClientFamily
+import org.siloserver.silo.model.settings.SiloClientFamily
+
+/**
+ * The one place the phone app classifies itself as `mobile` vs `tablet` for
+ * synced UI customization.
+ *
+ * Always resolve this from the APPLICATION context. In multi-window an
+ * Activity carries its own override [android.content.res.Configuration] whose
+ * `smallestScreenWidthDp` can differ from the application's, so an
+ * Activity-derived answer would disagree with the value
+ * `DefaultUiCustomizationStore`'s `familyProvider` reads on every write —
+ * making `reclassifyClientFamily()` fire on a change the store cannot see, and
+ * stay silent on one it can.
+ */
+fun mobileUiCustomizationFamily(context: Context): SiloClientFamily {
+    val wire = androidClientFamily(
+        platform = "android",
+        smallestScreenWidthDp = context.resources.configuration.smallestScreenWidthDp,
+    )
+    return SiloClientFamily.entries.first { it.wire == wire }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -33,11 +33,14 @@ import org.siloserver.silo.common.player.backend.VideoPlaybackBackendFactory
 import org.siloserver.silo.common.player.video.VideoPlaybackSessionCoordinator
 import org.siloserver.silo.common.player.video.VideoPlaybackStarter
 import org.siloserver.silo.android.BuildConfig
+import org.siloserver.silo.android.mobileUiCustomizationFamily
 import org.siloserver.silo.common.network.AndroidDeviceMetadataProvider
 import org.siloserver.silo.common.network.SiloClientBuildIdentity
 import org.siloserver.silo.common.network.CleartextConsentStore
 import org.siloserver.silo.common.network.DataStoreCleartextConsentStore
 import org.siloserver.silo.common.settings.AndroidServerSettingsCache
+import org.siloserver.silo.common.settings.DefaultUiCustomizationStore
+import org.siloserver.silo.common.settings.UiCustomizationStore
 import android.content.SharedPreferences
 import org.siloserver.silo.network.AndroidServerRegistry
 import org.siloserver.silo.network.EncryptedTokenManagerImpl
@@ -179,9 +182,26 @@ val androidModule = module {
     // every collaborator that reports client identity (headers, playback
     // context, diagnostics) resolves this rather than deriving its own answer.
     single { SiloClientBuildIdentity(BuildConfig.BUILD_NUMBER, BuildConfig.RELEASE_CHANNEL) }
+    single<UiCustomizationStore> {
+        val context = androidContext()
+        // Shared with MainActivity's reclassification check so both read the
+        // same (application) Configuration.
+        val familyProvider = { mobileUiCustomizationFamily(context) }
+        DefaultUiCustomizationStore(
+            family = familyProvider(),
+            repository = get(),
+            tokenManager = get(),
+            cache = get(),
+            identityTransitions = get(),
+            scope = kotlinx.coroutines.CoroutineScope(
+                kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.IO,
+            ),
+            familyProvider = familyProvider,
+        )
+    }
     single<org.siloserver.silo.network.DeviceMetadataProvider> {
         AndroidDeviceMetadataProvider(
-            androidContext(),
+            context = androidContext(),
             platform = "android",
             buildIdentity = get(),
         )
@@ -432,7 +452,7 @@ val androidModule = module {
             tmdbId = args.second,
         )
     }
-    viewModel { SettingsViewModel(get(), get(), get(), get(), get(), get()) }
+    viewModel { SettingsViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { DiagnosticsViewModel(get()) }
     viewModel { DownloadsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { org.siloserver.silo.android.ui.screens.pairing.CompanionPairingViewModel(get(), get()) }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/BackdropCard.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/BackdropCard.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.android.ui.components
 
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -42,6 +43,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.siloserver.silo.model.catalog.MediaItemUserState
+import org.siloserver.silo.model.settings.CardCaptionPreset
 
 /**
  * Reserved height for the text block under a backdrop card: title (bodySmall)
@@ -86,6 +88,7 @@ fun BackdropCard(
      *  null keeps it decorative and the whole card opens the item page. */
     onOverlayClick: (() -> Unit)? = null,
 ) {
+    val presentation = LocalCardPresentation.current
     var menuExpanded by remember { mutableStateOf(false) }
     Column(
         modifier = modifier
@@ -165,55 +168,62 @@ fun BackdropCard(
             }
         }
 
-        Spacer(modifier = Modifier.height(6.dp))
+        if (presentation.caption != CardCaptionPreset.ARTWORK) {
+            Spacer(modifier = Modifier.height(6.dp))
 
-        // Fixed-height info block: episode cards draw up to three text lines,
-        // movie cards as few as one. In a mixed row (Continue Watching) the
-        // LazyRow's height would otherwise change with whichever items are
-        // visible, bouncing every row below it during horizontal scrolls.
-        Column(modifier = Modifier.height(backdropInfoBlockHeight)) {
-        if (seriesTitle != null) {
-            // Episode card: show series title, then episode tag + episode title
-            Text(
-                text = seriesTitle,
-                style = MaterialTheme.typography.bodySmall,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            val episodeTag = formatEpisodeTag(seasonNumber, episodeNumber)
-            val subtitle = if (episodeTag != null) "$episodeTag \u2022 $title" else title
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        } else {
-            // Movie card: just show the title
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
+            // Metadata mode reserves the tallest episode stack so mixed rows
+            // remain stable while scrolling. Title-only mode needs one line.
+            Column(
+                modifier = if (presentation.caption == CardCaptionPreset.TITLE_METADATA) {
+                    Modifier.height(backdropInfoBlockHeight)
+                } else {
+                    Modifier
+                },
+            ) {
+                if (seriesTitle != null) {
+                    Text(
+                        text = seriesTitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    if (presentation.caption == CardCaptionPreset.TITLE_METADATA) {
+                        val episodeTag = formatEpisodeTag(seasonNumber, episodeNumber)
+                        val subtitle = if (episodeTag != null) "$episodeTag \u2022 $title" else title
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                } else {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
 
-        // Remaining time
-        if (remainingMinutes != null && remainingMinutes > 0) {
-            Text(
-                text = "${remainingMinutes}m left",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-
+                if (
+                    presentation.caption == CardCaptionPreset.TITLE_METADATA &&
+                    remainingMinutes != null && remainingMinutes > 0
+                ) {
+                    Text(
+                        text = "${remainingMinutes}m left",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
         }
 
         MediaCardContextMenu(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaCard.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaCard.kt
@@ -1,6 +1,8 @@
 package org.siloserver.silo.android.ui.components
 
 import org.siloserver.silo.common.ui.components.ThumbhashImage
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
+import org.siloserver.silo.common.ui.components.forPosterPreset
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -36,6 +38,7 @@ import org.siloserver.silo.common.overlays.CardOverlayVariant
 import org.siloserver.silo.common.overlays.CardOverlays
 import org.siloserver.silo.common.overlays.LocalCardOverlayUiState
 import org.siloserver.silo.model.catalog.MediaItemUserState
+import org.siloserver.silo.model.settings.CardCaptionPreset
 import org.siloserver.silo.overlays.OverlayData
 
 object MediaGridDefaults {
@@ -46,6 +49,11 @@ object MediaGridDefaults {
     val PosterGridMinWidth = 104.dp
     val PosterGridHorizontalSpacing = 12.dp
     val PosterGridVerticalSpacing = 16.dp
+
+    @Composable
+    fun posterGridMinWidth(): Dp = PosterGridMinWidth.forPosterPreset(
+        LocalCardPresentation.current.posterSize,
+    )
 }
 
 /**
@@ -69,7 +77,7 @@ fun MediaCard(
     progress: Float? = null,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    width: Dp = 120.dp,
+    width: Dp? = null,
     artworkAspectRatio: Float = 2f / 3.3f,
     overlay: OverlayData? = null,
     actions: MediaCardActions = MediaCardActions(),
@@ -81,6 +89,8 @@ fun MediaCard(
     sharedContentId: String? = null,
 ) {
     val overlayState = LocalCardOverlayUiState.current
+    val presentation = LocalCardPresentation.current
+    val effectiveWidth = width ?: 120.dp.forPosterPreset(presentation.posterSize)
     var menuExpanded by remember { mutableStateOf(false) }
     // Unique per-placement hero key. Two placements of the same content id (e.g.
     // Continue Watching + a genre row) get distinct keys, so they never collide
@@ -93,7 +103,7 @@ fun MediaCard(
     // iOS MediaCard.swift: VStack(alignment: .leading, spacing: 4).
     Column(
         modifier = modifier
-            .width(width)
+            .width(effectiveWidth)
             .combinedClickable(
                 onClick = {
                     // Record which exact placement was tapped so the detail hero
@@ -165,18 +175,20 @@ fun MediaCard(
             }
         }
 
-        // iOS titleText: .siloSubheadline (14sp), 2 lines.
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        if (presentation.caption != CardCaptionPreset.ARTWORK) {
+            // iOS titleText: .siloSubheadline (14sp), 2 lines.
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
 
         val caption = subtitle ?: year?.takeIf { it > 0 }?.toString()
-        if (caption != null) {
+        if (caption != null && presentation.caption == CardCaptionPreset.TITLE_METADATA) {
             // iOS yearText: .siloCaption (12sp) at secondary text.
             Text(
                 text = caption,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
@@ -20,8 +20,9 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,6 +35,10 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navDeepLink
 import androidx.navigation.navArgument
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.map
 import org.siloserver.silo.android.cast.GoogleCastMiniBar
 import org.siloserver.silo.android.cast.SiloCastController
@@ -89,12 +94,66 @@ import org.siloserver.silo.cast.SiloCastPlaybackRequest
 import org.siloserver.silo.common.overlays.ProvideCardOverlays
 import org.siloserver.silo.common.player.video.VideoPlayerRouteArgs
 import org.siloserver.silo.common.settings.OverlayPrefsStore
+import org.siloserver.silo.common.settings.UiCustomizationStore
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
+import org.siloserver.silo.model.settings.effectiveCardPresentationForSupport
 import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.ServerRegistry
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 /** Page-to-page cross-fade duration (ms). Snappier than Compose Nav's 700ms default. */
 private const val PageFadeDurationMs = 200
+
+/** Identity that owns server-hydrated, profile-specific UI preferences. */
+internal data class UiCustomizationHydrationIdentity(
+    val serverId: String,
+    val profileId: String,
+)
+
+internal fun uiCustomizationHydrationIdentity(
+    serverId: String?,
+    profileId: String?,
+): UiCustomizationHydrationIdentity? {
+    val server = serverId?.takeIf { it.isNotBlank() } ?: return null
+    val profile = profileId?.takeIf { it.isNotBlank() } ?: return null
+    return UiCustomizationHydrationIdentity(server, profile)
+}
+
+internal fun shouldRefreshUiCustomization(
+    event: Lifecycle.Event,
+    identity: UiCustomizationHydrationIdentity?,
+): Boolean = event == Lifecycle.Event.ON_RESUME && identity != null
+
+internal enum class UiCustomizationHydrationAction { CLEAR, REFRESH }
+
+internal fun uiCustomizationHydrationAction(
+    identity: UiCustomizationHydrationIdentity?,
+): UiCustomizationHydrationAction = if (identity == null) {
+    UiCustomizationHydrationAction.CLEAR
+} else {
+    UiCustomizationHydrationAction.REFRESH
+}
+
+/** Prevents observer attachment to an already-resumed owner from duplicating identity hydration. */
+internal class UiCustomizationResumeRefreshGate(
+    skipSynchronizedResume: Boolean,
+) {
+    private var skipNextResume = skipSynchronizedResume
+
+    fun shouldRefresh(
+        event: Lifecycle.Event,
+        identity: UiCustomizationHydrationIdentity?,
+    ): Boolean {
+        if (event == Lifecycle.Event.ON_PAUSE) skipNextResume = false
+        if (!shouldRefreshUiCustomization(event, identity)) return false
+        if (skipNextResume) {
+            skipNextResume = false
+            return false
+        }
+        return true
+    }
+}
 
 internal class PlayerTargetProviderRegistration(
     val backStackEntryId: String,
@@ -126,8 +185,15 @@ fun AppNavigation(
     onRequeueExternalRoute: (String) -> Unit = {},
 ) {
     val tokenManager: TokenManager = koinInject()
-    val serverRegistry: org.siloserver.silo.network.ServerRegistry = koinInject()
+    val serverRegistry: ServerRegistry = koinInject()
+    val activeServerEntry by serverRegistry.activeEntry.collectAsState()
     val overlayPrefsStore: OverlayPrefsStore = koinInject()
+    val uiCustomizationStore: UiCustomizationStore = koinInject()
+    val cardPresentation by uiCustomizationStore.cardPresentation.collectAsState()
+    val uiCustomizationSupported by
+        uiCustomizationStore.uiCustomizationSupported.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val uiCustomizationRefreshScope = rememberCoroutineScope()
     val siloCastController: SiloCastController = koinInject()
     val diagnosticsViewModel = koinViewModel<DiagnosticsViewModel>()
     val diagnosticsState by diagnosticsViewModel.state.collectAsState()
@@ -259,19 +325,43 @@ fun AppNavigation(
         )
     }
 
-    // Re-read the authenticated profile id whenever the current destination
-    // changes (Login → ProfileSelection → Main). This drives card-overlay
-    // hydration off the authenticated identity instead of a one-shot at app
-    // start, where the user is still on Login and the settings calls 401.
+    // Drive hydration from the registry's atomic server/profile entry. A
+    // profile id is only unique within a server; keying on it alone leaves the
+    // previous server's cache active when two servers use the same id.
     val currentEntry by navController.currentBackStackEntryAsState()
     LaunchedEffect(currentEntry?.destination?.route) {
         DiagnosticsLifecycleLogger.route(currentEntry?.destination?.route)
     }
-    val overlaySessionKey by produceState<String?>(
-        initialValue = null,
-        currentEntry?.destination?.route,
-    ) {
-        value = tokenManager.getProfileId()
+    val overlaySessionKey = uiCustomizationHydrationIdentity(
+        serverId = activeServerEntry?.id,
+        profileId = activeServerEntry?.profileId,
+    )
+
+    // Rehydrate once for every distinct authenticated identity, including an
+    // in-place profile/server switch while this lifecycle is already resumed.
+    LaunchedEffect(overlaySessionKey, uiCustomizationStore) {
+        when (uiCustomizationHydrationAction(overlaySessionKey)) {
+            UiCustomizationHydrationAction.CLEAR -> uiCustomizationStore.clear()
+            UiCustomizationHydrationAction.REFRESH -> uiCustomizationStore.refresh()
+        }
+    }
+
+    // Keep one observer across identity changes and read its latest identity;
+    // those changes are hydrated above. A later real ON_RESUME still refreshes
+    // edits from another device and retries offline pending operations.
+    val latestOverlaySessionKey by rememberUpdatedState(overlaySessionKey)
+    DisposableEffect(lifecycleOwner, uiCustomizationStore) {
+        val refreshGate = UiCustomizationResumeRefreshGate(
+            skipSynchronizedResume = lifecycleOwner.lifecycle.currentState
+                .isAtLeast(Lifecycle.State.RESUMED),
+        )
+        val observer = LifecycleEventObserver { _, event ->
+            if (refreshGate.shouldRefresh(event, latestOverlaySessionKey)) {
+                uiCustomizationRefreshScope.launch { uiCustomizationStore.refresh() }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     ProvideCardOverlays(store = overlayPrefsStore, sessionKey = overlaySessionKey) {
@@ -286,6 +376,10 @@ fun AppNavigation(
     CompositionLocalProvider(
         LocalSharedTransitionScope provides this,
         LocalHeroSourceHandoff provides heroSourceHandoff,
+        LocalCardPresentation provides effectiveCardPresentationForSupport(
+            cardPresentation,
+            uiCustomizationSupported,
+        ),
     ) {
     Box(modifier = Modifier.fillMaxSize()) {
     NavHost(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/MobileMediaTabs.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/MobileMediaTabs.kt
@@ -1,22 +1,178 @@
 package org.siloserver.silo.android.ui.navigation
 
 import org.siloserver.silo.model.navigation.MediaModeCapabilities
+import org.siloserver.silo.model.settings.PrimaryMenu
+import org.siloserver.silo.model.settings.PrimaryMenuBuiltin
+import org.siloserver.silo.model.settings.PrimaryMenuItem
 
 val Tab.isUtilityTab: Boolean
     get() = this == Tab.Downloads
 
-// Apple-aligned shell: Home · Libraries · For You · Calendar, plus a Downloads
-// tab only when the user has downloads. There is no per-media-type tab —
-// library content (video / audio / reading) is reached through the Libraries picker.
+/** Aggregate layouts shown by the mobile settings surface. */
+enum class MobileNavigationPreset(val label: String) {
+    STANDARD("Standard"),
+    MEDIA_FIRST("Media first"),
+    MINIMAL("Minimal"),
+    CUSTOM("Custom"),
+}
+
+/** Downloads is dynamic utility chrome and is deliberately absent here. */
+val configurableMobileTabs: List<Tab> = listOf(
+    Tab.Home,
+    Tab.Libraries,
+    Tab.ForYou,
+    Tab.Calendar,
+)
+
+private val standardMobileTabs = configurableMobileTabs
+private val mediaFirstMobileTabs = listOf(
+    Tab.Libraries,
+    Tab.Home,
+    Tab.ForYou,
+    Tab.Calendar,
+)
+private val minimalMobileTabs = listOf(Tab.Home, Tab.ForYou)
+
+/**
+ * Projects the richer cross-client primary-menu document into mobile's four
+ * aggregate destinations. Media builtins and direct library/section/collection
+ * pins all lead to the Libraries hub; their first wire position determines the
+ * aggregate tab's position, and later entries are deduplicated visually.
+ */
+fun projectedMobileTabs(primaryMenu: PrimaryMenu?): List<Tab> {
+    if (primaryMenu == null) return standardMobileTabs
+    val projected = buildList {
+        primaryMenu.items.forEach { item ->
+            val tab = item.mobileTab()
+            if (tab !in this) add(tab)
+        }
+    }
+    // Cached or forward-version documents can be constructed outside the
+    // strict revision-5 codec. Keep the shell navigable even if none of their
+    // entries project to a destination this client can render.
+    return projected.ifEmpty { listOf(Tab.Home) }
+}
+
+fun mobileNavigationPreset(primaryMenu: PrimaryMenu?): MobileNavigationPreset =
+    when (projectedMobileTabs(primaryMenu)) {
+        standardMobileTabs -> MobileNavigationPreset.STANDARD
+        mediaFirstMobileTabs -> MobileNavigationPreset.MEDIA_FIRST
+        minimalMobileTabs -> MobileNavigationPreset.MINIMAL
+        else -> MobileNavigationPreset.CUSTOM
+    }
+
+/**
+ * Apple-aligned mobile shell. The server-authored order/visibility controls
+ * the four content destinations; Downloads remains an automatic trailing
+ * utility whenever local or server download state exists.
+ */
 fun visibleMobileTabs(
     @Suppress("UNUSED_PARAMETER") capabilities: MediaModeCapabilities,
     showDownloads: Boolean,
+    primaryMenu: PrimaryMenu? = null,
 ): List<Tab> = buildList {
-    add(Tab.Home)
-    add(Tab.Libraries)
-    add(Tab.ForYou)
-    add(Tab.Calendar)
+    addAll(projectedMobileTabs(primaryMenu))
     if (showDownloads) add(Tab.Downloads)
+}
+
+/** Raw mobile default used as the edit base once an inherited menu is changed. */
+fun defaultMobilePrimaryMenu(): PrimaryMenu = PrimaryMenu(
+    listOf(
+        PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+        // The mobile Libraries destination aggregates every media family.
+        // Keeping all four builtins in the wire document preserves semantic
+        // intent for another mobile client while Android renders one tab.
+        PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES),
+        PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.SERIES),
+        PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MUSIC),
+        PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+        PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+        PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR),
+    ),
+)
+
+/**
+ * Moves one aggregate destination while retaining every underlying wire item.
+ * Library, section, and collection entries move together in their original
+ * relative order, so editing For You or Calendar never destroys pins Android
+ * does not render as separate bottom tabs.
+ */
+fun moveMobileTab(menu: PrimaryMenu, tab: Tab, offset: Int): PrimaryMenu {
+    if (tab.isUtilityTab || offset == 0) return menu
+    val order = projectedMobileTabs(menu).toMutableList()
+    val from = order.indexOf(tab)
+    if (from < 0) return menu
+    val to = (from + offset).coerceIn(0, order.lastIndex)
+    if (from == to) return menu
+    order.add(to, order.removeAt(from))
+    return rebuildMobileMenu(menu, order)
+}
+
+/**
+ * Whether the aggregate destination can actually be hidden from this document.
+ *
+ * Home is contract-required and Downloads is automatic utility chrome. The
+ * Libraries hub additionally refuses to hide while the synced document pins a
+ * library, section, or collection: those pins are authored on iPhone/web,
+ * Android mobile has no editor for them, and they always project into the
+ * Libraries tab. Hiding would therefore be impossible to honour — the tab
+ * would stay on screen while the media builtins were stripped, and
+ * [showMobileTab] could never bring them back because the tab never
+ * disappeared. A `null` menu means "inherit the native default", which has no
+ * pins.
+ */
+fun canHideMobileTab(menu: PrimaryMenu?, tab: Tab): Boolean {
+    if (tab == Tab.Home || tab.isUtilityTab) return false
+    if (tab != Tab.Libraries) return true
+    return menu == null || menu.items.none { it !is PrimaryMenuItem.Builtin }
+}
+
+/**
+ * Hides one aggregate destination by removing only the builtin entries that
+ * project to it.
+ *
+ * Library, section, and collection pins are never removed: Android mobile does
+ * not author them, they are invisible as roots here (they are folded into the
+ * Libraries tab), and dropping them would permanently destroy destinations for
+ * every other client sharing the same `profile_client` document.
+ */
+fun hideMobileTab(menu: PrimaryMenu, tab: Tab): PrimaryMenu {
+    if (!canHideMobileTab(menu, tab)) return menu
+    return PrimaryMenu(
+        menu.items.filterNot { it is PrimaryMenuItem.Builtin && it.mobileTab() == tab },
+    )
+}
+
+/** Adds a missing aggregate destination at the end of the authored menu. */
+fun showMobileTab(menu: PrimaryMenu, tab: Tab): PrimaryMenu {
+    if (tab.isUtilityTab || tab in projectedMobileTabs(menu)) return menu
+    val additions = when (tab) {
+        Tab.Home -> listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME))
+        Tab.Libraries -> defaultMobilePrimaryMenu().items.filter { it.mobileTab() == Tab.Libraries }
+        Tab.ForYou -> listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU))
+        Tab.Calendar -> listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR))
+        Tab.Downloads -> emptyList()
+    }
+    return PrimaryMenu(menu.items + additions)
+}
+
+fun primaryMenuForMobilePreset(
+    preset: MobileNavigationPreset,
+    currentMenu: PrimaryMenu? = null,
+): PrimaryMenu? {
+    if (preset == MobileNavigationPreset.CUSTOM) return null
+    if (preset == MobileNavigationPreset.STANDARD && currentMenu == null) return null
+
+    val order = when (preset) {
+        MobileNavigationPreset.STANDARD -> standardMobileTabs
+        MobileNavigationPreset.MEDIA_FIRST -> mediaFirstMobileTabs
+        MobileNavigationPreset.MINIMAL -> minimalMobileTabs
+        MobileNavigationPreset.CUSTOM -> return null
+    }
+    return rebuildMobileMenuForPreset(
+        menu = currentMenu ?: defaultMobilePrimaryMenu(),
+        order = order,
+    )
 }
 
 fun fallbackMobileTab(
@@ -25,4 +181,54 @@ fun fallbackMobileTab(
 ): Tab? {
     if (defaultTab in visibleTabs) return defaultTab
     return visibleTabs.firstOrNull { !it.isUtilityTab } ?: visibleTabs.firstOrNull()
+}
+
+private fun PrimaryMenuItem.mobileTab(): Tab = when (this) {
+    is PrimaryMenuItem.Builtin -> when (destination) {
+        PrimaryMenuBuiltin.HOME -> Tab.Home
+        PrimaryMenuBuiltin.FOR_YOU -> Tab.ForYou
+        PrimaryMenuBuiltin.CALENDAR -> Tab.Calendar
+        PrimaryMenuBuiltin.MOVIES,
+        PrimaryMenuBuiltin.SERIES,
+        PrimaryMenuBuiltin.MUSIC,
+        PrimaryMenuBuiltin.AUDIOBOOKS -> Tab.Libraries
+    }
+    is PrimaryMenuItem.Library,
+    is PrimaryMenuItem.Section,
+    is PrimaryMenuItem.Collection -> Tab.Libraries
+}
+
+private fun rebuildMobileMenu(menu: PrimaryMenu, order: List<Tab>): PrimaryMenu {
+    val buckets = menu.items.groupBy { it.mobileTab() }
+    return PrimaryMenu(order.flatMap { buckets[it].orEmpty() })
+}
+
+/**
+ * Reorders the current aggregate buckets without replacing their rich wire
+ * items. A bucket missing from a custom/minimal menu is restored from the
+ * native default so selecting a preset still produces that preset's complete
+ * aggregate layout.
+ *
+ * A preset whose layout omits a bucket (Minimal has no Libraries) is held to
+ * the same invariant [canHideMobileTab] enforces on the hide path: an omitted
+ * bucket that still holds a library/section/collection pin is preserved whole,
+ * builtins included, appended in its original relative order. Stripping only
+ * its builtins would be unrecoverable — the pins keep the aggregate tab in
+ * [projectedMobileTabs], so [showMobileTab] short-circuits, [canHideMobileTab]
+ * refuses, and re-selecting a preset that includes the bucket never reaches the
+ * default restore below. An omitted bucket holding only builtins is dropped as
+ * the preset intends: the tab genuinely leaves the projection and Add Menu Item
+ * can put it back.
+ */
+private fun rebuildMobileMenuForPreset(menu: PrimaryMenu, order: List<Tab>): PrimaryMenu {
+    val currentBuckets = menu.items.groupBy { it.mobileTab() }
+    val defaultBuckets = defaultMobilePrimaryMenu().items.groupBy { it.mobileTab() }
+    val laid = order.flatMap { tab ->
+        currentBuckets[tab].orEmpty().ifEmpty { defaultBuckets[tab].orEmpty() }
+    }
+    val preservedTabs = currentBuckets.keys.filter { tab ->
+        tab !in order && currentBuckets.getValue(tab).any { it !is PrimaryMenuItem.Builtin }
+    }.toSet()
+    val preserved = menu.items.filter { it.mobileTab() in preservedTabs }
+    return PrimaryMenu(laid + preserved)
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt
@@ -71,10 +71,12 @@ import org.siloserver.silo.model.feature.MetadataAiFeatureStore
 import org.siloserver.silo.model.feature.RequestsFeatureStore
 import org.siloserver.silo.common.network.ServerReachabilityMonitor
 import org.siloserver.silo.common.network.ServerReachabilityStatus
+import org.siloserver.silo.common.settings.UiCustomizationStore
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.repository.AuthRepository
 import org.siloserver.silo.repository.PersonalDataRepository
+import org.siloserver.silo.model.settings.effectivePrimaryMenuForSupport
 import org.siloserver.silo.viewmodel.HomeViewModel
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -146,6 +148,10 @@ fun MainScreen(
     val reachabilityMonitor: ServerReachabilityMonitor = koinInject()
     val requestsFeatureStore: RequestsFeatureStore = koinInject()
     val metadataAiFeatureStore: MetadataAiFeatureStore = koinInject()
+    val uiCustomizationStore: UiCustomizationStore = koinInject()
+    val primaryMenu by uiCustomizationStore.primaryMenu.collectAsState()
+    val uiCustomizationSupported by
+        uiCustomizationStore.uiCustomizationSupported.collectAsState()
     val reachabilityState by reachabilityMonitor.state.collectAsState()
     val requestsEnabled by requestsFeatureStore.isEnabled.collectAsState()
     val reachabilityScope = rememberCoroutineScope()
@@ -179,7 +185,13 @@ fun MainScreen(
             profileId = activeEntry?.profileId ?: headerState.activeProfile?.id,
         )
     }
-    val visibleTabs = remember(mediaCapabilities, downloadRecords, activeScopeLocalBytes) {
+    val visibleTabs = remember(
+        mediaCapabilities,
+        downloadRecords,
+        activeScopeLocalBytes,
+        primaryMenu,
+        uiCustomizationSupported,
+    ) {
         val hasAnyDownload = shouldShowDownloadsTab(
             serverRecordCount = downloadRecords.size,
             activeScopeLocalBytes = activeScopeLocalBytes,
@@ -187,6 +199,10 @@ fun MainScreen(
         visibleMobileTabs(
             capabilities = mediaCapabilities,
             showDownloads = hasAnyDownload,
+            primaryMenu = effectivePrimaryMenuForSupport(
+                primaryMenu,
+                uiCustomizationSupported,
+            ),
         )
     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
@@ -63,6 +63,8 @@ import kotlinx.coroutines.launch
 import org.siloserver.silo.android.ui.components.MediaCard
 import org.siloserver.silo.android.ui.components.MediaGridDefaults
 import org.siloserver.silo.android.ui.components.rememberBrowseItemCardActions
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
+import org.siloserver.silo.common.ui.components.forPosterPreset
 import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.overlays.OverlayDataExtractor
 
@@ -97,7 +99,9 @@ fun CatalogGrid(
     header: (@Composable () -> Unit)? = null,
 ) {
     val gridState = rememberLazyGridState()
-    val cardWidth = viewDensity.minCardWidth
+    val cardWidth = viewDensity.minCardWidth.forPosterPreset(
+        LocalCardPresentation.current.posterSize,
+    )
 
     // Trigger load more when scrolled near bottom
     val shouldLoadMore by remember {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/collections/CollectionDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/collections/CollectionDetailScreen.kt
@@ -101,7 +101,7 @@ fun CollectionDetailScreen(
                         .padding(padding),
                 ) {
                     LazyVerticalGrid(
-                        columns = GridCells.Adaptive(MediaGridDefaults.PosterGridMinWidth),
+                        columns = GridCells.Adaptive(MediaGridDefaults.posterGridMinWidth()),
                         state = gridState,
                         contentPadding = PaddingValues(16.dp),
                         horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/collections/LibraryCollectionsScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/collections/LibraryCollectionsScreen.kt
@@ -234,7 +234,7 @@ fun LibraryCollectionsScreen(
                         .padding(padding),
                 ) {
                     LazyVerticalGrid(
-                        columns = GridCells.Adaptive(MediaGridDefaults.PosterGridMinWidth),
+                        columns = GridCells.Adaptive(MediaGridDefaults.posterGridMinWidth()),
                         contentPadding = PaddingValues(16.dp),
                         horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),
                         verticalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridVerticalSpacing),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
@@ -78,6 +78,8 @@ import org.siloserver.silo.android.ui.components.EmptyStateView
 import org.siloserver.silo.android.ui.components.ErrorView
 import org.siloserver.silo.android.ui.navigation.LocalBottomChromeInset
 import org.siloserver.silo.android.ui.components.MediaGridDefaults
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
+import org.siloserver.silo.common.ui.components.forPosterPreset
 import org.siloserver.silo.android.ui.components.MediaRowsSkeleton
 import org.siloserver.silo.android.ui.components.PosterGridSkeleton
 import org.siloserver.silo.android.ui.components.TabTopBarActions
@@ -1192,7 +1194,11 @@ private fun CollectionsTabContent(
             // column/row spacing and 16pt padding insets. Follows the Library
             // grid's view density so both tabs show the same column count.
             LazyVerticalGrid(
-                columns = GridCells.Adaptive(state.catalogDensity.minCardWidth),
+                columns = GridCells.Adaptive(
+                    state.catalogDensity.minCardWidth.forPosterPreset(
+                        LocalCardPresentation.current.posterSize,
+                    ),
+                ),
                 horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),
                 verticalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridVerticalSpacing),
                 modifier = Modifier.fillMaxSize(),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/people/PersonDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/people/PersonDetailScreen.kt
@@ -52,6 +52,7 @@ import org.siloserver.silo.android.ui.components.EmptyStateView
 import org.siloserver.silo.android.ui.components.ErrorView
 import org.siloserver.silo.android.ui.components.LoadingIndicator
 import org.siloserver.silo.android.ui.components.MediaCard
+import org.siloserver.silo.android.ui.components.MediaGridDefaults
 import org.siloserver.silo.android.ui.components.rememberBrowseItemCardActions
 import org.siloserver.silo.android.ui.theme.SiloOnSurface
 import org.siloserver.silo.android.ui.theme.SiloSecondaryText
@@ -160,7 +161,7 @@ private fun PersonDetailContent(
     onItemClick: (String) -> Unit,
 ) {
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = 110.dp),
+        columns = GridCells.Adaptive(minSize = MediaGridDefaults.posterGridMinWidth()),
         contentPadding = PaddingValues(
             start = SafePadding,
             end = SafePadding,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/personal/PersonalMediaGridContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/personal/PersonalMediaGridContent.kt
@@ -247,7 +247,7 @@ private fun PersonalMediaGridContent(
                 // contentPadding goes inside the grid so items scroll edge to
                 // edge under any chrome the caller reserved space for.
                 LazyVerticalGrid(
-                    columns = GridCells.Adaptive(MediaGridDefaults.PosterGridMinWidth),
+                    columns = GridCells.Adaptive(MediaGridDefaults.posterGridMinWidth()),
                     state = gridState,
                     contentPadding = PaddingValues(
                         start = 16.dp + contentPadding.calculateStartPadding(layoutDirection),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/search/SearchResults.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/search/SearchResults.kt
@@ -79,7 +79,7 @@ fun SearchResults(
     }
 
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(MediaGridDefaults.PosterGridMinWidth),
+        columns = GridCells.Adaptive(MediaGridDefaults.posterGridMinWidth()),
         state = gridState,
         contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 24.dp),
         horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),
@@ -112,7 +112,7 @@ fun SearchResults(
                 type = item.type,
                 userState = userState,
                 onClick = { onItemClick(item.contentId) },
-                width = MediaGridDefaults.PosterGridMinWidth,
+                width = MediaGridDefaults.posterGridMinWidth(),
                 overlay = org.siloserver.silo.overlays.OverlayDataExtractor.fromBrowseItem(item),
                 actions = actions,
             )

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsScreen.kt
@@ -54,6 +54,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import org.siloserver.silo.android.ui.components.SiloConfirmDialog
 import org.siloserver.silo.android.ui.components.SiloTopBar
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.unit.dp
+import org.siloserver.silo.android.ui.navigation.MobileNavigationPreset
+import org.siloserver.silo.android.ui.navigation.Tab
 import org.siloserver.silo.android.ui.screens.downloads.DownloadsViewModel
 import org.siloserver.silo.android.ui.screens.settings.diagnostics.DiagnosticsViewModel
 import org.siloserver.silo.android.ui.screens.settings.diagnostics.shouldShowDiagnosticsEntry
@@ -73,6 +77,8 @@ import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.siloserver.silo.model.feature.MetadataAiFeatureStore
 import org.siloserver.silo.model.metadata.MetadataAiOnView
+import org.siloserver.silo.model.settings.CardPresentation
+import org.siloserver.silo.model.settings.CardPresentationPreset
 
 /**
  * Main settings screen organized in grouped sections.
@@ -162,6 +168,153 @@ fun SettingsScreen(
                     onPairDevice = onPairDevice,
                     onSignOut = viewModel::logout,
                 )
+            }
+
+            if (state.uiCustomizationAvailable &&
+                (state.primaryMenuUsesDeviceOverride ||
+                    state.cardPresentationUsesDeviceOverride)
+            ) {
+                item {
+                    SettingsSectionCard {
+                        SettingsSectionHeader(title = "Interface Sync")
+                        Text(
+                            text = "This device has interface settings that override the " +
+                                "synced ${if (state.primaryMenuUsesDeviceOverride && state.cardPresentationUsesDeviceOverride) "menu and card" else "family"} choices.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                        TextButton(onClick = viewModel::useFamilyInterfaceSettings) {
+                            Text("Use Synced Family Settings")
+                        }
+                    }
+                }
+            }
+
+            if (state.uiCustomizationAvailable) {
+                item { SettingsSectionCard {
+                    SettingsSectionHeader(title = "Top Menu")
+                    SettingsDropdownRow(
+                        label = "Layout Preset",
+                        value = state.mobileNavigationPreset.label,
+                        options = MobileNavigationPreset.entries
+                            .filterNot { it == MobileNavigationPreset.CUSTOM }
+                            .map { it.label },
+                        onOptionSelected = { label ->
+                            MobileNavigationPreset.entries
+                                .firstOrNull { it.label == label }
+                                ?.let(viewModel::setMobileNavigationPreset)
+                        },
+                        enabled = !state.primaryMenuUsesDeviceOverride,
+                    )
+                    state.mobileMenuTabs.forEachIndexed { index, tab ->
+                        val actions = buildList {
+                            if (index > 0) add("Move Earlier")
+                            if (index < state.mobileMenuTabs.lastIndex) add("Move Later")
+                            if (tab in state.hideableMobileMenuTabs) add("Hide")
+                        }
+                        SettingsDropdownRow(
+                            label = tab.label,
+                            value = "${index + 1} of ${state.mobileMenuTabs.size}",
+                            options = actions,
+                            onOptionSelected = { action ->
+                                when (action) {
+                                    "Move Earlier" -> viewModel.moveMobileMenuTab(tab, -1)
+                                    "Move Later" -> viewModel.moveMobileMenuTab(tab, 1)
+                                    "Hide" -> viewModel.hideMobileMenuTab(tab)
+                                }
+                            },
+                            enabled = !state.primaryMenuUsesDeviceOverride,
+                        )
+                    }
+                    if (state.addableMobileMenuTabs.isNotEmpty()) {
+                        SettingsDropdownRow(
+                            label = "Add Menu Item",
+                            value = "${state.addableMobileMenuTabs.size} available",
+                            options = state.addableMobileMenuTabs.map { it.label },
+                            onOptionSelected = { label ->
+                                state.addableMobileMenuTabs
+                                    .firstOrNull { it.label == label }
+                                    ?.let(viewModel::showMobileMenuTab)
+                            },
+                            enabled = !state.primaryMenuUsesDeviceOverride,
+                        )
+                    }
+                    Text(
+                        text = "Media and pinned library items share the Libraries tab. Downloads, Search, and Profile remain automatic utilities.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                } }
+
+                item { SettingsSectionCard {
+                    SettingsSectionHeader(title = "Appearance")
+                    SettingsDropdownRow(
+                        label = "Card Preset",
+                        value = CardPresentationPreset.matching(
+                            CardPresentation(state.posterSize, state.cardCaption),
+                        )?.label ?: "Custom",
+                        options = CardPresentationPreset.entries.map { it.label },
+                        onOptionSelected = { label ->
+                            CardPresentationPreset.entries
+                                .firstOrNull { it.label == label }
+                                ?.let(viewModel::setCardPresentationPreset)
+                        },
+                        enabled = !state.cardPresentationUsesDeviceOverride,
+                    )
+                    SettingsDropdownRow(
+                        label = "Poster Size",
+                        value = state.posterSize.label,
+                        options = org.siloserver.silo.model.settings.PosterSizePreset.entries
+                            .map { it.label },
+                        onOptionSelected = { label ->
+                            org.siloserver.silo.model.settings.PosterSizePreset.entries
+                                .firstOrNull { it.label == label }
+                                ?.let(viewModel::setPosterSize)
+                        },
+                        enabled = !state.cardPresentationUsesDeviceOverride,
+                    )
+                    SettingsDropdownRow(
+                        label = "Card Captions",
+                        value = state.cardCaption.label,
+                        options = org.siloserver.silo.model.settings.CardCaptionPreset.entries
+                            .map { it.label },
+                        onOptionSelected = { label ->
+                            org.siloserver.silo.model.settings.CardCaptionPreset.entries
+                                .firstOrNull { it.label == label }
+                                ?.let(viewModel::setCardCaption)
+                        },
+                        enabled = !state.cardPresentationUsesDeviceOverride,
+                    )
+                } }
+            } else {
+                // Android TV parity (TvSettingsScreen General pane): when the
+                // capability check fails the surface must say so rather than
+                // silently render nothing where Top Menu and Appearance were.
+                // The two failures are distinct: `false` is a settled answer
+                // about the server, `null` is an unresolved one that a reopen
+                // can still turn into either.
+                item {
+                    val unsupported = state.uiCustomizationSupport == false
+                    SettingsSection(title = "Interface") {
+                        SettingsProse(
+                            title = if (unsupported) {
+                                "Layout and card customization require a newer server"
+                            } else {
+                                "Interface settings are temporarily unavailable"
+                            },
+                            body = if (unsupported) {
+                                "This server cannot store the menu order and card appearance " +
+                                    "shared across your devices. Everything else on this screen " +
+                                    "still works. Ask whoever runs the server to update it."
+                            } else {
+                                "The server capability could not be resolved, so layout and card " +
+                                    "customization are hidden for now. Reopen Settings to retry."
+                            },
+                        )
+                    }
+                }
             }
 
             if (shouldShowDiagnosticsEntry(diagnosticsState)) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
@@ -2,15 +2,36 @@ package org.siloserver.silo.android.ui.screens.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import org.siloserver.silo.android.ui.navigation.MobileNavigationPreset
+import org.siloserver.silo.android.ui.navigation.Tab
+import org.siloserver.silo.android.ui.navigation.canHideMobileTab
+import org.siloserver.silo.android.ui.navigation.configurableMobileTabs
+import org.siloserver.silo.android.ui.navigation.defaultMobilePrimaryMenu
+import org.siloserver.silo.android.ui.navigation.hideMobileTab
+import org.siloserver.silo.android.ui.navigation.mobileNavigationPreset
+import org.siloserver.silo.android.ui.navigation.moveMobileTab
+import org.siloserver.silo.android.ui.navigation.primaryMenuForMobilePreset
+import org.siloserver.silo.android.ui.navigation.projectedMobileTabs
+import org.siloserver.silo.android.ui.navigation.showMobileTab
 import org.siloserver.silo.common.settings.LibraryPlaybackPrefsStore
 import org.siloserver.silo.common.settings.OverlayPrefsStore
 import org.siloserver.silo.common.settings.PlayerSettingsStore
+import org.siloserver.silo.common.settings.UiCustomizationStore
 import org.siloserver.silo.domain.player.IntroSkipMode
 import org.siloserver.silo.domain.settings.ProfileSettingsController
 import org.siloserver.silo.model.auth.User
 import org.siloserver.silo.model.download.DownloadQuality
 import org.siloserver.silo.model.notifications.NotificationPreferencesUpdate
 import org.siloserver.silo.model.settings.QualityPresets
+import org.siloserver.silo.model.settings.CardCaptionPreset
+import org.siloserver.silo.model.settings.CardPresentation
+import org.siloserver.silo.model.settings.CardPresentationPreset
+import org.siloserver.silo.model.settings.PosterSizePreset
+import org.siloserver.silo.model.settings.PrimaryMenu
+import org.siloserver.silo.model.settings.SettingScope
+import org.siloserver.silo.model.settings.effectiveCardPresentationForSupport
+import org.siloserver.silo.model.settings.effectivePrimaryMenuForSupport
+import org.siloserver.silo.model.settings.supportsUiCustomization
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.AuthRepository
 import org.siloserver.silo.repository.NotificationsRepository
@@ -51,6 +72,8 @@ data class SettingsUiState(
     // the local defaults either way.
     val settingsAvailability: ProfileSettingsController.Availability =
         ProfileSettingsController.Availability.UNKNOWN,
+    /** true=supported, false=confirmed incompatible, null=not resolved/transient failure. */
+    val uiCustomizationSupport: Boolean? = null,
 
     // Playback
     // The quality picker composes playback.preferred_quality (a resolution
@@ -70,6 +93,17 @@ data class SettingsUiState(
     val dvProfile7HDR10Fallback: Boolean = true,
     val subtitleMatchesDevice: Boolean = false,
     val showAudiobooks: Boolean = false,
+    val posterSize: PosterSizePreset = PosterSizePreset.STANDARD,
+    val cardCaption: CardCaptionPreset = CardCaptionPreset.TITLE_METADATA,
+    val primaryMenuOverride: PrimaryMenu? = null,
+    val primaryMenuUsesDeviceOverride: Boolean = false,
+    val cardPresentationUsesDeviceOverride: Boolean = false,
+    val mobileMenuTabs: List<Tab> = configurableMobileTabs,
+    val addableMobileMenuTabs: List<Tab> = emptyList(),
+    val hideableMobileMenuTabs: List<Tab> = configurableMobileTabs.filter { tab ->
+        canHideMobileTab(menu = null, tab = tab)
+    },
+    val mobileNavigationPreset: MobileNavigationPreset = MobileNavigationPreset.STANDARD,
     val subtitleAppearance: org.siloserver.silo.model.settings.SubtitleAppearance =
         org.siloserver.silo.model.settings.SubtitleAppearance.DEFAULT,
     // Up Next card: auto-play the next episode at countdown expiry, and how
@@ -105,7 +139,22 @@ data class SettingsUiState(
     val notifyWatchlist: Boolean = true,
     val notifyContinueWatching: Boolean = true,
     val notifyNextUp: Boolean = true,
-)
+) {
+    /** Presentation may remain cached while UNKNOWN, but revision-5 writes must stay disabled. */
+    val uiCustomizationAvailable: Boolean
+        get() = canAuthorUiCustomization
+
+    internal val canAuthorUiCustomization: Boolean
+        get() = uiCustomizationSupport == true
+}
+
+internal fun SettingsUiState.withObservedUiCustomizationSupport(
+    supported: Boolean?,
+): SettingsUiState = copy(uiCustomizationSupport = supported)
+
+internal fun phoneUiCustomizationAvailable(
+    result: ProfileSettingsController.LoadResult,
+): Boolean = result.capabilities?.supportsUiCustomization == true
 
 class SettingsViewModel(
     private val authRepository: AuthRepository,
@@ -114,6 +163,7 @@ class SettingsViewModel(
     private val overlayPrefsStore: OverlayPrefsStore,
     private val notificationsRepository: NotificationsRepository,
     private val profileSettings: ProfileSettingsController,
+    private val uiCustomizationStore: UiCustomizationStore,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
@@ -124,7 +174,59 @@ class SettingsViewModel(
         observePlayerSettings()
         observePlaybackBehaviorSettings()
         observeNotifications()
+        observeUiCustomization()
+        viewModelScope.launch { uiCustomizationStore.refresh() }
     }
+
+    private fun observeUiCustomization() {
+        combine(
+            uiCustomizationStore.primaryMenu,
+            uiCustomizationStore.cardPresentation,
+            uiCustomizationStore.primaryMenuSource,
+            uiCustomizationStore.cardPresentationSource,
+            uiCustomizationStore.uiCustomizationSupported,
+        ) { menu, presentation, menuSource, cardSource, supported ->
+            UiCustomizationSnapshot(menu, presentation, menuSource, cardSource, supported)
+        }
+            .onEach { customization ->
+                val menu = effectivePrimaryMenuForSupport(
+                    customization.menu,
+                    customization.supported,
+                )
+                val presentation = effectiveCardPresentationForSupport(
+                    customization.presentation,
+                    customization.supported,
+                )
+                val projected = projectedMobileTabs(menu)
+                _uiState.update {
+                    it.withObservedUiCustomizationSupport(customization.supported).copy(
+                        posterSize = presentation.posterSize,
+                        cardCaption = presentation.caption,
+                        primaryMenuOverride = menu,
+                        mobileMenuTabs = projected,
+                        addableMobileMenuTabs = configurableMobileTabs.filter { tab ->
+                            tab !in projected
+                        },
+                        hideableMobileMenuTabs = projected.filter { tab ->
+                            canHideMobileTab(menu, tab)
+                        },
+                        mobileNavigationPreset = mobileNavigationPreset(menu),
+                        primaryMenuUsesDeviceOverride =
+                            customization.menuSource == SettingScope.PROFILE_DEVICE.wire,
+                        cardPresentationUsesDeviceOverride =
+                            customization.cardSource == SettingScope.PROFILE_DEVICE.wire,
+                    )
+                }
+            }.launchIn(viewModelScope)
+    }
+
+    private data class UiCustomizationSnapshot(
+        val menu: PrimaryMenu?,
+        val presentation: CardPresentation,
+        val menuSource: String?,
+        val cardSource: String?,
+        val supported: Boolean?,
+    )
 
     private fun loadUserInfo() {
         viewModelScope.launch {
@@ -357,6 +459,7 @@ class SettingsViewModel(
             // stale rows flash before the fresh fetch lands.
             libraryPlaybackPrefsStore.clear()
             overlayPrefsStore.clear()
+            uiCustomizationStore.clear()
             _uiState.update { it.copy(loggedOut = true) }
         }
     }
@@ -411,6 +514,72 @@ class SettingsViewModel(
 
     fun setShowAudiobooks(enabled: Boolean) {
         viewModelScope.launch { playerSettingsStore.setShowAudiobooks(enabled) }
+    }
+
+    fun setPosterSize(value: PosterSizePreset) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.cardPresentationUsesDeviceOverride) return
+        uiCustomizationStore.updateCardPresentation { current ->
+            current.copy(posterSize = value)
+        }
+    }
+
+    fun setMobileNavigationPreset(value: MobileNavigationPreset) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.primaryMenuUsesDeviceOverride) return
+        if (value == MobileNavigationPreset.CUSTOM) return
+        val menu = primaryMenuForMobilePreset(
+            preset = value,
+            currentMenu = uiCustomizationStore.primaryMenu.value,
+        )
+        if (menu == null) {
+            uiCustomizationStore.resetPrimaryMenu()
+        } else {
+            uiCustomizationStore.setPrimaryMenu(menu)
+        }
+    }
+
+    fun moveMobileMenuTab(tab: Tab, offset: Int) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.primaryMenuUsesDeviceOverride) return
+        uiCustomizationStore.updatePrimaryMenu(defaultMobilePrimaryMenu()) { current ->
+            moveMobileTab(current, tab, offset)
+        }
+    }
+
+    fun hideMobileMenuTab(tab: Tab) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.primaryMenuUsesDeviceOverride) return
+        uiCustomizationStore.updatePrimaryMenu(defaultMobilePrimaryMenu()) { current ->
+            hideMobileTab(current, tab)
+        }
+    }
+
+    fun showMobileMenuTab(tab: Tab) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.primaryMenuUsesDeviceOverride) return
+        uiCustomizationStore.updatePrimaryMenu(defaultMobilePrimaryMenu()) { current ->
+            showMobileTab(current, tab)
+        }
+    }
+
+    fun setCardPresentationPreset(value: CardPresentationPreset) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.cardPresentationUsesDeviceOverride) return
+        uiCustomizationStore.setCardPresentation(value.presentation)
+    }
+
+    fun setCardCaption(value: CardCaptionPreset) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.cardPresentationUsesDeviceOverride) return
+        uiCustomizationStore.updateCardPresentation { current ->
+            current.copy(caption = value)
+        }
+    }
+
+    fun useFamilyInterfaceSettings() {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        uiCustomizationStore.useFamilySettings()
     }
 
     fun setSubtitleAppearance(value: org.siloserver.silo.model.settings.SubtitleAppearance) {

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/MobileMediaTabsTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/MobileMediaTabsTest.kt
@@ -2,6 +2,10 @@ package org.siloserver.silo.android.ui.navigation
 
 import org.siloserver.silo.model.navigation.MediaMode
 import org.siloserver.silo.model.navigation.MediaModeCapabilities
+import org.siloserver.silo.model.settings.PrimaryMenu
+import org.siloserver.silo.model.settings.PrimaryMenuBuiltin
+import org.siloserver.silo.model.settings.PrimaryMenuItem
+import org.siloserver.silo.model.settings.effectivePrimaryMenuForSupport
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -9,54 +13,189 @@ import kotlin.test.assertTrue
 
 class MobileMediaTabsTest {
 
-    // Apple-aligned shell: Home · Libraries · For You · Calendar, independent of which
-    // media types the libraries contain. Library content (video / audio /
-    // reading) is reached through the Libraries picker. Downloads only appears
-    // when the user has downloads.
+    @Test
+    fun emptyAuthoredMenuFallsBackToAFocusableHomeTab() {
+        assertEquals(listOf(Tab.Home), projectedMobileTabs(PrimaryMenu(emptyList())))
+    }
+    private val capabilities = MediaModeCapabilities(listOf(MediaMode.Video))
     private val baseLabels = listOf("Home", "Libraries", "For You", "Calendar")
 
     @Test
-    fun fixedTabsAppendDownloadsWhenPresent() {
-        val tabs = visibleMobileTabs(
-            capabilities = MediaModeCapabilities(listOf(MediaMode.Video)),
-            showDownloads = true,
-        )
-
-        assertEquals(baseLabels + "Downloads", tabs.map { it.label })
-    }
-
-    @Test
-    fun tabsAreFixedRegardlessOfLibraryTypes() {
+    fun inheritedTabsAppendDynamicDownloadsWhenPresent() {
         assertEquals(
-            baseLabels,
-            visibleMobileTabs(MediaModeCapabilities(listOf(MediaMode.Audio)), showDownloads = false)
-                .map { it.label },
-        )
-        assertEquals(
-            baseLabels,
-            visibleMobileTabs(MediaModeCapabilities(listOf(MediaMode.Reading)), showDownloads = false)
-                .map { it.label },
-        )
-        assertEquals(
-            baseLabels,
-            visibleMobileTabs(MediaModeCapabilities(emptyList()), showDownloads = false)
-                .map { it.label },
+            baseLabels + "Downloads",
+            visibleMobileTabs(capabilities, showDownloads = true).map { it.label },
         )
     }
 
     @Test
-    fun downloadsStaysHiddenWhenNoDownloadsExist() {
-        val tabs = visibleMobileTabs(
-            capabilities = MediaModeCapabilities(listOf(MediaMode.Video, MediaMode.Audio)),
-            showDownloads = false,
+    fun confirmedUnsupportedServerUsesNativeTabsButUnknownKeepsOfflineCache() {
+        val cachedMinimal = requireNotNull(
+            primaryMenuForMobilePreset(MobileNavigationPreset.MINIMAL),
         )
 
-        assertEquals(baseLabels, tabs.map { it.label })
-        assertFalse(Tab.Downloads in tabs)
+        assertEquals(
+            baseLabels,
+            visibleMobileTabs(
+                capabilities,
+                showDownloads = false,
+                primaryMenu = effectivePrimaryMenuForSupport(cachedMinimal, false),
+            ).map { it.label },
+        )
+        assertEquals(
+            listOf("Home", "For You"),
+            visibleMobileTabs(
+                capabilities,
+                showDownloads = false,
+                primaryMenu = effectivePrimaryMenuForSupport(cachedMinimal, null),
+            ).map { it.label },
+        )
     }
 
     @Test
-    fun choosesFirstVisibleMediaTabBeforeDownloads() {
+    fun richWireDestinationsCollapseToOneLibrariesTabAtTheirFirstPosition() {
+        val menu = PrimaryMenu(
+            listOf(
+                builtin(PrimaryMenuBuiltin.CALENDAR),
+                PrimaryMenuItem.Section(7, "recent", "Recently Added"),
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                PrimaryMenuItem.Collection("favorites", "Favorites", libraryId = 7),
+                builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Library(8, "Series"),
+            ),
+        )
+
+        assertEquals(
+            listOf(Tab.Calendar, Tab.Libraries, Tab.ForYou, Tab.Home),
+            projectedMobileTabs(menu),
+        )
+    }
+
+    @Test
+    fun movingAggregateLibrariesKeepsEveryUnderlyingWireItemInRelativeOrder() {
+        val section = PrimaryMenuItem.Section(7, "recent", "Recently Added")
+        val collection = PrimaryMenuItem.Collection("favorites", "Favorites", libraryId = 7)
+        val library = PrimaryMenuItem.Library(8, "Series")
+        val home = builtin(PrimaryMenuBuiltin.HOME)
+        val forYou = builtin(PrimaryMenuBuiltin.FOR_YOU)
+        val calendar = builtin(PrimaryMenuBuiltin.CALENDAR)
+        val menu = PrimaryMenu(listOf(home, section, forYou, collection, calendar, library))
+
+        val moved = moveMobileTab(menu, Tab.Libraries, offset = 2)
+
+        assertEquals(
+            listOf(Tab.Home, Tab.ForYou, Tab.Calendar, Tab.Libraries),
+            projectedMobileTabs(moved),
+        )
+        assertEquals(listOf(home, forYou, calendar, section, collection, library), moved.items)
+    }
+
+    @Test
+    fun hidingUnrelatedTabPreservesPinnedSectionsAndCollectionsExactly() {
+        val section = PrimaryMenuItem.Section(7, "recent", "Recently Added")
+        val collection = PrimaryMenuItem.Collection("favorites", "Favorites", libraryId = 7)
+        val menu = PrimaryMenu(
+            listOf(
+                builtin(PrimaryMenuBuiltin.HOME),
+                section,
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                collection,
+                builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+        )
+
+        val hidden = hideMobileTab(menu, Tab.ForYou)
+
+        assertEquals(
+            listOf(builtin(PrimaryMenuBuiltin.HOME), section, collection, builtin(PrimaryMenuBuiltin.CALENDAR)),
+            hidden.items,
+        )
+        assertEquals(listOf(Tab.Home, Tab.Libraries, Tab.Calendar), projectedMobileTabs(hidden))
+    }
+
+    @Test
+    fun homeCannotBeHiddenAndMissingContentTabsCanBeShownAgain() {
+        val minimal = requireNotNull(primaryMenuForMobilePreset(MobileNavigationPreset.MINIMAL))
+
+        assertEquals(minimal, hideMobileTab(minimal, Tab.Home))
+        val restored = showMobileTab(
+            showMobileTab(minimal, Tab.Libraries),
+            Tab.Calendar,
+        )
+        assertEquals(
+            listOf(Tab.Home, Tab.ForYou, Tab.Libraries, Tab.Calendar),
+            projectedMobileTabs(restored),
+        )
+        assertEquals(4, restored.items.count { item ->
+            item is PrimaryMenuItem.Builtin && item.destination in setOf(
+                PrimaryMenuBuiltin.MOVIES,
+                PrimaryMenuBuiltin.SERIES,
+                PrimaryMenuBuiltin.MUSIC,
+                PrimaryMenuBuiltin.AUDIOBOOKS,
+            )
+        })
+    }
+
+    @Test
+    fun presetsHaveStableAggregateLayoutsAndStandardMeansInherit() {
+        assertEquals(null, primaryMenuForMobilePreset(MobileNavigationPreset.STANDARD))
+        assertEquals(
+            listOf(Tab.Libraries, Tab.Home, Tab.ForYou, Tab.Calendar),
+            projectedMobileTabs(
+                primaryMenuForMobilePreset(MobileNavigationPreset.MEDIA_FIRST),
+            ),
+        )
+        assertEquals(
+            listOf(Tab.Home, Tab.ForYou),
+            projectedMobileTabs(primaryMenuForMobilePreset(MobileNavigationPreset.MINIMAL)),
+        )
+    }
+
+    @Test
+    fun mediaFirstPresetReordersRichMenuWithoutReplacingPinnedItems() {
+        val home = builtin(PrimaryMenuBuiltin.HOME)
+        val forYou = builtin(PrimaryMenuBuiltin.FOR_YOU)
+        val calendar = builtin(PrimaryMenuBuiltin.CALENDAR)
+        val section = PrimaryMenuItem.Section(7, "recent", "My Recent Additions")
+        val collection = PrimaryMenuItem.Collection(
+            collectionId = "favorites",
+            label = "Family Favorites",
+            libraryId = 7,
+        )
+        val library = PrimaryMenuItem.Library(8, "Kids Series")
+        val current = PrimaryMenu(
+            listOf(home, forYou, section, calendar, collection, library),
+        )
+
+        val reordered = requireNotNull(
+            primaryMenuForMobilePreset(
+                preset = MobileNavigationPreset.MEDIA_FIRST,
+                currentMenu = current,
+            ),
+        )
+
+        assertEquals(
+            listOf(section, collection, library, home, forYou, calendar),
+            reordered.items,
+        )
+        assertEquals(
+            listOf(Tab.Libraries, Tab.Home, Tab.ForYou, Tab.Calendar),
+            projectedMobileTabs(reordered),
+        )
+    }
+
+    @Test
+    fun downloadsStaysFixedAtTheEndAndHiddenWhenEmpty() {
+        val menu = requireNotNull(primaryMenuForMobilePreset(MobileNavigationPreset.MEDIA_FIRST))
+        val withoutDownloads = visibleMobileTabs(capabilities, false, menu)
+        val withDownloads = visibleMobileTabs(capabilities, true, menu)
+
+        assertFalse(Tab.Downloads in withoutDownloads)
+        assertEquals(Tab.Downloads, withDownloads.last())
+    }
+
+    @Test
+    fun choosesFirstVisibleContentTabBeforeDownloads() {
         assertEquals(
             Tab.Home,
             fallbackMobileTab(
@@ -64,17 +203,270 @@ class MobileMediaTabsTest {
                 defaultTab = Tab.ForYou,
             ),
         )
+        assertTrue(Tab.Downloads.isUtilityTab)
     }
 
     @Test
-    fun keepsCurrentTabWhenStillVisible() {
-        assertEquals(
-            Tab.Downloads,
-            fallbackMobileTab(
-                visibleTabs = listOf(Tab.Home, Tab.Downloads),
-                defaultTab = Tab.Downloads,
+    fun hidingLibrariesIsRefusedWhilePinnedDestinationsExist() {
+        val section = PrimaryMenuItem.Section(7, "recent", "Recently Added")
+        val collection = PrimaryMenuItem.Collection("favorites", "Favorites", libraryId = 7)
+        val library = PrimaryMenuItem.Library(8, "Kids Series")
+        val menu = PrimaryMenu(
+            listOf(
+                builtin(PrimaryMenuBuiltin.HOME),
+                builtin(PrimaryMenuBuiltin.MOVIES),
+                section,
+                builtin(PrimaryMenuBuiltin.SERIES),
+                collection,
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                library,
+                builtin(PrimaryMenuBuiltin.CALENDAR),
             ),
         )
-        assertTrue(Tab.Downloads.isUtilityTab)
+
+        assertFalse(canHideMobileTab(menu, Tab.Libraries))
+        // Every pin survives, and so do the media builtins: a partial hide
+        // would strip them while the tab stayed on screen, leaving no way to
+        // restore them from the mobile editor.
+        assertEquals(menu, hideMobileTab(menu, Tab.Libraries))
+        assertEquals(
+            listOf(section, collection, library),
+            hideMobileTab(menu, Tab.Libraries).items.filterNot {
+                it is PrimaryMenuItem.Builtin
+            },
+        )
     }
+
+    @Test
+    fun hidingACalendarTabKeepsEveryPinnedDestinationByteForByte() {
+        val section = PrimaryMenuItem.Section(7, "recent", "Recently Added")
+        val collection = PrimaryMenuItem.Collection("favorites", "Favorites", libraryId = 7)
+        val library = PrimaryMenuItem.Library(8, "Kids Series")
+        val menu = PrimaryMenu(
+            listOf(
+                builtin(PrimaryMenuBuiltin.HOME),
+                section,
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                collection,
+                builtin(PrimaryMenuBuiltin.CALENDAR),
+                library,
+            ),
+        )
+
+        assertTrue(canHideMobileTab(menu, Tab.Calendar))
+        val hidden = hideMobileTab(menu, Tab.Calendar)
+
+        assertEquals(
+            listOf(
+                builtin(PrimaryMenuBuiltin.HOME),
+                section,
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                collection,
+                library,
+            ),
+            hidden.items,
+        )
+        assertEquals(listOf(Tab.Home, Tab.Libraries, Tab.ForYou), projectedMobileTabs(hidden))
+    }
+
+    @Test
+    fun hidingAndShowingATrailingTabRoundTripsTheExactDocument() {
+        val menu = defaultMobilePrimaryMenu()
+
+        val hidden = hideMobileTab(menu, Tab.Calendar)
+
+        assertEquals(
+            menu.items.filterNot { it == builtin(PrimaryMenuBuiltin.CALENDAR) },
+            hidden.items,
+        )
+        assertEquals(menu, showMobileTab(hidden, Tab.Calendar))
+    }
+
+    @Test
+    fun hidingLibrariesWithoutPinsRemovesOnlyMediaBuiltinsAndCanBeRestored() {
+        val menu = defaultMobilePrimaryMenu()
+        val mediaBuiltins = listOf(
+            builtin(PrimaryMenuBuiltin.MOVIES),
+            builtin(PrimaryMenuBuiltin.SERIES),
+            builtin(PrimaryMenuBuiltin.MUSIC),
+            builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+        )
+
+        assertTrue(canHideMobileTab(menu, Tab.Libraries))
+        val hidden = hideMobileTab(menu, Tab.Libraries)
+
+        assertEquals(
+            listOf(
+                builtin(PrimaryMenuBuiltin.HOME),
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+            hidden.items,
+        )
+        // Restoring appends the same media builtins, matching Apple's
+        // `addAvailableShortcut`; the aggregate simply lands last.
+        assertEquals(
+            hidden.items + mediaBuiltins,
+            showMobileTab(hidden, Tab.Libraries).items,
+        )
+    }
+
+    @Test
+    fun hideAffordanceMatchesWhatHidingCanActuallyHonour() {
+        val pinned = PrimaryMenu(
+            defaultMobilePrimaryMenu().items + PrimaryMenuItem.Library(8, "Kids Series"),
+        )
+
+        assertFalse(canHideMobileTab(null, Tab.Home))
+        assertFalse(canHideMobileTab(null, Tab.Downloads))
+        assertTrue(canHideMobileTab(null, Tab.Libraries))
+        assertTrue(canHideMobileTab(defaultMobilePrimaryMenu(), Tab.Libraries))
+        assertFalse(canHideMobileTab(pinned, Tab.Libraries))
+        assertTrue(canHideMobileTab(pinned, Tab.ForYou))
+        assertTrue(canHideMobileTab(pinned, Tab.Calendar))
+    }
+
+    @Test
+    fun minimalPresetKeepsAPinnedLibrariesBucketWholeIncludingItsBuiltins() {
+        val section = PrimaryMenuItem.Section(7, "recent", "Recently Added")
+        val library = PrimaryMenuItem.Library(8, "Kids Series")
+        val current = PrimaryMenu(
+            listOf(
+                builtin(PrimaryMenuBuiltin.HOME),
+                builtin(PrimaryMenuBuiltin.MOVIES),
+                section,
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                library,
+                builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+        )
+
+        val minimal = requireNotNull(
+            primaryMenuForMobilePreset(MobileNavigationPreset.MINIMAL, current),
+        )
+
+        // The pins keep Libraries in the projection, so stripping MOVIES would
+        // be unrecoverable from the mobile editor. Calendar holds only builtins
+        // and is dropped as the preset intends — Add Menu Item can restore it.
+        assertEquals(
+            listOf(
+                builtin(PrimaryMenuBuiltin.HOME),
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                builtin(PrimaryMenuBuiltin.MOVIES),
+                section,
+                library,
+            ),
+            minimal.items,
+        )
+    }
+
+    @Test
+    fun minimalPresetOverAPinnedDocumentPreservesEveryMediaBuiltinAndPin() {
+        val section = PrimaryMenuItem.Section(7, "recent", "Recently Added")
+        val library = PrimaryMenuItem.Library(8, "Kids Series")
+        val current = PrimaryMenu(
+            listOf(
+                builtin(PrimaryMenuBuiltin.HOME),
+                builtin(PrimaryMenuBuiltin.MOVIES),
+                section,
+                builtin(PrimaryMenuBuiltin.SERIES),
+                builtin(PrimaryMenuBuiltin.MUSIC),
+                builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                library,
+                builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+        )
+
+        val minimal = requireNotNull(
+            primaryMenuForMobilePreset(MobileNavigationPreset.MINIMAL, current),
+        )
+
+        assertEquals(
+            listOf(
+                builtin(PrimaryMenuBuiltin.HOME),
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                builtin(PrimaryMenuBuiltin.MOVIES),
+                section,
+                builtin(PrimaryMenuBuiltin.SERIES),
+                builtin(PrimaryMenuBuiltin.MUSIC),
+                builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+                library,
+            ),
+            minimal.items,
+        )
+        assertEquals(
+            listOf(Tab.Home, Tab.ForYou, Tab.Libraries),
+            projectedMobileTabs(minimal),
+        )
+    }
+
+    @Test
+    fun minimalPresetWithoutPinsStillDropsMediaBuiltinsAndTheyCanBeRestored() {
+        val current = defaultMobilePrimaryMenu()
+
+        val minimal = requireNotNull(
+            primaryMenuForMobilePreset(MobileNavigationPreset.MINIMAL, current),
+        )
+
+        assertEquals(
+            listOf(builtin(PrimaryMenuBuiltin.HOME), builtin(PrimaryMenuBuiltin.FOR_YOU)),
+            minimal.items,
+        )
+        assertEquals(listOf(Tab.Home, Tab.ForYou), projectedMobileTabs(minimal))
+
+        // Dropping is only acceptable because the tab leaves the projection and
+        // Add Menu Item can bring the whole bucket back.
+        val restored = showMobileTab(minimal, Tab.Libraries)
+
+        assertEquals(
+            minimal.items + listOf(
+                builtin(PrimaryMenuBuiltin.MOVIES),
+                builtin(PrimaryMenuBuiltin.SERIES),
+                builtin(PrimaryMenuBuiltin.MUSIC),
+                builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+            ),
+            restored.items,
+        )
+        assertEquals(
+            listOf(Tab.Home, Tab.ForYou, Tab.Libraries),
+            projectedMobileTabs(restored),
+        )
+    }
+
+    @Test
+    fun minimalThenStandardRoundTripsAPinnedDocumentToTheSameItemSet() {
+        val section = PrimaryMenuItem.Section(7, "recent", "Recently Added")
+        val library = PrimaryMenuItem.Library(8, "Kids Series")
+        val current = PrimaryMenu(
+            listOf(
+                builtin(PrimaryMenuBuiltin.HOME),
+                builtin(PrimaryMenuBuiltin.MOVIES),
+                section,
+                builtin(PrimaryMenuBuiltin.SERIES),
+                builtin(PrimaryMenuBuiltin.MUSIC),
+                builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+                builtin(PrimaryMenuBuiltin.FOR_YOU),
+                library,
+                builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+        )
+
+        val minimal = requireNotNull(
+            primaryMenuForMobilePreset(MobileNavigationPreset.MINIMAL, current),
+        )
+        val backToStandard = requireNotNull(
+            primaryMenuForMobilePreset(MobileNavigationPreset.STANDARD, minimal),
+        )
+
+        assertEquals(current.items.toSet(), backToStandard.items.toSet())
+        assertEquals(current.items.size, backToStandard.items.size)
+        assertEquals(
+            listOf(Tab.Home, Tab.Libraries, Tab.ForYou, Tab.Calendar),
+            projectedMobileTabs(backToStandard),
+        )
+    }
+
+    private fun builtin(destination: PrimaryMenuBuiltin) =
+        PrimaryMenuItem.Builtin(destination)
 }

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/UiCustomizationHydrationIdentityTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/UiCustomizationHydrationIdentityTest.kt
@@ -1,0 +1,71 @@
+package org.siloserver.silo.android.ui.navigation
+
+import androidx.lifecycle.Lifecycle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class UiCustomizationHydrationIdentityTest {
+    @Test
+    fun sameProfileOnDifferentServersProducesDifferentHydrationKeys() {
+        val serverA = uiCustomizationHydrationIdentity("server-a", "profile-1")
+        val serverB = uiCustomizationHydrationIdentity("server-b", "profile-1")
+
+        assertNotEquals(serverA, serverB)
+        assertEquals(
+            UiCustomizationHydrationIdentity("server-a", "profile-1"),
+            serverA,
+        )
+    }
+
+    @Test
+    fun incompleteIdentityDoesNotHydrateAuthenticatedPreferences() {
+        assertNull(uiCustomizationHydrationIdentity(null, "profile-1"))
+        assertNull(uiCustomizationHydrationIdentity("server-a", null))
+        assertNull(uiCustomizationHydrationIdentity("", "profile-1"))
+        assertNull(uiCustomizationHydrationIdentity("server-a", " "))
+    }
+
+    @Test
+    fun onlyResumeWithCompleteIdentityRefreshesCustomization() {
+        val identity = uiCustomizationHydrationIdentity("server-a", "profile-1")
+
+        assertTrue(shouldRefreshUiCustomization(Lifecycle.Event.ON_RESUME, identity))
+        assertFalse(shouldRefreshUiCustomization(Lifecycle.Event.ON_START, identity))
+        assertFalse(shouldRefreshUiCustomization(Lifecycle.Event.ON_RESUME, null))
+    }
+
+    @Test
+    fun everyNewCompleteIdentityPlansImmediateHydration() {
+        val first = uiCustomizationHydrationIdentity("server-a", "profile-1")
+        val switched = uiCustomizationHydrationIdentity("server-a", "profile-2")
+
+        assertNotEquals(first, switched)
+        assertEquals(
+            UiCustomizationHydrationAction.REFRESH,
+            uiCustomizationHydrationAction(first),
+        )
+        assertEquals(
+            UiCustomizationHydrationAction.REFRESH,
+            uiCustomizationHydrationAction(switched),
+        )
+        assertEquals(
+            UiCustomizationHydrationAction.CLEAR,
+            uiCustomizationHydrationAction(null),
+        )
+    }
+
+    @Test
+    fun resumedObserverAttachmentDoesNotDuplicateImmediateHydration() {
+        val identity = uiCustomizationHydrationIdentity("server-a", "profile-1")
+        val gate = UiCustomizationResumeRefreshGate(skipSynchronizedResume = true)
+
+        assertFalse(gate.shouldRefresh(Lifecycle.Event.ON_RESUME, identity))
+        assertFalse(gate.shouldRefresh(Lifecycle.Event.ON_PAUSE, identity))
+        assertTrue(gate.shouldRefresh(Lifecycle.Event.ON_RESUME, identity))
+        assertFalse(gate.shouldRefresh(Lifecycle.Event.ON_RESUME, null))
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/settings/UiCustomizationCapabilityTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/settings/UiCustomizationCapabilityTest.kt
@@ -1,0 +1,126 @@
+package org.siloserver.silo.android.ui.screens.settings
+
+import org.siloserver.silo.domain.settings.ProfileSettingsController
+import org.siloserver.silo.model.settings.SettingsContractCapabilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UiCustomizationCapabilityTest {
+    @Test
+    fun liveSupportOwnsControlVisibilityAndMutationGuardAcrossTransitions() {
+        var state = SettingsUiState().withObservedUiCustomizationSupport(false)
+        assertFalse(state.uiCustomizationAvailable)
+        assertFalse(state.canAuthorUiCustomization)
+
+        state = state.withObservedUiCustomizationSupport(true)
+        assertTrue(state.uiCustomizationAvailable)
+        assertTrue(state.canAuthorUiCustomization)
+
+        state = state.withObservedUiCustomizationSupport(false)
+        assertFalse(state.uiCustomizationAvailable)
+        assertFalse(state.canAuthorUiCustomization)
+
+        state = state.withObservedUiCustomizationSupport(true)
+        assertTrue(state.uiCustomizationAvailable)
+        assertTrue(state.canAuthorUiCustomization)
+
+        // A profile/server switch publishes UNKNOWN before the replacement
+        // probe completes. Cached presentation remains in state, but writes
+        // and authoring controls must close immediately.
+        state = state.copy(posterSize = org.siloserver.silo.model.settings.PosterSizePreset.LARGE)
+            .withObservedUiCustomizationSupport(null)
+        assertEquals(
+            org.siloserver.silo.model.settings.PosterSizePreset.LARGE,
+            state.posterSize,
+        )
+        assertFalse(state.uiCustomizationAvailable)
+        assertFalse(state.canAuthorUiCustomization)
+
+        state = state.withObservedUiCustomizationSupport(false)
+        assertFalse(state.uiCustomizationAvailable)
+        assertFalse(state.canAuthorUiCustomization)
+    }
+
+    @Test
+    fun olderAndErroringServersFailClosed() {
+        assertFalse(
+            phoneUiCustomizationAvailable(
+                ProfileSettingsController.LoadResult(
+                    ProfileSettingsController.Availability.SERVER_UPGRADE_REQUIRED,
+                    snapshot = null,
+                ),
+            ),
+        )
+        assertFalse(
+            phoneUiCustomizationAvailable(
+                ProfileSettingsController.LoadResult(
+                    ProfileSettingsController.Availability.UNAVAILABLE,
+                    snapshot = null,
+                ),
+            ),
+        )
+        assertFalse(
+            available(
+                SettingsContractCapabilities(
+                    revision = 4,
+                    supportsBatchedEffective = true,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            ),
+        )
+        assertFalse(
+            available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsBatchedEffective = true,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = false,
+                ),
+            ),
+        )
+        assertFalse(
+            available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsBatchedEffective = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            ),
+        )
+        assertFalse(
+            available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun revisionFiveWithEveryRequiredCapabilityEnablesControls() {
+        assertTrue(
+            available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsBatchedEffective = true,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            ),
+        )
+    }
+
+    private fun available(capabilities: SettingsContractCapabilities): Boolean =
+        phoneUiCustomizationAvailable(
+            ProfileSettingsController.LoadResult(
+                ProfileSettingsController.Availability.AVAILABLE,
+                snapshot = null,
+                capabilities = capabilities,
+            ),
+        )
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/data/preferences/TvLibraryScopeStore.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/data/preferences/TvLibraryScopeStore.kt
@@ -1,16 +1,35 @@
 package org.siloserver.silo.tv.data.preferences
 
 import android.content.Context
+import androidx.datastore.core.DataMigration
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
 import org.siloserver.silo.model.personal.UserLibrary
+import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.IdentityTransition
+import org.siloserver.silo.network.IdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionKind
+import org.siloserver.silo.network.IdentityTransitionPhase
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.tv.ui.shell.TvLibraryTabType
+import java.security.MessageDigest
+import java.util.UUID
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onSubscription
 
 /**
  * Per-profile, per-type store for the selected library *scope* on the
@@ -22,31 +41,60 @@ import kotlinx.coroutines.flow.first
  * per server, per type, so reopening a tab lands on the user's last choice
  * instead of snapping back to the first library.
  *
- * Storage mirrors [TvLibrarySelectionStore]: a file-per-profile DataStore
- * (hashed profileId in the filename) so two profiles never clobber each
- * other. Within that file, each scope is partitioned by a key combining the
- * active serverId and the [TvLibraryTabType] — matching tvOS's
- * `serverId·profileId·type` keying so two servers under one profile keep
- * independent scopes.
+ * Storage uses a file per profile and credential owner (both hashed in the
+ * filename), then partitions values by server and [TvLibraryTabType]. This
+ * keeps replacement accounts and temporary playback overlays isolated even
+ * when they reuse the same server/profile identifiers.
+ *
+ * Builds before owner namespacing keyed the file on the profile id alone.
+ * Upgrading into a namespaced file therefore imports the pre-upgrade file
+ * once, as a [DataMigration] so it completes before the store publishes any
+ * value. Only the first owner observed for a profile may import, so a later
+ * account swap onto the same profile id starts clean; the pre-upgrade file is
+ * never deleted, so a downgrade still finds its data.
  *
  * When no profile is active (sign-in / profile-selection), reads return null
  * and writes are silent no-ops.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class TvLibraryScopeStore(
     private val context: Context,
     private val tokenManager: TokenManager,
-    private val dataStoreFactory: (profileId: String) -> DataStore<Preferences> = { profileId ->
-        PreferenceDataStoreFactory.create(
-            produceFile = { context.preferencesDataStoreFile(fileNameFor(profileId)) },
-        )
-    },
+    private val identityTransitions: IdentityTransitionBarrier,
+    private val dataStoreFactory: (
+        fileName: String,
+        migrations: List<DataMigration<Preferences>>,
+    ) -> DataStore<Preferences> =
+        { fileName, migrations ->
+            PreferenceDataStoreFactory.create(
+                migrations = migrations,
+                produceFile = { context.preferencesDataStoreFile(fileName) },
+            )
+        },
 ) {
 
     private val storeCache = mutableMapOf<String, DataStore<Preferences>>()
+    private val legacyProcessOwnerId = UUID.randomUUID().toString()
 
-    private fun storeFor(profileId: String): DataStore<Preferences> =
+    private fun storeFor(identity: StorageIdentity): DataStore<Preferences> =
+        cachedStore(fileNameFor(identity.storageNamespace)) {
+            if (identity.canImportLegacy) listOf(LegacyScopeImport(identity)) else emptyList()
+        }
+
+    private fun legacyStoreFor(identity: StorageIdentity): DataStore<Preferences> =
+        cachedStore(identity.legacyFileName) { emptyList() }
+
+    /**
+     * One live DataStore per file. DataStore rejects a second active instance
+     * over the same file, and [LegacyScopeImport] opens the pre-upgrade file
+     * from inside the namespaced store's own migration.
+     */
+    private fun cachedStore(
+        fileName: String,
+        migrations: () -> List<DataMigration<Preferences>>,
+    ): DataStore<Preferences> =
         synchronized(storeCache) {
-            storeCache.getOrPut(profileId) { dataStoreFactory(profileId) }
+            storeCache.getOrPut(fileName) { dataStoreFactory(fileName, migrations()) }
         }
 
     /**
@@ -55,9 +103,8 @@ class TvLibraryScopeStore(
      * active.
      */
     suspend fun getSelectedLibraryId(type: TvLibraryTabType): Int? {
-        val profileId = tokenManager.getProfileId() ?: return null
-        val serverId = tokenManager.getCurrentServerId() ?: DEFAULT_SERVER_ID
-        return storeFor(profileId).data.first()[scopeKey(serverId, type)]
+        val identity = currentIdentity() ?: return null
+        return getSelectedLibraryId(identity, type)
     }
 
     /**
@@ -66,27 +113,59 @@ class TvLibraryScopeStore(
      * default like Apple TV; device+profile local (never server-synced).
      */
     suspend fun getShowAudiobooksTab(): Boolean {
-        val profileId = tokenManager.getProfileId() ?: return false
-        val serverId = tokenManager.getCurrentServerId() ?: DEFAULT_SERVER_ID
-        return storeFor(profileId).data.first()[showAudiobooksKey(serverId)] ?: false
+        val identity = currentIdentity() ?: return false
+        return getShowAudiobooksTab(identity)
     }
 
+    /** Live legacy value, re-keyed after every completed identity transition. */
+    fun showAudiobooksTabFlow(): Flow<Boolean> =
+        identityTransitions.transitions
+            // Subscribe before the initial read. `onStart` would leave a gap
+            // where a profile switch could complete before SharedFlow was
+            // actually observed, binding this long-lived flow to the old key.
+            .onSubscription {
+                emit(
+                    identityTransitions.latestTransition.value
+                        ?: IdentityTransition(
+                            phase = IdentityTransitionPhase.DID_CHANGE,
+                            kind = IdentityTransitionKind.PROFILE_SWITCH,
+                            generation = identityTransitions.generation.value,
+                        ),
+                )
+            }
+            .flatMapLatest { transition ->
+                flow {
+                    // Stop publishing the previous owner's value at the inline
+                    // privacy boundary. The completed transition below will
+                    // replace this safe default with the newly-active owner's
+                    // persisted value.
+                    if (transition.phase == IdentityTransitionPhase.WILL_CHANGE) {
+                        emit(false)
+                        return@flow
+                    }
+                    val identity = currentIdentity()
+                    if (identity == null) {
+                        emit(false)
+                        return@flow
+                    }
+                    emitAll(
+                        storeFor(identity).data.map { preferences ->
+                            preferences[showAudiobooksKey(identity.serverId)] ?: false
+                        }.distinctUntilChanged(),
+                    )
+                }
+            }
+            .distinctUntilChanged()
+
     suspend fun setShowAudiobooksTab(show: Boolean) {
-        val profileId = tokenManager.getProfileId() ?: return
-        val serverId = tokenManager.getCurrentServerId() ?: DEFAULT_SERVER_ID
-        storeFor(profileId).edit { prefs ->
-            prefs[showAudiobooksKey(serverId)] = show
-        }
+        val identity = currentIdentity() ?: return
+        setShowAudiobooksTab(identity, show)
     }
 
     /** Persist [id] as the scope for [type] under the active profile/server. */
     suspend fun setSelectedLibraryId(id: Int?, type: TvLibraryTabType) {
-        val profileId = tokenManager.getProfileId() ?: return
-        val serverId = tokenManager.getCurrentServerId() ?: DEFAULT_SERVER_ID
-        val key = scopeKey(serverId, type)
-        storeFor(profileId).edit { prefs ->
-            if (id == null) prefs.remove(key) else prefs[key] = id
-        }
+        val identity = currentIdentity() ?: return
+        setSelectedLibraryId(identity, id, type)
     }
 
     /**
@@ -100,16 +179,179 @@ class TvLibraryScopeStore(
         type: TvLibraryTabType,
         libraries: List<UserLibrary>,
     ): UserLibrary? {
-        val storedId = getSelectedLibraryId(type)
+        // Keep one atomic identity for both the read and stale-value repair. A
+        // profile switch between two independent public calls must not repair
+        // the newly-active account with the previous account's resolution.
+        val identity = currentIdentity()
+        val storedId = identity?.let { getSelectedLibraryId(it, type) }
         val resolved = resolve(storedId, type, libraries)
         // Real eviction: if a stored id no longer matches a live library we
         // fell back to a different one — repersist it so the stale id can't
         // resurrect if that library reappears later.
-        if (resolved != null && storedId != null && storedId != resolved.id) {
-            setSelectedLibraryId(resolved.id, type)
+        if (identity != null && resolved != null && storedId != null && storedId != resolved.id) {
+            setSelectedLibraryId(identity, resolved.id, type)
         }
         return resolved
     }
+
+    private suspend fun currentIdentity(): StorageIdentity? {
+        val snapshot = tokenManager.snapshotCurrentScope() ?: return null
+        val profileId = snapshot.profileId?.takeIf { it.isNotBlank() } ?: return null
+        val serverId = snapshot.serverId.takeIf { it.isNotBlank() } ?: DEFAULT_SERVER_ID
+        val owner = ownerDescriptor(snapshot)
+        return StorageIdentity(
+            serverId = serverId,
+            storageNamespace = sha256("$profileId\u0000${sha256(owner)}"),
+            legacyFileName = legacyFileNameFor(profileId),
+            canImportLegacy = ownerMayImportLegacy(owner),
+        )
+    }
+
+    /**
+     * The raw ownership descriptor behind the hashed namespace. Kept unhashed
+     * here so [ownerMayImportLegacy] can tell a durable account apart from an
+     * ephemeral one.
+     */
+    private fun ownerDescriptor(snapshot: AuthScopeSnapshot): String =
+        snapshot.credentialGenerationId
+            ?.takeIf { it.isNotBlank() }
+            ?.let { "temporary:$it" }
+            ?: snapshot.credentialOwnerId
+                ?.takeIf { it.isNotBlank() }
+                ?.let { "persistent:$it" }
+            ?: snapshot.credentialEpoch
+                .takeIf { it != 0L }
+                ?.let { "persistent_epoch:$it" }
+            ?: snapshot.profileToken
+                ?.takeIf { it.isNotBlank() }
+                ?.let { "legacy_profile_token:$it" }
+            // Old/custom token managers may not stamp any durable owner. A
+            // profile token is isolated but may rotate; if even that is absent,
+            // a process-local fallback deliberately sacrifices restart
+            // continuity. Both choices favor isolation over silently inheriting
+            // another account's local preferences.
+            ?: "legacy_process:$legacyProcessOwnerId:${snapshot.identityGeneration}"
+
+    /**
+     * Only a durable, persistent owner may claim the pre-upgrade file. A
+     * temporary playback overlay is deliberately isolated, and the
+     * process-local fallback changes every launch — letting either one claim
+     * would burn the single import on an identity that cannot keep the data,
+     * permanently stranding the real account's preferences.
+     */
+    private fun ownerMayImportLegacy(owner: String): Boolean =
+        !owner.startsWith("temporary:") && !owner.startsWith("legacy_process:")
+
+    private suspend fun getSelectedLibraryId(
+        identity: StorageIdentity,
+        type: TvLibraryTabType,
+    ): Int? = storeFor(identity).data.first()[scopeKey(identity.serverId, type)]
+
+    private suspend fun setSelectedLibraryId(
+        identity: StorageIdentity,
+        id: Int?,
+        type: TvLibraryTabType,
+    ) {
+        val key = scopeKey(identity.serverId, type)
+        storeFor(identity).edit { prefs ->
+            if (id == null) prefs.remove(key) else prefs[key] = id
+        }
+    }
+
+    private suspend fun getShowAudiobooksTab(identity: StorageIdentity): Boolean =
+        storeFor(identity).data.first()[showAudiobooksKey(identity.serverId)] ?: false
+
+    private suspend fun setShowAudiobooksTab(identity: StorageIdentity, show: Boolean) {
+        storeFor(identity).edit { prefs ->
+            prefs[showAudiobooksKey(identity.serverId)] = show
+        }
+    }
+
+    private data class StorageIdentity(
+        val serverId: String,
+        val storageNamespace: String,
+        val legacyFileName: String,
+        val canImportLegacy: Boolean,
+    )
+
+    /**
+     * Copies the pre-upgrade, profile-only-keyed file into this owner's
+     * namespaced file exactly once.
+     *
+     * Runs as a [DataMigration] so DataStore completes it before the first
+     * value is published — concurrent first reads all observe the imported
+     * data, never a half-migrated default. [legacyImportedKey] in the new file
+     * makes it one-shot per namespace even after the user clears every
+     * preference; [legacyOwnerClaimKey] in the old file makes it one-shot per
+     * profile, so a second, different owner on the same profile id starts
+     * clean instead of inheriting the previous account's choices.
+     *
+     * The old file is read before it is claimed, so a profile that never had
+     * one does not get an empty file created for it, and it is never deleted:
+     * a downgrade still finds exactly the data it wrote.
+     */
+    private inner class LegacyScopeImport(
+        private val identity: StorageIdentity,
+    ) : DataMigration<Preferences> {
+
+        override suspend fun shouldMigrate(currentData: Preferences): Boolean =
+            currentData[legacyImportedKey] != true
+
+        override suspend fun migrate(currentData: Preferences): Preferences {
+            val imported = currentData.toMutablePreferences()
+            // Stamped whatever happens below: a missing or unreadable legacy
+            // file is a clean no-op, not a retry on every launch.
+            imported[legacyImportedKey] = true
+
+            val legacy = legacyOrNull { legacyStoreFor(identity).data.first() }
+            if (legacy == null || legacy.asMap().isEmpty()) return imported.toPreferences()
+
+            val claimed = if (legacy[legacyOwnerClaimKey] == null) {
+                // Check-and-claim in one edit so two owners racing their first
+                // read cannot both decide they were first.
+                legacyOrNull {
+                    legacyStoreFor(identity).edit { prefs ->
+                        if (prefs[legacyOwnerClaimKey] == null) {
+                            prefs[legacyOwnerClaimKey] = identity.storageNamespace
+                        }
+                    }
+                }
+            } else {
+                legacy
+            } ?: return imported.toPreferences()
+
+            // A foreign claim means this owner arrived after the upgrade.
+            if (claimed[legacyOwnerClaimKey] != identity.storageNamespace) {
+                return imported.toPreferences()
+            }
+
+            claimed.asMap().forEach { (key, value) ->
+                if (key.name == legacyOwnerClaimKey.name) return@forEach
+                if (key.name == legacyImportedKey.name) return@forEach
+                // A crash between claiming and committing retries the import;
+                // anything already written here wins over the old value.
+                if (currentData.contains(key)) return@forEach
+                @Suppress("UNCHECKED_CAST")
+                imported[key as Preferences.Key<Any>] = value
+            }
+            return imported.toPreferences()
+        }
+
+        override suspend fun cleanUp() = Unit
+    }
+
+    /**
+     * Legacy storage is best-effort: a deleted, corrupt or unreadable file
+     * must leave the store on defaults rather than crash or wedge the flow.
+     */
+    private suspend fun <T> legacyOrNull(block: suspend () -> T): T? =
+        try {
+            block()
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Throwable) {
+            null
+        }
 
     companion object {
         private const val DEFAULT_SERVER_ID = "default"
@@ -139,14 +381,26 @@ class TvLibraryScopeStore(
         private fun showAudiobooksKey(serverId: String) =
             androidx.datastore.preferences.core.booleanPreferencesKey("show_audiobooks_$serverId")
 
-        // Filename pattern aligns with [TvLibrarySelectionStore.fileNameFor].
-        private fun fileNameFor(profileId: String): String =
-            "tv_library_scope_${profileHash(profileId)}"
+        private fun fileNameFor(storageNamespace: String): String =
+            "tv_library_scope_$storageNamespace"
 
-        private fun profileHash(profileId: String): String =
-            java.security.MessageDigest.getInstance("SHA-256")
-                .digest(profileId.toByteArray(Charsets.UTF_8))
+        /**
+         * The pre-owner-namespacing filename: profile id alone, truncated
+         * hash. Read once per profile by [LegacyScopeImport]; never written
+         * except for the one claim marker, and never deleted.
+         */
+        internal fun legacyFileNameFor(profileId: String): String =
+            "tv_library_scope_${sha256(profileId).take(16)}"
+
+        /** Set in the namespaced file once its legacy import has run. */
+        private val legacyImportedKey = booleanPreferencesKey("legacy_scope_imported_v1")
+
+        /** Set in the legacy file to the namespace that imported it. */
+        private val legacyOwnerClaimKey = stringPreferencesKey("legacy_scope_owner_claim")
+
+        private fun sha256(value: String): String =
+            MessageDigest.getInstance("SHA-256")
+                .digest(value.toByteArray(Charsets.UTF_8))
                 .joinToString(separator = "") { "%02x".format(it) }
-                .take(16)
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -12,12 +12,15 @@ import org.siloserver.silo.common.network.SiloClientBuildIdentity
 import org.siloserver.silo.common.network.CleartextConsentStore
 import org.siloserver.silo.common.network.DataStoreCleartextConsentStore
 import org.siloserver.silo.common.settings.AndroidServerSettingsCache
+import org.siloserver.silo.common.settings.DefaultUiCustomizationStore
+import org.siloserver.silo.common.settings.UiCustomizationStore
 import android.content.SharedPreferences
 import org.siloserver.silo.network.AndroidServerRegistry
 import org.siloserver.silo.network.EncryptedTokenManagerImpl
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.network.createSecureSharedPrefs
+import org.siloserver.silo.model.settings.SiloClientFamily
 import org.siloserver.silo.tv.ui.screens.servers.TvServerListViewModel
 import org.siloserver.silo.common.player.AudioCapabilityManager
 import org.siloserver.silo.common.player.AudioTrackManager
@@ -65,6 +68,7 @@ import org.siloserver.silo.tv.watchnext.WatchNextRepository
 import org.siloserver.silo.tv.watchnext.WatchNextSeeder
 import android.net.Uri
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
@@ -147,11 +151,25 @@ val androidTvModule = module {
     // androidModule for why every identity reporter resolves this instead of
     // deriving its own answer.
     single { SiloClientBuildIdentity(BuildConfig.BUILD_NUMBER, BuildConfig.RELEASE_CHANNEL) }
+    single<SiloClientFamily> { SiloClientFamily.TV }
+    single<UiCustomizationStore> {
+        DefaultUiCustomizationStore(
+            family = get(),
+            repository = get(),
+            tokenManager = get(),
+            cache = get(),
+            identityTransitions = get(),
+            scope = kotlinx.coroutines.CoroutineScope(
+                kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.IO,
+            ),
+        )
+    }
     single<org.siloserver.silo.network.DeviceMetadataProvider> {
         AndroidDeviceMetadataProvider(
-            androidContext(),
+            context = androidContext(),
             platform = "android-tv",
             buildIdentity = get(),
+            clientFamily = get<SiloClientFamily>().wire,
         )
     }
     // Player infrastructure (duplicate-for-now; extract to :android-player later).
@@ -259,7 +277,7 @@ val androidTvModule = module {
 
     // Skyline per-profile·server·type library scope (persisted across launches).
     single {
-        org.siloserver.silo.tv.data.preferences.TvLibraryScopeStore(androidContext(), get())
+        org.siloserver.silo.tv.data.preferences.TvLibraryScopeStore(androidContext(), get(), get())
     }
 
     // One-shot legacy `tv_prefs` import (playback settings → server device
@@ -405,12 +423,22 @@ val androidTvModule = module {
     }
     viewModel { org.siloserver.silo.tv.ui.screens.browse.TvBrowseViewModel(get()) }
     viewModel { params ->
+        val customization = get<UiCustomizationStore>()
+        val libraryScope = get<TvLibraryScopeStore>()
         org.siloserver.silo.tv.ui.screens.people.TvPersonDetailViewModel(
             catalogRepository = get(),
             personId = params.get(),
             personalDataRepository = getOrNull(),
-            showAudiobooksProvider = {
-                get<TvLibraryScopeStore>().getShowAudiobooksTab()
+            audiobookVisibilityPolicyFlow = combine(
+                customization.primaryMenu,
+                customization.uiCustomizationSupported,
+                libraryScope.showAudiobooksTabFlow(),
+            ) { menu, supported, legacy ->
+                org.siloserver.silo.tv.ui.shell.TvAudiobookVisibilityPolicy(
+                    primaryMenu = menu,
+                    uiCustomizationSupported = supported,
+                    legacyFallback = legacy,
+                )
             },
         )
     }
@@ -433,7 +461,7 @@ val androidTvModule = module {
             title = params.get(),
         )
     }
-    viewModel { TvSearchViewModel(get(), get(), get()) }
+    viewModel { TvSearchViewModel(get(), get(), get(), get()) }
     viewModel { params ->
         TvItemDetailViewModel(
             catalogRepository = get(),
@@ -522,6 +550,8 @@ val androidTvModule = module {
             overlayPrefsStore = get(),
             legacyTvPrefsMigration = get(),
             profileSettings = get(),
+            personalDataRepository = get(),
+            uiCustomizationStore = get(),
             tvLibraryScopeStore = getOrNull(),
         )
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
@@ -39,6 +39,8 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import org.siloserver.silo.model.catalog.BrowseItem
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
+import org.siloserver.silo.common.ui.components.forPosterPreset
 import org.siloserver.silo.overlays.OverlayDataExtractor
 import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.rememberTvGridBringIntoViewSpec
@@ -138,6 +140,9 @@ fun TvCatalogGrid(
             }
         }
     }
+    val posterPreset = LocalCardPresentation.current.posterSize
+    val effectiveMinCellWidth = minCellWidth.forPosterPreset(posterPreset)
+    val effectiveFixedColumnCount = fixedColumnCount?.forPosterPreset(posterPreset)
 
     // Backoff gate against an endless load-more retry storm. When a load-more
     // completes without growing the list while the server still reports more
@@ -211,8 +216,8 @@ fun TvCatalogGrid(
     ) {
     LazyVerticalGrid(
         state = resolvedGridState,
-        columns = fixedColumnCount?.let { GridCells.Fixed(it) }
-            ?: GridCells.Adaptive(minSize = minCellWidth),
+        columns = effectiveFixedColumnCount?.let { GridCells.Fixed(it) }
+            ?: GridCells.Adaptive(minSize = effectiveMinCellWidth),
         horizontalArrangement = Arrangement.spacedBy(horizontalSpacing),
         verticalArrangement = Arrangement.spacedBy(verticalSpacing),
         contentPadding = contentPadding,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvEpisodeCard.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvEpisodeCard.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.tv.ui.components
 
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -41,6 +42,7 @@ import org.siloserver.silo.common.overlays.CardOverlayVariant
 import org.siloserver.silo.common.overlays.CardOverlays
 import org.siloserver.silo.common.overlays.LocalCardOverlayUiState
 import org.siloserver.silo.overlays.OverlayData
+import org.siloserver.silo.model.settings.CardCaptionPreset
 import org.siloserver.silo.tv.ui.theme.ProgressFill
 import org.siloserver.silo.tv.ui.theme.ProgressTrack
 import org.siloserver.silo.tv.ui.theme.RowDimens
@@ -75,6 +77,7 @@ fun TvEpisodeCard(
     actions: TvMediaCardActions = TvMediaCardActions(),
 ) {
     val overlayState = LocalCardOverlayUiState.current
+    val presentation = LocalCardPresentation.current
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
 
@@ -178,41 +181,45 @@ fun TvEpisodeCard(
             }
         }
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 7.dp),
-            horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Text(
-                text = seriesTitle ?: title,
-                style = MaterialTheme.typography.titleSmall.copy(
-                    fontSize = 15.5.sp,
-                    lineHeight = 18.5.sp,
-                ),
-                color = if (isFocused) Color.White else Color.White.copy(alpha = 0.78f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            val secondaryLine = if (seriesTitle != null) title else year?.toString()
-            if (secondaryLine != null) {
+        if (presentation.caption != CardCaptionPreset.ARTWORK) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 7.dp),
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
                 Text(
-                    text = secondaryLine,
-                    style = MaterialTheme.typography.bodySmall.copy(
-                        fontSize = 14.sp,
-                        lineHeight = 18.sp,
+                    text = seriesTitle ?: title,
+                    style = MaterialTheme.typography.titleSmall.copy(
+                        fontSize = 15.5.sp,
+                        lineHeight = 18.5.sp,
                     ),
-                    color = Color.White.copy(alpha = 0.75f),
+                    color = if (isFocused) Color.White else Color.White.copy(alpha = 0.78f),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    textAlign = TextAlign.Start,
                     modifier = Modifier.fillMaxWidth(),
                 )
+                val secondaryLine = if (seriesTitle != null) title else year?.toString()
+                if (
+                    secondaryLine != null &&
+                    presentation.caption == CardCaptionPreset.TITLE_METADATA
+                ) {
+                    Text(
+                        text = secondaryLine,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontSize = 14.sp,
+                            lineHeight = 18.sp,
+                        ),
+                        color = Color.White.copy(alpha = 0.75f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Start,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         }
-
     }
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCard.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCard.kt
@@ -1,6 +1,8 @@
 package org.siloserver.silo.tv.ui.components
 
 import org.siloserver.silo.common.ui.components.ThumbhashImage
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
+import org.siloserver.silo.common.ui.components.forPosterPreset
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -44,6 +46,7 @@ import org.siloserver.silo.common.overlays.CardOverlayVariant
 import org.siloserver.silo.common.overlays.CardOverlays
 import org.siloserver.silo.common.overlays.LocalCardOverlayUiState
 import org.siloserver.silo.model.catalog.MediaItemUserState
+import org.siloserver.silo.model.settings.CardCaptionPreset
 import org.siloserver.silo.overlays.OverlayData
 import org.siloserver.silo.tv.ui.theme.ProgressTrack
 import org.siloserver.silo.tv.ui.theme.ProgressFill
@@ -84,14 +87,16 @@ fun TvMediaCard(
     actions: TvMediaCardActions = TvMediaCardActions(),
 ) {
     val overlayState = LocalCardOverlayUiState.current
+    val presentation = LocalCardPresentation.current
+    val effectiveWidth = width.forPosterPreset(presentation.posterSize)
     val effectiveAspectRatio = artworkAspectRatio
         ?: tvArtworkAspectRatioForMediaType(mediaType)
         ?: (2f / 3f)
-    val height = width / effectiveAspectRatio
-    val watchedBadgeSize = (width * RowDimens.WatchedBadgeSizeFraction)
+    val height = effectiveWidth / effectiveAspectRatio
+    val watchedBadgeSize = (effectiveWidth * RowDimens.WatchedBadgeSizeFraction)
         .coerceIn(RowDimens.WatchedBadgeMinSize, RowDimens.WatchedBadgeMaxSize)
     val watchedBadgeIconSize = watchedBadgeSize * RowDimens.WatchedBadgeIconSizeFraction
-    val watchedBadgePadding = (width * RowDimens.WatchedBadgePaddingFraction)
+    val watchedBadgePadding = (effectiveWidth * RowDimens.WatchedBadgePaddingFraction)
         .coerceIn(RowDimens.WatchedBadgeMinPadding, RowDimens.WatchedBadgeMaxPadding)
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
@@ -105,7 +110,7 @@ fun TvMediaCard(
         modifier = if (fillWidth) {
             modifier
         } else {
-            modifier.width(width)
+            modifier.width(effectiveWidth)
         },
     ) {
         TvMediaCardContextMenu(
@@ -133,7 +138,7 @@ fun TvMediaCard(
             } else {
                 cardModifier
                     .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
-                    .size(width, height)
+                    .size(effectiveWidth, height)
             },
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
@@ -195,26 +200,27 @@ fun TvMediaCard(
             }
         }
 
-        Spacer(modifier = Modifier.height(11.dp))
+        if (presentation.caption != CardCaptionPreset.ARTWORK) {
+            Spacer(modifier = Modifier.height(11.dp))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall.copy(
+                    fontSize = 15.5.sp,
+                    lineHeight = 18.5.sp,
+                ),
+                color = if (isFocused) {
+                    Color.White
+                } else {
+                    Color.White.copy(alpha = 0.78f)
+                },
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
 
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleSmall.copy(
-                fontSize = 15.5.sp,
-                lineHeight = 18.5.sp,
-            ),
-            color = if (isFocused) {
-                Color.White
-            } else {
-                Color.White.copy(alpha = 0.78f)
-            },
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            textAlign = TextAlign.Start,
-            modifier = Modifier.fillMaxWidth(),
-        )
-
-        if (year != null && year > 0) {
+        if (year != null && year > 0 && presentation.caption == CardCaptionPreset.TITLE_METADATA) {
             Text(
                 text = year.toString(),
                 style = MaterialTheme.typography.bodySmall.copy(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvReferenceShelfCard.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvReferenceShelfCard.kt
@@ -32,7 +32,9 @@ import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.ThumbhashImage
+import org.siloserver.silo.model.settings.CardCaptionPreset
 import org.siloserver.silo.tv.ui.theme.ProgressFill
 import org.siloserver.silo.tv.ui.theme.ProgressTrack
 import org.siloserver.silo.tv.ui.theme.siloCardDefaults
@@ -54,6 +56,7 @@ fun TvReferenceShelfCard(
     userState: org.siloserver.silo.model.catalog.MediaItemUserState? = null,
     actions: TvMediaCardActions = TvMediaCardActions(),
 ) {
+    val presentation = LocalCardPresentation.current
     val shape = RoundedCornerShape(12.dp)
     val focus = siloCardDefaults(shape = shape, focusedScale = 1f)
 
@@ -84,86 +87,92 @@ fun TvReferenceShelfCard(
                     modifier = Modifier.fillMaxSize(),
                 )
 
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        Brush.verticalGradient(
-                            0f to Color.Transparent,
-                            0.55f to Color.Transparent,
-                            0.83f to Color.Black.copy(alpha = 0.52f),
-                            1f to Color.Black.copy(alpha = 0.86f),
-                        ),
-                    ),
-            )
+                if (presentation.caption != CardCaptionPreset.ARTWORK) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(
+                                Brush.verticalGradient(
+                                    0f to Color.Transparent,
+                                    0.55f to Color.Transparent,
+                                    0.83f to Color.Black.copy(alpha = 0.52f),
+                                    1f to Color.Black.copy(alpha = 0.86f),
+                                ),
+                            ),
+                    )
+                }
 
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .border(1.dp, Color.White.copy(alpha = 0.08f), shape),
-            )
-
-            Column(
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 10.dp),
-            ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.headlineSmall,
-                    color = Color.White,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .border(1.dp, Color.White.copy(alpha = 0.08f), shape),
                 )
 
-                if (!subtitle.isNullOrBlank() || !detail.isNullOrBlank()) {
-                    Row(
+                if (presentation.caption != CardCaptionPreset.ARTWORK) {
+                    Column(
                         modifier = Modifier
+                            .align(Alignment.BottomStart)
                             .fillMaxWidth()
-                            .padding(top = 3.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+                            .padding(horizontal = 12.dp, vertical = 10.dp),
                     ) {
-                        if (!subtitle.isNullOrBlank()) {
-                            Text(
-                                text = subtitle,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = Color.White.copy(alpha = 0.8f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f),
-                            )
-                        }
-                        if (!detail.isNullOrBlank()) {
-                            Text(
-                                text = detail,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = Color.White.copy(alpha = 0.8f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.headlineSmall,
+                            color = Color.White,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+
+                        if (
+                            presentation.caption == CardCaptionPreset.TITLE_METADATA &&
+                            (!subtitle.isNullOrBlank() || !detail.isNullOrBlank())
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 3.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                if (!subtitle.isNullOrBlank()) {
+                                    Text(
+                                        text = subtitle,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = Color.White.copy(alpha = 0.8f),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                }
+                                if (!detail.isNullOrBlank()) {
+                                    Text(
+                                        text = detail,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = Color.White.copy(alpha = 0.8f),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                            }
                         }
                     }
                 }
-            }
 
-            if (progress != null && progress > 0f) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(3.dp)
-                        .align(Alignment.BottomStart)
-                        .background(ProgressTrack),
-                ) {
+                if (progress != null && progress > 0f) {
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth(progress.coerceIn(0f, 1f))
+                            .fillMaxWidth()
                             .height(3.dp)
-                            .background(ProgressFill),
-                    )
+                            .align(Alignment.BottomStart)
+                            .background(ProgressTrack),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth(progress.coerceIn(0f, 1f))
+                                .height(3.dp)
+                                .background(ProgressFill),
+                        )
+                    }
                 }
-            }
-
             }
         }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -56,7 +56,11 @@ import org.siloserver.silo.tv.ui.screens.watchtogether.tvWatchTogetherDestinatio
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.watchtogether.WatchTogetherEntryTarget
 import org.siloserver.silo.watchtogether.watchTogetherEntryTarget
+import androidx.compose.runtime.CompositionLocalProvider
 import org.siloserver.silo.common.overlays.ProvideCardOverlays
+import org.siloserver.silo.common.settings.UiCustomizationStore
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
+import org.siloserver.silo.model.settings.effectiveCardPresentationForSupport
 import org.siloserver.silo.common.diagnostics.DiagnosticsLifecycleLogger
 import org.siloserver.silo.common.settings.LibraryPlaybackPrefsStore
 import org.siloserver.silo.common.settings.OverlayPrefsStore
@@ -335,6 +339,7 @@ fun TvAppNavigation(
     val authRepository: AuthRepository = koinInject()
     val profileRepository: ProfileRepository = koinInject()
     val overlayPrefsStore: OverlayPrefsStore = koinInject()
+    val uiCustomizationStore: UiCustomizationStore = koinInject()
     val libraryPlaybackPrefsStore: LibraryPlaybackPrefsStore = koinInject()
     val watchNextSeeder: WatchNextSeeder = koinInject()
     val siloCastReceiver: TvSiloCastReceiver = koinInject()
@@ -546,7 +551,20 @@ fun TvAppNavigation(
         value = tokenManager.getProfileId()
     }
 
+    // Card presentation is provided HERE rather than inside TvMainShell so it
+    // also reaches the routes that render TvMediaCard/TvCatalogGrid outside the
+    // shell — item detail, library-collection detail, person detail — and so it
+    // sits alongside the existing card-overlay provider.
+    val cardPresentation by uiCustomizationStore.cardPresentation.collectAsState()
+    val cardPresentationSupported by
+        uiCustomizationStore.uiCustomizationSupported.collectAsState()
     ProvideCardOverlays(store = overlayPrefsStore, sessionKey = overlaySessionKey) {
+    CompositionLocalProvider(
+        LocalCardPresentation provides effectiveCardPresentationForSupport(
+            cardPresentation,
+            cardPresentationSupported,
+        ),
+    ) {
     Box(modifier = Modifier.fillMaxSize()) {
     NavHost(
         navController = navController,
@@ -1302,6 +1320,7 @@ fun TvAppNavigation(
             onDontSend = { diagnosticsViewModel.declinePrompt(prompt) },
             allowAlwaysSend = diagnosticsState.allowsAutomaticUpload,
         )
+    }
     }
     }
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
@@ -63,6 +63,8 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import org.siloserver.silo.common.ui.components.ThumbhashImage
+import org.siloserver.silo.common.ui.components.LocalCardPresentation
+import org.siloserver.silo.common.ui.components.forPosterPreset
 import org.siloserver.silo.model.catalog.AudiobookGroup
 import org.siloserver.silo.model.section.LibraryCollection
 import org.siloserver.silo.tv.ui.components.TvAlphabetRail
@@ -466,12 +468,16 @@ private fun LibraryGrid(
     onClearFilters: () -> Unit = {},
 ) {
     var attachedRestoreItemId by remember { mutableStateOf<String?>(null) }
+    val posterGridColumns = LibraryBrowseGridColumns.forPosterPreset(
+        LocalCardPresentation.current.posterSize,
+    )
     val nearEnd by remember(
         gridState,
         state.browseHasMore,
         state.browseItems.size,
         state.browseLoading,
         state.browseLoadingMore,
+        posterGridColumns,
     ) {
         derivedStateOf {
             if (!state.browseHasMore || state.browseLoading || state.browseLoadingMore) {
@@ -481,7 +487,7 @@ private fun LibraryGrid(
                 state.browseItems.isNotEmpty() &&
                     lastVisible != null &&
                     lastVisible.index >= state.browseItems.size -
-                        (LibraryGridLoadMoreRowsThreshold * LibraryBrowseGridColumns)
+                        (LibraryGridLoadMoreRowsThreshold * posterGridColumns)
             }
         }
     }
@@ -504,7 +510,7 @@ private fun LibraryGrid(
     ) {
         LazyVerticalGrid(
             state = gridState,
-            columns = GridCells.Fixed(LibraryBrowseGridColumns),
+            columns = GridCells.Fixed(posterGridColumns),
             modifier = Modifier
                 .fillMaxSize()
                 // Entry lands on the return-target card while its requester is
@@ -661,6 +667,9 @@ private fun AudiobookGroupsTab(
     onRetry: () -> Unit,
     onInitialContentFocus: () -> Unit,
 ) {
+    val posterGridColumns = LibraryGridColumns.forPosterPreset(
+        LocalCardPresentation.current.posterSize,
+    )
     val gridState: LazyGridState = rememberLazyGridState()
     val firstGroupFocusRequester = remember { FocusRequester() }
     var groupGridHasFocus by remember { mutableStateOf(false) }
@@ -672,6 +681,7 @@ private fun AudiobookGroupsTab(
         state.audiobookGroups.size,
         state.audiobookGroupsLoading,
         state.audiobookGroupsLoadingMore,
+        posterGridColumns,
     ) {
         derivedStateOf {
             if (!state.audiobookGroupsHasMore || state.audiobookGroupsLoading || state.audiobookGroupsLoadingMore) {
@@ -681,7 +691,7 @@ private fun AudiobookGroupsTab(
                 state.audiobookGroups.isNotEmpty() &&
                     lastVisible != null &&
                     lastVisible.index >= state.audiobookGroups.size -
-                        (LibraryGridLoadMoreRowsThreshold * LibraryGridColumns)
+                        (LibraryGridLoadMoreRowsThreshold * posterGridColumns)
             }
         }
     }
@@ -712,7 +722,7 @@ private fun AudiobookGroupsTab(
     ) {
         LazyVerticalGrid(
             state = gridState,
-            columns = GridCells.Fixed(LibraryGridColumns),
+            columns = GridCells.Fixed(posterGridColumns),
             modifier = Modifier
                 .fillMaxSize()
                 .onFocusChanged { groupGridHasFocus = it.hasFocus },
@@ -923,6 +933,9 @@ private fun CollectionsTab(
     onRetry: () -> Unit,
     onInitialContentFocus: () -> Unit,
 ) {
+    val posterGridColumns = LibraryGridColumns.forPosterPreset(
+        LocalCardPresentation.current.posterSize,
+    )
     val entryFocusRequester = remember { FocusRequester() }
     var collectionGridHasFocus by remember { mutableStateOf(false) }
     var initialFocusRequested by remember { mutableStateOf(false) }
@@ -989,7 +1002,7 @@ private fun CollectionsTab(
     ) {
         LazyVerticalGrid(
             state = gridState,
-            columns = GridCells.Fixed(LibraryGridColumns),
+            columns = GridCells.Fixed(posterGridColumns),
             modifier = Modifier
                 .fillMaxSize()
                 .onFocusChanged { collectionGridHasFocus = it.hasFocus }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailViewModel.kt
@@ -6,14 +6,19 @@ import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.model.catalog.Person
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.catalog.personWorksFiltersForTv
+import org.siloserver.silo.model.personal.UserLibrary
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.CatalogRepository
+import org.siloserver.silo.tv.ui.shell.TvAudiobookVisibilityPolicy
 import org.siloserver.silo.tv.ui.util.visibleOnTv
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -66,6 +71,8 @@ class TvPersonDetailViewModel(
     private val personId: Long,
     private val personalDataRepository: org.siloserver.silo.repository.PersonalDataRepository? = null,
     private val showAudiobooksProvider: suspend () -> Boolean = { true },
+    private val showAudiobooksFlow: Flow<Boolean>? = null,
+    private val audiobookVisibilityPolicyFlow: Flow<TvAudiobookVisibilityPolicy>? = null,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TvPersonDetailUiState())
@@ -73,10 +80,17 @@ class TvPersonDetailViewModel(
 
     // The chip row is the intersection of two independently-loaded gates;
     // either may resolve first, so each stores its result and recomputes.
-    private val showAudiobooksDeferred = viewModelScope.async { showAudiobooksProvider() }
     private var libraryGatedFilters: List<TvPersonMediaFilter> =
         TvPersonMediaFilters.filterNot { it == TvPersonMediaFilter.Audiobooks }
     private var filtersWithContent: Set<TvPersonMediaFilter>? = null
+    private var currentLibraries: List<UserLibrary>? = null
+    private var currentLibraryTypes: Set<String>? = null
+    private var currentAudiobookVisibilityPolicy: TvAudiobookVisibilityPolicy? = null
+    // Fail closed until the preference's first value arrives. Person details
+    // can load before either the local preference or the library list, and a
+    // hidden audiobook must never flash in the All filmography meanwhile.
+    private var currentShowAudiobooks = false
+    private var filterProbeGeneration = 0
 
     init {
         // Gate the filmography filter chips by the libraries this profile can
@@ -84,34 +98,74 @@ class TvPersonDetailViewModel(
         // libraries shouldn't offer Audiobooks/Music filters. All/Movies/TV
         // always show; failures keep the full set (graceful degrade).
         viewModelScope.launch {
-            val allowAudiobooks = showAudiobooksDeferred.await()
             val result = personalDataRepository?.listUserLibraries()
-            val types = (result as? ApiResult.Success)?.data
+            currentLibraries = (result as? ApiResult.Success)?.data
+            currentLibraryTypes = currentLibraries
                 ?.map { it.type.lowercase() }
                 ?.toSet()
-            libraryGatedFilters = TvPersonMediaFilters.filter { filter ->
-                when (filter) {
-                    TvPersonMediaFilter.Audiobooks ->
-                        allowAudiobooks && (
-                            types == null ||
-                                types.any { org.siloserver.silo.model.navigation.isAudiobookLikeLibraryType(it) }
-                            )
-                    TvPersonMediaFilter.Music ->
-                        types == null || types.any { it == "music" || it == "audio" }
-                    else -> true
-                }
+            val policy = currentAudiobookVisibilityPolicy
+            if (policy != null) {
+                applyAudiobookVisibility(policy.resolve(currentLibraries.orEmpty()))
+            } else {
+                updateLibraryGatedFilters()
             }
-            recomputeAvailableFilters()
+        }
+
+        // Resolve the privacy-sensitive visibility gate independently of the
+        // network-backed library lookup. A slow or failed lookup must not keep
+        // this collector from publishing the local/synced preference.
+        viewModelScope.launch {
+            val policyFlow = audiobookVisibilityPolicyFlow
+            if (policyFlow != null) {
+                policyFlow.collectLatest { policy ->
+                    currentAudiobookVisibilityPolicy = policy
+                    applyAudiobookVisibility(policy.resolve(currentLibraries.orEmpty()))
+                }
+            } else {
+                val visibility = showAudiobooksFlow ?: flowOf(showAudiobooksProvider())
+                visibility.collectLatest(::applyAudiobookVisibility)
+            }
         }
     }
 
-    init {
+    private fun applyAudiobookVisibility(allowAudiobooks: Boolean) {
+        val changed = currentShowAudiobooks != allowAudiobooks
+        currentShowAudiobooks = allowAudiobooks
+        updateLibraryGatedFilters()
+        if (changed && _uiState.value.person != null) {
+            loadItems(_uiState.value.selectedFilter, reset = true)
+        }
+    }
+
+    private fun updateLibraryGatedFilters() {
+        val types = currentLibraryTypes
+        libraryGatedFilters = TvPersonMediaFilters.filter { filter ->
+            when (filter) {
+                TvPersonMediaFilter.Audiobooks ->
+                    currentShowAudiobooks && (
+                        types == null ||
+                            types.any {
+                                org.siloserver.silo.model.navigation
+                                    .isAudiobookLikeLibraryType(it)
+                            }
+                        )
+                TvPersonMediaFilter.Music ->
+                    types == null || types.any { it == "music" || it == "audio" }
+                else -> true
+            }
+        }
+        recomputeAvailableFilters()
+        probeFiltersWithContent()
+    }
+
+    private fun probeFiltersWithContent() {
         // Hide media-type chips the person has no works for: probe each
         // type's server-side total with limit=1. A failed probe keeps its
         // chip (graceful degrade, same policy as the library gate).
+        val generation = ++filterProbeGeneration
+        val allowAudiobooks = currentShowAudiobooks
         viewModelScope.launch {
             if (personId <= 0L) return@launch
-            val allowAudiobooks = showAudiobooksDeferred.await()
             val probed = TvPersonMediaFilters
                 .filter { it.mediaType != null && (allowAudiobooks || it != TvPersonMediaFilter.Audiobooks) }
                 .map { filter ->
@@ -127,6 +181,7 @@ class TvPersonDetailViewModel(
                     }
                 }
                 .awaitAll()
+            if (generation != filterProbeGeneration) return@launch
             filtersWithContent = probed
                 .filter { (_, total) -> total == null || total > 0 }
                 .map { (filter, _) -> filter }
@@ -218,7 +273,7 @@ class TvPersonDetailViewModel(
         val gen = if (reset) ++itemsGeneration else itemsGeneration
         if (reset) resetPaging()
         viewModelScope.launch {
-            val allowAudiobooks = showAudiobooksDeferred.await()
+            val allowAudiobooks = currentShowAudiobooks
             _uiState.update {
                 it.copy(
                     isLoadingItems = true,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchViewModel.kt
@@ -6,12 +6,15 @@ import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.navigation.isAudiobookLikeLibraryType
 import org.siloserver.silo.model.navigation.tvMediaModeCapabilities
+import org.siloserver.silo.model.personal.UserLibrary
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.errorMessage
 import org.siloserver.silo.repository.CatalogRepository
 import org.siloserver.silo.repository.PersonalDataRepository
 import org.siloserver.silo.tv.ui.util.visibleOnTv
 import org.siloserver.silo.tv.data.preferences.TvLibraryScopeStore
+import org.siloserver.silo.common.settings.UiCustomizationStore
+import org.siloserver.silo.tv.ui.shell.TvAudiobookVisibilityPolicy
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -19,6 +22,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -35,6 +41,7 @@ class TvSearchViewModel(
     private val catalogRepository: CatalogRepository,
     private val personalDataRepository: PersonalDataRepository,
     private val libraryScopeStore: TvLibraryScopeStore,
+    private val uiCustomizationStore: UiCustomizationStore,
 ) : ViewModel() {
 
     data class UiState(
@@ -56,7 +63,19 @@ class TvSearchViewModel(
     private val _uiState = MutableStateFlow(UiState())
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
-    init { loadAvailableMediaTypes() }
+    init {
+        viewModelScope.launch {
+            combine(
+                uiCustomizationStore.primaryMenu,
+                uiCustomizationStore.uiCustomizationSupported,
+                libraryScopeStore.showAudiobooksTabFlow(),
+            ) { menu, supported, legacy ->
+                TvAudiobookVisibilityPolicy(menu, supported, legacy)
+            }
+                .distinctUntilChanged()
+                .collectLatest(::loadAvailableMediaTypes)
+        }
+    }
 
     /**
      * Derive the visible media-type chips from the user's libraries (parity with
@@ -64,46 +83,58 @@ class TvSearchViewModel(
      * audio library. "All" is always present. If the active filter becomes
      * unavailable it falls back to All.
      */
-    private fun loadAvailableMediaTypes() {
-        viewModelScope.launch {
-            val libraries = when (val result = personalDataRepository.listUserLibraries()) {
-                is ApiResult.Success -> result.data
-                else -> return@launch
-            }
-            val caps = libraries.tvMediaModeCapabilities()
-            val showAudiobooks = libraryScopeStore.getShowAudiobooksTab()
-            // The "Audiobooks" chip sends type=audiobook, so gate it on an
-            // actual audiobook-like library — hasAudio also covers music, which
-            // wouldn't match the audiobook filter.
-            val hasAudiobooks = libraries.any { isAudiobookLikeLibraryType(it.type) }
-            val types = buildList {
-                add(TvSearchMediaType.All)
-                if (caps.hasVideo) {
-                    add(TvSearchMediaType.Movies)
-                    add(TvSearchMediaType.Series)
+    private suspend fun loadAvailableMediaTypes(visibility: TvAudiobookVisibilityPolicy) {
+        var libraries: List<UserLibrary>? = null
+        for (attempt in 0 until libraryLoadMaxAttempts) {
+            when (val result = personalDataRepository.listUserLibraries()) {
+                is ApiResult.Success -> {
+                    libraries = result.data
+                    break
                 }
-                if (showAudiobooks && hasAudiobooks) add(TvSearchMediaType.Audiobooks)
+                is ApiResult.Error,
+                is ApiResult.NetworkError -> if (attempt < libraryLoadMaxAttempts - 1) {
+                    delay(libraryLoadRetryDelayMillis)
+                }
             }
-            val current = _uiState.value
-            val nextMediaType = if (current.mediaType in types) current.mediaType else TvSearchMediaType.All
-            _uiState.update {
-                it.copy(
-                    availableMediaTypes = types,
-                    mediaType = nextMediaType,
-                    showAudiobooks = showAudiobooks,
-                )
+        }
+        val resolvedLibraries = libraries ?: return
+        val showAudiobooks = visibility.resolve(resolvedLibraries)
+        val caps = resolvedLibraries.tvMediaModeCapabilities()
+        // The "Audiobooks" chip sends type=audiobook, so gate it on an
+        // actual audiobook-like library — hasAudio also covers music, which
+        // wouldn't match the audiobook filter.
+        val hasAudiobooks = resolvedLibraries.any { isAudiobookLikeLibraryType(it.type) }
+        val types = buildList {
+            add(TvSearchMediaType.All)
+            if (caps.hasVideo) {
+                add(TvSearchMediaType.Movies)
+                add(TvSearchMediaType.Series)
             }
-            // If the active filter was forced to change while a query is live,
-            // re-run so results aren't left stale under the old filter.
-            if (
-                (nextMediaType != current.mediaType || showAudiobooks != current.showAudiobooks) &&
-                current.query.isNotBlank()
-            ) {
-                searchGeneration += 1
-                searchJob?.cancel()
-                loadMoreJob?.cancel()
-                searchJob = viewModelScope.launch { runSearchInternal(reset = true) }
-            }
+            if (showAudiobooks && hasAudiobooks) add(TvSearchMediaType.Audiobooks)
+        }
+        val current = _uiState.value
+        val nextMediaType = if (current.mediaType in types) {
+            current.mediaType
+        } else {
+            TvSearchMediaType.All
+        }
+        _uiState.update {
+            it.copy(
+                availableMediaTypes = types,
+                mediaType = nextMediaType,
+                showAudiobooks = showAudiobooks,
+            )
+        }
+        // If the active filter was forced to change while a query is live,
+        // re-run so results aren't left stale under the old filter.
+        if (
+            (nextMediaType != current.mediaType || showAudiobooks != current.showAudiobooks) &&
+            current.query.isNotBlank()
+        ) {
+            searchGeneration += 1
+            searchJob?.cancel()
+            loadMoreJob?.cancel()
+            searchJob = viewModelScope.launch { runSearchInternal(reset = true) }
         }
     }
 
@@ -120,6 +151,11 @@ class TvSearchViewModel(
     // query's results (it sent the new query at the old query's offset otherwise).
     private var searchGeneration = 0
     private var resultsGeneration = 0
+
+    private companion object {
+        const val libraryLoadMaxAttempts = 3
+        const val libraryLoadRetryDelayMillis = 400L
+    }
 
     fun onQueryChanged(query: String) {
         searchGeneration += 1

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
@@ -92,6 +92,12 @@ import org.siloserver.silo.model.settings.LanguageOptions
 import org.siloserver.silo.domain.player.IntroSkipMode
 import org.siloserver.silo.domain.settings.ProfileSettingsController
 import org.siloserver.silo.model.settings.QualityPresets
+import org.siloserver.silo.model.settings.CardCaptionPreset
+import org.siloserver.silo.model.settings.CardPresentation
+import org.siloserver.silo.model.settings.CardPresentationPreset
+import org.siloserver.silo.model.settings.PosterSizePreset
+import org.siloserver.silo.model.settings.PrimaryMenuItem
+import org.siloserver.silo.model.settings.UiCustomizationCodec
 import org.siloserver.silo.model.settings.SettingKeys
 import org.siloserver.silo.model.settings.SubtitleBackgroundStylePreset
 import org.siloserver.silo.model.settings.SubtitleAppearance
@@ -153,6 +159,18 @@ fun TvSettingsScreen(
     var categoryColumnHasFocus by remember { mutableStateOf(false) }
     var detailFocusRequest by remember { mutableStateOf(0) }
     var showSignOutConfirm by remember { mutableStateOf(false) }
+    var unresolvedCustomizationFocusFallback by remember { mutableStateOf(false) }
+    LaunchedEffect(state.uiCustomizationSupport) {
+        unresolvedCustomizationFocusFallback = false
+        if (state.uiCustomizationSupport == null) {
+            delay(UiCustomizationFocusFallbackDelayMillis)
+            unresolvedCustomizationFocusFallback = true
+        }
+    }
+    val generalInitialFocusTarget = tvGeneralInitialFocusTarget(
+        state = state,
+        allowUnresolvedReadOnly = unresolvedCustomizationFocusFallback,
+    )
 
     LaunchedEffect(Unit) {
         // Was four attempts judged on requestFocus() returning true — that is
@@ -198,8 +216,16 @@ fun TvSettingsScreen(
             .claimFocusOrReport(target = "settings_category", action = "eligibility_fallback")
     }
 
-    LaunchedEffect(detailFocusRequest) {
+    LaunchedEffect(detailFocusRequest, selectedCategory, generalInitialFocusTarget) {
         if (detailFocusRequest > 0) {
+            // The General pane defers its own initial focus while the
+            // customization capability is still unresolved: claiming the detail
+            // column now would land on a row that is about to be replaced.
+            if (selectedCategory == TvSettingsCategory.General &&
+                generalInitialFocusTarget == TvGeneralInitialFocusTarget.DEFER
+            ) {
+                return@LaunchedEffect
+            }
             requestFocusUntilObserved(
                 maxAttempts = TvContentInitialFocusMaxAttempts,
                 awaitAttempt = { withFrameNanos { } },
@@ -237,6 +263,7 @@ fun TvSettingsScreen(
         diagnosticsState = diagnosticsState,
         diagnosticsViewModel = diagnosticsViewModel,
         selectedCategory = selectedCategory,
+        generalInitialFocusTarget = generalInitialFocusTarget,
         categoryFocusRequesters = categoryFocusRequesters,
         detailFocusRequester = detailFocusRequester,
         onDetailFocusChanged = { detailHasFocus = it },
@@ -280,6 +307,15 @@ fun TvSettingsScreen(
         onSubtitleDeviceOverrideEnabledChanged = viewModel::setSubtitleDeviceOverrideEnabled,
         onSubtitleMatchesDeviceChanged = viewModel::onSubtitleMatchesDeviceChanged,
         onShowAudiobooksTabChanged = viewModel::onShowAudiobooksTabChanged,
+        onNavigationPresetSelected = viewModel::setNavigationPreset,
+        onMoveMenuItem = viewModel::moveMenuItem,
+        onRemoveMenuItem = viewModel::removeMenuItem,
+        onAddMenuItem = viewModel::addMenuItem,
+        onUnpinShortcut = viewModel::unpinShortcut,
+        onCardPresentationPresetChanged = viewModel::setCardPresentationPreset,
+        onPosterSizeChanged = viewModel::setPosterSize,
+        onCardCaptionChanged = viewModel::setCardCaption,
+        onUseFamilyInterfaceSettings = viewModel::useFamilyInterfaceSettings,
     )
 
     if (showSignOutConfirm) {
@@ -374,6 +410,7 @@ private fun SettingsSplitLayout(
     diagnosticsState: org.siloserver.silo.common.diagnostics.DiagnosticsUiState,
     diagnosticsViewModel: TvDiagnosticsViewModel,
     selectedCategory: TvSettingsCategory,
+    generalInitialFocusTarget: TvGeneralInitialFocusTarget,
     categoryFocusRequesters: Map<TvSettingsCategory, FocusRequester>,
     detailFocusRequester: FocusRequester,
     onDetailFocusChanged: (Boolean) -> Unit,
@@ -383,6 +420,15 @@ private fun SettingsSplitLayout(
     onCategorySelected: (TvSettingsCategory) -> Unit,
     onEnterCategory: (TvSettingsCategory) -> Unit,
     onShowAudiobooksTabChanged: (Boolean) -> Unit,
+    onNavigationPresetSelected: (TvSettingsViewModel.NavigationPreset) -> Unit,
+    onMoveMenuItem: (String, Int) -> Unit,
+    onRemoveMenuItem: (String) -> Unit,
+    onAddMenuItem: (String) -> Unit,
+    onUnpinShortcut: (String) -> Unit,
+    onCardPresentationPresetChanged: (CardPresentationPreset) -> Unit,
+    onPosterSizeChanged: (PosterSizePreset) -> Unit,
+    onCardCaptionChanged: (CardCaptionPreset) -> Unit,
+    onUseFamilyInterfaceSettings: () -> Unit,
     onSwitchProfile: () -> Unit,
     onManageServers: () -> Unit,
     onOpenDiagnosticsReport: (reportId: String) -> Unit,
@@ -437,6 +483,7 @@ private fun SettingsSplitLayout(
         SettingsRail(
             state = state,
             visibleCategories = tvSettingsVisibleCategories(diagnosticsState.profileEligible),
+            generalInitialFocusTarget = generalInitialFocusTarget,
             selectedCategory = selectedCategory,
             categoryFocusRequesters = categoryFocusRequesters,
             detailFocusRequester = detailFocusRequester,
@@ -452,12 +499,22 @@ private fun SettingsSplitLayout(
         )
         SettingsDetailPane(
             state = state,
+            generalInitialFocusTarget = generalInitialFocusTarget,
             diagnosticsState = diagnosticsState,
             diagnosticsViewModel = diagnosticsViewModel,
             selectedCategory = selectedCategory,
             detailFocusRequester = detailFocusRequester,
             onDetailFocusChanged = onDetailFocusChanged,
             onShowAudiobooksTabChanged = onShowAudiobooksTabChanged,
+            onNavigationPresetSelected = onNavigationPresetSelected,
+            onMoveMenuItem = onMoveMenuItem,
+            onRemoveMenuItem = onRemoveMenuItem,
+            onAddMenuItem = onAddMenuItem,
+            onUnpinShortcut = onUnpinShortcut,
+            onCardPresentationPresetChanged = onCardPresentationPresetChanged,
+            onPosterSizeChanged = onPosterSizeChanged,
+            onCardCaptionChanged = onCardCaptionChanged,
+            onUseFamilyInterfaceSettings = onUseFamilyInterfaceSettings,
             onManageServers = onManageServers,
             onOpenDiagnosticsReport = onOpenDiagnosticsReport,
             onQualityPresetSelected = onQualityPresetSelected,
@@ -513,6 +570,7 @@ private fun SettingsSplitLayout(
 private fun SettingsRail(
     state: TvSettingsViewModel.UiState,
     visibleCategories: List<TvSettingsCategory>,
+    generalInitialFocusTarget: TvGeneralInitialFocusTarget,
     selectedCategory: TvSettingsCategory,
     categoryFocusRequesters: Map<TvSettingsCategory, FocusRequester>,
     detailFocusRequester: FocusRequester,
@@ -556,7 +614,14 @@ private fun SettingsRail(
                 },
                 // Entry focus lands on General, not the profile row.
                 focusRequester = categoryFocusRequesters.getValue(category),
-                rightFocusRequester = detailFocusRequester,
+                rightFocusRequester = if (
+                    category == TvSettingsCategory.General &&
+                    generalInitialFocusTarget == TvGeneralInitialFocusTarget.DEFER
+                ) {
+                    FocusRequester.Cancel
+                } else {
+                    detailFocusRequester
+                },
             )
         }
         Spacer(modifier = Modifier.weight(1f))
@@ -713,12 +778,22 @@ private fun SettingsRailActionRow(
 @Composable
 private fun SettingsDetailPane(
     state: TvSettingsViewModel.UiState,
+    generalInitialFocusTarget: TvGeneralInitialFocusTarget,
     diagnosticsState: org.siloserver.silo.common.diagnostics.DiagnosticsUiState,
     diagnosticsViewModel: TvDiagnosticsViewModel,
     selectedCategory: TvSettingsCategory,
     detailFocusRequester: FocusRequester,
     onDetailFocusChanged: (Boolean) -> Unit,
     onShowAudiobooksTabChanged: (Boolean) -> Unit,
+    onNavigationPresetSelected: (TvSettingsViewModel.NavigationPreset) -> Unit,
+    onMoveMenuItem: (String, Int) -> Unit,
+    onRemoveMenuItem: (String) -> Unit,
+    onAddMenuItem: (String) -> Unit,
+    onUnpinShortcut: (String) -> Unit,
+    onCardPresentationPresetChanged: (CardPresentationPreset) -> Unit,
+    onPosterSizeChanged: (PosterSizePreset) -> Unit,
+    onCardCaptionChanged: (CardCaptionPreset) -> Unit,
+    onUseFamilyInterfaceSettings: () -> Unit,
     onManageServers: () -> Unit,
     onOpenDiagnosticsReport: (reportId: String) -> Unit,
     /** Receives a [QualityPresets] preset id. */
@@ -778,7 +853,17 @@ private fun SettingsDetailPane(
             TvSettingsCategory.General -> TvGeneralSettingsPane(
                 state = state,
                 firstFocusRequester = detailFocusRequester,
+                initialFocusTarget = generalInitialFocusTarget,
                 onShowAudiobooksTabChanged = onShowAudiobooksTabChanged,
+                onNavigationPresetSelected = onNavigationPresetSelected,
+                onMoveMenuItem = onMoveMenuItem,
+                onRemoveMenuItem = onRemoveMenuItem,
+                onAddMenuItem = onAddMenuItem,
+                onUnpinShortcut = onUnpinShortcut,
+                onCardPresentationPresetChanged = onCardPresentationPresetChanged,
+                onPosterSizeChanged = onPosterSizeChanged,
+                onCardCaptionChanged = onCardCaptionChanged,
+                onUseFamilyInterfaceSettings = onUseFamilyInterfaceSettings,
             )
             TvSettingsCategory.Playback -> TvPlaybackSettingsPane(
                 state = state,
@@ -846,13 +931,72 @@ private fun SettingsDetailPane(
 private fun TvGeneralSettingsPane(
     state: TvSettingsViewModel.UiState,
     firstFocusRequester: FocusRequester,
+    initialFocusTarget: TvGeneralInitialFocusTarget,
     onShowAudiobooksTabChanged: (Boolean) -> Unit,
+    onNavigationPresetSelected: (TvSettingsViewModel.NavigationPreset) -> Unit,
+    onMoveMenuItem: (String, Int) -> Unit,
+    onRemoveMenuItem: (String) -> Unit,
+    onAddMenuItem: (String) -> Unit,
+    onUnpinShortcut: (String) -> Unit,
+    onCardPresentationPresetChanged: (CardPresentationPreset) -> Unit,
+    onPosterSizeChanged: (PosterSizePreset) -> Unit,
+    onCardCaptionChanged: (CardCaptionPreset) -> Unit,
+    onUseFamilyInterfaceSettings: () -> Unit,
 ) {
+    var activePicker by remember { mutableStateOf<GeneralPicker?>(null) }
+    val menuEditingEnabled = state.uiCustomizationAvailable &&
+        !state.primaryMenuUsesDeviceOverride &&
+        state.customizationLibrariesResolved
+    val audiobookToggleEnabled = tvAudiobookToggleEnabled(state)
+    // Same set the ViewModel feeds moveVisibleTvMenuItem: the two projections
+    // must agree or a move offset would address the wrong row.
+    val editorVisibleLibraryIds = remember(state.libraries) {
+        state.libraries.mapTo(mutableSetOf()) { it.id }
+    }
+    val editorMenuItems = remember(state.menuItems, editorVisibleLibraryIds) {
+        visibleTvMenuItems(state.menuItems, editorVisibleLibraryIds)
+    }
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(10.dp),
         contentPadding = PaddingValues(bottom = Spacing.xxxl),
     ) {
+        if (initialFocusTarget == TvGeneralInitialFocusTarget.READ_ONLY) {
+            item {
+                SettingsGroup(title = "Interface Sync") {
+                    SettingsValueRow(
+                        label = "Interface settings",
+                        value = "Temporarily unavailable",
+                        onClick = {},
+                        focusRequester = firstFocusRequester,
+                        showChevron = false,
+                    )
+                    SettingsFooterText(
+                        text = "The server capability could not be resolved. Existing interface settings remain visible but read-only.",
+                    )
+                }
+            }
+        }
+        if (state.uiCustomizationAvailable &&
+            (state.primaryMenuUsesDeviceOverride ||
+            state.cardPresentationUsesDeviceOverride
+            )
+        ) {
+            item {
+                SettingsGroup(title = "Interface Sync") {
+                    SettingsActionRow(
+                        label = "Use Synced TV Settings",
+                        onClick = onUseFamilyInterfaceSettings,
+                        focusRequester = firstFocusRequester.takeIf {
+                            initialFocusTarget == TvGeneralInitialFocusTarget.SYNC
+                        },
+                    )
+                    SettingsFooterText(
+                        text = "This device has older device-specific interface settings. Clear them to use choices shared with other TVs on this profile.",
+                    )
+                }
+            }
+        }
         item {
             // tvOS TVGeneralSettingsPane TOP MENU parity: the Audiobooks tab
             // is opt-in (hidden by default) even when the server has an
@@ -862,19 +1006,259 @@ private fun TvGeneralSettingsPane(
                     label = "Show Audiobooks",
                     checked = state.showAudiobooksTab,
                     onCheckedChange = onShowAudiobooksTabChanged,
-                    focusRequester = firstFocusRequester,
+                    focusRequester = firstFocusRequester.takeIf {
+                        initialFocusTarget == TvGeneralInitialFocusTarget.AUDIOBOOKS
+                    },
+                    enabled = audiobookToggleEnabled,
                 )
+                SettingsValueRow(
+                    label = "Layout Preset",
+                    value = state.navigationPreset.label,
+                    onClick = { activePicker = GeneralPicker.NavigationPreset },
+                    focusRequester = firstFocusRequester.takeIf {
+                        initialFocusTarget == TvGeneralInitialFocusTarget.LAYOUT_PRESET
+                    },
+                    enabled = menuEditingEnabled,
+                )
+                editorMenuItems
+                    .forEachIndexed { position, item ->
+                        val identity = UiCustomizationCodec.identity(item)
+                        SettingsValueRow(
+                            label = item.label,
+                            value = "${position + 1} of ${editorMenuItems.size}",
+                            onClick = { activePicker = GeneralPicker.MenuItem(identity) },
+                            // A profile_device row outranks family sync. Keep
+                            // the effective layout visible but read-only until
+                            // the user explicitly clears that device row.
+                            enabled = menuEditingEnabled &&
+                                (identity != "builtin:home" || editorMenuItems.size > 1),
+                        )
+                    }
+                if (state.addableMenuItems.isNotEmpty()) {
+                    SettingsValueRow(
+                        label = "Add Menu Item",
+                        value = "${state.addableMenuItems.size} available",
+                        onClick = { activePicker = GeneralPicker.AddMenuItem },
+                        enabled = menuEditingEnabled,
+                    )
+                }
                 SettingsFooterText(
-                    text = "Adds an Audiobooks tab to the top menu when your server has an audiobook library. Hidden by default.",
+                    text = when {
+                        !state.uiCustomizationAvailable ->
+                            "Layout and card customization require a newer server. Show Audiobooks remains stored on this TV."
+                        state.customizationLibrariesLoadFailed ->
+                            "Library destinations could not be loaded, so menu changes are disabled. Reopen Settings to retry."
+                        !state.customizationLibrariesResolved ->
+                            "Loading library destinations before enabling menu changes."
+                        state.menuItems.size >= TvPrimaryMenuMaxItems ->
+                            "The top menu has reached its $TvPrimaryMenuMaxItems-item limit. Hide an item before adding another."
+                        state.shortcuts.items.size >= TvNavigationShortcutsMaxItems ->
+                            "The profile has reached its $TvNavigationShortcutsMaxItems-shortcut limit. Unpin a shortcut before adding another library to the menu."
+                        else ->
+                            "Order, visibility, and pinned libraries sync with other TVs on this profile. Search and Profile stay fixed."
+                    },
                 )
             }
         }
-        // No Library group — tvOS parity: Apple's TVSettingsView has no such
-        // section (it is iOS-only). On TV these destinations live in the
-        // For You dropdown (Watchlist/Favorites), the profile menu
-        // (Watchlist/Favorites/History), Home (Browse), and each library's
-        // cascade (Collections). (QA 2026-07-08.)
+        if (state.uiCustomizationAvailable && state.shortcuts.items.isNotEmpty()) {
+            item {
+                SettingsGroup(title = "Pinned Shortcuts") {
+                    SettingsValueRow(
+                        label = "Manage Pinned Shortcuts",
+                        value = "${state.shortcuts.items.size} pinned",
+                        onClick = { activePicker = GeneralPicker.PinnedShortcuts },
+                    )
+                    SettingsFooterText(
+                        text = "Unpinning removes only the profile shortcut. It does not hide or reorder the top menu.",
+                    )
+                }
+            }
+        }
+        item {
+            SettingsGroup(title = "Cards") {
+                SettingsValueRow(
+                    label = "Preset",
+                    value = CardPresentationPreset.matching(
+                        CardPresentation(state.posterSize, state.cardCaption),
+                    )?.label ?: "Custom",
+                    onClick = { activePicker = GeneralPicker.CardPreset },
+                    focusRequester = firstFocusRequester.takeIf {
+                        initialFocusTarget == TvGeneralInitialFocusTarget.CARD_PRESET
+                    },
+                    enabled = state.uiCustomizationAvailable &&
+                        !state.cardPresentationUsesDeviceOverride,
+                )
+                SettingsValueRow(
+                    label = "Poster Size",
+                    value = state.posterSize.label,
+                    onClick = { activePicker = GeneralPicker.PosterSize },
+                    enabled = state.uiCustomizationAvailable &&
+                        !state.cardPresentationUsesDeviceOverride,
+                )
+                SettingsValueRow(
+                    label = "Captions",
+                    value = state.cardCaption.label,
+                    onClick = { activePicker = GeneralPicker.CardCaption },
+                    enabled = state.uiCustomizationAvailable &&
+                        !state.cardPresentationUsesDeviceOverride,
+                )
+                SettingsFooterText(
+                    text = "Applies to poster rows and grids on every TV in this profile's TV family.",
+                )
+            }
+        }
     }
+
+    when (val picker = activePicker) {
+        GeneralPicker.NavigationPreset -> TvSettingsPickerSheet(
+            title = "Top Menu Preset",
+            options = TvSettingsViewModel.NavigationPreset.entries
+                .filterNot { it == TvSettingsViewModel.NavigationPreset.CUSTOM }
+                .map { PickerOption(it.wire, it.label) },
+            selectedId = state.navigationPreset.wire,
+            onSelect = { id ->
+                TvSettingsViewModel.NavigationPreset.entries.firstOrNull { it.wire == id }
+                    ?.let(onNavigationPresetSelected)
+                activePicker = null
+            },
+            onDismiss = { activePicker = null },
+        )
+        GeneralPicker.CardPreset -> TvSettingsPickerSheet(
+            title = "Card Preset",
+            options = CardPresentationPreset.entries.map { PickerOption(it.wire, it.label) },
+            selectedId = CardPresentationPreset.matching(
+                CardPresentation(state.posterSize, state.cardCaption),
+            )?.wire ?: "",
+            onSelect = { id ->
+                CardPresentationPreset.fromWire(id)?.let(onCardPresentationPresetChanged)
+                activePicker = null
+            },
+            onDismiss = { activePicker = null },
+        )
+        GeneralPicker.PosterSize -> TvSettingsPickerSheet(
+            title = "Poster Size",
+            options = PosterSizePreset.entries.map { PickerOption(it.wire, it.label) },
+            selectedId = state.posterSize.wire,
+            onSelect = { id ->
+                PosterSizePreset.entries.firstOrNull { it.wire == id }?.let(onPosterSizeChanged)
+                activePicker = null
+            },
+            onDismiss = { activePicker = null },
+        )
+        GeneralPicker.CardCaption -> TvSettingsPickerSheet(
+            title = "Card Captions",
+            options = CardCaptionPreset.entries.map { PickerOption(it.wire, it.label) },
+            selectedId = state.cardCaption.wire,
+            onSelect = { id ->
+                CardCaptionPreset.entries.firstOrNull { it.wire == id }?.let(onCardCaptionChanged)
+                activePicker = null
+            },
+            onDismiss = { activePicker = null },
+        )
+        GeneralPicker.AddMenuItem -> TvSettingsPickerSheet(
+            title = "Add Menu Item",
+            options = state.addableMenuItems.map {
+                PickerOption(UiCustomizationCodec.identity(it), it.label)
+            },
+            selectedId = "",
+            onSelect = { id -> onAddMenuItem(id); activePicker = null },
+            onDismiss = { activePicker = null },
+        )
+        GeneralPicker.PinnedShortcuts -> TvSettingsPickerSheet(
+            title = "Unpin Shortcut",
+            options = state.shortcuts.items.map {
+                PickerOption(UiCustomizationCodec.identity(it), "Unpin ${it.label}")
+            },
+            selectedId = "",
+            onSelect = { id -> onUnpinShortcut(id); activePicker = null },
+            onDismiss = { activePicker = null },
+        )
+        is GeneralPicker.MenuItem -> {
+            val index = editorMenuItems.indexOfFirst {
+                UiCustomizationCodec.identity(it) == picker.identity
+            }
+            val isHome = picker.identity == "builtin:home"
+            val options = buildList {
+                if (index > 0) add(PickerOption("earlier", "Move Earlier"))
+                if (index in 0 until editorMenuItems.lastIndex) {
+                    add(PickerOption("later", "Move Later"))
+                }
+                if (!isHome) add(PickerOption("hide", "Hide from Menu"))
+            }
+            TvSettingsPickerSheet(
+                title = editorMenuItems.getOrNull(index)?.label ?: "Menu Item",
+                options = options,
+                selectedId = "",
+                onSelect = { action ->
+                    when (action) {
+                        "earlier" -> onMoveMenuItem(picker.identity, -1)
+                        "later" -> onMoveMenuItem(picker.identity, 1)
+                        "hide" -> onRemoveMenuItem(picker.identity)
+                    }
+                    activePicker = null
+                },
+                onDismiss = { activePicker = null },
+            )
+        }
+        null -> Unit
+    }
+}
+
+internal fun tvAudiobookToggleEnabled(state: TvSettingsViewModel.UiState): Boolean =
+    when (state.uiCustomizationSupport) {
+        true -> !state.primaryMenuUsesDeviceOverride &&
+            state.customizationLibrariesResolved &&
+            (state.showAudiobooksTab || canEnableTvAudiobooksTab(state.menuItems))
+        false -> true
+        null -> false
+    }
+
+internal enum class TvGeneralInitialFocusTarget {
+    SYNC,
+    AUDIOBOOKS,
+    LAYOUT_PRESET,
+    CARD_PRESET,
+    READ_ONLY,
+    DEFER,
+}
+
+/** Selects exactly one attached, enabled General row, or defers while support is unknown. */
+internal fun tvGeneralInitialFocusTarget(
+    state: TvSettingsViewModel.UiState,
+    allowUnresolvedReadOnly: Boolean = false,
+): TvGeneralInitialFocusTarget {
+    if (state.uiCustomizationSupport == null) {
+        return if (allowUnresolvedReadOnly) {
+            TvGeneralInitialFocusTarget.READ_ONLY
+        } else {
+            TvGeneralInitialFocusTarget.DEFER
+        }
+    }
+    if (state.uiCustomizationAvailable &&
+        (state.primaryMenuUsesDeviceOverride || state.cardPresentationUsesDeviceOverride)
+    ) {
+        return TvGeneralInitialFocusTarget.SYNC
+    }
+    if (tvAudiobookToggleEnabled(state)) return TvGeneralInitialFocusTarget.AUDIOBOOKS
+
+    val menuEditingEnabled = state.uiCustomizationAvailable &&
+        !state.primaryMenuUsesDeviceOverride &&
+        state.customizationLibrariesResolved
+    if (menuEditingEnabled) return TvGeneralInitialFocusTarget.LAYOUT_PRESET
+    if (state.uiCustomizationAvailable && !state.cardPresentationUsesDeviceOverride) {
+        return TvGeneralInitialFocusTarget.CARD_PRESET
+    }
+    return TvGeneralInitialFocusTarget.DEFER
+}
+
+private sealed interface GeneralPicker {
+    data object NavigationPreset : GeneralPicker
+    data object CardPreset : GeneralPicker
+    data object PosterSize : GeneralPicker
+    data object CardCaption : GeneralPicker
+    data object AddMenuItem : GeneralPicker
+    data object PinnedShortcuts : GeneralPicker
+    data class MenuItem(val identity: String) : GeneralPicker
 }
 
 @Composable
@@ -1983,6 +2367,7 @@ internal fun SettingsValueRow(
     focusRequester: FocusRequester? = null,
     enabled: Boolean = true,
     modifier: Modifier = Modifier,
+    showChevron: Boolean = true,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
@@ -2027,15 +2412,19 @@ internal fun SettingsValueRow(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            Icon(
-                imageVector = Icons.Default.ChevronRight,
-                contentDescription = null,
-                tint = (if (isFocused) FocusedContent else Color.White).copy(alpha = 0.55f),
-                modifier = Modifier.size(14.dp),
-            )
+            if (showChevron) {
+                Icon(
+                    imageVector = Icons.Default.ChevronRight,
+                    contentDescription = null,
+                    tint = (if (isFocused) FocusedContent else Color.White).copy(alpha = 0.55f),
+                    modifier = Modifier.size(14.dp),
+                )
+            }
         }
     }
 }
+
+private const val UiCustomizationFocusFallbackDelayMillis = 1_500L
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
@@ -6,10 +6,24 @@ import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.common.settings.LibraryPlaybackPrefsStore
 import org.siloserver.silo.common.settings.OverlayPrefsStore
 import org.siloserver.silo.common.settings.PlayerSettingsStore
+import org.siloserver.silo.common.settings.UiCustomizationStore
 import org.siloserver.silo.model.auth.User
 import org.siloserver.silo.domain.player.IntroSkipMode
 import org.siloserver.silo.domain.settings.ProfileSettingsController
 import org.siloserver.silo.model.settings.QualityPresets
+import org.siloserver.silo.model.settings.CardCaptionPreset
+import org.siloserver.silo.model.settings.CardPresentationPreset
+import org.siloserver.silo.model.settings.NavigationShortcuts
+import org.siloserver.silo.model.settings.PosterSizePreset
+import org.siloserver.silo.model.settings.PrimaryMenu
+import org.siloserver.silo.model.settings.PrimaryMenuBuiltin
+import org.siloserver.silo.model.settings.PrimaryMenuItem
+import org.siloserver.silo.model.settings.SettingScope
+import org.siloserver.silo.model.settings.UiCustomizationCodec
+import org.siloserver.silo.model.settings.UiCustomizationLimits
+import org.siloserver.silo.model.settings.effectiveCardPresentationForSupport
+import org.siloserver.silo.model.settings.effectivePrimaryMenuForSupport
+import org.siloserver.silo.model.settings.supportsUiCustomization
 import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.model.settings.SubtitleBackgroundStylePreset
 import org.siloserver.silo.model.settings.SubtitleFontSizePreset
@@ -19,9 +33,13 @@ import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.repository.AuthRepository
 import org.siloserver.silo.repository.ProfileRepository
+import org.siloserver.silo.repository.PersonalDataRepository
 import org.siloserver.silo.tv.data.preferences.LegacyTvPrefsMigration
 import org.siloserver.silo.tv.data.preferences.SubtitleMode
 import org.siloserver.silo.tv.data.preferences.SubtitleSize
+import org.siloserver.silo.tv.ui.shell.TvLibraryTabType
+import org.siloserver.silo.tv.ui.shell.resolvedTvAudiobookVisibility
+import org.siloserver.silo.tv.ui.util.visibleOnTv
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,6 +48,207 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+
+internal const val TvPrimaryMenuMaxItems = UiCustomizationLimits.MAX_PRIMARY_MENU_ITEMS
+internal const val TvNavigationShortcutsMaxItems = UiCustomizationLimits.MAX_NAVIGATION_SHORTCUT_ITEMS
+
+internal sealed interface TvNavigationPresetMutation {
+    data object ResetPrimaryMenu : TvNavigationPresetMutation
+    data class SetPrimaryMenu(val value: PrimaryMenu) : TvNavigationPresetMutation
+}
+
+internal fun prepareTvNavigationPresetMutation(
+    preset: TvSettingsViewModel.NavigationPreset,
+    libraries: List<org.siloserver.silo.model.personal.UserLibrary>,
+    showAudiobooks: Boolean,
+    librariesResolved: Boolean,
+): TvNavigationPresetMutation? {
+    if (!librariesResolved || preset == TvSettingsViewModel.NavigationPreset.CUSTOM) return null
+    return when (preset) {
+        // Standard is the native, availability-aware baseline. Clearing the
+        // authored family row keeps it dynamic as libraries are added or
+        // removed instead of freezing today's resolved library types.
+        TvSettingsViewModel.NavigationPreset.STANDARD ->
+            TvNavigationPresetMutation.ResetPrimaryMenu
+        TvSettingsViewModel.NavigationPreset.MEDIA_FIRST ->
+            TvNavigationPresetMutation.SetPrimaryMenu(
+                mediaFirstTvMenu(libraries, showAudiobooks),
+            )
+        TvSettingsViewModel.NavigationPreset.MINIMAL ->
+            TvNavigationPresetMutation.SetPrimaryMenu(minimalTvMenu())
+        TvSettingsViewModel.NavigationPreset.CUSTOM -> null
+    }
+}
+
+internal fun standardTvMenu(
+    libraries: List<org.siloserver.silo.model.personal.UserLibrary>,
+    showAudiobooks: Boolean,
+): PrimaryMenu = PrimaryMenu(
+    buildList {
+        add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME))
+        if (libraries.any(TvLibraryTabType.Movies::matches)) {
+            add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES))
+        }
+        if (libraries.any(TvLibraryTabType.Series::matches)) {
+            add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.SERIES))
+        }
+        if (libraries.any(TvLibraryTabType.Music::matches)) {
+            add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MUSIC))
+        }
+        if (showAudiobooks && libraries.any(TvLibraryTabType.Audiobooks::matches)) {
+            add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS))
+        }
+        add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU))
+        add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR))
+    },
+)
+
+internal fun mediaFirstTvMenu(
+    libraries: List<org.siloserver.silo.model.personal.UserLibrary>,
+    showAudiobooks: Boolean,
+): PrimaryMenu {
+    val standard = standardTvMenu(libraries, showAudiobooks).items
+    val home = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME)
+    val personal = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU)
+    val calendar = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR)
+    val media = standard.filterNot { it == home || it == personal || it == calendar }
+    return PrimaryMenu(media + home + personal + calendar)
+}
+
+internal fun minimalTvMenu(): PrimaryMenu = PrimaryMenu(
+    listOf(
+        PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+        PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+    ),
+)
+
+/**
+ * Prepares the two documents produced by adding a TV menu item. Returning
+ * `null` means the edit would violate a server contract limit and therefore
+ * must be rejected before either optimistic store write starts.
+ */
+internal data class TvMenuItemAddition(
+    val primaryMenu: PrimaryMenu,
+    val shortcuts: NavigationShortcuts?,
+)
+
+internal fun prepareTvMenuItemAddition(
+    menuItems: List<PrimaryMenuItem>,
+    currentShortcuts: NavigationShortcuts,
+    item: PrimaryMenuItem,
+): TvMenuItemAddition? {
+    val identity = UiCustomizationCodec.identity(item)
+    if (menuItems.size >= TvPrimaryMenuMaxItems ||
+        menuItems.any { UiCustomizationCodec.identity(it) == identity }
+    ) {
+        return null
+    }
+
+    val needsShortcut = item is PrimaryMenuItem.Library &&
+        currentShortcuts.items.none { UiCustomizationCodec.identity(it) == identity }
+    val shortcuts = when {
+        !needsShortcut -> null
+        currentShortcuts.items.size >= TvNavigationShortcutsMaxItems -> return null
+        else -> NavigationShortcuts(currentShortcuts.items + item)
+    }
+
+    return TvMenuItemAddition(
+        primaryMenu = PrimaryMenu(menuItems + item),
+        shortcuts = shortcuts,
+    )
+}
+
+internal fun canEnableTvAudiobooksTab(menuItems: List<PrimaryMenuItem>): Boolean =
+    PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS) in menuItems ||
+    menuItems.size < TvPrimaryMenuMaxItems
+
+internal fun resolvedTvAudiobooksTab(
+    effectiveMenu: PrimaryMenu?,
+    legacyFallback: Boolean,
+    libraries: List<org.siloserver.silo.model.personal.UserLibrary> = emptyList(),
+): Boolean = resolvedTvAudiobookVisibility(
+    primaryMenu = effectiveMenu,
+    uiCustomizationSupported = true,
+    legacyFallback = legacyFallback,
+    libraries = libraries,
+)
+
+internal fun tvUiCustomizationAvailable(
+    result: ProfileSettingsController.LoadResult,
+): Boolean = tvUiCustomizationSupport(result) == true
+
+internal fun tvUiCustomizationSupport(
+    result: ProfileSettingsController.LoadResult,
+): Boolean? {
+    val capabilities = result.capabilities
+    return when {
+        capabilities != null -> capabilities.supportsUiCustomization
+        result.availability ==
+            ProfileSettingsController.Availability.SERVER_UPGRADE_REQUIRED -> false
+        // A successful probe always carries its decoded capabilities. Treat a
+        // malformed/manual AVAILABLE result without them as confirmed unusable.
+        result.availability == ProfileSettingsController.Availability.AVAILABLE -> false
+        else -> null
+    }
+}
+
+internal fun TvSettingsViewModel.UiState.withObservedUiCustomizationSupport(
+    supported: Boolean?,
+): TvSettingsViewModel.UiState = copy(uiCustomizationSupport = supported)
+
+/**
+ * Materializes an inherited native menu when the legacy audiobook toggle is
+ * changed so the choice becomes a real family-synced document. Returning
+ * `null` means an existing override already expresses the requested state.
+ * Callers must apply [canEnableTvAudiobooksTab] before enabling.
+ */
+internal fun prepareTvAudiobookMenuWrite(
+    currentOverride: PrimaryMenu?,
+    inheritedMenu: PrimaryMenu,
+    enabled: Boolean,
+): PrimaryMenu? {
+    val currentItems = currentOverride?.items ?: inheritedMenu.items
+    val audiobook = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS)
+    val nextItems = if (enabled) {
+        if (audiobook in currentItems) {
+            currentItems
+        } else {
+            val insertAt = currentItems.indexOfFirst {
+                it == PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU)
+            }.takeIf { it >= 0 } ?: currentItems.size
+            currentItems.toMutableList().apply { add(insertAt, audiobook) }
+        }
+    } else {
+        currentItems.filterNot { it == audiobook }
+    }
+    return PrimaryMenu(nextItems).takeIf {
+        currentOverride == null || nextItems != currentItems
+    }
+}
+
+internal data class TvAudiobookToggleMutation(
+    val legacyValue: Boolean,
+    val primaryMenu: PrimaryMenu?,
+)
+
+/** Route the pre-contract toggle locally, and only author a menu when supported. */
+internal fun prepareTvAudiobookToggleMutation(
+    customizationAvailable: Boolean,
+    currentOverride: PrimaryMenu?,
+    inheritedMenu: PrimaryMenu?,
+    enabled: Boolean,
+): TvAudiobookToggleMutation = TvAudiobookToggleMutation(
+    legacyValue = enabled,
+    primaryMenu = if (customizationAvailable) {
+        prepareTvAudiobookMenuWrite(
+            currentOverride = currentOverride,
+            inheritedMenu = checkNotNull(inheritedMenu),
+            enabled = enabled,
+        )
+    } else {
+        null
+    },
+)
 
 /**
  * ViewModel for the TV settings screen. Server-managed device settings
@@ -54,10 +273,19 @@ class TvSettingsViewModel(
     private val overlayPrefsStore: OverlayPrefsStore,
     private val legacyTvPrefsMigration: LegacyTvPrefsMigration,
     private val profileSettings: ProfileSettingsController,
+    private val personalDataRepository: PersonalDataRepository,
+    private val uiCustomizationStore: UiCustomizationStore,
     private val tvLibraryScopeStore: org.siloserver.silo.tv.data.preferences.TvLibraryScopeStore? = null,
 ) : ViewModel() {
 
     enum class NavAction { SIGNED_OUT, SWITCH_PROFILE }
+
+    enum class NavigationPreset(val wire: String, val label: String) {
+        STANDARD("standard", "Standard"),
+        MEDIA_FIRST("media_first", "Media first"),
+        MINIMAL("minimal", "Minimal"),
+        CUSTOM("custom", "Custom"),
+    }
 
     data class UiState(
         val user: User? = null,
@@ -73,6 +301,8 @@ class TvSettingsViewModel(
         // showing rows whose edits go nowhere; playback is unaffected.
         val settingsAvailability: ProfileSettingsController.Availability =
             ProfileSettingsController.Availability.UNKNOWN,
+        /** true=supported, false=confirmed incompatible, null=not resolved/transient failure. */
+        val uiCustomizationSupport: Boolean? = null,
         // Quality is two orthogonal values behind one picker:
         // playback.preferred_quality (resolution) and
         // playback.max_bitrate_kbps (bandwidth; null = uncapped). The preset
@@ -98,7 +328,25 @@ class TvSettingsViewModel(
         val introSkipMode: IntroSkipMode = IntroSkipMode.Default,
         val matchContentFrameRate: Boolean = false,
         val dolbyVisionEnabled: Boolean = true,
-        val showAudiobooksTab: Boolean = false,
+        /** Local fallback used only while no server-authored primary menu is effective. */
+        val legacyShowAudiobooksTab: Boolean = false,
+        val posterSize: PosterSizePreset = PosterSizePreset.STANDARD,
+        val cardCaption: CardCaptionPreset = CardCaptionPreset.TITLE_METADATA,
+        val primaryMenuOverride: PrimaryMenu? = null,
+        val primaryMenuUsesDeviceOverride: Boolean = false,
+        val cardPresentationUsesDeviceOverride: Boolean = false,
+        val menuItems: List<PrimaryMenuItem> = listOf(
+            PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+            PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+            PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR),
+        ),
+        val addableMenuItems: List<PrimaryMenuItem> = emptyList(),
+        val navigationPreset: NavigationPreset = NavigationPreset.STANDARD,
+        val libraries: List<org.siloserver.silo.model.personal.UserLibrary> = emptyList(),
+        /** True only after the library request succeeds, including an empty result. */
+        val customizationLibrariesResolved: Boolean = false,
+        val customizationLibrariesLoadFailed: Boolean = false,
+        val shortcuts: NavigationShortcuts = NavigationShortcuts.EMPTY,
         val subtitleMatchesDevice: Boolean = false,
         val dvProfile7HDR10Fallback: Boolean = true,
         val autoSkipCredits: Boolean = false,
@@ -110,7 +358,26 @@ class TvSettingsViewModel(
         // (0 = at the very end). Mirrors tvOS `nextUpPromptSeconds`.
         val nextUpPromptSeconds: Int = 10,
         val navAction: NavAction? = null,
-    )
+    ) {
+        /** Presentation may remain cached while UNKNOWN, but revision-5 writes must stay disabled. */
+        val uiCustomizationAvailable: Boolean
+            get() = canAuthorUiCustomization
+
+        internal val canAuthorUiCustomization: Boolean
+            get() = uiCustomizationSupport == true
+
+        /**
+         * A resolved family/device menu is authoritative. The old local flag
+         * remains only as the native-menu fallback when no menu row exists.
+         */
+        val showAudiobooksTab: Boolean
+            get() = resolvedTvAudiobookVisibility(
+                primaryMenu = primaryMenuOverride,
+                uiCustomizationSupported = uiCustomizationSupport,
+                legacyFallback = legacyShowAudiobooksTab,
+                libraries = libraries,
+            )
+    }
 
     private val _uiState = MutableStateFlow(UiState())
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
@@ -119,6 +386,8 @@ class TvSettingsViewModel(
         loadUser()
         loadSettings()
         observePlayerSettings()
+        observeUiCustomization()
+        loadCustomizationLibraries()
     }
 
     /**
@@ -203,10 +472,237 @@ class TvSettingsViewModel(
             // The store writes them to its DataStore; observePlayerSettings()
             // mirrors them into _uiState.
             playerSettingsStore.refreshFromServer()
+            uiCustomizationStore.refresh()
 
             loadProfileSettings()
         }
     }
+
+    private fun observeUiCustomization() {
+        viewModelScope.launch {
+            combine(
+                uiCustomizationStore.primaryMenu,
+                uiCustomizationStore.shortcuts,
+                uiCustomizationStore.cardPresentation,
+                uiCustomizationStore.primaryMenuSource,
+                uiCustomizationStore.cardPresentationSource,
+            ) { menu, shortcuts, card, menuSource, cardSource ->
+                CustomizationSnapshot(menu, shortcuts, card, menuSource, cardSource, null)
+            }
+                .combine(uiCustomizationStore.uiCustomizationSupported) { snapshot, supported ->
+                    snapshot.copy(supported = supported)
+                }
+                .collect { customization ->
+                    _uiState.update { state ->
+                        val support = customization.supported
+                        val menu = effectivePrimaryMenuForSupport(
+                            customization.menu,
+                            support,
+                        )
+                        val card = effectiveCardPresentationForSupport(
+                            customization.card,
+                            support,
+                        )
+                        projectMenu(
+                            state.withObservedUiCustomizationSupport(support).copy(
+                                primaryMenuOverride = menu,
+                                shortcuts = customization.shortcuts,
+                                posterSize = card.posterSize,
+                                cardCaption = card.caption,
+                                primaryMenuUsesDeviceOverride =
+                                    customization.menuSource == SettingScope.PROFILE_DEVICE.wire,
+                                cardPresentationUsesDeviceOverride =
+                                    customization.cardSource == SettingScope.PROFILE_DEVICE.wire,
+                            ),
+                        )
+                    }
+                }
+        }
+    }
+
+    private data class CustomizationSnapshot(
+        val menu: PrimaryMenu?,
+        val shortcuts: NavigationShortcuts,
+        val card: org.siloserver.silo.model.settings.CardPresentation,
+        val menuSource: String?,
+        val cardSource: String?,
+        val supported: Boolean?,
+    )
+
+    private fun loadCustomizationLibraries() {
+        viewModelScope.launch {
+            when (val result = personalDataRepository.listUserLibraries()) {
+                is ApiResult.Success -> _uiState.update { state ->
+                    projectMenu(
+                        state.copy(
+                            libraries = result.data.visibleOnTv().sortedBy { it.sortOrder },
+                            customizationLibrariesResolved = true,
+                            customizationLibrariesLoadFailed = false,
+                        ),
+                    )
+                }
+                is ApiResult.Error, is ApiResult.NetworkError -> _uiState.update { state ->
+                    state.copy(
+                        customizationLibrariesResolved = false,
+                        customizationLibrariesLoadFailed = true,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun projectMenu(state: UiState): UiState {
+        val standard = standardTvMenu(state.libraries, state.showAudiobooksTab)
+        val effective = effectivePrimaryMenuForSupport(
+            state.primaryMenuOverride,
+            state.uiCustomizationSupport,
+        ) ?: standard
+        val candidates = menuCandidates(state.libraries)
+        val existing = effective.items.map(UiCustomizationCodec::identity).toSet()
+        val preset = when (effective.items.map(UiCustomizationCodec::identity)) {
+            standard.items.map(UiCustomizationCodec::identity) -> NavigationPreset.STANDARD
+            mediaFirstTvMenu(state.libraries, state.showAudiobooksTab).items
+                .map(UiCustomizationCodec::identity) -> NavigationPreset.MEDIA_FIRST
+            minimalTvMenu().items.map(UiCustomizationCodec::identity) -> NavigationPreset.MINIMAL
+            else -> NavigationPreset.CUSTOM
+        }
+        return state.copy(
+            menuItems = effective.items,
+            addableMenuItems = candidates.filter { candidate ->
+                UiCustomizationCodec.identity(candidate) !in existing &&
+                    prepareTvMenuItemAddition(
+                        menuItems = effective.items,
+                        currentShortcuts = state.shortcuts,
+                        item = candidate,
+                    ) != null
+            },
+            navigationPreset = preset,
+        )
+    }
+
+    fun setNavigationPreset(preset: NavigationPreset) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.primaryMenuUsesDeviceOverride) return
+        val state = _uiState.value
+        when (val mutation = prepareTvNavigationPresetMutation(
+            preset = preset,
+            libraries = state.libraries,
+            showAudiobooks = state.showAudiobooksTab,
+            librariesResolved = state.customizationLibrariesResolved,
+        )) {
+            TvNavigationPresetMutation.ResetPrimaryMenu ->
+                uiCustomizationStore.resetPrimaryMenu()
+            is TvNavigationPresetMutation.SetPrimaryMenu ->
+                uiCustomizationStore.setPrimaryMenu(mutation.value)
+            null -> Unit
+        }
+    }
+
+    fun moveMenuItem(identity: String, offset: Int) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.primaryMenuUsesDeviceOverride) return
+        if (!_uiState.value.customizationLibrariesResolved) return
+        // The editor's own projection: state.libraries is already visibleOnTv()
+        // filtered, so a foreign ebook pin is never an offset target.
+        val visibleLibraryIds = _uiState.value.libraries.mapTo(mutableSetOf()) { it.id }
+        val fallback = PrimaryMenu(editableMenuItems())
+        uiCustomizationStore.updatePrimaryMenu(fallback) { current ->
+            val moved = moveVisibleTvMenuItem(
+                items = current.items,
+                identity = identity,
+                offset = offset,
+                visibleLibraryIds = visibleLibraryIds,
+            ) ?: return@updatePrimaryMenu current
+            PrimaryMenu(moved)
+        }
+    }
+
+    fun removeMenuItem(identity: String) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.primaryMenuUsesDeviceOverride) return
+        if (!_uiState.value.customizationLibrariesResolved) return
+        if (identity == "builtin:home") return
+        val fallback = PrimaryMenu(editableMenuItems())
+        uiCustomizationStore.updatePrimaryMenu(fallback) { current ->
+            PrimaryMenu(
+                current.items.filterNot { UiCustomizationCodec.identity(it) == identity },
+            )
+        }
+    }
+
+    fun addMenuItem(identity: String) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.primaryMenuUsesDeviceOverride) return
+        if (!_uiState.value.customizationLibrariesResolved) return
+        val item = _uiState.value.addableMenuItems
+            .firstOrNull { UiCustomizationCodec.identity(it) == identity } ?: return
+        prepareTvMenuItemAddition(
+            menuItems = editableMenuItems(),
+            currentShortcuts = uiCustomizationStore.shortcuts.value,
+            item = item,
+        ) ?: return
+
+        val fallback = PrimaryMenu(editableMenuItems())
+        val prepare: (PrimaryMenu) -> PrimaryMenu? = { current ->
+            prepareTvMenuItemAddition(
+                menuItems = current.items,
+                currentShortcuts = uiCustomizationStore.shortcuts.value,
+                item = item,
+            )?.primaryMenu
+        }
+        if (item !is PrimaryMenuItem.Builtin) {
+            uiCustomizationStore.updatePrimaryMenuAndShortcut(
+                fallback = fallback,
+                item = item,
+                present = true,
+                transform = prepare,
+            )
+        } else {
+            uiCustomizationStore.updatePrimaryMenu(fallback) { current ->
+                prepare(current) ?: current
+            }
+        }
+    }
+
+    fun setPosterSize(value: PosterSizePreset) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.cardPresentationUsesDeviceOverride) return
+        uiCustomizationStore.updateCardPresentation { current ->
+            current.copy(posterSize = value)
+        }
+    }
+
+    fun setCardPresentationPreset(value: CardPresentationPreset) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.cardPresentationUsesDeviceOverride) return
+        uiCustomizationStore.setCardPresentation(value.presentation)
+    }
+
+    fun setCardCaption(value: CardCaptionPreset) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        if (_uiState.value.cardPresentationUsesDeviceOverride) return
+        uiCustomizationStore.updateCardPresentation { current ->
+            current.copy(caption = value)
+        }
+    }
+
+    fun useFamilyInterfaceSettings() {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        uiCustomizationStore.useFamilySettings()
+    }
+
+    /** Remove only the profile shortcut; the top-menu layout is intentionally unchanged. */
+    fun unpinShortcut(identity: String) {
+        if (!_uiState.value.canAuthorUiCustomization) return
+        val item = _uiState.value.shortcuts.items.firstOrNull {
+            UiCustomizationCodec.identity(it) == identity
+        } ?: return
+        uiCustomizationStore.setShortcutPresent(item, present = false)
+    }
+
+    private fun editableMenuItems(): List<PrimaryMenuItem> =
+        _uiState.value.primaryMenuOverride?.items
+            ?: standardTvMenu(_uiState.value.libraries, _uiState.value.showAudiobooksTab).items
 
     /**
      * Resolves the profile-scoped preferences through the canonical settings
@@ -221,18 +717,24 @@ class TvSettingsViewModel(
         viewModelScope.launch {
             val result = profileSettings.load()
             _uiState.update { state ->
-                val snapshot = result.snapshot ?: return@update state.copy(
-                    settingsAvailability = result.availability,
-                )
-                state.copy(
-                    settingsAvailability = result.availability,
-                    subtitleMode = SubtitleMode.fromWire(snapshot.subtitleMode),
-                    subtitleLanguage = snapshot.subtitleLanguage,
-                    metadataLanguage = snapshot.metadataLanguage,
-                    showForcedSubtitles = snapshot.showForcedSubtitles,
-                    audioLanguageSuggestions = snapshot.audioLanguageSuggestions,
-                    subtitleLanguageSuggestions = snapshot.subtitleLanguageSuggestions,
-                    metadataLanguageSuggestions = snapshot.metadataLanguageSuggestions,
+                val snapshot = result.snapshot
+                projectMenu(
+                    if (snapshot == null) {
+                        state.copy(
+                            settingsAvailability = result.availability,
+                        )
+                    } else {
+                        state.copy(
+                            settingsAvailability = result.availability,
+                            subtitleMode = SubtitleMode.fromWire(snapshot.subtitleMode),
+                            subtitleLanguage = snapshot.subtitleLanguage,
+                            metadataLanguage = snapshot.metadataLanguage,
+                            showForcedSubtitles = snapshot.showForcedSubtitles,
+                            audioLanguageSuggestions = snapshot.audioLanguageSuggestions,
+                            subtitleLanguageSuggestions = snapshot.subtitleLanguageSuggestions,
+                            metadataLanguageSuggestions = snapshot.metadataLanguageSuggestions,
+                        )
+                    },
                 )
             }
         }
@@ -350,7 +852,7 @@ class TvSettingsViewModel(
         viewModelScope.launch {
             tvLibraryScopeStore?.let { store ->
                 val value = runCatching { store.getShowAudiobooksTab() }.getOrDefault(false)
-                _uiState.update { it.copy(showAudiobooksTab = value) }
+                _uiState.update { projectMenu(it.copy(legacyShowAudiobooksTab = value)) }
             }
         }
         viewModelScope.launch {
@@ -550,7 +1052,47 @@ class TvSettingsViewModel(
 
     /** tvOS navPrefs.showAudiobooks parity — opt-in Audiobooks top-menu tab. */
     fun onShowAudiobooksTabChanged(value: Boolean) {
-        _uiState.update { it.copy(showAudiobooksTab = value) }
+        val currentState = _uiState.value
+        if (currentState.uiCustomizationSupport == null) return
+        if (currentState.uiCustomizationSupport == false) {
+            val mutation = prepareTvAudiobookToggleMutation(
+                customizationAvailable = false,
+                currentOverride = currentState.primaryMenuOverride,
+                inheritedMenu = null,
+                enabled = value,
+            )
+            _uiState.update {
+                projectMenu(it.copy(legacyShowAudiobooksTab = mutation.legacyValue))
+            }
+            viewModelScope.launch {
+                runCatching { tvLibraryScopeStore?.setShowAudiobooksTab(value) }
+            }
+            return
+        }
+        if (currentState.primaryMenuUsesDeviceOverride) return
+        if (!currentState.customizationLibrariesResolved) return
+        val inheritedMenu = standardTvMenu(
+            currentState.libraries,
+            currentState.showAudiobooksTab,
+        )
+        val editableItems = currentState.primaryMenuOverride?.items ?: inheritedMenu.items
+        if (value && !canEnableTvAudiobooksTab(editableItems)) return
+
+        val mutation = prepareTvAudiobookToggleMutation(
+            customizationAvailable = true,
+            currentOverride = currentState.primaryMenuOverride,
+            inheritedMenu = inheritedMenu,
+            enabled = value,
+        )
+        _uiState.update {
+            projectMenu(
+                it.copy(
+                    legacyShowAudiobooksTab = mutation.legacyValue,
+                    primaryMenuOverride = mutation.primaryMenu ?: it.primaryMenuOverride,
+                ),
+            )
+        }
+        mutation.primaryMenu?.let(uiCustomizationStore::setPrimaryMenu)
         viewModelScope.launch {
             runCatching { tvLibraryScopeStore?.setShowAudiobooksTab(value) }
         }
@@ -612,6 +1154,7 @@ class TvSettingsViewModel(
             // `PlaybackPrefsStore.clear()` in the sign-out path.
             libraryPlaybackPrefsStore.clear()
             overlayPrefsStore.clear()
+            uiCustomizationStore.clear()
             _uiState.update { it.copy(navAction = NavAction.SIGNED_OUT) }
         }
     }
@@ -641,6 +1184,29 @@ class TvSettingsViewModel(
         SubtitleFontSizePreset.Large,
         SubtitleFontSizePreset.XLarge,
         SubtitleFontSizePreset.XXLarge -> SubtitleSize.Large
+    }
+
+    private fun menuCandidates(
+        libraries: List<org.siloserver.silo.model.personal.UserLibrary>,
+    ): List<PrimaryMenuItem> = buildList {
+        add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME))
+        if (libraries.any(TvLibraryTabType.Movies::matches)) {
+            add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES))
+        }
+        if (libraries.any(TvLibraryTabType.Series::matches)) {
+            add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.SERIES))
+        }
+        if (libraries.any(TvLibraryTabType.Music::matches)) {
+            add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MUSIC))
+        }
+        if (libraries.any(TvLibraryTabType.Audiobooks::matches)) {
+            add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS))
+        }
+        add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU))
+        add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR))
+        libraries.forEach { library ->
+            add(PrimaryMenuItem.Library(library.id, library.name))
+        }
     }
 
     private data class Snapshot(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvVisiblePrimaryMenu.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvVisiblePrimaryMenu.kt
@@ -1,0 +1,65 @@
+package org.siloserver.silo.tv.ui.screens.settings
+
+import org.siloserver.silo.model.settings.PrimaryMenuItem
+import org.siloserver.silo.model.settings.UiCustomizationCodec
+
+/**
+ * Roots the Android TV menu editor can currently render and focus.
+ *
+ * [visibleLibraryIds] are the ids of the libraries this TV can actually show
+ * (already `visibleOnTv()`-filtered by the caller). A family=tv document is
+ * shared with clients that do expose ebooks/reading, so a library pin authored
+ * elsewhere can name a library Android TV must never surface — filtering here
+ * keeps such a pin out of the editor exactly as `visibleTvRoots` keeps it out
+ * of the bar. Deliberately has no default: every call site must state its set,
+ * so a future caller cannot silently drop every library pin.
+ */
+internal fun visibleTvMenuItems(
+    items: List<PrimaryMenuItem>,
+    visibleLibraryIds: Set<Int>,
+): List<PrimaryMenuItem> = items.filter { item ->
+    when (item) {
+        is PrimaryMenuItem.Builtin -> true
+        is PrimaryMenuItem.Library -> item.libraryId in visibleLibraryIds
+        else -> false
+    }
+}
+
+/**
+ * Moves one editor-visible root and weaves that projection through the complete
+ * synced document. Unsupported section/collection roots keep their exact slots
+ * and relative order, so an Android TV reorder cannot silently move or discard
+ * destinations authored by another TV-family client.
+ *
+ * Returns `null` for an unknown item, a zero offset, or a visible boundary.
+ */
+internal fun moveVisibleTvMenuItem(
+    items: List<PrimaryMenuItem>,
+    identity: String,
+    offset: Int,
+    visibleLibraryIds: Set<Int>,
+): List<PrimaryMenuItem>? {
+    if (offset == 0) return null
+    val visible = visibleTvMenuItems(items, visibleLibraryIds)
+    val from = visible.indexOfFirst { UiCustomizationCodec.identity(it) == identity }
+    if (from < 0) return null
+    val to = from + offset
+    if (to !in visible.indices) return null
+
+    val reordered = visible.toMutableList()
+    val moved = reordered.removeAt(from)
+    reordered.add(to, moved)
+
+    val visibleIdentities = visible
+        .mapTo(mutableSetOf(), UiCustomizationCodec::identity)
+    val replacements = reordered.iterator()
+    return buildList(items.size) {
+        items.forEach { item ->
+            if (UiCustomizationCodec.identity(item) in visibleIdentities) {
+                add(replacements.next())
+            } else {
+                add(item)
+            }
+        }
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -105,7 +105,10 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 import androidx.lifecycle.compose.LifecycleResumeEffect
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
 import org.siloserver.silo.common.diagnostics.DiagnosticsFocusLogger
+import org.siloserver.silo.common.settings.UiCustomizationStore
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.common.ui.components.ProfileAvatarRef
 import org.siloserver.silo.tv.ui.theme.SiloOnSurface
@@ -120,6 +123,7 @@ import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.model.feature.CLIENT_WATCH_TOGETHER_SURFACE_ENABLED
 import org.siloserver.silo.model.feature.RequestsFeatureStore
 import org.siloserver.silo.model.personal.UserLibrary
+import org.siloserver.silo.model.settings.effectivePrimaryMenuForSupport
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.ServerRegistry
@@ -175,6 +179,17 @@ import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
  */
 private const val CONTENT_HANDOFF_ATTEMPTS = 3
 
+internal fun shouldRefreshTvUiCustomization(serverId: String?, profileId: String?): Boolean =
+    !serverId.isNullOrBlank() && !profileId.isNullOrBlank()
+
+internal data class TvLegacyAudiobookVisibility(
+    val show: Boolean = false,
+    val isResolved: Boolean = false,
+)
+
+internal fun resolvedTvLegacyAudiobookVisibility(show: Boolean) =
+    TvLegacyAudiobookVisibility(show = show, isResolved = true)
+
 /**
  * Main authenticated TV shell. Mirrors `TVMainTabView` on tvOS: a content
  * `NavHost` with a `TvTopMenuBar` overlay that hosts Search / Home / Libraries
@@ -217,6 +232,11 @@ fun TvMainShell(
     val requestsFeatureStore: RequestsFeatureStore = koinInject()
     val metadataAiFeatureStore: org.siloserver.silo.model.feature.MetadataAiFeatureStore = koinInject()
     val serverRegistry: ServerRegistry = koinInject()
+    val uiCustomizationStore: UiCustomizationStore = koinInject()
+    val primaryMenu by uiCustomizationStore.primaryMenu.collectAsState()
+    val uiCustomizationSupported by
+        uiCustomizationStore.uiCustomizationSupported.collectAsState()
+    val uiCustomizationRefreshScope = rememberCoroutineScope()
     val reachabilityState by reachabilityMonitor.state.collectAsState()
     val requestsEnabled by requestsFeatureStore.isEnabled.collectAsState()
     val activeServerEntry by serverRegistry.activeEntry.collectAsState()
@@ -227,6 +247,26 @@ fun TvMainShell(
     val currentWatchTogetherRoom by watchTogetherViewModel.currentRoom.collectAsState()
     var watchTogetherEntryOpen by rememberSaveable { mutableStateOf(false) }
     var watchTogetherJoinOpen by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(activeServerEntry?.id, activeServerEntry?.profileId) {
+        if (!shouldRefreshTvUiCustomization(
+                activeServerEntry?.id,
+                activeServerEntry?.profileId,
+            )
+        ) {
+            uiCustomizationStore.clear()
+        }
+    }
+    LifecycleResumeEffect(activeServerEntry?.id to activeServerEntry?.profileId) {
+        if (shouldRefreshTvUiCustomization(
+                activeServerEntry?.id,
+                activeServerEntry?.profileId,
+            )
+        ) {
+            uiCustomizationRefreshScope.launch { uiCustomizationStore.refresh() }
+        }
+        onPauseOrDispose { }
+    }
 
     LaunchedEffect(watchTogetherState.result) {
         val room = watchTogetherState.result ?: return@LaunchedEffect
@@ -261,22 +301,76 @@ fun TvMainShell(
     // Skyline tab set (§3.1): Home + present library-type tabs + Calendar.
     // tvOS parity: the Audiobooks tab is opt-in via Settings > General
     // (hidden by default); the store is device+profile local.
-    var showAudiobooksTab by remember { mutableStateOf(false) }
-    // Gates the snap-to-Home redirect below (alongside librariesLoaded) so a
-    // restored/deep-linked main/audiobooks route isn't ejected before this
-    // async DataStore read has landed.
-    var showAudiobooksTabResolved by remember { mutableStateOf(false) }
-    // The store exposes no Flow and Settings is an in-shell NavHost route (so no
-    // ON_RESUME fires when the user backs out of it), which is why a one-shot
-    // read left the tab bar stale after toggling the setting. Re-read on every
-    // shell route change — a cheap DataStore lookup — so toggling Settings >
-    // "Show Audiobooks tab" takes effect on return, without recreating the shell.
-    LaunchedEffect(libraries, currentEntry?.destination?.route) {
-        showAudiobooksTab = runCatching { tvLibraryScopeStore.getShowAudiobooksTab() }.getOrDefault(false)
-        showAudiobooksTabResolved = true
+    // Start hidden and unresolved so a restored Audiobooks route cannot be
+    // rejected before the first DataStore value arrives. The store's live flow
+    // emits a safe false at every WILL_CHANGE boundary, then rekeys to the new
+    // atomic owner on DID_CHANGE; the shell therefore never keeps rendering the
+    // previous owner's legacy visibility while the new namespace is loading.
+    val legacyAudiobookVisibility by produceState(
+        initialValue = TvLegacyAudiobookVisibility(),
+        tvLibraryScopeStore,
+    ) {
+        tvLibraryScopeStore.showAudiobooksTabFlow()
+            .catch { emit(false) }
+            .collect { show ->
+                value = resolvedTvLegacyAudiobookVisibility(show)
+            }
     }
-    val visibleRoots = remember(libraries, showAudiobooksTab) {
-        visibleTvRoots(libraries, showAudiobooks = showAudiobooksTab)
+    val showAudiobooksTab = legacyAudiobookVisibility.show
+    val showAudiobooksTabResolved = legacyAudiobookVisibility.isResolved
+    val visibleRoots = remember(
+        libraries,
+        showAudiobooksTab,
+        primaryMenu,
+        uiCustomizationSupported,
+    ) {
+        visibleTvRoots(
+            libraries,
+            showAudiobooks = showAudiobooksTab,
+            primaryMenu = effectivePrimaryMenuForSupport(
+                primaryMenu,
+                uiCustomizationSupported,
+            ),
+        )
+    }
+    // Media roots share one route per type, so the route alone cannot tell a
+    // built-in Movies tab from a direct pinned-library tab. Retain the exact
+    // bar destination the viewer committed so focus/highlight never jumps to
+    // a sibling tab that happens to render the same route.
+    var selectedLibraryDestinationIdentity by rememberSaveable(
+        activeServerEntry?.id,
+        activeServerEntry?.profileId,
+    ) {
+        mutableStateOf<String?>(null)
+    }
+    val selectedLibraryDestination = remember(
+        selectedLibraryDestinationIdentity,
+        visibleRoots,
+    ) {
+        resolveSavedTvLibraryDestination(
+            identity = selectedLibraryDestinationIdentity,
+            destinations = visibleRoots,
+        )
+    }
+    val uiCustomizationResolved = uiCustomizationSupported != null || primaryMenu != null
+    LaunchedEffect(
+        selectedLibraryDestinationIdentity,
+        selectedLibraryDestination,
+        visibleRoots,
+        librariesLoaded,
+        showAudiobooksTabResolved,
+        uiCustomizationResolved,
+    ) {
+        if (librariesLoaded && showAudiobooksTabResolved &&
+            uiCustomizationResolved &&
+            selectedLibraryDestinationIdentity != null &&
+            selectedLibraryDestination == null
+        ) {
+            // The authored menu no longer contains this semantic destination.
+            // Clear the saved identity so a later menu re-adding the same root
+            // does not unexpectedly revive an old exact-tab selection.
+            selectedLibraryDestinationIdentity = null
+        }
     }
 
     // In-session scope/pill selections per library type. Scope selections are
@@ -591,8 +685,25 @@ fun TvMainShell(
         )
     }
 
-    val selectedRoot by remember(currentRoute) {
-        derivedStateOf { mapRouteToRoot(currentRoute) }
+    val selectedRoot by remember(
+        currentRoute,
+        visibleRoots,
+        selectedLibraryDestination,
+        resolvedLibraries.toMap(),
+        scopeSelections.toMap(),
+    ) {
+        derivedStateOf {
+            val routeRoot = mapRouteToRoot(currentRoute)
+            val selectedLibraryId = (routeRoot as? TvRootDestination.LibraryType)?.let { root ->
+                scopeSelections[root.type] ?: resolvedLibraries[root.type]?.id
+            }
+            selectedTvRoot(
+                routeRoot = routeRoot,
+                destinations = visibleRoots,
+                selectedLibraryId = selectedLibraryId,
+                exactSelection = selectedLibraryDestination,
+            )
+        }
     }
     // Where an Up out of content lands on the bar. The selected root when there
     // is one; For You's dropdown children (Watchlist / Favorites) map to the
@@ -745,6 +856,9 @@ fun TvMainShell(
     }
 
     val onSelectRoot: (TvRootDestination) -> Unit = { dest ->
+        if (dest is TvRootDestination.LibraryType) {
+            selectedLibraryDestinationIdentity = dest.saveableSelectionIdentity()
+        }
         val route = dest.toRoute()
         if (dest == TvRootDestination.ForYou) {
             // Same reason as Home below: an explicit tab selection ends the
@@ -813,7 +927,21 @@ fun TvMainShell(
     // Commit a scope (and optionally a section pill) from the cascade: persist
     // the library scope, record the session pill, navigate to that type's route,
     // close the panel, and move focus into the freshly-scoped content.
-    val commitScope: (TvLibraryTabType, UserLibrary, TvLibraryPill) -> Unit = { type, library, pill ->
+    fun commitScope(
+        type: TvLibraryTabType,
+        library: UserLibrary,
+        pill: TvLibraryPill,
+        explicitDestination: TvRootDestination.LibraryType? = null,
+    ) {
+        val panelDestination = (focusState.openPanel as? TvTopMenuPanel.Root)
+            ?.dest as? TvRootDestination.LibraryType
+        selectedLibraryDestinationIdentity = committedTvLibraryDestination(
+            type = type,
+            libraryId = library.id,
+            explicitDestination = explicitDestination,
+            panelDestination = panelDestination,
+            destinations = visibleRoots,
+        )?.saveableSelectionIdentity()
         scopeSelections[type] = library.id
         pillSelections[type] = pill
         // Bump the per-type section nonce so re-committing the SAME pill still
@@ -1421,17 +1549,31 @@ fun TvMainShell(
             destinations = visibleRoots,
             accountState = accountSnapshot,
             onSelectRoot = onSelectRoot,
-            onSelectTab = { type ->
+            onSelectTab = { destination ->
+                val type = destination.type
+                selectedLibraryDestinationIdentity = destination.saveableSelectionIdentity()
                 // Enter/Select on a library-type tab jumps straight to that
                 // type's Recommended content. Prefer a full scope commit (so it
                 // lands on Recommended and closes any open preview panel); fall
                 // back to a plain route nav if the active library hasn't
                 // resolved yet.
-                val activeLib = activeLibrary(type)
+                val activeLib = destination.libraryId?.let { id ->
+                    libraries.firstOrNull { it.id == id && type.matches(it) }
+                } ?: activeLibrary(type)
                 if (activeLib != null) {
-                    commitScope(type, activeLib, TvLibraryPill.Recommended)
+                    commitScope(
+                        type,
+                        activeLib,
+                        TvLibraryPill.Recommended,
+                        explicitDestination = destination,
+                    )
                 } else {
-                    onSelectRoot(TvRootDestination.LibraryType(type))
+                    // Pass the exact bar destination through: a synthetic
+                    // LibraryType(type) would make onSelectRoot overwrite the
+                    // identity just recorded above with the built-in tab's,
+                    // so a pinned library selected before the library list
+                    // resolved would highlight and restore the built-in tab.
+                    onSelectRoot(destination)
                 }
             },
             onSearchClick = onSearchPressed,
@@ -1560,7 +1702,10 @@ fun TvMainShell(
                     TvCascadeSelector(
                         type = dest.type,
                         libraries = libraries.filter { dest.type.matches(it) },
-                        currentScopeId = activeLibrary(dest.type)?.id,
+                        currentScopeId = cascadeCurrentScopeId(
+                            destination = dest,
+                            activeLibraryId = activeLibrary(dest.type)?.id,
+                        ),
                         libraryHasCollections = { id ->
                             librariesWithCollections?.contains(id) ?: true
                         },

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMediaDestinations.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMediaDestinations.kt
@@ -1,7 +1,43 @@
 package org.siloserver.silo.tv.ui.shell
 
 import org.siloserver.silo.model.personal.UserLibrary
+import org.siloserver.silo.model.settings.PrimaryMenu
+import org.siloserver.silo.model.settings.PrimaryMenuBuiltin
+import org.siloserver.silo.model.settings.PrimaryMenuItem
+import org.siloserver.silo.model.settings.UiCustomizationCodec
+import org.siloserver.silo.model.settings.effectivePrimaryMenuForSupport
 import org.siloserver.silo.tv.ui.navigation.TvMainRoute
+
+/** Capability-aware audiobook visibility that can resolve authored library IDs after loading. */
+data class TvAudiobookVisibilityPolicy(
+    val primaryMenu: PrimaryMenu?,
+    val uiCustomizationSupported: Boolean?,
+    val legacyFallback: Boolean,
+) {
+    fun resolve(libraries: List<UserLibrary> = emptyList()): Boolean =
+        effectivePrimaryMenuForSupport(primaryMenu, uiCustomizationSupported)
+            ?.items
+            ?.any { item ->
+                item == PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS) ||
+                    item is PrimaryMenuItem.Library && libraries.any { library ->
+                        library.id == item.libraryId &&
+                            tabTypeFor(library) == TvLibraryTabType.Audiobooks
+                    }
+            }
+            ?: legacyFallback
+}
+
+/** One capability-aware source of truth for every TV audiobook surface. */
+fun resolvedTvAudiobookVisibility(
+    primaryMenu: PrimaryMenu?,
+    uiCustomizationSupported: Boolean?,
+    legacyFallback: Boolean,
+    libraries: List<UserLibrary> = emptyList(),
+): Boolean = TvAudiobookVisibilityPolicy(
+    primaryMenu = primaryMenu,
+    uiCustomizationSupported = uiCustomizationSupported,
+    legacyFallback = legacyFallback,
+).resolve(libraries)
 
 /**
  * Skyline content-type-first shell (§3.1): a fixed root order of `Home`, then
@@ -16,7 +52,40 @@ fun visibleTvRoots(
     /** tvOS navPrefs.showAudiobooks parity: the Audiobooks tab is opt-in
      *  (hidden by default) even when an audiobook library exists. */
     showAudiobooks: Boolean = false,
+    primaryMenu: PrimaryMenu? = null,
 ): List<TvRootDestination> = buildList {
+    if (primaryMenu != null) {
+        primaryMenu.items.forEach { item ->
+            when (item) {
+                is PrimaryMenuItem.Builtin -> builtinRoot(
+                    destination = item.destination,
+                    libraries = libraries,
+                    // Once a family-authored menu exists, its own inclusion or
+                    // omission is authoritative. The legacy device flag only
+                    // shapes the null/native fallback menu.
+                    showAudiobooks = true,
+                )?.let(::add)
+                is PrimaryMenuItem.Library -> {
+                    val library = libraries.firstOrNull { it.id == item.libraryId }
+                    val type = library?.let(::tabTypeFor)
+                    if (library != null && type != null) {
+                        add(TvRootDestination.LibraryType(type, library.id, item.label))
+                    }
+                }
+                // Android TV can open these from their existing library and
+                // collection surfaces, but has no stable root route for them.
+                // Preserve them in the wire document; omit them from the bar.
+                is PrimaryMenuItem.Section,
+                is PrimaryMenuItem.Collection -> Unit
+            }
+        }
+        // Strict revision-5 documents always contain Home. Still protect the
+        // focus graph from manually-constructed, stale, or future documents
+        // whose entries cannot be rendered by this version of Android TV.
+        if (isEmpty()) add(TvRootDestination.Home)
+        return@buildList
+    }
+
     add(TvRootDestination.Home)
     TvLibraryTabType.entries
         .filter { type -> libraries.any { type.matches(it) } }
@@ -27,7 +96,135 @@ fun visibleTvRoots(
     add(TvRootDestination.Calendar)
 }
 
+private fun builtinRoot(
+    destination: PrimaryMenuBuiltin,
+    libraries: List<UserLibrary>,
+    showAudiobooks: Boolean,
+): TvRootDestination? = when (destination) {
+    PrimaryMenuBuiltin.HOME -> TvRootDestination.Home
+    PrimaryMenuBuiltin.FOR_YOU -> TvRootDestination.ForYou
+    PrimaryMenuBuiltin.CALENDAR -> TvRootDestination.Calendar
+    PrimaryMenuBuiltin.MOVIES -> typeRoot(TvLibraryTabType.Movies, libraries, true)
+    PrimaryMenuBuiltin.SERIES -> typeRoot(TvLibraryTabType.Series, libraries, true)
+    PrimaryMenuBuiltin.MUSIC -> typeRoot(TvLibraryTabType.Music, libraries, true)
+    PrimaryMenuBuiltin.AUDIOBOOKS ->
+        typeRoot(TvLibraryTabType.Audiobooks, libraries, showAudiobooks)
+}
+
+private fun typeRoot(
+    type: TvLibraryTabType,
+    libraries: List<UserLibrary>,
+    enabled: Boolean,
+): TvRootDestination? =
+    TvRootDestination.LibraryType(type).takeIf { enabled && libraries.any(type::matches) }
+
+private fun tabTypeFor(library: UserLibrary): TvLibraryTabType? =
+    TvLibraryTabType.entries.firstOrNull { it.matches(library) }
+
 fun firstTvRoute(): String = TvMainRoute.Home.route
 
 fun TvRootDestination.isVisibleIn(destinations: List<TvRootDestination>): Boolean =
-    this in destinations
+    when (this) {
+        is TvRootDestination.LibraryType -> destinations.any { destination ->
+            destination is TvRootDestination.LibraryType && destination.type == type
+        }
+        else -> this in destinations
+    }
+
+/**
+ * Resolves the exact bar entry to highlight for a route. Library pins and
+ * built-in media roots intentionally share one content route, so [routeRoot]
+ * alone is not enough to preserve D-pad focus identity.
+ */
+fun selectedTvRoot(
+    routeRoot: TvRootDestination?,
+    destinations: List<TvRootDestination>,
+    selectedLibraryId: Int?,
+    exactSelection: TvRootDestination.LibraryType?,
+): TvRootDestination? {
+    if (routeRoot !is TvRootDestination.LibraryType) return routeRoot
+    val libraryRoots = destinations.filterIsInstance<TvRootDestination.LibraryType>()
+    return exactSelection
+        ?.takeIf { it.type == routeRoot.type && it in libraryRoots }
+        ?: selectedLibraryId?.let { libraryId ->
+            libraryRoots.firstOrNull {
+                it.type == routeRoot.type && it.libraryId == libraryId
+            }
+        }
+        // A customized menu can expose only direct-library entries for a
+        // media type. Never return the synthetic route root in that case: it
+        // is not part of the visible focus graph, so the bar would render no
+        // selected entry and Up could not restore focus deterministically.
+        ?: libraryRoots.firstOrNull { it.type == routeRoot.type }
+        ?: routeRoot
+}
+
+/**
+ * Saveable identity for the exact media tab selected by the viewer.
+ *
+ * Labels are presentation, not identity: resolving this value against the
+ * current visible roots after recreation picks up a renamed pinned library
+ * without accidentally changing a built-in Movies selection into that pin.
+ */
+internal fun TvRootDestination.LibraryType.saveableSelectionIdentity(): String =
+    libraryId?.let { id ->
+        UiCustomizationCodec.identity(PrimaryMenuItem.Library(id, title))
+    } ?: UiCustomizationCodec.identity(
+        PrimaryMenuItem.Builtin(
+            when (type) {
+                TvLibraryTabType.Movies -> PrimaryMenuBuiltin.MOVIES
+                TvLibraryTabType.Series -> PrimaryMenuBuiltin.SERIES
+                TvLibraryTabType.Music -> PrimaryMenuBuiltin.MUSIC
+                TvLibraryTabType.Audiobooks -> PrimaryMenuBuiltin.AUDIOBOOKS
+            },
+        ),
+    )
+
+/** Resolves a restored semantic identity to today's root object and label. */
+internal fun resolveSavedTvLibraryDestination(
+    identity: String?,
+    destinations: List<TvRootDestination>,
+): TvRootDestination.LibraryType? {
+    if (identity == null) return null
+    return destinations
+        .filterIsInstance<TvRootDestination.LibraryType>()
+        .firstOrNull { it.saveableSelectionIdentity() == identity }
+}
+
+/**
+ * Preserves the exact bar identity when committing a library scope. A direct
+ * tab selection is authoritative over any same-type panel that happened to be
+ * open from an earlier dwell preview; otherwise the panel that produced the
+ * commit owns the identity. This keeps a stale built-in Movies preview from
+ * replacing a just-selected pinned Movies destination merely because its
+ * `libraryId == null` used to act as a wildcard.
+ */
+internal fun committedTvLibraryDestination(
+    type: TvLibraryTabType,
+    libraryId: Int,
+    explicitDestination: TvRootDestination.LibraryType?,
+    panelDestination: TvRootDestination.LibraryType?,
+    destinations: List<TvRootDestination>,
+): TvRootDestination.LibraryType? {
+    val libraryRoots = destinations.filterIsInstance<TvRootDestination.LibraryType>()
+    fun eligible(destination: TvRootDestination.LibraryType?): TvRootDestination.LibraryType? =
+        destination?.takeIf {
+            it in libraryRoots && it.type == type &&
+                (it.libraryId == null || it.libraryId == libraryId)
+        }
+
+    return eligible(explicitDestination)
+        ?: eligible(panelDestination)
+        ?: libraryRoots.firstOrNull { it.type == type && it.libraryId == libraryId }
+        ?: libraryRoots.firstOrNull { it.type == type && it.libraryId == null }
+}
+
+/**
+ * Chooses the initial scope for a media-root cascade. A direct library pin is
+ * its own scope even when another library of the same type is currently open;
+ * built-in type roots continue from the active library for that type.
+ */
+internal fun cascadeCurrentScopeId(
+    destination: TvRootDestination.LibraryType,
+    activeLibraryId: Int?,
+): Int? = destination.libraryId ?: activeLibraryId

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvRootDestination.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvRootDestination.kt
@@ -9,11 +9,21 @@ package org.siloserver.silo.tv.ui.shell
  * becomes a Home row in a later stage). Mirrors tvOS `TVRootDestination`.
  */
 sealed class TvRootDestination {
-    /** Curated landing surface. Always the first tab. */
+    /** Curated landing surface. Always present, but user-orderable. */
     data object Home : TvRootDestination()
 
-    /** A library content-type tab (Movies / Series / Music / Audiobooks). */
-    data class LibraryType(val type: TvLibraryTabType) : TvRootDestination()
+    /**
+     * A library content-type tab (Movies / Series / Music / Audiobooks).
+     * [libraryId] and [customLabel] turn it into a direct pinned-library tab
+     * while reusing the same content route and native focus/cascade graph.
+     */
+    data class LibraryType(
+        val type: TvLibraryTabType,
+        val libraryId: Int? = null,
+        val customLabel: String? = null,
+    ) : TvRootDestination() {
+        val title: String get() = customLabel ?: type.title
+    }
 
     /** Personal recommendations ("For You") — tvOS `.recommendations`. */
     data object ForYou : TvRootDestination()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
@@ -4,6 +4,10 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.focusGroup
@@ -119,12 +123,14 @@ object TvTopMenuLayout {
 
 /**
  * Identifies which menu button currently holds focus. Library-type tabs share
- * the [Tab] case keyed by [TvLibraryTabType]; the remaining cases are the
- * fixed Home/Calendar tabs plus the Search icon and trailing profile avatar.
+ * the [Tab] case keyed by the EXACT [TvRootDestination.LibraryType] — an
+ * authored menu can pin two libraries of the same media type, so the bare type
+ * is no longer a unique key. The remaining cases are the fixed Home/Calendar
+ * tabs plus the Search icon and trailing profile avatar.
  */
 private sealed class TvTopMenuFocus {
     data object Home : TvTopMenuFocus()
-    data class Tab(val type: TvLibraryTabType) : TvTopMenuFocus()
+    data class Tab(val destination: TvRootDestination.LibraryType) : TvTopMenuFocus()
     data object ForYou : TvTopMenuFocus()
     data object Calendar : TvTopMenuFocus()
     data object Search : TvTopMenuFocus()
@@ -167,7 +173,7 @@ fun TvTopMenuBar(
     destinations: List<TvRootDestination>,
     accountState: TvAccountState,
     onSelectRoot: (TvRootDestination) -> Unit,
-    onSelectTab: (TvLibraryTabType) -> Unit = {},
+    onSelectTab: (TvRootDestination.LibraryType) -> Unit = {},
     onSearchClick: () -> Unit,
     onProfileClick: () -> Unit,
     onProfileDwell: () -> Unit,
@@ -205,10 +211,14 @@ fun TvTopMenuBar(
     val forYouFocusRequester = remember { FocusRequester() }
     val searchFocusRequester = remember { FocusRequester() }
     val profileFocusRequester = remember { FocusRequester() }
-    // One requester per library-type tab; stable across recompositions so a
-    // focus request still lands after the visible-tab set changes.
+    // One requester per exact library destination (including direct library
+    // pins). The map is kept across recompositions so reorder/visibility edits
+    // do not replace requesters for destinations that stay in the focus graph.
     val tabFocusRequesters = remember {
-        TvLibraryTabType.entries.associateWith { FocusRequester() }
+        mutableMapOf<TvRootDestination.LibraryType, FocusRequester>()
+    }
+    destinations.filterIsInstance<TvRootDestination.LibraryType>().forEach { destination ->
+        tabFocusRequesters.getOrPut(destination) { FocusRequester() }
     }
 
     // Track which button currently holds focus so we can shape the capsule
@@ -245,7 +255,7 @@ fun TvTopMenuBar(
         TvRootDestination.Home -> TvTopMenuFocus.Home
         TvRootDestination.ForYou -> TvTopMenuFocus.ForYou
         TvRootDestination.Calendar -> TvTopMenuFocus.Calendar
-        is TvRootDestination.LibraryType -> TvTopMenuFocus.Tab(root.type)
+        is TvRootDestination.LibraryType -> TvTopMenuFocus.Tab(root)
     }
 
     fun focusForPanel(panel: TvTopMenuPanel): TvTopMenuFocus? = when (panel) {
@@ -255,7 +265,7 @@ fun TvTopMenuBar(
 
     fun requesterForFocus(focus: TvTopMenuFocus): FocusRequester = when (focus) {
         TvTopMenuFocus.Home -> homeFocusRequester
-        is TvTopMenuFocus.Tab -> tabFocusRequesters[focus.type] ?: homeFocusRequester
+        is TvTopMenuFocus.Tab -> tabFocusRequesters[focus.destination] ?: homeFocusRequester
         TvTopMenuFocus.ForYou -> forYouFocusRequester
         TvTopMenuFocus.Calendar -> calendarFocusRequester
         TvTopMenuFocus.Search -> searchFocusRequester
@@ -263,18 +273,28 @@ fun TvTopMenuBar(
     }
 
     fun panelForFocus(focus: TvTopMenuFocus?): TvTopMenuPanel? = when (focus) {
-        is TvTopMenuFocus.Tab ->
-            TvTopMenuPanel.Root(TvRootDestination.LibraryType(focus.type))
+        is TvTopMenuFocus.Tab -> TvTopMenuPanel.Root(focus.destination)
         TvTopMenuFocus.ForYou -> TvTopMenuPanel.Root(TvRootDestination.ForYou)
         else -> null
     }
 
-    fun selectedEntryRequester(): FocusRequester = when (val root = selectedRoot) {
-        TvRootDestination.Home -> homeFocusRequester
-        TvRootDestination.Calendar -> calendarFocusRequester
-        is TvRootDestination.LibraryType -> tabFocusRequesters[root.type] ?: homeFocusRequester
-        TvRootDestination.ForYou -> forYouFocusRequester
-        null -> if (isSearchActive) searchFocusRequester else homeFocusRequester
+    // An authored menu can drop the destination the current route belongs to.
+    // Resolving through the visible entry list keeps entry on a requester that
+    // is actually attached; the fallback picks a control that always composes.
+    fun selectedEntryRequester(): FocusRequester {
+        val root = selectedTopMenuEntry(selectedRoot, destinations)
+            ?: return when (
+                selectedTopMenuEntryFallback(selectedRoot, isSearchActive, destinations)
+            ) {
+                TvTopMenuEntryFallback.HOME -> homeFocusRequester
+                TvTopMenuEntryFallback.SEARCH -> searchFocusRequester
+            }
+        return when (root) {
+            TvRootDestination.Home -> homeFocusRequester
+            TvRootDestination.Calendar -> calendarFocusRequester
+            is TvRootDestination.LibraryType -> tabFocusRequesters[root] ?: homeFocusRequester
+            TvRootDestination.ForYou -> forYouFocusRequester
+        }
     }
 
     // Focus the selected tab when `focusRequest` actually changes (the
@@ -382,7 +402,7 @@ fun TvTopMenuBar(
         }
         if (focus is TvTopMenuFocus.Tab) {
             delay(if (openPanel == null) TopMenuInitialPreviewDelayMillis else TopMenuPanelSwitchDelayMillis)
-            onDwell(TvTopMenuPanel.Root(TvRootDestination.LibraryType(focus.type)))
+            onDwell(TvTopMenuPanel.Root(focus.destination))
         } else if (focus is TvTopMenuFocus.ForYou) {
             delay(if (openPanel == null) TopMenuInitialPreviewDelayMillis else TopMenuPanelSwitchDelayMillis)
             onDwell(TvTopMenuPanel.Root(TvRootDestination.ForYou))
@@ -411,6 +431,14 @@ fun TvTopMenuBar(
     // pick (which, with the old align-zoned layout, wrongly landed in the
     // trailing cluster). On non-tab routes (Search) we enter the search icon.
     val barEntryRequester = selectedEntryRequester()
+    // Explicit left/right neighbours make bar traversal independent of the 2D
+    // focus search, which cannot reliably cross a scrolling viewport.
+    val rootFocusRequesters = destinations.map { destination ->
+        requesterForFocus(focusForRoot(destination))
+    }
+    val firstRootFocusRequester = rootFocusRequesters.firstOrNull()
+    val lastRootFocusRequester = rootFocusRequesters.lastOrNull()
+    val centerScrollState = rememberScrollState()
 
     // Publish the synchronous anchor-focus hook. This runs on the composition
     // thread, so a Back handler can move focus BEFORE it removes the panel.
@@ -505,7 +533,7 @@ fun TvTopMenuBar(
                     // cascade rows guard against the same way).
                     (event.key == Key.DirectionCenter || event.key == Key.Enter) &&
                         focus is TvTopMenuFocus.Tab -> {
-                        if (event.type == KeyEventType.KeyUp) onSelectTab(focus.type)
+                        if (event.type == KeyEventType.KeyUp) onSelectTab(focus.destination)
                         true
                     }
                     else -> false
@@ -523,14 +551,24 @@ fun TvTopMenuBar(
             TvSiloWordmark()
         }
 
-        Spacer(modifier = Modifier.weight(1f))
-
-        // Center cluster: Search · Home · library-type tabs · Calendar.
-        // tvOS parity (TVTopMenuBar.tabCluster): search sits just left of Home,
-        // and an invisible same-size twin at the trailing end keeps the tab
-        // group itself screen-centered.
+        // Center cluster: Search · authored roots. tvOS parity
+        // (TVTopMenuBar.tabCluster): search sits just left of the roots, and an
+        // invisible same-size twin at the trailing end keeps the group centered.
+        // The Box centers a short menu but constrains a long one to the span
+        // between brand and profile: an authored menu may carry up to 64
+        // entries, and letting that Row measure at its natural width pushed both
+        // ends of the chrome off screen. Every entry stays composed, so its
+        // stable FocusRequester still works while scrolled out of view.
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .height(TvSkyline.barHeight),
+            contentAlignment = Alignment.Center,
+        ) {
         Row(
-            modifier = Modifier.height(TvSkyline.barHeight),
+            modifier = Modifier
+                .height(TvSkyline.barHeight)
+                .horizontalScroll(centerScrollState),
             horizontalArrangement = Arrangement.spacedBy(TvSkyline.tabSpacing),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -540,6 +578,7 @@ fun TvTopMenuBar(
                 isFocused = focusedButton == TvTopMenuFocus.Search,
                 canFocus = canFocusButton(TvTopMenuFocus.Search),
                 focusRequester = searchFocusRequester,
+                rightFocusRequester = firstRootFocusRequester ?: profileFocusRequester,
                 onFocusChanged = { hasFocus ->
                     focusedButton = if (hasFocus) {
                         TvTopMenuFocus.Search
@@ -550,7 +589,11 @@ fun TvTopMenuBar(
                 onClick = onSearchClick,
             )
 
-            destinations.forEach { destination ->
+            destinations.forEachIndexed { index, destination ->
+                val leftFocusRequester = rootFocusRequesters.getOrNull(index - 1)
+                    ?: searchFocusRequester
+                val rightFocusRequester = rootFocusRequesters.getOrNull(index + 1)
+                    ?: profileFocusRequester
                 when (destination) {
                     TvRootDestination.Home -> TvTopMenuTab(
                         label = "Home",
@@ -558,6 +601,8 @@ fun TvTopMenuBar(
                         isFocused = focusedButton == TvTopMenuFocus.Home,
                         canFocus = canFocusButton(TvTopMenuFocus.Home),
                         focusRequester = homeFocusRequester,
+                        leftFocusRequester = leftFocusRequester,
+                        rightFocusRequester = rightFocusRequester,
                         onFocusChanged = { hasFocus ->
                             focusedButton = if (hasFocus) {
                                 TvTopMenuFocus.Home
@@ -569,22 +614,26 @@ fun TvTopMenuBar(
                     )
 
                     is TvRootDestination.LibraryType -> {
-                        val type = destination.type
                         val panel = TvTopMenuPanel.Root(destination)
                         TvTopMenuTab(
-                            label = type.title,
+                            label = destination.title,
                             isSelected = selectedRoot == destination,
-                            isFocused = focusedButton == TvTopMenuFocus.Tab(type),
-                            canFocus = canFocusButton(TvTopMenuFocus.Tab(type)),
-                            focusRequester = tabFocusRequesters[type] ?: homeFocusRequester,
+                            isFocused = focusedButton == TvTopMenuFocus.Tab(destination),
+                            canFocus = canFocusButton(TvTopMenuFocus.Tab(destination)),
+                            focusRequester = tabFocusRequesters[destination]
+                                ?: homeFocusRequester,
+                            leftFocusRequester = leftFocusRequester,
+                            rightFocusRequester = rightFocusRequester,
                             onFocusChanged = { hasFocus ->
                                 focusedButton = if (hasFocus) {
-                                    TvTopMenuFocus.Tab(type)
+                                    TvTopMenuFocus.Tab(destination)
                                 } else {
-                                    focusedButton.takeUnless { it == TvTopMenuFocus.Tab(type) }
+                                    focusedButton.takeUnless {
+                                        it == TvTopMenuFocus.Tab(destination)
+                                    }
                                 }
                             },
-                            onClick = { onSelectTab(type) },
+                            onClick = { onSelectTab(destination) },
                             // Library-type tabs publish their anchor so the shell
                             // can position the cascade panel under them. The
                             // d-pad-down → enter-panel intercept lives on the
@@ -601,6 +650,8 @@ fun TvTopMenuBar(
                         isFocused = focusedButton == TvTopMenuFocus.ForYou,
                         canFocus = canFocusButton(TvTopMenuFocus.ForYou),
                         focusRequester = forYouFocusRequester,
+                        leftFocusRequester = leftFocusRequester,
+                        rightFocusRequester = rightFocusRequester,
                         onFocusChanged = { hasFocus ->
                             focusedButton = if (hasFocus) {
                                 TvTopMenuFocus.ForYou
@@ -623,6 +674,8 @@ fun TvTopMenuBar(
                         isFocused = focusedButton == TvTopMenuFocus.Calendar,
                         canFocus = canFocusButton(TvTopMenuFocus.Calendar),
                         focusRequester = calendarFocusRequester,
+                        leftFocusRequester = leftFocusRequester,
+                        rightFocusRequester = rightFocusRequester,
                         onFocusChanged = { hasFocus ->
                             focusedButton = if (hasFocus) {
                                 TvTopMenuFocus.Calendar
@@ -639,8 +692,7 @@ fun TvTopMenuBar(
             // centered on screen with search sitting to its left.
             Spacer(modifier = Modifier.size(TvSkyline.barIconSize))
         }
-
-        Spacer(modifier = Modifier.weight(1f))
+        }
 
         // Trailing cluster: profile avatar.
         Row(
@@ -655,6 +707,7 @@ fun TvTopMenuBar(
                 isFocused = focusedButton == TvTopMenuFocus.Profile,
                 canFocus = canFocusButton(TvTopMenuFocus.Profile),
                 focusRequester = profileFocusRequester,
+                leftFocusRequester = lastRootFocusRequester ?: searchFocusRequester,
                 onFocusChanged = { hasFocus ->
                     focusedButton = if (hasFocus) TvTopMenuFocus.Profile else focusedButton.takeUnless { it == TvTopMenuFocus.Profile }
                     if (!hasFocus) onProfileBlur()
@@ -732,13 +785,21 @@ private fun TvTopMenuTab(
     isFocused: Boolean,
     canFocus: Boolean,
     focusRequester: FocusRequester,
+    leftFocusRequester: FocusRequester,
+    rightFocusRequester: FocusRequester,
     onFocusChanged: (Boolean) -> Unit,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    // A tab scrolled outside the center viewport still holds a live requester,
+    // so focus can land on it off screen. Bring it back into view on arrival.
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
     val isInteractionFocused by interactionSource.collectIsFocusedAsState()
-    LaunchedEffect(isInteractionFocused) { onFocusChanged(isInteractionFocused) }
+    LaunchedEffect(isInteractionFocused) {
+        onFocusChanged(isInteractionFocused)
+        if (isInteractionFocused) bringIntoViewRequester.bringIntoView()
+    }
 
     val shape = RoundedCornerShape(percent = 50)
     val containerColor = when {
@@ -777,7 +838,12 @@ private fun TvTopMenuTab(
             focusedBorder = Border(border = BorderStroke(0.dp, Color.Transparent), shape = shape),
         ),
         modifier = modifier
-            .focusProperties { this.canFocus = canFocus }
+            .bringIntoViewRequester(bringIntoViewRequester)
+            .focusProperties {
+                this.canFocus = canFocus
+                left = leftFocusRequester
+                right = rightFocusRequester
+            }
             .focusRequester(focusRequester)
             .height(TvSkyline.tabPillHeight),
     ) {
@@ -816,12 +882,17 @@ private fun TvTopMenuIconButton(
     isFocused: Boolean,
     canFocus: Boolean,
     focusRequester: FocusRequester,
+    rightFocusRequester: FocusRequester,
     onFocusChanged: (Boolean) -> Unit,
     onClick: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
     val isInteractionFocused by interactionSource.collectIsFocusedAsState()
-    LaunchedEffect(isInteractionFocused) { onFocusChanged(isInteractionFocused) }
+    LaunchedEffect(isInteractionFocused) {
+        onFocusChanged(isInteractionFocused)
+        if (isInteractionFocused) bringIntoViewRequester.bringIntoView()
+    }
 
     val shape = CircleShape
     val containerColor = if (isFocused) SiloOnSurface else Color.Transparent
@@ -845,7 +916,11 @@ private fun TvTopMenuIconButton(
             focusedBorder = Border(border = BorderStroke(0.dp, Color.Transparent), shape = shape),
         ),
         modifier = Modifier
-            .focusProperties { this.canFocus = canFocus }
+            .bringIntoViewRequester(bringIntoViewRequester)
+            .focusProperties {
+                this.canFocus = canFocus
+                right = rightFocusRequester
+            }
             .focusRequester(focusRequester)
             .size(TvSkyline.barIconSize),
     ) {
@@ -872,6 +947,7 @@ private fun TvTopMenuProfileButton(
     isFocused: Boolean,
     canFocus: Boolean,
     focusRequester: FocusRequester,
+    leftFocusRequester: FocusRequester,
     onFocusChanged: (Boolean) -> Unit,
     onClick: () -> Unit,
 ) {
@@ -899,7 +975,10 @@ private fun TvTopMenuProfileButton(
             focusedBorder = Border(border = BorderStroke(0.dp, Color.Transparent), shape = shape),
         ),
         modifier = Modifier
-            .focusProperties { this.canFocus = canFocus }
+            .focusProperties {
+                this.canFocus = canFocus
+                left = leftFocusRequester
+            }
             .focusRequester(focusRequester)
             .size(TvSkyline.barIconSize),
     ) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuFocusRequest.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuFocusRequest.kt
@@ -10,6 +10,33 @@ internal fun isTopMenuFocusTargetAvailable(
     TvTopMenuPanel.Profile, null -> true
 }
 
+/** Returns only a destination whose focus requester is attached to the current bar. */
+internal fun selectedTopMenuEntry(
+    selectedRoot: TvRootDestination?,
+    destinations: List<TvRootDestination>,
+): TvRootDestination? = selectedRoot?.takeIf { it in destinations }
+
+internal enum class TvTopMenuEntryFallback {
+    HOME,
+    SEARCH,
+}
+
+/**
+ * Preserves Home as the normal detail-route entry while using the always-composed
+ * Search control when an authored root disappeared or Home itself is hidden.
+ */
+internal fun selectedTopMenuEntryFallback(
+    selectedRoot: TvRootDestination?,
+    isSearchActive: Boolean,
+    destinations: List<TvRootDestination>,
+): TvTopMenuEntryFallback = if (
+    isSearchActive || selectedRoot != null || TvRootDestination.Home !in destinations
+) {
+    TvTopMenuEntryFallback.SEARCH
+} else {
+    TvTopMenuEntryFallback.HOME
+}
+
 internal suspend fun handleTopMenuFocusRequestIfAvailable(
     requestIdentity: Pair<Int, TvTopMenuPanel?>,
     lastHandledRequest: Pair<Int, TvTopMenuPanel?>,

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/data/preferences/TvLibraryScopeStoreTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/data/preferences/TvLibraryScopeStoreTest.kt
@@ -1,18 +1,42 @@
 package org.siloserver.silo.tv.data.preferences
 
+import android.content.ContextWrapper
+import androidx.datastore.core.DataMigration
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import org.siloserver.silo.model.personal.UserLibrary
+import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionKind
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.TokenManagerImpl
 import org.siloserver.silo.tv.ui.shell.TvLibraryTabType
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
-/**
- * Exercises [TvLibraryScopeStore.resolve], the pure scope-resolution rule
- * (the getters/setters need a Context-backed DataStore, so the testable
- * surface is the resolution rule, mirroring tvOS
- * `TVLibraryScopeStore.resolvedLibrary`).
- */
+/** Exercises scope resolution plus account-safe, reactive preference storage. */
 class TvLibraryScopeStoreTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
 
     private fun lib(id: Int, type: String, name: String = "lib$id") =
         UserLibrary(id = id, name = name, type = type)
@@ -64,5 +88,445 @@ class TvLibraryScopeStoreTest {
         assertNull(
             TvLibraryScopeStore.resolve(storedId = null, type = TvLibraryTabType.Music, libraries = movies),
         )
+    }
+
+    @Test
+    fun `audiobook visibility flow rekeys after profile switch`() = runBlocking {
+        val transitions = DefaultIdentityTransitionBarrier()
+        val tokens = SnapshotTokenManager(scope(profileId = "profile-a"))
+        val store = store(tokens, transitions)
+        store.setShowAudiobooksTab(true)
+
+        val emissions = Channel<Boolean>(Channel.UNLIMITED)
+        val collector = launch(Dispatchers.Default) {
+            store.showAudiobooksTabFlow().collect(emissions::send)
+        }
+        try {
+            assertTrue(withTimeout(5_000) { emissions.receive() })
+
+            transitions.changing(IdentityTransitionKind.PROFILE_SWITCH) {
+                tokens.currentSnapshot = scope(profileId = "profile-b")
+            }
+
+            assertFalse(withTimeout(5_000) { emissions.receive() })
+        } finally {
+            collector.cancel()
+        }
+    }
+
+    @Test
+    fun `reads and writes use one atomic snapshot identity`() = runBlocking {
+        val transitions = DefaultIdentityTransitionBarrier()
+        val tokens = SnapshotTokenManager(
+            initial = scope(
+                profileId = "snapshot-profile",
+                serverId = "snapshot-server",
+            ),
+            legacyProfileId = "different-profile",
+            legacyServerId = "different-server",
+        )
+        val store = store(tokens, transitions)
+
+        store.setShowAudiobooksTab(true)
+        store.setSelectedLibraryId(2, TvLibraryTabType.Movies)
+
+        assertTrue(store.getShowAudiobooksTab())
+        assertEquals(2, store.getSelectedLibraryId(TvLibraryTabType.Movies))
+        assertEquals(0, tokens.separateIdentityReadCount)
+
+        tokens.currentSnapshot = scope(
+            profileId = "snapshot-profile",
+            serverId = "different-server",
+        )
+        assertFalse(store.getShowAudiobooksTab())
+        assertNull(store.getSelectedLibraryId(TvLibraryTabType.Movies))
+    }
+
+    @Test
+    fun `replacement account cannot inherit the previous owners preferences`() = runBlocking {
+        val transitions = DefaultIdentityTransitionBarrier()
+        val ownerA = scope(profileId = "shared-profile", credentialOwnerId = "owner-a")
+        val ownerB = scope(profileId = "shared-profile", credentialOwnerId = "owner-b")
+        val tokens = SnapshotTokenManager(ownerA)
+        val store = store(tokens, transitions)
+        store.setShowAudiobooksTab(true)
+        store.setSelectedLibraryId(2, TvLibraryTabType.Movies)
+
+        val emissions = Channel<Boolean>(Channel.UNLIMITED)
+        val collector = launch(Dispatchers.Default) {
+            store.showAudiobooksTabFlow().collect(emissions::send)
+        }
+        try {
+            assertTrue(withTimeout(5_000) { emissions.receive() })
+
+            transitions.changing(IdentityTransitionKind.SIGN_IN) {
+                tokens.currentSnapshot = ownerB
+            }
+
+            assertFalse(withTimeout(5_000) { emissions.receive() })
+            assertNull(store.getSelectedLibraryId(TvLibraryTabType.Movies))
+
+            transitions.changing(IdentityTransitionKind.SIGN_IN) {
+                tokens.currentSnapshot = ownerA
+            }
+
+            assertTrue(withTimeout(5_000) { emissions.receive() })
+            assertEquals(2, store.getSelectedLibraryId(TvLibraryTabType.Movies))
+        } finally {
+            collector.cancel()
+        }
+    }
+
+    @Test
+    fun `temporary overlay enter and exit preserve both preference namespaces`() = runBlocking {
+        val transitions = DefaultIdentityTransitionBarrier()
+        val persistent = scope(profileId = "profile-a", credentialOwnerId = "owner-a")
+        val temporary = scope(
+            profileId = "profile-a",
+            credentialOwnerId = null,
+            credentialGenerationId = "temporary-generation-a",
+        )
+        val tokens = SnapshotTokenManager(persistent)
+        val store = store(tokens, transitions)
+        store.setSelectedLibraryId(1, TvLibraryTabType.Movies)
+
+        val emissions = Channel<Boolean>(Channel.UNLIMITED)
+        val collector = launch(Dispatchers.Default) {
+            store.showAudiobooksTabFlow().collect(emissions::send)
+        }
+        try {
+            assertFalse(withTimeout(5_000) { emissions.receive() })
+
+            transitions.changing(IdentityTransitionKind.TEMPORARY_SCOPE_BEGIN) {
+                tokens.currentSnapshot = temporary
+            }
+            assertNull(store.getSelectedLibraryId(TvLibraryTabType.Movies))
+
+            store.setShowAudiobooksTab(true)
+            assertTrue(withTimeout(5_000) { emissions.receive() })
+            store.setSelectedLibraryId(2, TvLibraryTabType.Movies)
+
+            transitions.changing(IdentityTransitionKind.TEMPORARY_SCOPE_END) {
+                tokens.currentSnapshot = persistent
+            }
+            assertFalse(withTimeout(5_000) { emissions.receive() })
+            assertEquals(1, store.getSelectedLibraryId(TvLibraryTabType.Movies))
+
+            transitions.changing(IdentityTransitionKind.TEMPORARY_SCOPE_BEGIN) {
+                tokens.currentSnapshot = temporary
+            }
+            assertTrue(withTimeout(5_000) { emissions.receive() })
+            assertEquals(2, store.getSelectedLibraryId(TvLibraryTabType.Movies))
+        } finally {
+            collector.cancel()
+        }
+    }
+
+    @Test
+    fun `visibility flow hides the previous owner before loading the next owner`() = runBlocking {
+        val transitions = DefaultIdentityTransitionBarrier()
+        val persistent = scope(profileId = "profile-a", credentialOwnerId = "owner-a")
+        val temporary = scope(
+            profileId = "profile-a",
+            credentialOwnerId = null,
+            credentialGenerationId = "temporary-generation-a",
+        )
+        val tokens = SnapshotTokenManager(persistent)
+        val store = store(tokens, transitions)
+        store.setShowAudiobooksTab(true)
+        tokens.currentSnapshot = temporary
+        store.setShowAudiobooksTab(true)
+        tokens.currentSnapshot = persistent
+
+        val emissions = Channel<Boolean>(Channel.UNLIMITED)
+        val collector = launch(Dispatchers.Default) {
+            store.showAudiobooksTabFlow().collect(emissions::send)
+        }
+        try {
+            assertTrue(withTimeout(5_000) { emissions.receive() })
+
+            transitions.changing(IdentityTransitionKind.TEMPORARY_SCOPE_BEGIN) {
+                tokens.currentSnapshot = temporary
+            }
+
+            assertFalse(withTimeout(5_000) { emissions.receive() })
+            assertTrue(withTimeout(5_000) { emissions.receive() })
+        } finally {
+            collector.cancel()
+        }
+    }
+
+    @Test
+    fun `subscriber created inside transition stays hidden until real did change`() = runBlocking {
+        val transitions = DefaultIdentityTransitionBarrier()
+        val persistent = scope(profileId = "profile-a", credentialOwnerId = "owner-a")
+        val temporary = scope(
+            profileId = "profile-a",
+            credentialOwnerId = null,
+            credentialGenerationId = "temporary-generation-a",
+        )
+        val tokens = SnapshotTokenManager(persistent)
+        val store = store(tokens, transitions)
+        store.setShowAudiobooksTab(true)
+        tokens.currentSnapshot = temporary
+        store.setShowAudiobooksTab(true)
+        tokens.currentSnapshot = persistent
+
+        val emissions = Channel<Boolean>(Channel.UNLIMITED)
+        var collector: Job? = null
+        try {
+            transitions.changing(IdentityTransitionKind.TEMPORARY_SCOPE_BEGIN) {
+                // Start collecting after WILL_CHANGE was published but before
+                // the identity snapshot changes. The replayed WILL_CHANGE must
+                // suppress the previous owner's true value.
+                collector = launch(Dispatchers.Default) {
+                    store.showAudiobooksTabFlow().collect(emissions::send)
+                }
+                assertFalse(withTimeout(5_000) { emissions.receive() })
+                tokens.currentSnapshot = temporary
+            }
+
+            assertTrue(withTimeout(5_000) { emissions.receive() })
+        } finally {
+            collector?.cancel()
+        }
+    }
+
+    @Test
+    fun `same owner survives profile token and snapshot generation changes`() = runBlocking {
+        val transitions = DefaultIdentityTransitionBarrier()
+        val initial = scope(
+            profileId = "profile-a",
+            credentialOwnerId = "durable-owner",
+            profileToken = "pin-token-a",
+            identityGeneration = 1,
+            credentialEpoch = 10,
+        )
+        val tokens = SnapshotTokenManager(initial)
+        val store = store(tokens, transitions)
+        store.setShowAudiobooksTab(true)
+        store.setSelectedLibraryId(2, TvLibraryTabType.Movies)
+
+        tokens.currentSnapshot = initial.copy(
+            profileToken = "pin-token-b",
+            identityGeneration = 99,
+            credentialEpoch = 11,
+        )
+
+        assertTrue(store.getShowAudiobooksTab())
+        assertEquals(2, store.getSelectedLibraryId(TvLibraryTabType.Movies))
+    }
+
+    @Test
+    fun `preferences written before owner namespacing survive the upgrade`() = runBlocking {
+        val factory = TestStoreFactory(tempFolder.root)
+        factory.seedLegacy(profileId = "profile-a", movieScopeId = 7, showAudiobooks = true)
+
+        val tokens = SnapshotTokenManager(
+            scope(profileId = "profile-a", credentialOwnerId = "owner-a"),
+        )
+        val store = store(tokens, DefaultIdentityTransitionBarrier(), factory)
+
+        assertTrue(store.getShowAudiobooksTab())
+        assertEquals(7, store.getSelectedLibraryId(TvLibraryTabType.Movies))
+        factory.shutdown()
+    }
+
+    @Test
+    fun `a second owner on the same profile does not inherit legacy preferences`() = runBlocking {
+        val factory = TestStoreFactory(tempFolder.root)
+        factory.seedLegacy(profileId = "shared-profile", movieScopeId = 7, showAudiobooks = true)
+
+        val tokens = SnapshotTokenManager(
+            scope(profileId = "shared-profile", credentialOwnerId = "owner-a"),
+        )
+        val store = store(tokens, DefaultIdentityTransitionBarrier(), factory)
+        assertEquals(7, store.getSelectedLibraryId(TvLibraryTabType.Movies))
+        assertTrue(store.getShowAudiobooksTab())
+
+        // A genuinely different account reusing the profile id starts clean.
+        tokens.currentSnapshot = scope(profileId = "shared-profile", credentialOwnerId = "owner-b")
+        assertNull(store.getSelectedLibraryId(TvLibraryTabType.Movies))
+        assertFalse(store.getShowAudiobooksTab())
+
+        // ...and claiming stays with the owner that upgraded.
+        tokens.currentSnapshot = scope(profileId = "shared-profile", credentialOwnerId = "owner-a")
+        assertEquals(7, store.getSelectedLibraryId(TvLibraryTabType.Movies))
+        factory.shutdown()
+    }
+
+    @Test
+    fun `absent legacy file is a clean no-op and is not created`() = runBlocking {
+        val factory = TestStoreFactory(tempFolder.root)
+        val tokens = SnapshotTokenManager(
+            scope(profileId = "profile-a", credentialOwnerId = "owner-a"),
+        )
+        val store = store(tokens, DefaultIdentityTransitionBarrier(), factory)
+
+        assertNull(store.getSelectedLibraryId(TvLibraryTabType.Movies))
+        assertFalse(store.getShowAudiobooksTab())
+        assertFalse(legacyFile("profile-a").exists())
+        factory.shutdown()
+    }
+
+    @Test
+    fun `legacy import runs once and does not clobber a later write`() = runBlocking {
+        val firstRun = TestStoreFactory(tempFolder.root)
+        firstRun.seedLegacy(profileId = "profile-a", movieScopeId = 7, showAudiobooks = true)
+        val first = store(
+            SnapshotTokenManager(scope(profileId = "profile-a", credentialOwnerId = "owner-a")),
+            DefaultIdentityTransitionBarrier(),
+            firstRun,
+        )
+        assertEquals(7, first.getSelectedLibraryId(TvLibraryTabType.Movies))
+        assertTrue(first.getShowAudiobooksTab())
+
+        first.setSelectedLibraryId(9, TvLibraryTabType.Movies)
+        first.setShowAudiobooksTab(false)
+        // Release every file so the "next launch" can reopen them.
+        firstRun.shutdown()
+
+        val secondRun = TestStoreFactory(tempFolder.root)
+        val second = store(
+            SnapshotTokenManager(scope(profileId = "profile-a", credentialOwnerId = "owner-a")),
+            DefaultIdentityTransitionBarrier(),
+            secondRun,
+        )
+        assertEquals(9, second.getSelectedLibraryId(TvLibraryTabType.Movies))
+        assertFalse(second.getShowAudiobooksTab())
+        secondRun.shutdown()
+    }
+
+    @Test
+    fun `temporary overlay neither inherits nor consumes the legacy import`() = runBlocking {
+        val factory = TestStoreFactory(tempFolder.root)
+        factory.seedLegacy(profileId = "profile-a", movieScopeId = 7, showAudiobooks = true)
+
+        val tokens = SnapshotTokenManager(
+            scope(
+                profileId = "profile-a",
+                credentialOwnerId = null,
+                credentialGenerationId = "temporary-generation-a",
+            ),
+        )
+        val store = store(tokens, DefaultIdentityTransitionBarrier(), factory)
+        assertNull(store.getSelectedLibraryId(TvLibraryTabType.Movies))
+        assertFalse(store.getShowAudiobooksTab())
+
+        // The durable owner still gets the one import the overlay must not spend.
+        tokens.currentSnapshot = scope(profileId = "profile-a", credentialOwnerId = "owner-a")
+        assertEquals(7, store.getSelectedLibraryId(TvLibraryTabType.Movies))
+        assertTrue(store.getShowAudiobooksTab())
+        factory.shutdown()
+    }
+
+    private fun legacyFile(profileId: String) = File(
+        tempFolder.root,
+        "${TvLibraryScopeStore.legacyFileNameFor(profileId)}.preferences_pb",
+    )
+
+    private suspend fun TestStoreFactory.seedLegacy(
+        profileId: String,
+        serverId: String = "server-a",
+        movieScopeId: Int? = null,
+        showAudiobooks: Boolean? = null,
+    ) {
+        // Written with the pre-upgrade key spellings on purpose: the wire
+        // format of the old file is exactly what the import has to understand.
+        create(TvLibraryScopeStore.legacyFileNameFor(profileId), emptyList()).edit { prefs ->
+            movieScopeId?.let { prefs[intPreferencesKey("scope_${serverId}_movies")] = it }
+            showAudiobooks?.let { prefs[booleanPreferencesKey("show_audiobooks_$serverId")] = it }
+        }
+    }
+
+    /**
+     * Mirrors the production factory: one live DataStore per file (DataStore
+     * rejects a second instance over the same file, and the legacy import
+     * opens a file these tests also seed) and migrations forwarded through.
+     * Each store owns a cancellable scope so a restart can be simulated.
+     */
+    private class TestStoreFactory(private val root: File) {
+        private val stores = mutableMapOf<String, DataStore<Preferences>>()
+        private val scopes = mutableListOf<CoroutineScope>()
+
+        fun create(
+            fileName: String,
+            migrations: List<DataMigration<Preferences>>,
+        ): DataStore<Preferences> = synchronized(stores) {
+            stores.getOrPut(fileName) {
+                val scope = CoroutineScope(Dispatchers.IO + Job())
+                scopes += scope
+                PreferenceDataStoreFactory.create(
+                    migrations = migrations,
+                    scope = scope,
+                    produceFile = { File(root, "$fileName.preferences_pb") },
+                )
+            }
+        }
+
+        /** Releases every file so a restarted factory can reopen them. */
+        suspend fun shutdown() {
+            val active = synchronized(stores) {
+                val running = scopes.toList()
+                stores.clear()
+                scopes.clear()
+                running
+            }
+            active.forEach { it.coroutineContext[Job]!!.cancelAndJoin() }
+        }
+    }
+
+    private fun store(
+        tokens: TokenManager,
+        transitions: DefaultIdentityTransitionBarrier,
+        factory: TestStoreFactory = TestStoreFactory(tempFolder.root),
+    ) = TvLibraryScopeStore(
+        context = object : ContextWrapper(null) {},
+        tokenManager = tokens,
+        identityTransitions = transitions,
+        dataStoreFactory = { fileName, migrations -> factory.create(fileName, migrations) },
+    )
+
+    private fun scope(
+        profileId: String,
+        serverId: String = "server-a",
+        credentialOwnerId: String? = "owner-a",
+        credentialGenerationId: String? = null,
+        profileToken: String? = "profile-token",
+        identityGeneration: Long = 1,
+        credentialEpoch: Long = 1,
+    ) = AuthScopeSnapshot(
+        serverId = serverId,
+        profileId = profileId,
+        serverUrl = "https://$serverId.example.test",
+        profileToken = profileToken,
+        credentialGenerationId = credentialGenerationId,
+        identityGeneration = identityGeneration,
+        credentialOwnerId = credentialOwnerId,
+        credentialEpoch = credentialEpoch,
+    )
+
+    private class SnapshotTokenManager(
+        initial: AuthScopeSnapshot,
+        private val legacyProfileId: String? = initial.profileId,
+        private val legacyServerId: String? = initial.serverId,
+    ) : TokenManager by TokenManagerImpl() {
+        @Volatile
+        var currentSnapshot: AuthScopeSnapshot? = initial
+
+        var separateIdentityReadCount: Int = 0
+            private set
+
+        override suspend fun snapshotCurrentScope(): AuthScopeSnapshot? = currentSnapshot
+
+        override suspend fun getProfileId(): String? {
+            separateIdentityReadCount += 1
+            return legacyProfileId
+        }
+
+        override suspend fun getCurrentServerId(): String? {
+            separateIdentityReadCount += 1
+            return legacyServerId
+        }
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailSubtitlePreferenceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailSubtitlePreferenceTest.kt
@@ -198,6 +198,8 @@ class TvItemDetailSubtitlePreferenceTest {
             keys: List<String>,
             libraryIds: List<Int>,
             seriesIds: List<String>,
+            profileId: String?,
+            authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
         ): ApiResult<EffectiveSettingValuesResponse> = ApiResult.Success(effective)
     }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailViewModelTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailViewModelTest.kt
@@ -2,7 +2,9 @@ package org.siloserver.silo.tv.ui.screens.people
 
 import org.siloserver.silo.network.SiloJson
 import org.siloserver.silo.network.api.CatalogApi
+import org.siloserver.silo.network.api.PersonalDataApi
 import org.siloserver.silo.repository.CatalogRepository
+import org.siloserver.silo.repository.PersonalDataRepository
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockRequestHandleScope
@@ -13,14 +15,17 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
@@ -94,6 +99,91 @@ class TvPersonDetailViewModelTest {
         assertFalse(viewModel.uiState.value.items.any { it.type == "audiobook" })
     }
 
+    @Test
+    fun slowLibraryLookupCannotExposeAudiobooksBeforeHiddenPreferenceIsObserved() = runPersonTest {
+        val libraryRequestStarted = CompletableDeferred<Unit>()
+        val releaseLibraryResponse = CompletableDeferred<Unit>()
+        val personalDataClient = HttpClient(
+            MockEngine { request ->
+                assertEquals("/api/v1/user/libraries", request.url.encodedPath)
+                libraryRequestStarted.complete(Unit)
+                releaseLibraryResponse.await()
+                respondJson(
+                    """[{"id":9,"name":"Audiobooks","type":"audiobooks","sort_order":0}]""",
+                )
+            },
+        ) {
+            install(ContentNegotiation) { json(SiloJson) }
+        }
+        val visibility = MutableStateFlow(false)
+        val viewModel = TvPersonDetailViewModel(
+            catalogRepository = repositoryFor(mutableListOf()),
+            personId = 7,
+            personalDataRepository = PersonalDataRepository(PersonalDataApi(personalDataClient)),
+            showAudiobooksFlow = visibility,
+        ).also { createdViewModels += it }
+
+        try {
+            libraryRequestStarted.await()
+            awaitState(viewModel) {
+                !it.isLoading && !it.isLoadingItems && it.items.isNotEmpty()
+            }
+
+            assertFalse(viewModel.uiState.value.items.any { it.type == "audiobook" })
+            assertFalse(
+                viewModel.uiState.value.availableFilters.contains(TvPersonMediaFilter.Audiobooks),
+            )
+        } finally {
+            releaseLibraryResponse.complete(Unit)
+            viewModel.viewModelScope.cancel()
+            viewModel.viewModelScope.coroutineContext[Job]?.join()
+            personalDataClient.close()
+        }
+    }
+
+    @Test
+    fun syncedAudiobookVisibilityUpdatesFiltersAndLoadedResults() = runPersonTest {
+        val visibility = MutableStateFlow(false)
+        val queries = mutableListOf<Map<String, String?>>()
+        val viewModel = TvPersonDetailViewModel(
+            catalogRepository = repositoryFor(queries),
+            personId = 7,
+            showAudiobooksFlow = visibility,
+        ).also { createdViewModels += it }
+        awaitState(viewModel) {
+            !it.isLoading && !it.isLoadingItems && it.items.isNotEmpty() &&
+                TvPersonMediaFilter.Audiobooks !in it.availableFilters
+        }
+        assertFalse(viewModel.uiState.value.items.any { it.type == "audiobook" })
+
+        visibility.value = true
+        awaitState(viewModel) {
+            !it.isLoadingItems &&
+                TvPersonMediaFilter.Audiobooks in it.availableFilters &&
+                it.items.any { item -> item.type == "audiobook" }
+        }
+        viewModel.applyFilter(TvPersonMediaFilter.Audiobooks)
+        awaitState(viewModel) {
+            !it.isLoadingItems &&
+                it.selectedFilter == TvPersonMediaFilter.Audiobooks &&
+                it.items.map { item -> item.contentId } == listOf("audiobook-filtered")
+        }
+
+        val queriesBeforeHide = queries.size
+        visibility.value = false
+        awaitState(viewModel) {
+            !it.isLoadingItems &&
+                TvPersonMediaFilter.Audiobooks !in it.availableFilters &&
+                it.selectedFilter == TvPersonMediaFilter.All &&
+                it.items.none { item -> item.type == "audiobook" }
+        }
+        assertTrue(
+            queries.drop(queriesBeforeHide).any { query ->
+                query["limit"] == "60" && query["type"] == null
+            },
+        )
+    }
+
     private val createdViewModels = mutableListOf<androidx.lifecycle.ViewModel>()
 
     private fun createViewModel(
@@ -111,7 +201,10 @@ class TvPersonDetailViewModelTest {
             // dispatch on Dispatchers.Main, and one still alive when a later
             // test calls setMain throws IllegalStateException from
             // TestMainDispatcher — the CI-only flake on this class.
-            createdViewModels.forEach { it.viewModelScope.cancel() }
+            createdViewModels.forEach { viewModel ->
+                viewModel.viewModelScope.cancel()
+                viewModel.viewModelScope.coroutineContext[Job]?.join()
+            }
             createdViewModels.clear()
             Dispatchers.resetMain()
         }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvCustomizationLimitsTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvCustomizationLimitsTest.kt
@@ -1,0 +1,570 @@
+package org.siloserver.silo.tv.ui.screens.settings
+
+import org.siloserver.silo.model.personal.UserLibrary
+import org.siloserver.silo.model.settings.NavigationShortcuts
+import org.siloserver.silo.model.settings.PrimaryMenu
+import org.siloserver.silo.model.settings.PrimaryMenuBuiltin
+import org.siloserver.silo.model.settings.PrimaryMenuItem
+import org.siloserver.silo.model.settings.UiCustomizationCodec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TvCustomizationLimitsTest {
+    private val home = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME)
+
+    @Test
+    fun visibleMenuMoveWeavesAroundUnsupportedRootsWithoutMovingThem() {
+        val section = PrimaryMenuItem.Section(7, "recent", "Recent")
+        val movies = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES)
+        val authored = listOf(home, section, movies)
+
+        assertEquals(listOf(home, movies), visibleTvMenuItems(authored, emptySet()))
+        assertEquals(
+            listOf(movies, section, home),
+            moveVisibleTvMenuItem(
+                items = authored,
+                identity = "builtin:movies",
+                offset = -1,
+                visibleLibraryIds = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun editorHidesLibraryPinsAbsentFromTheTvVisibleLibraryList() {
+        // A family=tv document authored by a client that does expose ebooks:
+        // library 9 is a reading library, so it never reaches the TV-visible
+        // library list and must not become a reorderable editor row.
+        val ebookPin = PrimaryMenuItem.Library(9, "Books")
+        val moviesPin = PrimaryMenuItem.Library(1, "Movies")
+        val authored = listOf(home, ebookPin, moviesPin)
+        val visibleLibraryIds = setOf(1)
+
+        assertEquals(
+            listOf(home, moviesPin),
+            visibleTvMenuItems(authored, visibleLibraryIds),
+        )
+        assertFalse(ebookPin in visibleTvMenuItems(authored, visibleLibraryIds))
+
+        // The hidden pin keeps its exact slot while a visible row weaves past it.
+        assertEquals(
+            listOf(moviesPin, ebookPin, home),
+            moveVisibleTvMenuItem(
+                items = authored,
+                identity = UiCustomizationCodec.identity(moviesPin),
+                offset = -1,
+                visibleLibraryIds = visibleLibraryIds,
+            ),
+        )
+        // And it can never be moved itself.
+        assertNull(
+            moveVisibleTvMenuItem(
+                items = authored,
+                identity = UiCustomizationCodec.identity(ebookPin),
+                offset = -1,
+                visibleLibraryIds = visibleLibraryIds,
+            ),
+        )
+    }
+
+    @Test
+    fun visibleMenuMoveRejectsProjectionBoundariesAndUnsupportedIdentities() {
+        val authored = listOf(
+            home,
+            PrimaryMenuItem.Section(7, "recent", "Recent"),
+            PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES),
+        )
+
+        assertNull(moveVisibleTvMenuItem(authored, "builtin:home", -1, emptySet()))
+        assertNull(moveVisibleTvMenuItem(authored, "builtin:movies", 1, emptySet()))
+        assertNull(moveVisibleTvMenuItem(authored, "section:7:recent", -1, emptySet()))
+        assertNull(moveVisibleTvMenuItem(authored, "builtin:movies", 0, emptySet()))
+    }
+
+    @Test
+    fun visibleMenuMovePreservesAFullContractSizedDocument() {
+        val movies = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES)
+        val hidden = List(TvPrimaryMenuMaxItems - 2) { index ->
+            PrimaryMenuItem.Section(7, "section-$index", "Section $index")
+        }
+        val authored = listOf(home) + hidden + movies
+
+        val moved = assertNotNull(
+            moveVisibleTvMenuItem(authored, "builtin:movies", -1, emptySet()),
+        )
+
+        assertEquals(TvPrimaryMenuMaxItems, moved.size)
+        assertEquals(movies, moved.first())
+        assertEquals(hidden, moved.subList(1, moved.lastIndex))
+        assertEquals(home, moved.last())
+    }
+
+    @Test
+    fun primaryMenuAdditionStopsAtContractLimit() {
+        val existing = buildList {
+            add(home)
+            repeat(TvPrimaryMenuMaxItems - 1) { index ->
+                add(PrimaryMenuItem.Library(index + 1, "Library ${index + 1}"))
+            }
+        }
+
+        assertNull(
+            prepareTvMenuItemAddition(
+                menuItems = existing,
+                currentShortcuts = NavigationShortcuts.EMPTY,
+                item = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+        )
+    }
+
+    @Test
+    fun primaryMenuAdditionCanReachButNotExceedContractLimit() {
+        val existing = buildList {
+            add(home)
+            repeat(TvPrimaryMenuMaxItems - 2) { index ->
+                add(PrimaryMenuItem.Library(index + 1, "Library ${index + 1}"))
+            }
+        }
+
+        val addition = assertNotNull(
+            prepareTvMenuItemAddition(
+                menuItems = existing,
+                currentShortcuts = NavigationShortcuts.EMPTY,
+                item = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+        )
+
+        assertEquals(TvPrimaryMenuMaxItems, addition.primaryMenu.items.size)
+        assertNull(addition.shortcuts)
+    }
+
+    @Test
+    fun newLibraryIsRejectedBeforeEitherWriteWhenShortcutsAreAtLimit() {
+        val shortcuts = NavigationShortcuts(
+            List(TvNavigationShortcutsMaxItems) { index ->
+                PrimaryMenuItem.Library(index + 1, "Library ${index + 1}")
+            },
+        )
+
+        assertNull(
+            prepareTvMenuItemAddition(
+                menuItems = listOf(home),
+                currentShortcuts = shortcuts,
+                item = PrimaryMenuItem.Library(10_000, "New Library"),
+            ),
+        )
+    }
+
+    @Test
+    fun unpinFreesShortcutCapacityWithoutChangingTheMenu() {
+        val pinnedMenuItem = PrimaryMenuItem.Library(1, "Pinned Library")
+        val menu = PrimaryMenu(listOf(home, pinnedMenuItem))
+        val fullShortcuts = NavigationShortcuts(
+            List(TvNavigationShortcutsMaxItems) { index ->
+                PrimaryMenuItem.Library(index + 1, "Library ${index + 1}")
+            },
+        )
+        val unpinnedShortcuts = NavigationShortcuts(
+            fullShortcuts.items.filterNot {
+                UiCustomizationCodec.identity(it) ==
+                    UiCustomizationCodec.identity(pinnedMenuItem)
+            },
+        )
+
+        val addition = assertNotNull(
+            prepareTvMenuItemAddition(
+                menuItems = menu.items,
+                currentShortcuts = unpinnedShortcuts,
+                item = PrimaryMenuItem.Library(10_000, "New Library"),
+            ),
+        )
+
+        assertEquals(listOf(home, pinnedMenuItem), menu.items)
+        assertEquals(TvNavigationShortcutsMaxItems, addition.shortcuts?.items?.size)
+    }
+
+    @Test
+    fun shortcutAdditionCanReachButNotExceedContractLimit() {
+        val shortcuts = NavigationShortcuts(
+            List(TvNavigationShortcutsMaxItems - 1) { index ->
+                PrimaryMenuItem.Library(index + 1, "Library ${index + 1}")
+            },
+        )
+
+        val addition = assertNotNull(
+            prepareTvMenuItemAddition(
+                menuItems = listOf(home),
+                currentShortcuts = shortcuts,
+                item = PrimaryMenuItem.Library(10_000, "New Library"),
+            ),
+        )
+
+        assertEquals(TvNavigationShortcutsMaxItems, addition.shortcuts?.items?.size)
+    }
+
+    @Test
+    fun existingShortcutDoesNotConsumeCapacityWhenLibraryJoinsMenu() {
+        val existingLibrary = PrimaryMenuItem.Library(1, "Library 1")
+        val shortcuts = NavigationShortcuts(
+            buildList {
+                add(existingLibrary)
+                repeat(TvNavigationShortcutsMaxItems - 1) { index ->
+                    add(PrimaryMenuItem.Library(index + 2, "Library ${index + 2}"))
+                }
+            },
+        )
+
+        val addition = assertNotNull(
+            prepareTvMenuItemAddition(
+                menuItems = listOf(home),
+                currentShortcuts = shortcuts,
+                item = existingLibrary,
+            ),
+        )
+
+        assertEquals(listOf(home, existingLibrary), addition.primaryMenu.items)
+        assertNull(addition.shortcuts)
+    }
+
+    @Test
+    fun audiobookToggleCannotGrowAFullPrimaryMenu() {
+        val fullMenu = buildList {
+            add(home)
+            repeat(TvPrimaryMenuMaxItems - 1) { index ->
+                add(PrimaryMenuItem.Library(index + 1, "Library ${index + 1}"))
+            }
+        }
+
+        assertFalse(
+            canEnableTvAudiobooksTab(menuItems = fullMenu),
+        )
+    }
+
+    @Test
+    fun audiobookToggleCanStayEnabledWhenItsMenuItemAlreadyExists() {
+        val fullMenu = buildList {
+            add(home)
+            add(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS))
+            repeat(TvPrimaryMenuMaxItems - 2) { index ->
+                add(PrimaryMenuItem.Library(index + 1, "Library ${index + 1}"))
+            }
+        }
+
+        assertTrue(
+            canEnableTvAudiobooksTab(menuItems = fullMenu),
+        )
+    }
+
+    @Test
+    fun effectiveMenuWithoutAudiobooksOverridesEnabledLegacyFallback() {
+        val effectiveMenu = minimalTvMenu()
+
+        assertFalse(
+            resolvedTvAudiobooksTab(
+                effectiveMenu = effectiveMenu,
+                legacyFallback = true,
+            ),
+        )
+    }
+
+    @Test
+    fun inheritedEffectiveMenuWithAudiobooksOverridesDisabledLegacyFallback() {
+        val inheritedEffectiveMenu = PrimaryMenu(
+            listOf(
+                home,
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+            ),
+        )
+
+        assertTrue(
+            resolvedTvAudiobooksTab(
+                effectiveMenu = inheritedEffectiveMenu,
+                legacyFallback = false,
+            ),
+        )
+    }
+
+    @Test
+    fun legacyAudiobookFlagIsUsedOnlyWithoutAnEffectiveMenu() {
+        assertTrue(
+            resolvedTvAudiobooksTab(
+                effectiveMenu = null,
+                legacyFallback = true,
+            ),
+        )
+        assertFalse(
+            resolvedTvAudiobooksTab(
+                effectiveMenu = null,
+                legacyFallback = false,
+            ),
+        )
+    }
+
+    @Test
+    fun olderServerKeepsAudiobookToggleLocalEnabledAndIgnoresCachedMenu() {
+        val cachedMenu = minimalTvMenu()
+        val mutation = prepareTvAudiobookToggleMutation(
+            customizationAvailable = false,
+            currentOverride = cachedMenu,
+            inheritedMenu = null,
+            enabled = true,
+        )
+        val state = TvSettingsViewModel.UiState(
+            uiCustomizationSupport = false,
+            legacyShowAudiobooksTab = mutation.legacyValue,
+            primaryMenuOverride = cachedMenu,
+        )
+
+        assertTrue(state.showAudiobooksTab)
+        assertTrue(tvAudiobookToggleEnabled(state))
+        assertNull(mutation.primaryMenu)
+    }
+
+    @Test
+    fun supportedServerRoutesAudiobookToggleThroughSyncedMenu() {
+        val current = minimalTvMenu()
+        val mutation = prepareTvAudiobookToggleMutation(
+            customizationAvailable = true,
+            currentOverride = current,
+            inheritedMenu = current,
+            enabled = true,
+        )
+        val menuWrite = assertNotNull(mutation.primaryMenu)
+        val state = TvSettingsViewModel.UiState(
+            uiCustomizationSupport = true,
+            customizationLibrariesResolved = true,
+            legacyShowAudiobooksTab = mutation.legacyValue,
+            primaryMenuOverride = menuWrite,
+            menuItems = menuWrite.items,
+        )
+
+        assertTrue(state.showAudiobooksTab)
+        assertTrue(tvAudiobookToggleEnabled(state))
+        assertTrue(
+            PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS) in menuWrite.items,
+        )
+    }
+
+    @Test
+    fun unresolvedCapabilityKeepsAudiobookToggleDisabled() {
+        val state = TvSettingsViewModel.UiState(
+            uiCustomizationSupport = null,
+            legacyShowAudiobooksTab = true,
+        )
+
+        assertTrue(state.showAudiobooksTab)
+        assertFalse(tvAudiobookToggleEnabled(state))
+    }
+
+    @Test
+    fun generalInitialFocusDefersOnlyWhileCapabilityIsUnknown() {
+        assertEquals(
+            TvGeneralInitialFocusTarget.DEFER,
+            tvGeneralInitialFocusTarget(
+                TvSettingsViewModel.UiState(uiCustomizationSupport = null),
+            ),
+        )
+        assertEquals(
+            TvGeneralInitialFocusTarget.READ_ONLY,
+            tvGeneralInitialFocusTarget(
+                TvSettingsViewModel.UiState(uiCustomizationSupport = null),
+                allowUnresolvedReadOnly = true,
+            ),
+        )
+        assertEquals(
+            TvGeneralInitialFocusTarget.AUDIOBOOKS,
+            tvGeneralInitialFocusTarget(
+                TvSettingsViewModel.UiState(uiCustomizationSupport = false),
+            ),
+        )
+        assertEquals(
+            TvGeneralInitialFocusTarget.CARD_PRESET,
+            tvGeneralInitialFocusTarget(
+                TvSettingsViewModel.UiState(uiCustomizationSupport = true),
+            ),
+        )
+    }
+
+    @Test
+    fun generalInitialFocusChoosesOneEnabledSupportedRow() {
+        val supported = TvSettingsViewModel.UiState(
+            uiCustomizationSupport = true,
+            customizationLibrariesResolved = true,
+        )
+        assertEquals(
+            TvGeneralInitialFocusTarget.AUDIOBOOKS,
+            tvGeneralInitialFocusTarget(supported),
+        )
+
+        val fullMenu = List(TvPrimaryMenuMaxItems) { index ->
+            PrimaryMenuItem.Library(index + 1, "Library ${index + 1}")
+        }
+        assertEquals(
+            TvGeneralInitialFocusTarget.LAYOUT_PRESET,
+            tvGeneralInitialFocusTarget(supported.copy(menuItems = fullMenu)),
+        )
+
+        // The sync action precedes Top Menu and must be the sole requester
+        // even when the audiobook row would otherwise also be enabled.
+        assertEquals(
+            TvGeneralInitialFocusTarget.SYNC,
+            tvGeneralInitialFocusTarget(
+                supported.copy(cardPresentationUsesDeviceOverride = true),
+            ),
+        )
+    }
+
+    @Test
+    fun toggleDirectionChangesTheEffectiveMenuInsteadOfTheContradictingLegacyFlag() {
+        val effectiveMenu = minimalTvMenu()
+        val checked = resolvedTvAudiobooksTab(
+            effectiveMenu = effectiveMenu,
+            legacyFallback = true,
+        )
+
+        val write = assertNotNull(
+            prepareTvAudiobookMenuWrite(
+                currentOverride = effectiveMenu,
+                inheritedMenu = effectiveMenu,
+                enabled = !checked,
+            ),
+        )
+
+        assertTrue(resolvedTvAudiobooksTab(write, legacyFallback = true))
+        assertTrue(
+            write.items.contains(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+            ),
+        )
+    }
+
+    @Test
+    fun disablingAnAuthoredAudiobookItemChangesTheEffectiveMenu() {
+        val effectiveMenu = PrimaryMenu(
+            listOf(
+                home,
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+            ),
+        )
+        val checked = resolvedTvAudiobooksTab(
+            effectiveMenu = effectiveMenu,
+            legacyFallback = false,
+        )
+
+        val write = assertNotNull(
+            prepareTvAudiobookMenuWrite(
+                currentOverride = effectiveMenu,
+                inheritedMenu = effectiveMenu,
+                enabled = !checked,
+            ),
+        )
+
+        assertFalse(resolvedTvAudiobooksTab(write, legacyFallback = false))
+    }
+
+    @Test
+    fun unresolvedLibrariesCannotMaterializeAProfileMenuPreset() {
+        assertNull(
+            prepareTvNavigationPresetMutation(
+                preset = TvSettingsViewModel.NavigationPreset.MEDIA_FIRST,
+                libraries = emptyList(),
+                showAudiobooks = false,
+                librariesResolved = false,
+            ),
+        )
+    }
+
+    @Test
+    fun standardPresetClearsTheOverrideInsteadOfFreezingCurrentLibraries() {
+        assertEquals(
+            TvNavigationPresetMutation.ResetPrimaryMenu,
+            prepareTvNavigationPresetMutation(
+                preset = TvSettingsViewModel.NavigationPreset.STANDARD,
+                libraries = listOf(
+                    UserLibrary(id = 1, name = "Movies", type = "movies", sortOrder = 0),
+                ),
+                showAudiobooks = false,
+                librariesResolved = true,
+            ),
+        )
+    }
+
+    @Test
+    fun resolvedMediaFirstPresetIncludesAvailableMediaBeforeHome() {
+        val mutation = assertIs<TvNavigationPresetMutation.SetPrimaryMenu>(
+            prepareTvNavigationPresetMutation(
+                preset = TvSettingsViewModel.NavigationPreset.MEDIA_FIRST,
+                libraries = listOf(
+                    UserLibrary(id = 1, name = "Movies", type = "movies", sortOrder = 0),
+                ),
+                showAudiobooks = false,
+                librariesResolved = true,
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES),
+                home,
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+            mutation.value.items,
+        )
+    }
+
+    @Test
+    fun inheritedAudiobookToggleMaterializesAFamilyMenu() {
+        val inherited = PrimaryMenu(
+            listOf(
+                home,
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+        )
+
+        val write = assertNotNull(
+            prepareTvAudiobookMenuWrite(
+                currentOverride = null,
+                inheritedMenu = inherited,
+                enabled = true,
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                home,
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR),
+            ),
+            write.items,
+        )
+    }
+
+    @Test
+    fun inheritedDisabledAudiobookStateIsStillMaterializedForFamilySync() {
+        val inherited = PrimaryMenu(
+            listOf(
+                home,
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+            ),
+        )
+
+        assertEquals(
+            inherited,
+            prepareTvAudiobookMenuWrite(
+                currentOverride = null,
+                inheritedMenu = inherited,
+                enabled = false,
+            ),
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvUiCustomizationCapabilityTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvUiCustomizationCapabilityTest.kt
@@ -1,0 +1,145 @@
+package org.siloserver.silo.tv.ui.screens.settings
+
+import org.siloserver.silo.domain.settings.ProfileSettingsController
+import org.siloserver.silo.model.settings.SettingsContractCapabilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TvUiCustomizationCapabilityTest {
+    @Test
+    fun liveSupportOwnsControlVisibilityAndMutationGuardAcrossTransitions() {
+        var state = TvSettingsViewModel.UiState()
+            .withObservedUiCustomizationSupport(false)
+        assertFalse(state.uiCustomizationAvailable)
+        assertFalse(state.canAuthorUiCustomization)
+
+        state = state.withObservedUiCustomizationSupport(true)
+        assertTrue(state.uiCustomizationAvailable)
+        assertTrue(state.canAuthorUiCustomization)
+
+        state = state.withObservedUiCustomizationSupport(false)
+        assertFalse(state.uiCustomizationAvailable)
+        assertFalse(state.canAuthorUiCustomization)
+
+        state = state.withObservedUiCustomizationSupport(true)
+        assertTrue(state.uiCustomizationAvailable)
+        assertTrue(state.canAuthorUiCustomization)
+
+        // A profile/server switch publishes UNKNOWN before the replacement
+        // probe completes. Cached presentation remains in state, but writes
+        // and authoring controls must close immediately.
+        state = state.copy(posterSize = org.siloserver.silo.model.settings.PosterSizePreset.LARGE)
+            .withObservedUiCustomizationSupport(null)
+        assertEquals(
+            org.siloserver.silo.model.settings.PosterSizePreset.LARGE,
+            state.posterSize,
+        )
+        assertFalse(state.uiCustomizationAvailable)
+        assertFalse(state.canAuthorUiCustomization)
+
+        state = state.withObservedUiCustomizationSupport(false)
+        assertFalse(state.uiCustomizationAvailable)
+        assertFalse(state.canAuthorUiCustomization)
+    }
+
+    @Test
+    fun olderAndErroringServersFailClosed() {
+        assertEquals(
+            false,
+            tvUiCustomizationSupport(
+                ProfileSettingsController.LoadResult(
+                    ProfileSettingsController.Availability.SERVER_UPGRADE_REQUIRED,
+                    snapshot = null,
+                ),
+            ),
+        )
+        assertNull(
+            tvUiCustomizationSupport(
+                ProfileSettingsController.LoadResult(
+                    ProfileSettingsController.Availability.UNAVAILABLE,
+                    snapshot = null,
+                ),
+            ),
+        )
+        assertFalse(
+            tvUiCustomizationAvailable(
+                ProfileSettingsController.LoadResult(
+                    ProfileSettingsController.Availability.SERVER_UPGRADE_REQUIRED,
+                    snapshot = null,
+                ),
+            ),
+        )
+        assertFalse(
+            tvUiCustomizationAvailable(
+                ProfileSettingsController.LoadResult(
+                    ProfileSettingsController.Availability.UNAVAILABLE,
+                    snapshot = null,
+                ),
+            ),
+        )
+        assertFalse(
+            available(
+                SettingsContractCapabilities(
+                    revision = 4,
+                    supportsBatchedEffective = true,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            ),
+        )
+        assertFalse(
+            available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsBatchedEffective = true,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = false,
+                ),
+            ),
+        )
+        assertFalse(
+            available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsBatchedEffective = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            ),
+        )
+        assertFalse(
+            available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun revisionFiveWithEveryRequiredCapabilityEnablesControls() {
+        assertTrue(
+            available(
+                SettingsContractCapabilities(
+                    revision = 5,
+                    supportsBatchedEffective = true,
+                    supportsIdempotentWrites = true,
+                    supportsAtomicShortcuts = true,
+                ),
+            ),
+        )
+    }
+
+    private fun available(capabilities: SettingsContractCapabilities): Boolean =
+        tvUiCustomizationAvailable(
+            ProfileSettingsController.LoadResult(
+                ProfileSettingsController.Availability.AVAILABLE,
+                snapshot = null,
+                capabilities = capabilities,
+            ),
+        )
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvMediaDestinationsTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvMediaDestinationsTest.kt
@@ -1,9 +1,15 @@
 package org.siloserver.silo.tv.ui.shell
 
 import org.siloserver.silo.model.personal.UserLibrary
+import org.siloserver.silo.model.settings.PrimaryMenu
+import org.siloserver.silo.model.settings.PrimaryMenuBuiltin
+import org.siloserver.silo.model.settings.PrimaryMenuItem
+import org.siloserver.silo.model.settings.effectivePrimaryMenuForSupport
 import org.siloserver.silo.tv.ui.navigation.TvMainRoute
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class TvMediaDestinationsTest {
 
@@ -41,6 +47,18 @@ class TvMediaDestinationsTest {
     }
 
     @Test
+    fun unrenderableAuthoredMenuStillProvidesAFocusableHomeRoot() {
+        val menu = PrimaryMenu(
+            listOf(PrimaryMenuItem.Section(7, "recent", "Recent")),
+        )
+
+        assertEquals(
+            listOf(TvRootDestination.Home),
+            visibleTvRoots(emptyList(), primaryMenu = menu),
+        )
+    }
+
+    @Test
     fun onlyPresentTypesYieldTabs() {
         val libraries = listOf(library(1, "audiobook"))
         // tvOS parity: the Audiobooks tab is OPT-IN (hidden by default) even
@@ -67,5 +85,328 @@ class TvMediaDestinationsTest {
     @Test
     fun firstRouteIsAlwaysHome() {
         assertEquals(TvMainRoute.Home.route, firstTvRoute())
+    }
+
+    @Test
+    fun customizedOrderAndPinnedLibraryBecomeExactFocusableRoots() {
+        val libraries = listOf(library(7, "movies"), library(8, "series"))
+        val menu = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.CALENDAR),
+                PrimaryMenuItem.Library(7, "Family Movies"),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.SERIES),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                TvRootDestination.Calendar,
+                TvRootDestination.LibraryType(
+                    TvLibraryTabType.Movies,
+                    libraryId = 7,
+                    customLabel = "Family Movies",
+                ),
+                TvRootDestination.Home,
+                TvRootDestination.LibraryType(TvLibraryTabType.Series),
+            ),
+            visibleTvRoots(libraries, primaryMenu = menu),
+        )
+    }
+
+    @Test
+    fun unavailableAndUnsupportedCustomItemsAreOmittedWithoutChangingOrder() {
+        val menu = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Library(999, "Gone"),
+                PrimaryMenuItem.Section(7, "recent", "Recent"),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.MOVIES),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                TvRootDestination.Home,
+                TvRootDestination.LibraryType(TvLibraryTabType.Movies),
+            ),
+            visibleTvRoots(listOf(library(7, "movies")), primaryMenu = menu),
+        )
+    }
+
+    @Test
+    fun pinnedLibraryKeepsItsSharedMediaRouteVisible() {
+        val pinned = TvRootDestination.LibraryType(
+            TvLibraryTabType.Movies,
+            libraryId = 7,
+            customLabel = "Family Movies",
+        )
+
+        assertTrue(
+            TvRootDestination.LibraryType(TvLibraryTabType.Movies)
+                .isVisibleIn(listOf(TvRootDestination.Home, pinned)),
+        )
+    }
+
+    @Test
+    fun explicitFamilyMenuOverridesTheLegacyAudiobookVisibilityFlag() {
+        val menu = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                TvRootDestination.Home,
+                TvRootDestination.LibraryType(TvLibraryTabType.Audiobooks),
+            ),
+            visibleTvRoots(
+                libraries = listOf(library(9, "audiobooks")),
+                showAudiobooks = false,
+                primaryMenu = menu,
+            ),
+        )
+    }
+
+    @Test
+    fun confirmedUnsupportedServerRestoresLegacyAudiobookRootFromCachedMenu() {
+        val libraries = listOf(library(9, "audiobooks"))
+        val cachedMinimal = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.FOR_YOU),
+            ),
+        )
+
+        assertTrue(
+            TvRootDestination.LibraryType(TvLibraryTabType.Audiobooks) in visibleTvRoots(
+                libraries = libraries,
+                showAudiobooks = true,
+                primaryMenu = effectivePrimaryMenuForSupport(cachedMinimal, false),
+            ),
+        )
+        assertTrue(
+            TvRootDestination.LibraryType(TvLibraryTabType.Audiobooks) !in visibleTvRoots(
+                libraries = libraries,
+                showAudiobooks = true,
+                primaryMenu = effectivePrimaryMenuForSupport(cachedMinimal, null),
+            ),
+        )
+    }
+
+    @Test
+    fun audiobookVisibilityUsesSyncedMenuOnlyWhenCapabilityIsNotRejected() {
+        val menuWithAudiobooks = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.AUDIOBOOKS),
+            ),
+        )
+        val menuWithoutAudiobooks = PrimaryMenu(
+            listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME)),
+        )
+
+        assertTrue(resolvedTvAudiobookVisibility(menuWithAudiobooks, true, false))
+        assertFalse(resolvedTvAudiobookVisibility(menuWithoutAudiobooks, true, true))
+        assertTrue(resolvedTvAudiobookVisibility(menuWithoutAudiobooks, false, true))
+        assertFalse(resolvedTvAudiobookVisibility(menuWithoutAudiobooks, null, true))
+    }
+
+    @Test
+    fun directAudiobookLibraryPlacementEnablesOnlyItsMatchingMediaVisibility() {
+        val directAudiobook = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Library(9, "Pinned Audiobooks"),
+            ),
+        )
+        val directMovies = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Library(7, "Pinned Movies"),
+            ),
+        )
+        val libraries = listOf(library(7, "movies"), library(9, "audiobooks"))
+
+        assertTrue(resolvedTvAudiobookVisibility(directAudiobook, true, false, libraries))
+        assertFalse(resolvedTvAudiobookVisibility(directMovies, true, false, libraries))
+    }
+
+    @Test
+    fun exactPinnedAndBuiltinTabsKeepDistinctSelectionIdentity() {
+        val builtin = TvRootDestination.LibraryType(TvLibraryTabType.Movies)
+        val pinned = TvRootDestination.LibraryType(
+            TvLibraryTabType.Movies,
+            libraryId = 7,
+            customLabel = "Family Movies",
+        )
+        val destinations = listOf(TvRootDestination.Home, builtin, pinned)
+
+        assertEquals(
+            builtin,
+            selectedTvRoot(
+                routeRoot = builtin,
+                destinations = destinations,
+                selectedLibraryId = 7,
+                exactSelection = builtin,
+            ),
+        )
+        assertEquals(
+            pinned,
+            selectedTvRoot(
+                routeRoot = builtin,
+                destinations = destinations,
+                selectedLibraryId = 7,
+                exactSelection = pinned,
+            ),
+        )
+    }
+
+    @Test
+    fun savedSemanticSelectionRestoresTheExactTabWithCurrentLabelsAfterRecreation() {
+        val builtin = TvRootDestination.LibraryType(TvLibraryTabType.Movies)
+        val pinnedBeforeRecreation = TvRootDestination.LibraryType(
+            TvLibraryTabType.Movies,
+            libraryId = 7,
+            customLabel = "Family Movies",
+        )
+        val pinnedAfterRecreation = pinnedBeforeRecreation.copy(customLabel = "Movie Night")
+        val destinationsAfterRecreation = listOf(
+            TvRootDestination.Home,
+            builtin,
+            pinnedAfterRecreation,
+        )
+
+        val savedBuiltin = builtin.saveableSelectionIdentity()
+        val savedPinned = pinnedBeforeRecreation.saveableSelectionIdentity()
+
+        assertEquals("builtin:movies", savedBuiltin)
+        assertEquals("library:7", savedPinned)
+        assertEquals(
+            builtin,
+            resolveSavedTvLibraryDestination(savedBuiltin, destinationsAfterRecreation),
+        )
+        assertEquals(
+            pinnedAfterRecreation,
+            resolveSavedTvLibraryDestination(savedPinned, destinationsAfterRecreation),
+            "restoration must resolve the semantic pin against its current authored label",
+        )
+    }
+
+    @Test
+    fun removedAuthoredRootClearsExactSelectionAndFallsBackToAVisibleSibling() {
+        val routeRoot = TvRootDestination.LibraryType(TvLibraryTabType.Movies)
+        val removedPinned = TvRootDestination.LibraryType(
+            TvLibraryTabType.Movies,
+            libraryId = 7,
+            customLabel = "Family Movies",
+        )
+        val changedDestinations = listOf(TvRootDestination.Home, routeRoot)
+
+        val restored = resolveSavedTvLibraryDestination(
+            removedPinned.saveableSelectionIdentity(),
+            changedDestinations,
+        )
+
+        assertEquals(null, restored, "a removed authored root must not retain stale exact state")
+        assertEquals(
+            routeRoot,
+            selectedTvRoot(
+                routeRoot = routeRoot,
+                destinations = changedDestinations,
+                selectedLibraryId = 7,
+                exactSelection = restored,
+            ),
+        )
+    }
+
+    @Test
+    fun missingExactSelectionFallsBackToFirstVisibleRootOfTheSameType() {
+        val routeRoot = TvRootDestination.LibraryType(TvLibraryTabType.Movies)
+        val firstVisible = TvRootDestination.LibraryType(
+            TvLibraryTabType.Movies,
+            libraryId = 7,
+            customLabel = "Family Movies",
+        )
+        val secondVisible = TvRootDestination.LibraryType(
+            TvLibraryTabType.Movies,
+            libraryId = 8,
+            customLabel = "Kids Movies",
+        )
+
+        assertEquals(
+            firstVisible,
+            selectedTvRoot(
+                routeRoot = routeRoot,
+                destinations = listOf(TvRootDestination.Home, firstVisible, secondVisible),
+                selectedLibraryId = 999,
+                exactSelection = TvRootDestination.LibraryType(
+                    TvLibraryTabType.Movies,
+                    libraryId = 123,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun explicitPinnedCommitBeatsAStaleSameTypeBuiltinPreview() {
+        val builtin = TvRootDestination.LibraryType(TvLibraryTabType.Movies)
+        val pinned = TvRootDestination.LibraryType(
+            TvLibraryTabType.Movies,
+            libraryId = 7,
+            customLabel = "Family Movies",
+        )
+
+        assertEquals(
+            pinned,
+            committedTvLibraryDestination(
+                type = TvLibraryTabType.Movies,
+                libraryId = 7,
+                explicitDestination = pinned,
+                panelDestination = builtin,
+                destinations = listOf(TvRootDestination.Home, builtin, pinned),
+            ),
+        )
+    }
+
+    @Test
+    fun cascadeCommitUsesItsPanelIdentityWithoutAnExplicitTabSelection() {
+        val builtin = TvRootDestination.LibraryType(TvLibraryTabType.Movies)
+        val pinned = TvRootDestination.LibraryType(
+            TvLibraryTabType.Movies,
+            libraryId = 7,
+            customLabel = "Family Movies",
+        )
+
+        assertEquals(
+            builtin,
+            committedTvLibraryDestination(
+                type = TvLibraryTabType.Movies,
+                libraryId = 7,
+                explicitDestination = null,
+                panelDestination = builtin,
+                destinations = listOf(TvRootDestination.Home, builtin, pinned),
+            ),
+        )
+    }
+
+    @Test
+    fun pinnedLibraryCascadeStartsFromItsOwnScope() {
+        val pinned = TvRootDestination.LibraryType(
+            TvLibraryTabType.Movies,
+            libraryId = 7,
+            customLabel = "Family Movies",
+        )
+
+        assertEquals(7, cascadeCurrentScopeId(pinned, activeLibraryId = 8))
+    }
+
+    @Test
+    fun builtinLibraryCascadeStartsFromTheActiveScope() {
+        val builtin = TvRootDestination.LibraryType(TvLibraryTabType.Movies)
+
+        assertEquals(8, cascadeCurrentScopeId(builtin, activeLibraryId = 8))
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuFocusRequestTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuFocusRequestTest.kt
@@ -83,6 +83,64 @@ class TvTopMenuFocusRequestTest {
     }
 
     @Test
+    fun selectedEntryIsClearedWhenItsRootIsNoLongerComposed() {
+        val movies = TvRootDestination.LibraryType(TvLibraryTabType.Movies)
+
+        assertEquals(
+            movies,
+            selectedTopMenuEntry(
+                selectedRoot = movies,
+                destinations = listOf(TvRootDestination.Home, movies),
+            ),
+        )
+        assertEquals(
+            null,
+            selectedTopMenuEntry(
+                selectedRoot = movies,
+                destinations = listOf(TvRootDestination.Home),
+            ),
+        )
+    }
+
+    @Test
+    fun selectedEntryFallbackDistinguishesDetailSearchAndHiddenRootRoutes() {
+        val destinations = listOf(TvRootDestination.Home, TvRootDestination.Calendar)
+
+        assertEquals(
+            TvTopMenuEntryFallback.HOME,
+            selectedTopMenuEntryFallback(
+                selectedRoot = null,
+                isSearchActive = false,
+                destinations = destinations,
+            ),
+        )
+        assertEquals(
+            TvTopMenuEntryFallback.SEARCH,
+            selectedTopMenuEntryFallback(
+                selectedRoot = null,
+                isSearchActive = true,
+                destinations = destinations,
+            ),
+        )
+        assertEquals(
+            TvTopMenuEntryFallback.SEARCH,
+            selectedTopMenuEntryFallback(
+                selectedRoot = TvRootDestination.ForYou,
+                isSearchActive = false,
+                destinations = destinations,
+            ),
+        )
+        assertEquals(
+            TvTopMenuEntryFallback.SEARCH,
+            selectedTopMenuEntryFallback(
+                selectedRoot = null,
+                isSearchActive = false,
+                destinations = listOf(TvRootDestination.Calendar),
+            ),
+        )
+    }
+
+    @Test
     fun focusRequestRemainsPendingUntilItsLibraryDestinationAppears() = runTest {
         val movies = TvRootDestination.LibraryType(TvLibraryTabType.Movies)
         val identity = 1 to TvTopMenuPanel.Root(movies)

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvUiCustomizationLifecycleTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvUiCustomizationLifecycleTest.kt
@@ -1,0 +1,33 @@
+package org.siloserver.silo.tv.ui.shell
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvUiCustomizationLifecycleTest {
+    @Test
+    fun resumeRefreshRequiresCompleteServerAndProfileIdentity() {
+        assertTrue(shouldRefreshTvUiCustomization("server-a", "profile-1"))
+        assertFalse(shouldRefreshTvUiCustomization(null, "profile-1"))
+        assertFalse(shouldRefreshTvUiCustomization("server-a", null))
+        assertFalse(shouldRefreshTvUiCustomization("", "profile-1"))
+        assertFalse(shouldRefreshTvUiCustomization("server-a", " "))
+    }
+
+    @Test
+    fun legacyAudiobookVisibilityStartsHiddenUntilTheFlowResolves() {
+        val initial = TvLegacyAudiobookVisibility()
+        assertFalse(initial.show)
+        assertFalse(initial.isResolved)
+
+        assertEquals(
+            TvLegacyAudiobookVisibility(show = true, isResolved = true),
+            resolvedTvLegacyAudiobookVisibility(show = true),
+        )
+        assertEquals(
+            TvLegacyAudiobookVisibility(show = false, isResolved = true),
+            resolvedTvLegacyAudiobookVisibility(show = false),
+        )
+    }
+}

--- a/shared/src/androidMain/kotlin/org/siloserver/silo/network/AndroidServerRegistry.kt
+++ b/shared/src/androidMain/kotlin/org/siloserver/silo/network/AndroidServerRegistry.kt
@@ -195,6 +195,7 @@ class AndroidServerRegistry(
         refreshToken: String,
         expiryEpochMs: Long,
         lifetimeMs: Long,
+        credentialOwnerId: String,
     ) {
         mutex.withLock {
             check(_entries.value.any { it.id == serverId }) { "account replacement target is not registered" }
@@ -215,6 +216,13 @@ class AndroidServerRegistry(
                 .putString(serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_REFRESH_TOKEN), refreshToken)
                 .putLong(serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_TOKEN_EXPIRY), expiryEpochMs)
                 .putLong(serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_TOKEN_LIFETIME), lifetimeMs)
+                // Rotated in the same transaction as the credentials so a
+                // durable cache keyed on the owner id can never observe the new
+                // account's tokens under the previous account's ownership.
+                .putString(
+                    serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_CREDENTIAL_OWNER_ID),
+                    credentialOwnerId,
+                )
             val profileIdKey = serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_PROFILE_ID)
             val profileTokenKey = serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_PROFILE_TOKEN)
             if (profileId == null) editor.remove(profileIdKey) else editor.putString(profileIdKey, profileId)
@@ -239,6 +247,7 @@ class AndroidServerRegistry(
                 .remove(serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_TOKEN_LIFETIME))
                 .remove(serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_PROFILE_ID))
                 .remove(serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_PROFILE_TOKEN))
+                .remove(serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_CREDENTIAL_OWNER_ID))
             check(commitEditor(editor)) { "unable to durably sign out account" }
             applyStateLocked(state)
         }

--- a/shared/src/androidMain/kotlin/org/siloserver/silo/network/EncryptedTokenManagerImpl.kt
+++ b/shared/src/androidMain/kotlin/org/siloserver/silo/network/EncryptedTokenManagerImpl.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.network
 
 import android.content.SharedPreferences
+import java.util.UUID
 import org.siloserver.silo.network.AndroidServerRegistry.Companion.serverScopedKey
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -53,6 +54,7 @@ class EncryptedTokenManagerImpl(
     private var tokenLifetimeMs: Long? = null
     private var profileId: String? = null
     private var profileToken: String? = null
+    private var persistentCredentialOwnerId: String? = null
     private var temporaryScope: TemporaryAuthScope? = null
 
     /**
@@ -197,6 +199,10 @@ class EncryptedTokenManagerImpl(
                 mutex.withLock {
                     val lifetimeMs = expiresIn * 1_000L
                     val expiryEpochMs = System.currentTimeMillis() + lifetimeMs
+                    // A replacement login is a new durable account boundary:
+                    // rotate the owner id so caches scoped to the previous
+                    // account cannot be adopted by this one.
+                    val credentialOwnerId = UUID.randomUUID().toString()
                     // Registry selection and token/profile slots share the same
                     // encrypted preferences file, so commit them atomically and
                     // synchronously before publishing the cache.
@@ -208,6 +214,7 @@ class EncryptedTokenManagerImpl(
                         refreshToken = refreshToken,
                         expiryEpochMs = expiryEpochMs,
                         lifetimeMs = lifetimeMs,
+                        credentialOwnerId = credentialOwnerId,
                     )
                     activeServerId = targetServerId
                     this.profileId = profileId
@@ -216,6 +223,7 @@ class EncryptedTokenManagerImpl(
                     this.refreshToken = refreshToken
                     tokenExpiryEpochMs = expiryEpochMs
                     tokenLifetimeMs = lifetimeMs
+                    persistentCredentialOwnerId = credentialOwnerId
                     persistentCredentialEpoch += 1
                     afterAccountSessionCommit()
                 }
@@ -304,6 +312,7 @@ class EncryptedTokenManagerImpl(
                     .remove(serverScopedKey(serverId, KEY_TOKEN_LIFETIME))
                     .remove(serverScopedKey(serverId, KEY_PROFILE_ID))
                     .remove(serverScopedKey(serverId, KEY_PROFILE_TOKEN))
+                    .remove(serverScopedKey(serverId, KEY_CREDENTIAL_OWNER_ID))
                 check(editor.commit()) { "unable to durably sign out account" }
                 registry.signOut(serverId)
             }
@@ -316,6 +325,7 @@ class EncryptedTokenManagerImpl(
         tokenLifetimeMs = null
         profileId = null
         profileToken = null
+        persistentCredentialOwnerId = null
         if (committedSignOut) afterAccountSignOutCommit()
     }
 
@@ -502,6 +512,7 @@ class EncryptedTokenManagerImpl(
             profileToken = profileToken,
             identityGeneration = identityTransitions.generation.value,
             isIdentityGenerationStamped = true,
+            credentialOwnerId = ensurePersistentCredentialOwnerId(serverId),
             credentialEpoch = persistentCredentialEpoch,
         )
     }
@@ -703,6 +714,7 @@ class EncryptedTokenManagerImpl(
             tokenLifetimeMs = null
             profileId = null
             profileToken = null
+            persistentCredentialOwnerId = null
             return
         }
         accessToken = prefs.getString(serverScopedKey(serverId, KEY_ACCESS_TOKEN), null)
@@ -713,6 +725,25 @@ class EncryptedTokenManagerImpl(
         tokenLifetimeMs = if (prefs.contains(lifetimeKey)) prefs.getLong(lifetimeKey, 0L) else null
         profileId = prefs.getString(serverScopedKey(serverId, KEY_PROFILE_ID), null)
         profileToken = prefs.getString(serverScopedKey(serverId, KEY_PROFILE_TOKEN), null)
+        persistentCredentialOwnerId =
+            prefs.getString(serverScopedKey(serverId, KEY_CREDENTIAL_OWNER_ID), null)
+    }
+
+    /**
+     * Stable account-slot identity for durable local ownership. Existing
+     * installs receive one lazily on their first live snapshot; sign-out
+     * removes it and account replacement rotates it, so a replacement login
+     * cannot inherit the previous account's cache even when the server and
+     * profile identifiers happen to match.
+     */
+    private fun ensurePersistentCredentialOwnerId(serverId: String): String {
+        persistentCredentialOwnerId?.takeIf { it.isNotBlank() }?.let { return it }
+        val created = UUID.randomUUID().toString()
+        persistentCredentialOwnerId = created
+        prefs.edit()
+            .putString(serverScopedKey(serverId, KEY_CREDENTIAL_OWNER_ID), created)
+            .apply()
+        return created
     }
 
     internal companion object {
@@ -722,6 +753,7 @@ class EncryptedTokenManagerImpl(
         const val KEY_TOKEN_LIFETIME = "token_lifetime_ms"
         const val KEY_PROFILE_ID = "profile_id"
         const val KEY_PROFILE_TOKEN = "profile_token"
+        const val KEY_CREDENTIAL_OWNER_ID = "credential_owner_id"
         // Retained only so [AndroidServerRegistry.migrateLegacyIfNeeded] can
         // strip the pre-multi-server unprefixed key off disk.
         const val KEY_SERVER_URL = "server_url"

--- a/shared/src/androidUnitTest/kotlin/org/siloserver/silo/network/EncryptedTokenManagerScopeGenerationTest.kt
+++ b/shared/src/androidUnitTest/kotlin/org/siloserver/silo/network/EncryptedTokenManagerScopeGenerationTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -394,6 +395,161 @@ class EncryptedTokenManagerScopeGenerationTest {
         assertEquals(generation, transitions.generation.value)
         assertTrue(observed.isEmpty())
     }
+
+    // ---- Durable credential owner identity ----
+    //
+    // credentialOwnerId is the ONE identity field on AuthScopeSnapshot that is
+    // durable: identityGeneration and credentialEpoch are process-scoped and
+    // reset every launch, so caches that own data across restarts (
+    // UiCustomizationStore, TvLibraryScopeStore) key their ownership on this
+    // instead. Its lifecycle is therefore a storage-isolation contract.
+
+    @Test
+    fun accountReplacementRotatesTheDurableCredentialOwnerTogetherWithTheNewTokens() = runTest {
+        val preferences = seededRegistryPreferences(activeServerId = "server-a", includeServerB = false)
+        val transitions = DefaultIdentityTransitionBarrier()
+        val registry = AndroidServerRegistry(preferences, identityTransitions = transitions)
+        val manager = EncryptedTokenManagerImpl(
+            prefs = preferences,
+            registry = registry,
+            identityTransitions = transitions,
+        )
+        manager.saveTokens("account-a-access", "account-a-refresh", 3600)
+        val before = checkNotNull(manager.snapshotCurrentScope())
+        val ownerA = checkNotNull(before.credentialOwnerId)
+        assertEquals(ownerA, preferences.getString(credentialOwnerKey("server-a"), null))
+
+        manager.replaceAccountSession(
+            serverId = "server-a",
+            accessToken = "account-b-access",
+            refreshToken = "account-b-refresh",
+            expiresIn = 3600,
+            profileId = "account-b-profile",
+            profileToken = "account-b-profile-token",
+        )
+
+        val after = checkNotNull(manager.snapshotCurrentScope())
+        val ownerB = checkNotNull(after.credentialOwnerId)
+        assertNotEquals(ownerA, ownerB)
+        // Rotated on disk inside the same editor transaction as the tokens, so
+        // no reader can ever see account B's credentials under owner A.
+        assertEquals(ownerB, preferences.getString(credentialOwnerKey("server-a"), null))
+        assertEquals("account-b-access", manager.getAccessToken())
+        assertEquals("account-b-access", manager.getAccessTokenForScope(after))
+        assertNull(manager.getAccessTokenForScope(before))
+    }
+
+    @Test
+    fun signOutRemovesTheDurableCredentialOwnerAndTheNextOwnerIsFresh() = runTest {
+        val preferences = seededRegistryPreferences(activeServerId = "server-a", includeServerB = false)
+        val transitions = DefaultIdentityTransitionBarrier()
+        val registry = AndroidServerRegistry(preferences, identityTransitions = transitions)
+        val manager = EncryptedTokenManagerImpl(
+            prefs = preferences,
+            registry = registry,
+            identityTransitions = transitions,
+        )
+        manager.saveTokens("account-a-access", "account-a-refresh", 3600)
+        val ownerA = checkNotNull(manager.snapshotCurrentScope()?.credentialOwnerId)
+
+        manager.clearTokens()
+
+        // Assert the removal BEFORE snapshotting again: the lazy backfill would
+        // otherwise re-create the key and hide a missing removal.
+        assertFalse(preferences.contains(credentialOwnerKey("server-a")))
+        assertNotEquals(ownerA, manager.snapshotCurrentScope()?.credentialOwnerId)
+    }
+
+    /** The non-AndroidServerRegistry sign-out fallback owns the same removal. */
+    @Test
+    fun signOutWithoutTheAndroidRegistryAlsoRemovesTheDurableCredentialOwner() = runTest {
+        val preferences = inMemoryPreferences()
+        val manager = EncryptedTokenManagerImpl(
+            prefs = preferences,
+            registry = FakeServerRegistry(),
+        )
+        manager.saveTokens("account-a-access", "account-a-refresh", 3600)
+        val ownerA = checkNotNull(manager.snapshotCurrentScope()?.credentialOwnerId)
+        assertTrue(preferences.contains(credentialOwnerKey("server-a")))
+
+        manager.clearTokens()
+
+        assertFalse(preferences.contains(credentialOwnerKey("server-a")))
+        assertNotEquals(ownerA, manager.snapshotCurrentScope()?.credentialOwnerId)
+    }
+
+    /**
+     * Installs that predate the key have credentials on disk and no owner id.
+     * The backfill must mint exactly one and keep it — a value that changed per
+     * snapshot or per launch would orphan every owner-keyed cache.
+     */
+    @Test
+    fun installPredatingTheOwnerKeyBackfillsOneStableDurableCredentialOwner() = runTest {
+        val preferences = inMemoryPreferences(
+            AndroidServerRegistry.serverScopedKey("server-a", EncryptedTokenManagerImpl.KEY_ACCESS_TOKEN) to
+                "existing-access",
+            AndroidServerRegistry.serverScopedKey("server-a", EncryptedTokenManagerImpl.KEY_REFRESH_TOKEN) to
+                "existing-refresh",
+        )
+        assertFalse(preferences.contains(credentialOwnerKey("server-a")))
+        val manager = EncryptedTokenManagerImpl(
+            prefs = preferences,
+            registry = FakeServerRegistry(),
+        )
+
+        val backfilled = checkNotNull(manager.snapshotCurrentScope()?.credentialOwnerId)
+
+        assertTrue(backfilled.isNotBlank())
+        assertEquals(backfilled, preferences.getString(credentialOwnerKey("server-a"), null))
+        assertEquals(backfilled, manager.snapshotCurrentScope()?.credentialOwnerId)
+
+        // Simulated process restart over the same durable preferences.
+        val restarted = EncryptedTokenManagerImpl(
+            prefs = preferences,
+            registry = FakeServerRegistry(),
+        )
+        assertEquals("existing-access", restarted.getAccessToken())
+        assertEquals(backfilled, restarted.snapshotCurrentScope()?.credentialOwnerId)
+    }
+
+    /**
+     * A temporary (guest / remote-playback) overlay must not be attributable to
+     * the signed-in account's durable caches, and must not consume or rotate
+     * the account's owner id on the way in or out.
+     */
+    @Test
+    fun aTemporaryOverlayCarriesNoDurableOwnerAndLeavesTheAccountOwnerIntact() = runTest {
+        val manager = EncryptedTokenManagerImpl(
+            prefs = inMemoryPreferences(),
+            registry = FakeServerRegistry(),
+        )
+        manager.saveTokens("saved-access", "saved-refresh", 3600)
+        val accountOwner = checkNotNull(manager.snapshotCurrentScope()?.credentialOwnerId)
+        manager.beginTemporaryScope(
+            TemporaryAuthScope(
+                generationId = "overlay-1",
+                serverId = "overlay-server",
+                serverUrl = "https://overlay.example",
+                accessToken = "overlay-access",
+                refreshToken = "overlay-refresh",
+                profileId = "overlay-profile",
+                profileToken = "overlay-profile-token",
+                expiresAtEpochMs = Long.MAX_VALUE,
+            ),
+        )
+
+        val guest = checkNotNull(manager.snapshotCurrentScope())
+
+        assertNull(guest.credentialOwnerId)
+        assertEquals("overlay-1", guest.credentialGenerationId)
+
+        manager.endTemporaryScope()
+
+        assertEquals(accountOwner, manager.snapshotCurrentScope()?.credentialOwnerId)
+    }
+
+    private fun credentialOwnerKey(serverId: String): String =
+        AndroidServerRegistry.serverScopedKey(serverId, EncryptedTokenManagerImpl.KEY_CREDENTIAL_OWNER_ID)
 
     private class FakeServerRegistry : ServerRegistry {
         private val serverA = ServerEntry(id = "server-a", url = "https://server-a.example")

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/domain/settings/ProfileSettingsController.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/domain/settings/ProfileSettingsController.kt
@@ -2,6 +2,7 @@ package org.siloserver.silo.domain.settings
 
 import org.siloserver.silo.model.settings.EffectiveSettingValue
 import org.siloserver.silo.model.settings.SettingKeys
+import org.siloserver.silo.model.settings.SettingsContractCapabilities
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.api.SettingsCapabilitiesResult
 import org.siloserver.silo.repository.SettingsRepository
@@ -65,6 +66,8 @@ class ProfileSettingsController(
     data class LoadResult(
         val availability: Availability,
         val snapshot: Snapshot?,
+        /** Exact successful capability probe; null for old/erroring servers. */
+        val capabilities: SettingsContractCapabilities? = null,
     )
 
     /**
@@ -89,7 +92,10 @@ class ProfileSettingsController(
      * [Availability.UNAVAILABLE] for the same reason.
      */
     suspend fun load(): LoadResult {
-        val availability = when (repository.contractCapabilities()) {
+        val capabilityResult = repository.contractCapabilities()
+        val capabilities = (capabilityResult as? SettingsCapabilitiesResult.Available)
+            ?.capabilities
+        val availability = when (capabilityResult) {
             is SettingsCapabilitiesResult.Available -> Availability.AVAILABLE
             is SettingsCapabilitiesResult.ServerUpgradeRequired ->
                 Availability.SERVER_UPGRADE_REQUIRED
@@ -99,9 +105,9 @@ class ProfileSettingsController(
         if (availability != Availability.AVAILABLE) return LoadResult(availability, null)
 
         return when (val result = repository.getEffectiveValues(PROFILE_KEYS)) {
-            is ApiResult.Success -> LoadResult(availability, snapshotOf(result.data))
+            is ApiResult.Success -> LoadResult(availability, snapshotOf(result.data), capabilities)
             is ApiResult.Error, is ApiResult.NetworkError ->
-                LoadResult(Availability.UNAVAILABLE, null)
+                LoadResult(Availability.UNAVAILABLE, null, capabilities)
         }
     }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/SettingValueModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/SettingValueModels.kt
@@ -16,13 +16,14 @@ import kotlinx.serialization.json.JsonNull
  */
 
 /**
- * The five scopes an explicit value can live at, in the server's wire
+ * The scopes an explicit value can live at, in the server's wire
  * spelling. Kept as an enum for request construction only — response fields
  * stay raw strings so a server that adds a scope cannot break deserialization.
  */
 enum class SettingScope(val wire: String) {
     ACCOUNT("account"),
     PROFILE("profile"),
+    PROFILE_CLIENT("profile_client"),
     PROFILE_DEVICE("profile_device"),
     PROFILE_LIBRARY("profile_library"),
     PROFILE_SERIES("profile_series"),
@@ -33,7 +34,8 @@ enum class SettingScope(val wire: String) {
  *
  * Only the content ids travel with the request: `scope` plus `library_id` /
  * `series_id` go in the query string. The profile and device parts of the
- * identity come from the session headers (`X-Profile-Id`, `X-Silo-Device-Id`)
+ * identity come from the session headers (`X-Profile-Id`,
+ * `X-Silo-Client-Family`, `X-Silo-Device-Id`)
  * that the auth interceptor already attaches — the server reads them from
  * there deliberately, so one profile cannot write another's settings by
  * naming it in the query.
@@ -49,6 +51,8 @@ data class SettingScopeIdentity(
     val libraryId: Int? = null,
     /** Set only for [SettingScope.PROFILE_SERIES]. */
     val seriesId: String? = null,
+    /** Request-pinned family for durable client/device-scoped mutations. */
+    val clientFamily: SiloClientFamily? = null,
 ) {
     init {
         require((scope == SettingScope.PROFILE_LIBRARY) == (libraryId != null)) {
@@ -59,6 +63,13 @@ data class SettingScopeIdentity(
             "series_id is required for profile_series and forbidden elsewhere"
         }
         seriesId?.let { require(it.isNotBlank()) { "series_id must not be blank" } }
+        require(
+            clientFamily == null ||
+                scope == SettingScope.PROFILE_CLIENT ||
+                scope == SettingScope.PROFILE_DEVICE,
+        ) {
+            "client_family is only valid for profile_client or profile_device"
+        }
     }
 
     companion object {
@@ -66,8 +77,11 @@ data class SettingScopeIdentity(
 
         fun profile(): SettingScopeIdentity = SettingScopeIdentity(SettingScope.PROFILE)
 
-        fun profileDevice(): SettingScopeIdentity =
-            SettingScopeIdentity(SettingScope.PROFILE_DEVICE)
+        fun profileClient(clientFamily: SiloClientFamily? = null): SettingScopeIdentity =
+            SettingScopeIdentity(SettingScope.PROFILE_CLIENT, clientFamily = clientFamily)
+
+        fun profileDevice(clientFamily: SiloClientFamily? = null): SettingScopeIdentity =
+            SettingScopeIdentity(SettingScope.PROFILE_DEVICE, clientFamily = clientFamily)
 
         fun profileLibrary(libraryId: Int): SettingScopeIdentity =
             SettingScopeIdentity(SettingScope.PROFILE_LIBRARY, libraryId = libraryId)
@@ -92,12 +106,31 @@ data class SettingsContractCapabilities(
     val scopes: List<String> = emptyList(),
     @SerialName("supports_batched_effective") val supportsBatchedEffective: Boolean = false,
     @SerialName("supports_idempotent_writes") val supportsIdempotentWrites: Boolean = false,
+    @SerialName("supports_atomic_shortcuts") val supportsAtomicShortcuts: Boolean = false,
 )
+
+/**
+ * UI customization first shipped with contract revision 5 and depends on the
+ * batched effective reads, the atomic shortcut membership endpoint, and stable
+ * idempotency receipts. All checks are intentional: revision alone cannot
+ * distinguish an older partial implementation, and a missing capability field
+ * must fail closed.
+ */
+val SettingsContractCapabilities.supportsUiCustomization: Boolean
+    get() = revision >= 5 && supportsBatchedEffective &&
+        supportsIdempotentWrites && supportsAtomicShortcuts
 
 /** Body for `PUT /api/v1/settings/values/{key}`: `{"value": …}`. */
 @Serializable
 data class SettingValueWriteRequest(
     val value: JsonElement,
+)
+
+/** Atomic profile-wide membership change for one navigation shortcut. */
+@Serializable
+data class NavigationShortcutItemWriteRequest(
+    val item: JsonElement,
+    val present: Boolean,
 )
 
 /**
@@ -111,6 +144,7 @@ data class StoredSettingValue(
     val key: String,
     val scope: String,
     @SerialName("profile_id") val profileId: String? = null,
+    @SerialName("client_family") val clientFamily: String? = null,
     @SerialName("device_id") val deviceId: String? = null,
     @SerialName("library_id") val libraryId: Int? = null,
     @SerialName("series_id") val seriesId: String? = null,
@@ -141,6 +175,7 @@ data class EffectiveSettingValue(
     @SerialName("suggested_values") val suggestedValues: List<String> = emptyList(),
     val scope: String? = null,
     @SerialName("profile_id") val profileId: String? = null,
+    @SerialName("client_family") val clientFamily: String? = null,
     @SerialName("device_id") val deviceId: String? = null,
     @SerialName("library_id") val libraryId: Int? = null,
     @SerialName("series_id") val seriesId: String? = null,

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/UiCustomization.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/UiCustomization.kt
@@ -1,0 +1,322 @@
+package org.siloserver.silo.model.settings
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.put
+
+/** Canonical like-device families used by `X-Silo-Client-Family`. */
+enum class SiloClientFamily(val wire: String) {
+    TV("tv"),
+    MOBILE("mobile"),
+    TABLET("tablet"),
+    DESKTOP("desktop"),
+    WEB("web"),
+}
+
+enum class PosterSizePreset(val wire: String, val label: String) {
+    COMPACT("compact", "Compact"),
+    STANDARD("standard", "Standard"),
+    LARGE("large", "Large");
+
+    companion object {
+        fun fromWire(value: String?): PosterSizePreset? =
+            entries.firstOrNull { it.wire == value }
+    }
+}
+
+enum class CardCaptionPreset(val wire: String, val label: String) {
+    TITLE_METADATA("title_metadata", "Title & metadata"),
+    TITLE("title", "Title only"),
+    ARTWORK("artwork", "Artwork only");
+
+    companion object {
+        fun fromWire(value: String?): CardCaptionPreset? =
+            entries.firstOrNull { it.wire == value }
+    }
+}
+
+data class CardPresentation(
+    val posterSize: PosterSizePreset = PosterSizePreset.STANDARD,
+    val caption: CardCaptionPreset = CardCaptionPreset.TITLE_METADATA,
+) {
+    companion object {
+        val DEFAULT = CardPresentation()
+    }
+}
+
+/**
+ * Friendly combinations shared by every client UI. These are shortcuts over
+ * the canonical two-axis card presentation value, not a separate wire value,
+ * so choosing either granular control naturally produces a Custom state when
+ * it no longer matches one of these combinations.
+ */
+enum class CardPresentationPreset(
+    val wire: String,
+    val label: String,
+    val presentation: CardPresentation,
+) {
+    BALANCED(
+        "balanced",
+        "Balanced",
+        CardPresentation(PosterSizePreset.STANDARD, CardCaptionPreset.TITLE_METADATA),
+    ),
+    COMPACT(
+        "compact",
+        "Compact",
+        CardPresentation(PosterSizePreset.COMPACT, CardCaptionPreset.TITLE),
+    ),
+    CINEMA(
+        "cinema",
+        "Cinema",
+        CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.TITLE),
+    ),
+    ARTWORK_ONLY(
+        "artwork_only",
+        "Artwork Only",
+        CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK),
+    );
+
+    companion object {
+        fun fromWire(value: String?): CardPresentationPreset? =
+            entries.firstOrNull { it.wire == value }
+
+        fun matching(value: CardPresentation): CardPresentationPreset? =
+            entries.firstOrNull { it.presentation == value }
+    }
+}
+
+enum class PrimaryMenuBuiltin(val wire: String, val label: String) {
+    HOME("home", "Home"),
+    MOVIES("movies", "Movies"),
+    SERIES("series", "Series"),
+    MUSIC("music", "Music"),
+    AUDIOBOOKS("audiobooks", "Audiobooks"),
+    FOR_YOU("for_you", "For You"),
+    CALENDAR("calendar", "Calendar");
+
+    companion object {
+        fun fromWire(value: String?): PrimaryMenuBuiltin? =
+            entries.firstOrNull { it.wire == value }
+    }
+}
+
+sealed interface PrimaryMenuItem {
+    val label: String
+
+    data class Builtin(val destination: PrimaryMenuBuiltin) : PrimaryMenuItem {
+        override val label: String get() = destination.label
+    }
+
+    data class Library(
+        val libraryId: Int,
+        override val label: String,
+    ) : PrimaryMenuItem
+
+    data class Section(
+        val libraryId: Int,
+        val sectionId: String,
+        override val label: String,
+    ) : PrimaryMenuItem
+
+    data class Collection(
+        val collectionId: String,
+        override val label: String,
+        val libraryId: Int? = null,
+    ) : PrimaryMenuItem
+}
+
+data class PrimaryMenu(val items: List<PrimaryMenuItem>)
+
+/**
+ * A confirmed incompatible server must not activate revision-5 cached UI
+ * values. A null capability is deliberately treated as unknown so an offline
+ * launch can continue using its last trusted presentation.
+ */
+fun effectivePrimaryMenuForSupport(
+    value: PrimaryMenu?,
+    uiCustomizationSupported: Boolean?,
+): PrimaryMenu? = value.takeUnless { uiCustomizationSupported == false }
+
+fun effectiveCardPresentationForSupport(
+    value: CardPresentation,
+    uiCustomizationSupported: Boolean?,
+): CardPresentation = value.takeUnless { uiCustomizationSupported == false }
+    ?: CardPresentation.DEFAULT
+
+data class NavigationShortcuts(val items: List<PrimaryMenuItem>) {
+    companion object {
+        val EMPTY = NavigationShortcuts(emptyList())
+    }
+}
+
+/** Server-contract collection bounds shared by codecs and client editors. */
+object UiCustomizationLimits {
+    const val MAX_PRIMARY_MENU_ITEMS = 64
+    const val MAX_NAVIGATION_SHORTCUT_ITEMS = 256
+}
+
+/**
+ * Strict, defensive codecs for settings-manifest revision 5.
+ *
+ * The server validates writes, but locally cached values survive server
+ * switches and app upgrades. Rejecting malformed cache documents as a whole
+ * keeps navigation usable (the caller falls back to its native default) and
+ * guarantees Android never renders a menu without Home.
+ */
+object UiCustomizationCodec {
+    fun parseCardPresentation(value: JsonElement?): CardPresentation? {
+        val obj = value as? JsonObject ?: return null
+        if (obj.keys != setOf("poster_size", "caption")) return null
+        val size = PosterSizePreset.fromWire(obj.string("poster_size")) ?: return null
+        val caption = CardCaptionPreset.fromWire(obj.string("caption")) ?: return null
+        return CardPresentation(size, caption)
+    }
+
+    fun encodeCardPresentation(value: CardPresentation): JsonObject = buildJsonObject {
+        put("poster_size", value.posterSize.wire)
+        put("caption", value.caption.wire)
+    }
+
+    /** `null` means inherit the client's native/default primary menu. */
+    fun parsePrimaryMenu(value: JsonElement?): PrimaryMenu? {
+        if (value == null || value is JsonNull) return null
+        val obj = value as? JsonObject ?: return null
+        if (obj.keys != setOf("items")) return null
+        val array = obj["items"] as? JsonArray ?: return null
+        if (array.size !in 1..UiCustomizationLimits.MAX_PRIMARY_MENU_ITEMS) return null
+        val items = array.map { parseItem(it, allowBuiltin = true) ?: return null }
+        if (items.map(::identity).toSet().size != items.size) return null
+        if (items.count { it == PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME) } != 1) return null
+        return PrimaryMenu(items)
+    }
+
+    fun encodePrimaryMenu(value: PrimaryMenu): JsonObject = buildJsonObject {
+        put("items", buildJsonArray { value.items.forEach { add(encodeItem(it)) } })
+    }
+
+    fun parseShortcuts(value: JsonElement?): NavigationShortcuts? {
+        val obj = value as? JsonObject ?: return null
+        if (obj.keys != setOf("items")) return null
+        val array = obj["items"] as? JsonArray ?: return null
+        if (array.size > UiCustomizationLimits.MAX_NAVIGATION_SHORTCUT_ITEMS) return null
+        val items = array.map { parseItem(it, allowBuiltin = false) ?: return null }
+        if (items.map(::identity).toSet().size != items.size) return null
+        return NavigationShortcuts(items)
+    }
+
+    fun encodeShortcuts(value: NavigationShortcuts): JsonObject = buildJsonObject {
+        put("items", buildJsonArray { value.items.forEach { add(encodeItem(it)) } })
+    }
+
+    /** One non-builtin shortcut item for the atomic membership endpoint. */
+    fun parseShortcutItem(value: JsonElement?): PrimaryMenuItem? =
+        value?.let { parseItem(it, allowBuiltin = false) }
+
+    fun encodeShortcutItem(value: PrimaryMenuItem): JsonObject? {
+        if (value is PrimaryMenuItem.Builtin) return null
+        return encodeItem(value).takeIf { parseShortcutItem(it) != null }
+    }
+
+    fun identity(item: PrimaryMenuItem): String = when (item) {
+        is PrimaryMenuItem.Builtin -> "builtin:${item.destination.wire}"
+        is PrimaryMenuItem.Library -> "library:${item.libraryId}"
+        is PrimaryMenuItem.Section -> "section:${item.libraryId}:${item.sectionId}"
+        is PrimaryMenuItem.Collection ->
+            "collection:${item.libraryId ?: ""}:${item.collectionId}"
+    }
+
+    private fun parseItem(value: JsonElement, allowBuiltin: Boolean): PrimaryMenuItem? {
+        val obj = value as? JsonObject ?: return null
+        return when (obj.string("type")) {
+            "builtin" -> {
+                if (!allowBuiltin || obj.keys != setOf("type", "destination")) return null
+                PrimaryMenuBuiltin.fromWire(obj.string("destination"))
+                    ?.let { PrimaryMenuItem.Builtin(it) }
+            }
+            "library" -> {
+                if (obj.keys != setOf("type", "library_id", "label")) return null
+                val id = obj.positiveInt("library_id") ?: return null
+                val label = obj.boundedLabel("label") ?: return null
+                PrimaryMenuItem.Library(id, label)
+            }
+            "section" -> {
+                if (obj.keys != setOf("type", "library_id", "section_id", "label")) return null
+                val libraryId = obj.positiveInt("library_id") ?: return null
+                val sectionId = obj.boundedTargetId("section_id") ?: return null
+                val label = obj.boundedLabel("label") ?: return null
+                PrimaryMenuItem.Section(libraryId, sectionId, label)
+            }
+            "collection" -> {
+                val allowed = setOf("type", "collection_id", "label", "library_id")
+                if (obj.keys.any { it !in allowed } || obj.keys.none { it == "collection_id" } ||
+                    obj.keys.none { it == "label" }
+                ) return null
+                val collectionId = obj.boundedTargetId("collection_id")
+                    ?: return null
+                val label = obj.boundedLabel("label") ?: return null
+                val libraryId = obj["library_id"]?.let {
+                    obj.positiveInt("library_id") ?: return null
+                }
+                PrimaryMenuItem.Collection(collectionId, label, libraryId)
+            }
+            else -> null
+        }
+    }
+
+    private fun encodeItem(item: PrimaryMenuItem): JsonObject = buildJsonObject {
+        when (item) {
+            is PrimaryMenuItem.Builtin -> {
+                put("type", "builtin")
+                put("destination", item.destination.wire)
+            }
+            is PrimaryMenuItem.Library -> {
+                put("type", "library")
+                put("library_id", item.libraryId)
+                put("label", item.label)
+            }
+            is PrimaryMenuItem.Section -> {
+                put("type", "section")
+                put("library_id", item.libraryId)
+                put("section_id", item.sectionId)
+                put("label", item.label)
+            }
+            is PrimaryMenuItem.Collection -> {
+                put("type", "collection")
+                put("collection_id", item.collectionId)
+                put("label", item.label)
+                item.libraryId?.let { put("library_id", it) }
+            }
+        }
+    }
+
+    private fun JsonObject.string(key: String): String? {
+        val primitive = get(key) as? JsonPrimitive ?: return null
+        return primitive.takeIf { it.isString }?.contentOrNull
+    }
+
+    private fun JsonObject.boundedString(key: String, maxLength: Int): String? =
+        string(key)?.takeIf { it.isNotEmpty() && it.length <= maxLength }
+
+    private fun JsonObject.boundedLabel(key: String): String? =
+        boundedString(key, maxLength = 256)?.takeIf { label ->
+            label.any { character -> !character.isWhitespace() }
+        }
+
+    private fun JsonObject.boundedTargetId(key: String): String? =
+        boundedString(key, maxLength = 128)?.takeIf { id ->
+            id.any { character -> !character.isWhitespace() }
+        }
+
+    private fun JsonObject.positiveInt(key: String): Int? {
+        val primitive = get(key) as? JsonPrimitive ?: return null
+        if (primitive.isString) return null
+        return primitive.intOrNull?.takeIf { it > 0 }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthInterceptorImpl.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthInterceptorImpl.kt
@@ -782,6 +782,11 @@ private suspend fun HttpRequestBuilder.attachSiloDeviceMetadataHeaders(
     header("X-Silo-Device-Id", device.id)
     header("X-Silo-Device-Name", device.name)
     header("X-Silo-Device-Platform", device.platform)
+    device.clientFamily?.takeIf { it.isNotBlank() }?.let {
+        if (!headers.contains("X-Silo-Client-Family")) {
+            header("X-Silo-Client-Family", it)
+        }
+    }
     device.clientName?.takeIf { it.isNotBlank() }?.let { header("X-Silo-Client", it) }
     device.clientVersion?.takeIf { it.isNotBlank() }?.let { header("X-Silo-Client-Version", it) }
     device.clientBuild?.takeIf { it.isNotBlank() }?.let { header("X-Silo-Client-Build", it) }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthScopeSnapshot.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthScopeSnapshot.kt
@@ -27,6 +27,14 @@ import io.ktor.util.AttributeKey
  * was active when this snapshot was captured. [isIdentityGenerationStamped]
  * distinguishes a legitimate capture at generation zero from a legacy,
  * hand-built scope that never captured the generation at all.
+ *
+ * [credentialOwnerId] is a durable, opaque identifier for the saved account
+ * slot. Unlike [credentialEpoch] and [identityGeneration] — both of which are
+ * process-scoped and reset on every launch — it is persisted alongside the
+ * credentials and survives process restarts, and unlike [profileToken] it does
+ * not rotate after PIN verification. Durable caches and outboxes can therefore
+ * use it as their account boundary without coupling ownership to an individual
+ * auth token or to a single process lifetime.
  */
 data class AuthScopeSnapshot(
     val serverId: String,
@@ -36,6 +44,7 @@ data class AuthScopeSnapshot(
     val credentialGenerationId: String? = null,
     val identityGeneration: Long = 0L,
     val isIdentityGenerationStamped: Boolean = false,
+    val credentialOwnerId: String? = null,
     /**
      * Bumped every time this server's PERSISTENT credentials are written or
      * cleared — i.e. by sign-in and sign-out, but deliberately NOT by a
@@ -58,6 +67,7 @@ data class AuthScopeSnapshot(
             "serverId=<redacted>, profileId=<redacted>, serverUrl=<redacted>, " +
             "profileToken=<redacted>, credentialGenerationId=<redacted>, " +
             "identityGeneration=<redacted>, isIdentityGenerationStamped=<redacted>, " +
+            "credentialOwnerId=<redacted>, " +
             "credentialEpoch=<redacted>)"
 }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/DeviceMetadataProvider.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/DeviceMetadataProvider.kt
@@ -4,6 +4,7 @@ data class SiloDeviceMetadata(
     val id: String,
     val name: String,
     val platform: String,
+    val clientFamily: String? = null,
     val clientName: String? = null,
     val clientVersion: String? = null,
     /**

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/IdentityTransitionBarrier.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/IdentityTransitionBarrier.kt
@@ -41,6 +41,7 @@ data class IdentityTransitionTarget(
 interface IdentityTransitionBarrier {
     val transitions: SharedFlow<IdentityTransition>
     val generation: StateFlow<Long>
+    val latestTransition: StateFlow<IdentityTransition?>
 
     /** Installs the inline privacy gate, which must complete before identity mutation. */
     fun installGate(listener: suspend (IdentityTransition) -> Unit)
@@ -72,6 +73,7 @@ class DefaultIdentityTransitionBarrier : IdentityTransitionBarrier {
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     private val _generation = MutableStateFlow(0L)
+    private val _latestTransition = MutableStateFlow<IdentityTransition?>(null)
 
     @Volatile
     private var gates: List<suspend (IdentityTransition) -> Unit> = emptyList()
@@ -81,6 +83,7 @@ class DefaultIdentityTransitionBarrier : IdentityTransitionBarrier {
 
     override val transitions: SharedFlow<IdentityTransition> = _transitions.asSharedFlow()
     override val generation: StateFlow<Long> = _generation.asStateFlow()
+    override val latestTransition: StateFlow<IdentityTransition?> = _latestTransition.asStateFlow()
 
     override fun installGate(listener: suspend (IdentityTransition) -> Unit) {
         // Gates are installed during sequential application startup. Publish an
@@ -115,20 +118,24 @@ class DefaultIdentityTransitionBarrier : IdentityTransitionBarrier {
             // This callback is the privacy boundary. It runs inline before new identity is visible.
             gates.forEach { gate -> gate(willChange) }
             _generation.value = nextGeneration
+            _latestTransition.value = willChange
             publish(willChange)
             try {
                 block()
             } finally {
-                publish(
-                    IdentityTransition(
-                        phase = IdentityTransitionPhase.DID_CHANGE,
-                        kind = kind,
-                        generation = nextGeneration,
-                        targetServerId = resolvedTarget.serverId,
-                        affectsCurrentIdentity = resolvedTarget.affectsCurrentIdentity,
-                        purgesPersistentIdentity = resolvedTarget.purgesPersistentIdentity,
-                    ),
+                val didChange = IdentityTransition(
+                    phase = IdentityTransitionPhase.DID_CHANGE,
+                    kind = kind,
+                    generation = nextGeneration,
+                    targetServerId = resolvedTarget.serverId,
+                    affectsCurrentIdentity = resolvedTarget.affectsCurrentIdentity,
+                    purgesPersistentIdentity = resolvedTarget.purgesPersistentIdentity,
                 )
+                // Keep the completed lifecycle marker replayable. Clearing an
+                // in-progress flag around publication would leave a narrow gap
+                // where a new subscriber could miss DID_CHANGE permanently.
+                _latestTransition.value = didChange
+                publish(didChange)
             }
         }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/SettingsApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/SettingsApi.kt
@@ -4,6 +4,7 @@ import org.siloserver.silo.model.settings.EffectiveSettingValuesResponse
 import org.siloserver.silo.model.settings.EffectiveSettingsResponse
 import org.siloserver.silo.model.settings.EffectiveSubtitleAppearance
 import org.siloserver.silo.model.settings.PlaybackSettingsKeys
+import org.siloserver.silo.model.settings.NavigationShortcutItemWriteRequest
 import org.siloserver.silo.model.settings.SettingEntry
 import org.siloserver.silo.model.settings.SettingScope
 import org.siloserver.silo.model.settings.SettingScopeIdentity
@@ -14,6 +15,8 @@ import org.siloserver.silo.model.settings.StoredSettingValue
 import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.model.settings.UpdateSettingRequest
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.authScope as pinAuthScope
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequestBuilder
 import kotlinx.serialization.Serializable
@@ -199,15 +202,21 @@ open class SettingsApi(private val client: HttpClient) {
      * season view spanning several series. Passing no [keys] resolves every
      * remote definition in the server's contract. [libraryIds] and
      * [seriesIds] widen the resolution to those content scopes; the profile
-     * and device parts of the context come from the session headers the auth
-     * interceptor already attaches.
+     * and client-family/device parts of the context come from the session
+     * headers the auth interceptor already attaches.
      */
     open suspend fun getEffectiveValues(
         keys: List<String> = emptyList(),
         libraryIds: List<Int> = emptyList(),
         seriesIds: List<String> = emptyList(),
+        profileId: String? = null,
+        authScope: AuthScopeSnapshot? = null,
     ): ApiResult<EffectiveSettingValuesResponse> = safeApiCall {
         client.get("/api/v1/settings/values/effective") {
+            authScope?.let(::pinAuthScope)
+            if (!profileId.isNullOrBlank()) {
+                header("X-Profile-Id", profileId)
+            }
             url {
                 if (keys.isNotEmpty()) parameters.append("keys", keys.joinToString(","))
                 if (libraryIds.isNotEmpty()) {
@@ -240,14 +249,41 @@ open class SettingsApi(private val client: HttpClient) {
         value: JsonElement,
         mutationId: String,
         profileId: String? = null,
+        authScope: AuthScopeSnapshot? = null,
     ): ApiResult<StoredSettingValue> = safeApiCall {
         client.put("/api/v1/settings/values/$key") {
+            authScope?.let(::pinAuthScope)
             applyScopeIdentity(scope, profileId)
             if (mutationId.isNotBlank()) {
                 header("X-Silo-Mutation-Id", mutationId)
             }
             contentType(ContentType.Application.Json)
             setBody(SettingValueWriteRequest(value))
+        }
+    }
+
+    /**
+     * Atomically add or remove one profile-wide navigation shortcut. The
+     * server owns the read/modify/write transaction so independent devices do
+     * not replace each other's catalog entries.
+     */
+    open suspend fun putNavigationShortcutItem(
+        item: JsonElement,
+        present: Boolean,
+        mutationId: String,
+        profileId: String? = null,
+        authScope: AuthScopeSnapshot? = null,
+    ): ApiResult<StoredSettingValue> = safeApiCall {
+        client.put("/api/v1/settings/values/nav.shortcuts/item") {
+            authScope?.let(::pinAuthScope)
+            if (!profileId.isNullOrBlank()) {
+                header("X-Profile-Id", profileId)
+            }
+            if (mutationId.isNotBlank()) {
+                header("X-Silo-Mutation-Id", mutationId)
+            }
+            contentType(ContentType.Application.Json)
+            setBody(NavigationShortcutItemWriteRequest(item = item, present = present))
         }
     }
 
@@ -261,8 +297,10 @@ open class SettingsApi(private val client: HttpClient) {
         key: String,
         scope: SettingScopeIdentity,
         profileId: String? = null,
+        authScope: AuthScopeSnapshot? = null,
     ): ApiResult<Unit> = safeApiCall {
         client.delete("/api/v1/settings/values/$key") {
+            authScope?.let(::pinAuthScope)
             applyScopeIdentity(scope, profileId)
         }
     }
@@ -274,8 +312,9 @@ open class SettingsApi(private val client: HttpClient) {
      * the session's `X-Profile-Id` header; an explicit [profileId] overrides
      * it (the interceptor only fills the header when absent), matching how
      * [setDeviceSetting] lets a parent act for a child profile. The device id
-     * is never set here — the interceptor always attaches
-     * `X-Silo-Device-Id`, and appending it again would send two values.
+     * always comes from the interceptor. A durable client/device mutation may
+     * carry an explicitly captured family; the interceptor only fills that
+     * header when this method did not pin one.
      */
     private fun HttpRequestBuilder.applyScopeIdentity(
         scope: SettingScopeIdentity,
@@ -288,6 +327,10 @@ open class SettingsApi(private val client: HttpClient) {
         }
         if (!profileId.isNullOrBlank() && scope.scope != SettingScope.ACCOUNT) {
             header("X-Profile-Id", profileId)
+        }
+        scope.clientFamily?.let { family ->
+            headers.remove("X-Silo-Client-Family")
+            header("X-Silo-Client-Family", family.wire)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/SettingsRepository.kt
@@ -3,10 +3,14 @@ package org.siloserver.silo.repository
 import org.siloserver.silo.model.settings.EffectiveSetting
 import org.siloserver.silo.model.settings.EffectiveSettingValue
 import org.siloserver.silo.model.settings.EffectiveSubtitleAppearance
+import org.siloserver.silo.model.settings.PrimaryMenuItem
 import org.siloserver.silo.model.settings.SettingScopeIdentity
+import org.siloserver.silo.model.settings.SiloClientFamily
 import org.siloserver.silo.model.settings.StoredSettingValue
 import org.siloserver.silo.model.settings.SubtitleAppearance
+import org.siloserver.silo.model.settings.UiCustomizationCodec
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
 import org.siloserver.silo.network.api.OverlayConfigResponse
 import org.siloserver.silo.network.api.SettingsApi
 import org.siloserver.silo.network.api.SettingsCapabilitiesResult
@@ -57,8 +61,16 @@ class SettingsRepository(
         keys: List<String> = emptyList(),
         libraryIds: List<Int> = emptyList(),
         seriesIds: List<String> = emptyList(),
+        profileId: String? = null,
+        authScope: AuthScopeSnapshot? = null,
     ): ApiResult<Map<String, EffectiveSettingValue>> =
-        settingsApi.getEffectiveValues(keys, libraryIds, seriesIds).map { response ->
+        settingsApi.getEffectiveValues(
+            keys,
+            libraryIds,
+            seriesIds,
+            profileId,
+            authScope,
+        ).map { response ->
             response.settings.associateBy { it.key }
         }
 
@@ -85,12 +97,59 @@ class SettingsRepository(
         key: String,
         value: JsonElement,
         mutationId: String = newSettingMutationId(),
+        profileId: String? = null,
     ): ApiResult<StoredSettingValue> =
         settingsApi.putValue(
             key = key,
             scope = SettingScopeIdentity.profile(),
             value = value,
             mutationId = mutationId,
+            profileId = profileId,
+        )
+
+    /** Atomically set one shortcut's desired membership at profile scope. */
+    suspend fun setNavigationShortcutPresent(
+        item: PrimaryMenuItem,
+        present: Boolean,
+        mutationId: String = newSettingMutationId(),
+        profileId: String? = null,
+        authScope: AuthScopeSnapshot? = null,
+    ): ApiResult<StoredSettingValue> {
+        val encoded = UiCustomizationCodec.encodeShortcutItem(item)
+            ?: return ApiResult.Error(
+                code = 400,
+                error = "invalid_shortcut_item",
+                message = "Navigation shortcuts cannot target built-in destinations",
+            )
+        return settingsApi.putNavigationShortcutItem(
+            item = encoded,
+            present = present,
+            mutationId = mutationId,
+            profileId = profileId,
+            authScope = authScope,
+        )
+    }
+
+    /**
+     * Write a value shared by this profile's current client family (TV,
+     * mobile, tablet, desktop, or web). The auth interceptor supplies the
+     * canonical `X-Silo-Client-Family` header alongside the profile identity.
+     */
+    suspend fun setProfileClientValue(
+        key: String,
+        value: JsonElement,
+        mutationId: String = newSettingMutationId(),
+        profileId: String? = null,
+        authScope: AuthScopeSnapshot? = null,
+        clientFamily: SiloClientFamily? = null,
+    ): ApiResult<StoredSettingValue> =
+        settingsApi.putValue(
+            key = key,
+            scope = SettingScopeIdentity.profileClient(clientFamily),
+            value = value,
+            mutationId = mutationId,
+            profileId = profileId,
+            authScope = authScope,
         )
 
     /**
@@ -98,8 +157,57 @@ class SettingsRepository(
      * nothing was stored there, which is the state the caller asked for, so it
      * reports success rather than an error the UI would have to special-case.
      */
-    suspend fun clearProfileValue(key: String): ApiResult<Unit> =
-        when (val result = settingsApi.deleteValue(key, SettingScopeIdentity.profile())) {
+    suspend fun clearProfileValue(key: String, profileId: String? = null): ApiResult<Unit> =
+        when (
+            val result = settingsApi.deleteValue(
+                key,
+                SettingScopeIdentity.profile(),
+                profileId,
+            )
+        ) {
+            is ApiResult.Error ->
+                if (result.code == 404) ApiResult.Success(Unit) else result
+            else -> result
+        }
+
+    /** Clear this family's override so contract/default resolution applies. */
+    suspend fun clearProfileClientValue(
+        key: String,
+        profileId: String? = null,
+        authScope: AuthScopeSnapshot? = null,
+        clientFamily: SiloClientFamily? = null,
+    ): ApiResult<Unit> =
+        when (
+            val result = settingsApi.deleteValue(
+                key,
+                SettingScopeIdentity.profileClient(clientFamily),
+                profileId,
+                authScope,
+            )
+        ) {
+            is ApiResult.Error ->
+                if (result.code == 404) ApiResult.Success(Unit) else result
+            else -> result
+        }
+
+    /**
+     * Clear the current device's higher-precedence override so the value
+     * inherited from this profile's client family becomes effective again.
+     */
+    suspend fun clearProfileDeviceValue(
+        key: String,
+        profileId: String? = null,
+        authScope: AuthScopeSnapshot? = null,
+        clientFamily: SiloClientFamily? = null,
+    ): ApiResult<Unit> =
+        when (
+            val result = settingsApi.deleteValue(
+                key,
+                SettingScopeIdentity.profileDevice(clientFamily),
+                profileId,
+                authScope,
+            )
+        ) {
             is ApiResult.Error ->
                 if (result.code == 404) ApiResult.Success(Unit) else result
             else -> result

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/domain/settings/ProfileSettingsControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/domain/settings/ProfileSettingsControllerTest.kt
@@ -49,6 +49,8 @@ class ProfileSettingsControllerTest {
             keys: List<String>,
             libraryIds: List<Int>,
             seriesIds: List<String>,
+            profileId: String?,
+            authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
         ): ApiResult<EffectiveSettingValuesResponse> = effective
 
         override suspend fun putValue(
@@ -57,6 +59,7 @@ class ProfileSettingsControllerTest {
             value: JsonElement,
             mutationId: String,
             profileId: String?,
+            authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
         ): ApiResult<StoredSettingValue> {
             calls += Call.Put(key, scope.scope, value)
             mutationIds += mutationId
@@ -67,6 +70,7 @@ class ProfileSettingsControllerTest {
             key: String,
             scope: SettingScopeIdentity,
             profileId: String?,
+            authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
         ): ApiResult<Unit> {
             calls += Call.Delete(key, scope.scope)
             return deleteResult

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/UiCustomizationTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/UiCustomizationTest.kt
@@ -1,0 +1,198 @@
+package org.siloserver.silo.model.settings
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class UiCustomizationTest {
+    @Test
+    fun cardPresentationRoundTripsExactWireShape() {
+        val value = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+
+        assertEquals(
+            value,
+            UiCustomizationCodec.parseCardPresentation(
+                UiCustomizationCodec.encodeCardPresentation(value),
+            ),
+        )
+        assertNull(
+            UiCustomizationCodec.parseCardPresentation(
+                json("""{"poster_size":"large","caption":"artwork","future":true}"""),
+            ),
+        )
+    }
+
+    @Test
+    fun cardPresentationPresetsMapToCanonicalTwoAxisValues() {
+        assertEquals(
+            CardPresentation(PosterSizePreset.STANDARD, CardCaptionPreset.TITLE_METADATA),
+            CardPresentationPreset.BALANCED.presentation,
+        )
+        assertEquals(
+            CardPresentation(PosterSizePreset.COMPACT, CardCaptionPreset.TITLE),
+            CardPresentationPreset.COMPACT.presentation,
+        )
+        assertEquals(
+            CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.TITLE),
+            CardPresentationPreset.CINEMA.presentation,
+        )
+        assertEquals(
+            CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK),
+            CardPresentationPreset.ARTWORK_ONLY.presentation,
+        )
+        assertEquals(
+            CardPresentationPreset.CINEMA,
+            CardPresentationPreset.matching(CardPresentationPreset.CINEMA.presentation),
+        )
+        assertNull(
+            CardPresentationPreset.matching(
+                CardPresentation(PosterSizePreset.COMPACT, CardCaptionPreset.ARTWORK),
+            ),
+        )
+    }
+
+    @Test
+    fun confirmedUnsupportedServerSuppressesCachedRevisionFivePresentation() {
+        val menu = PrimaryMenu(listOf(PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME)))
+        val card = CardPresentation(PosterSizePreset.LARGE, CardCaptionPreset.ARTWORK)
+
+        assertNull(effectivePrimaryMenuForSupport(menu, false))
+        assertEquals(CardPresentation.DEFAULT, effectiveCardPresentationForSupport(card, false))
+        assertEquals(menu, effectivePrimaryMenuForSupport(menu, true))
+        assertEquals(card, effectiveCardPresentationForSupport(card, true))
+        assertEquals(menu, effectivePrimaryMenuForSupport(menu, null))
+        assertEquals(card, effectiveCardPresentationForSupport(card, null))
+    }
+
+    @Test
+    fun primaryMenuRoundTripsEverySupportedItemShape() {
+        val menu = PrimaryMenu(
+            listOf(
+                PrimaryMenuItem.Library(7, "Movies"),
+                PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+                PrimaryMenuItem.Section(7, "recently-added", "Recently Added"),
+                PrimaryMenuItem.Collection("favorites", "Favorites", libraryId = 7),
+            ),
+        )
+
+        assertEquals(
+            menu,
+            UiCustomizationCodec.parsePrimaryMenu(UiCustomizationCodec.encodePrimaryMenu(menu)),
+        )
+    }
+
+    @Test
+    fun primaryMenuRejectsMissingOrDuplicateHomeAndDuplicateIdentity() {
+        assertNull(
+            UiCustomizationCodec.parsePrimaryMenu(
+                json("""{"items":[{"type":"builtin","destination":"calendar"}]}"""),
+            ),
+        )
+        assertNull(
+            UiCustomizationCodec.parsePrimaryMenu(
+                json(
+                    """{"items":[{"type":"builtin","destination":"home"},{"type":"builtin","destination":"home"}]}""",
+                ),
+            ),
+        )
+        assertNull(
+            UiCustomizationCodec.parsePrimaryMenu(
+                json(
+                    """{"items":[{"type":"builtin","destination":"home"},{"type":"library","library_id":7,"label":"A"},{"type":"library","library_id":7,"label":"B"}]}""",
+                ),
+            ),
+        )
+        assertNull(UiCustomizationCodec.parsePrimaryMenu(JsonNull))
+    }
+
+    @Test
+    fun shortcutsForbidBuiltinsButKeepCollectionLibraryOptional() {
+        assertNull(
+            UiCustomizationCodec.parseShortcuts(
+                json("""{"items":[{"type":"builtin","destination":"home"}]}"""),
+            ),
+        )
+        val shortcuts = NavigationShortcuts(
+            listOf(PrimaryMenuItem.Collection("watchlist", "Watchlist")),
+        )
+        assertEquals(
+            shortcuts,
+            UiCustomizationCodec.parseShortcuts(UiCustomizationCodec.encodeShortcuts(shortcuts)),
+        )
+    }
+
+    @Test
+    fun itemFieldsHonorTheCanonicalTypesAndBounds() {
+        assertNull(
+            UiCustomizationCodec.parsePrimaryMenu(
+                json(
+                    """{"items":[{"type":"builtin","destination":"home"},{"type":"library","library_id":"7","label":"Movies"}]}""",
+                ),
+            ),
+        )
+        assertNull(
+            UiCustomizationCodec.parsePrimaryMenu(
+                json(
+                    """{"items":[{"type":"builtin","destination":"home"},{"type":"library","library_id":7,"label":"   "}]}""",
+                ),
+            ),
+        )
+        assertNull(
+            UiCustomizationCodec.parsePrimaryMenu(
+                json(
+                    """{"items":[{"type":"builtin","destination":"home"},{"type":"section","library_id":7,"section_id":"${"x".repeat(129)}","label":"Recent"}]}""",
+                ),
+            ),
+        )
+        assertNull(
+            UiCustomizationCodec.parsePrimaryMenu(
+                json(
+                    """{"items":[{"type":"builtin","destination":"home"},{"type":"section","library_id":7,"section_id":"   ","label":"Recent"}]}""",
+                ),
+            ),
+        )
+        assertNull(
+            UiCustomizationCodec.parseShortcuts(
+                json(
+                    """{"items":[{"type":"collection","collection_id":"\t ","label":"Favorites"}]}""",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun profileClientScopeBuildsWithoutContentIdentity() {
+        assertEquals(
+            SettingScope.PROFILE_CLIENT,
+            SettingScopeIdentity.profileClient().scope,
+        )
+        assertEquals(
+            SiloClientFamily.TV,
+            SettingScopeIdentity.profileClient(SiloClientFamily.TV).clientFamily,
+        )
+        assertFailsWith<IllegalArgumentException> {
+            SettingScopeIdentity(
+                scope = SettingScope.PROFILE,
+                clientFamily = SiloClientFamily.TV,
+            )
+        }
+    }
+
+    @Test
+    fun semanticIdentitiesRemainDistinctWhenTargetIdsContainColons() {
+        val items = listOf(
+            PrimaryMenuItem.Section(7, "recent:4", "Recent"),
+            PrimaryMenuItem.Section(74, "recent", "Other Recent"),
+            PrimaryMenuItem.Collection(":7:favorites", "Unscoped"),
+            PrimaryMenuItem.Collection("favorites", "Scoped", libraryId = 7),
+            PrimaryMenuItem.Library(7, "Library"),
+        )
+
+        assertEquals(items.size, items.map(UiCustomizationCodec::identity).toSet().size)
+    }
+
+    private fun json(raw: String) = Json.parseToJsonElement(raw)
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/AuthScopeSnapshotRedactionTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/AuthScopeSnapshotRedactionTest.kt
@@ -1,0 +1,44 @@
+package org.siloserver.silo.network
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AuthScopeSnapshotRedactionTest {
+
+    /**
+     * Snapshots reach logs and diagnostics bundles through interpolation. The
+     * durable credentialOwnerId is a stable cross-launch account identifier, so
+     * it is redacted alongside the other identity fields rather than left as
+     * the one value that survives into a shipped log.
+     */
+    @Test
+    fun toStringRedactsTheDurableCredentialOwnerAlongWithEveryOtherIdentityField() {
+        val secrets = listOf(
+            "server-id-secret",
+            "profile-id-secret",
+            "https://private.example",
+            "profile-token-secret",
+            "overlay-generation-secret",
+            "11111111-2222-3333-4444-555555555555",
+        )
+        val snapshot = AuthScopeSnapshot(
+            serverId = secrets[0],
+            profileId = secrets[1],
+            serverUrl = secrets[2],
+            profileToken = secrets[3],
+            credentialGenerationId = secrets[4],
+            identityGeneration = 7L,
+            isIdentityGenerationStamped = true,
+            credentialOwnerId = secrets[5],
+            credentialEpoch = 9L,
+        )
+
+        val rendered = snapshot.toString()
+
+        assertTrue(rendered.contains("credentialOwnerId=<redacted>"), rendered)
+        secrets.forEach { secret ->
+            assertFalse(rendered.contains(secret), "leaked $secret in $rendered")
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/IdentityTransitionBarrierTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/IdentityTransitionBarrierTest.kt
@@ -9,6 +9,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class IdentityTransitionBarrierTest {
@@ -160,5 +163,62 @@ class IdentityTransitionBarrierTest {
         assertMutation(IdentityTransitionKind.SIGN_OUT) { tokens.signOutCurrentServer() }
         assertMutation(IdentityTransitionKind.TEMPORARY_SCOPE_BEGIN) { tokens.beginTemporaryScope(temporary) }
         assertMutation(IdentityTransitionKind.TEMPORARY_SCOPE_END) { tokens.endTemporaryScope() }
+    }
+
+    /**
+     * `latestTransition` is a replayable StateFlow, not a notification: it is
+     * what `TvLibraryScopeStore.showAudiobooksTabFlow()`'s `onSubscription`
+     * block reads to key a brand-new subscriber. It must move to WILL_CHANGE
+     * before the mutation is visible and then COME TO REST on a DID_CHANGE that
+     * still carries the resolved target, so a subscriber that arrives after the
+     * transition keys on the settled identity rather than staying gated.
+     */
+    @Test
+    fun latestTransitionMovesToWillChangeThenRestsOnADidChangeCarryingTheFullTarget() = runTest {
+        val barrier = DefaultIdentityTransitionBarrier()
+        assertNull(barrier.latestTransition.value)
+
+        val duringMutation = barrier.changing(
+            kind = IdentityTransitionKind.ACCOUNT_REPLACE,
+            target = {
+                IdentityTransitionTarget(
+                    serverId = "server-b",
+                    affectsCurrentIdentity = true,
+                    purgesPersistentIdentity = false,
+                )
+            },
+        ) { assertNotNull(barrier.latestTransition.value) }
+
+        assertEquals(IdentityTransitionPhase.WILL_CHANGE, duringMutation.phase)
+        assertEquals(IdentityTransitionKind.ACCOUNT_REPLACE, duringMutation.kind)
+        assertEquals("server-b", duringMutation.targetServerId)
+        assertEquals(1L, duringMutation.generation)
+
+        val settled = assertNotNull(barrier.latestTransition.value)
+        assertEquals(IdentityTransitionPhase.DID_CHANGE, settled.phase)
+        assertEquals(IdentityTransitionKind.ACCOUNT_REPLACE, settled.kind)
+        assertEquals(1L, settled.generation)
+        assertEquals("server-b", settled.targetServerId)
+        assertTrue(settled.affectsCurrentIdentity)
+        assertFalse(settled.purgesPersistentIdentity)
+    }
+
+    /** A failed mutation must still settle, or every later subscriber stays gated. */
+    @Test
+    fun latestTransitionSettlesOnDidChangeEvenWhenTheMutationFails() = runTest {
+        val barrier = DefaultIdentityTransitionBarrier()
+
+        assertFailsWith<IllegalStateException> {
+            barrier.changing(
+                kind = IdentityTransitionKind.SIGN_OUT,
+                target = { IdentityTransitionTarget(serverId = "server-a") },
+            ) { error("failed") }
+        }
+
+        val settled = assertNotNull(barrier.latestTransition.value)
+        assertEquals(IdentityTransitionPhase.DID_CHANGE, settled.phase)
+        assertEquals(IdentityTransitionKind.SIGN_OUT, settled.kind)
+        assertEquals("server-a", settled.targetServerId)
+        assertTrue(settled.purgesPersistentIdentity)
     }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/SiloAuthPluginPinTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/SiloAuthPluginPinTest.kt
@@ -145,6 +145,7 @@ class SiloAuthPluginPinTest {
         var authorization: String? = null
         var profileId: String? = null
         var profileToken: String? = null
+        var siloClientFamily: String? = null
         var siloClient: String? = null
         var siloClientVersion: String? = null
     }
@@ -160,6 +161,7 @@ class SiloAuthPluginPinTest {
                 captured.authorization = request.headers[HttpHeaders.Authorization]
                 captured.profileId = request.headers["X-Profile-Id"]
                 captured.profileToken = request.headers["X-Profile-Token"]
+                captured.siloClientFamily = request.headers["X-Silo-Client-Family"]
                 captured.siloClient = request.headers["X-Silo-Client"]
                 captured.siloClientVersion = request.headers["X-Silo-Client-Version"]
                 respond("{}", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
@@ -225,6 +227,7 @@ class SiloAuthPluginPinTest {
                     id = "device-1",
                     name = "Amazon AFTKA",
                     platform = "android-tv",
+                    clientFamily = "tv",
                     clientName = "Silo Android TV",
                     clientVersion = "0.2.3",
                 )
@@ -232,8 +235,33 @@ class SiloAuthPluginPinTest {
 
         client(tokenManager, captured, provider).post("/api/v1/playback/start")
 
+        assertEquals("tv", captured.siloClientFamily)
         assertEquals("Silo Android TV", captured.siloClient)
         assertEquals("0.2.3", captured.siloClientVersion)
+    }
+
+    @Test
+    fun explicitClientFamilyHeaderIsNotOverwrittenByLiveDeviceMetadata() = runTest {
+        val tokenManager = TokenManagerImpl().apply {
+            setServerUrl("https://silo.example")
+            saveTokens(accessToken = "ACCESS-A", refreshToken = "REFRESH-A", expiresIn = 3600)
+        }
+        val captured = Captured()
+        val provider = object : DeviceMetadataProvider {
+            override suspend fun current(): SiloDeviceMetadata =
+                SiloDeviceMetadata(
+                    id = "device-1",
+                    name = "Foldable",
+                    platform = "android",
+                    clientFamily = "tablet",
+                )
+        }
+
+        client(tokenManager, captured, provider).post("/api/v1/settings/values/ui.card_presentation") {
+            header("X-Silo-Client-Family", "mobile")
+        }
+
+        assertEquals("mobile", captured.siloClientFamily)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/SettingsApiValuesTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/SettingsApiValuesTest.kt
@@ -1,7 +1,12 @@
 package org.siloserver.silo.network.api
 
 import org.siloserver.silo.model.settings.EffectiveSettingValue
+import org.siloserver.silo.model.settings.PrimaryMenuItem
 import org.siloserver.silo.model.settings.SettingScopeIdentity
+import org.siloserver.silo.model.settings.SiloClientFamily
+import org.siloserver.silo.model.settings.SettingsContractCapabilities
+import org.siloserver.silo.model.settings.UiCustomizationCodec
+import org.siloserver.silo.model.settings.supportsUiCustomization
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.SiloJson
 import io.ktor.client.HttpClient
@@ -30,6 +35,48 @@ import kotlin.test.assertTrue
 
 /** Tests for the canonical settings API surface: `/settings/contract` and the `/settings/values` routes. */
 class SettingsApiValuesTest {
+
+    @Test
+    fun `ui customization fails closed unless revision atomic and idempotency match`() {
+        assertFalse(
+            SettingsContractCapabilities(
+                revision = 4,
+                supportsBatchedEffective = true,
+                supportsIdempotentWrites = true,
+                supportsAtomicShortcuts = true,
+            ).supportsUiCustomization,
+        )
+        assertFalse(SettingsContractCapabilities(revision = 5).supportsUiCustomization)
+        assertFalse(
+            SettingsContractCapabilities(
+                revision = 5,
+                supportsIdempotentWrites = true,
+                supportsAtomicShortcuts = true,
+            ).supportsUiCustomization,
+        )
+        assertFalse(
+            SettingsContractCapabilities(
+                revision = 5,
+                supportsBatchedEffective = true,
+                supportsAtomicShortcuts = true,
+            ).supportsUiCustomization,
+        )
+        assertFalse(
+            SettingsContractCapabilities(
+                revision = 5,
+                supportsBatchedEffective = true,
+                supportsIdempotentWrites = true,
+            ).supportsUiCustomization,
+        )
+        assertTrue(
+            SettingsContractCapabilities(
+                revision = 5,
+                supportsBatchedEffective = true,
+                supportsIdempotentWrites = true,
+                supportsAtomicShortcuts = true,
+            ).supportsUiCustomization,
+        )
+    }
 
     private class Captured {
         var method: HttpMethod? = null
@@ -71,10 +118,11 @@ class SettingsApiValuesTest {
     fun `getContractCapabilities parses the server capabilities shape`() = runTest {
         val (api, captured) = api(
             responseBody = """
-                {"api_version":1,"revision":4,"contract_etag":"\"abc123\"",
+                {"api_version":1,"revision":5,"contract_etag":"\"abc123\"",
                  "definition_count":41,
-                 "scopes":["account","profile","profile_device","profile_library","profile_series"],
-                 "supports_batched_effective":true,"supports_idempotent_writes":true}
+                 "scopes":["account","profile","profile_client","profile_device","profile_library","profile_series"],
+                 "supports_batched_effective":true,"supports_idempotent_writes":true,
+                 "supports_atomic_shortcuts":true}
             """.trimIndent(),
         )
 
@@ -83,12 +131,14 @@ class SettingsApiValuesTest {
         assertEquals("/api/v1/settings/contract/capabilities", captured.path)
         assertIs<SettingsCapabilitiesResult.Available>(result)
         assertEquals(1, result.capabilities.apiVersion)
-        assertEquals(4, result.capabilities.revision)
+        assertEquals(5, result.capabilities.revision)
         assertEquals("\"abc123\"", result.capabilities.contractEtag)
         assertEquals(41, result.capabilities.definitionCount)
-        assertEquals(5, result.capabilities.scopes.size)
+        assertEquals(6, result.capabilities.scopes.size)
+        assertTrue("profile_client" in result.capabilities.scopes)
         assertTrue(result.capabilities.supportsBatchedEffective)
         assertTrue(result.capabilities.supportsIdempotentWrites)
+        assertTrue(result.capabilities.supportsAtomicShortcuts)
     }
 
     @Test
@@ -157,12 +207,14 @@ class SettingsApiValuesTest {
             keys = listOf("playback.auto_play_next", "playback.preferred_quality"),
             libraryIds = listOf(3, 7),
             seriesIds = listOf("s1", "s2"),
+            profileId = "profile-pinned-at-request-start",
         )
 
         assertEquals("/api/v1/settings/values/effective", captured.path)
         assertEquals("playback.auto_play_next,playback.preferred_quality", captured.query["keys"])
         assertEquals("3,7", captured.query["library_ids"])
         assertEquals("s1,s2", captured.query["series_ids"])
+        assertEquals("profile-pinned-at-request-start", captured.headers["X-Profile-Id"])
 
         assertIs<ApiResult.Success<*>>(result)
         val response = (result as ApiResult.Success).data
@@ -256,6 +308,33 @@ class SettingsApiValuesTest {
     }
 
     @Test
+    fun `putValue sends profile client scope and decodes its family receipt`() = runTest {
+        val (api, captured) = api(
+            responseBody = """
+                {"key":"ui.card_presentation","scope":"profile_client",
+                 "profile_id":"p1","client_family":"tv",
+                 "value":{"poster_size":"large","caption":"artwork"}}
+            """.trimIndent(),
+        )
+
+        val result = api.putValue(
+            key = "ui.card_presentation",
+            scope = SettingScopeIdentity.profileClient(SiloClientFamily.MOBILE),
+            value = buildJsonObject {
+                put("poster_size", "large")
+                put("caption", "artwork")
+            },
+            mutationId = "mut-family",
+        )
+
+        assertEquals("profile_client", captured.query["scope"])
+        assertNull(captured.query["client_family"])
+        assertEquals("mobile", captured.headers["X-Silo-Client-Family"])
+        assertIs<ApiResult.Success<*>>(result)
+        assertEquals("tv", (result as ApiResult.Success).data.clientFamily)
+    }
+
+    @Test
     fun `putValue surfaces a mutation id conflict as a typed error`() = runTest {
         val (api, _) = api(
             status = HttpStatusCode.Conflict,
@@ -287,6 +366,42 @@ class SettingsApiValuesTest {
         )
 
         assertEquals("child-profile", captured.headers["X-Profile-Id"])
+    }
+
+    @Test
+    fun `putNavigationShortcutItem sends atomic intent body and stable mutation id`() = runTest {
+        val item = PrimaryMenuItem.Section(7, "recent", "Recently Added")
+        val encodedItem = checkNotNull(UiCustomizationCodec.encodeShortcutItem(item))
+        val (api, captured) = api(
+            responseBody = """
+                {"key":"nav.shortcuts","scope":"profile","profile_id":"p1",
+                 "value":{"items":[{"type":"section","library_id":7,
+                 "section_id":"recent","label":"Recently Added"}]},"revision":4}
+            """.trimIndent(),
+        )
+
+        val result = api.putNavigationShortcutItem(
+            item = encodedItem,
+            present = true,
+            mutationId = "shortcut-mut-1",
+            profileId = "profile-pinned-at-request-start",
+        )
+
+        assertEquals(HttpMethod.Put, captured.method)
+        assertEquals("/api/v1/settings/values/nav.shortcuts/item", captured.path)
+        assertTrue(captured.query.isEmpty())
+        assertEquals("shortcut-mut-1", captured.headers["X-Silo-Mutation-Id"])
+        assertEquals(
+            "profile-pinned-at-request-start",
+            captured.headers["X-Profile-Id"],
+        )
+        val body = SiloJson.parseToJsonElement(captured.body).jsonObject
+        assertEquals(encodedItem, body["item"])
+        assertEquals(true, body["present"]?.jsonPrimitive?.content?.toBoolean())
+
+        assertIs<ApiResult.Success<*>>(result)
+        assertEquals("nav.shortcuts", (result as ApiResult.Success).data.key)
+        assertEquals(4L, result.data.revision)
     }
 
     // ---- deletes ----

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/SettingsRepositoryShortcutTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/SettingsRepositoryShortcutTest.kt
@@ -1,0 +1,80 @@
+package org.siloserver.silo.repository
+
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonElement
+import org.siloserver.silo.model.settings.PrimaryMenuBuiltin
+import org.siloserver.silo.model.settings.PrimaryMenuItem
+import org.siloserver.silo.model.settings.StoredSettingValue
+import org.siloserver.silo.model.settings.UiCustomizationCodec
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.api.SettingsApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class SettingsRepositoryShortcutTest {
+    @Test
+    fun atomicShortcutWriteEncodesItemAndForwardsIntentIdentity() = runTest {
+        val api = CapturingSettingsApi()
+        val repository = SettingsRepository(api)
+        val item = PrimaryMenuItem.Collection("favorites", "Family Favorites", libraryId = 7)
+
+        val result = repository.setNavigationShortcutPresent(
+            item = item,
+            present = false,
+            mutationId = "shortcut-mut-2",
+            profileId = "profile-1",
+        )
+
+        assertIs<ApiResult.Success<*>>(result)
+        assertEquals(UiCustomizationCodec.encodeShortcutItem(item), api.item)
+        assertEquals(false, api.present)
+        assertEquals("shortcut-mut-2", api.mutationId)
+        assertEquals("profile-1", api.profileId)
+    }
+
+    @Test
+    fun builtinsAreRejectedBeforeAtomicShortcutRequest() = runTest {
+        val api = CapturingSettingsApi()
+        val repository = SettingsRepository(api)
+
+        val result = repository.setNavigationShortcutPresent(
+            item = PrimaryMenuItem.Builtin(PrimaryMenuBuiltin.HOME),
+            present = true,
+        )
+
+        assertIs<ApiResult.Error>(result)
+        assertEquals("invalid_shortcut_item", result.error)
+        assertEquals(null, api.item)
+    }
+
+    private class CapturingSettingsApi : SettingsApi(HttpClient()) {
+        var item: JsonElement? = null
+        var present: Boolean? = null
+        var mutationId: String? = null
+        var profileId: String? = null
+
+        override suspend fun putNavigationShortcutItem(
+            item: JsonElement,
+            present: Boolean,
+            mutationId: String,
+            profileId: String?,
+            authScope: org.siloserver.silo.network.AuthScopeSnapshot?,
+        ): ApiResult<StoredSettingValue> {
+            this.item = item
+            this.present = present
+            this.mutationId = mutationId
+            this.profileId = profileId
+            return ApiResult.Success(
+                StoredSettingValue(
+                    key = "nav.shortcuts",
+                    scope = "profile",
+                    value = kotlinx.serialization.json.buildJsonObject {
+                        put("items", kotlinx.serialization.json.buildJsonArray { })
+                    },
+                ),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Part of [Silo-Server/silo-server#376](https://github.com/Silo-Server/silo-server/issues/376).

Android phone and TV had fixed navigation/card presentation and could not synchronize these preferences across like devices.

Depends on [Silo-Server/silo-server#538](https://github.com/Silo-Server/silo-server/pull/538).

## Approach

- Add revision-5 settings support for client-family navigation, profile-wide shortcuts, and card presentation.
- Add Balanced, Compact, Cinema, and Artwork Only presets plus title/metadata visibility and poster sizing across phone and TV card/grid surfaces.
- Add phone aggregate-menu customization and Android TV D-pad/focus-safe top-menu editing for built-ins and direct libraries. Mobile collapses synced library, section, and collection placements into its Libraries tab; Android TV preserves synced section/collection placements without exposing them as unsupported shell roots or editor rows.
- Bind caches and durable outbox operations to an opaque credential owner plus atomic server/profile/family authority across refresh, replacement, temporary guest, pairing, sign-out, and restart transitions.
- Keep legacy reads available while failing closed on unsupported revision-5/atomic mutations.

## Validation

- Settings-contract fixtures are byte-identical to server commit `5e185e6e592613fb84529e192ce13c7551374ff1`.
- Focused lifecycle, settings, navigation, and TV identity tests pass.
- Full shared/android-shared/phone/TV unit-test matrix passes.
- Phone and Android TV debug APK assemblies pass.
- `git diff --check` passes.
- Independent bounded lifecycle review completed with no actionable findings. External autoreview failed closed before transmission because its secret scanner classified the production pairing credential signatures as secret-like content; the auth code was not weakened or renamed to bypass that guard.

APK assembly is not emulator or physical Android TV D-pad proof; no compatible AVD/device runtime session was available for this PR.

### AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): gpt-5.6-sol
- Involvement: fully AI-generated
- Adversarial review: findings were verified and resolved across credential-owner persistence, refresh versus replacement semantics, temporary guest scopes, atomic pairing/server activation, cache/outbox isolation, client-family pinning, and TV focus/identity rekeying.

## Checklist

- [x] I ran the full four-module unit matrix and both debug APK builds.
- [x] I verified the vendored contract against the exact server commit.
- [x] I ran independent identity-lifecycle closeout and documented the fail-closed external-review limitation.
