### PR TITLE
fix(phone): keep TV setup dialog above bottom nav

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/pairing/CompanionPairingBottomOverlay.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/pairing/CompanionPairingBottomOverlay.kt
@@ -15,16 +15,21 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CheckCircle
@@ -55,6 +60,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.siloserver.silo.android.ui.navigation.LocalBottomChromeInset
 import org.siloserver.silo.common.pairing.CompanionPairingApproval
 import org.siloserver.silo.common.pairing.CompanionPairingServer
 import org.siloserver.silo.common.pairing.CompanionPairingStatus
@@ -145,10 +151,20 @@ private fun PairingCard(
     onDecline: () -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val bottomInset = maxOf(
+        LocalBottomChromeInset.current,
+        WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding(),
+    )
+
     Card(
         modifier = Modifier
-            .navigationBarsPadding()
-            .padding(horizontal = 10.dp, vertical = 8.dp)
+            .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal))
+            .padding(
+                start = 10.dp,
+                top = 8.dp,
+                end = 10.dp,
+                bottom = bottomInset + 8.dp,
+            )
             .widthIn(max = 640.dp)
             .fillMaxWidth()
             .animateContentSize()


### PR DESCRIPTION
## Summary

- position the companion TV setup card above the main shell's measured bottom chrome
- account for the cast mini-bar when it is present
- preserve horizontal system-navigation insets for landscape and three-button navigation

## Root cause

The setup card only applied the system navigation-bar inset. The app's floating bottom navigation is rendered by the main `Scaffold` above that inset, so the card's action area could be drawn underneath the menu and make **Done** difficult to tap.

## User impact

The complete success dialog, including **Done**, now stays visible and tappable above the phone's bottom navigation across supported layouts.

## Validation

- `:androidApp:compileDebugKotlinAndroid` — passed on current `origin/main`
- `$autoreview --mode local --stream-engine-output` — final run clean with no actionable findings
- `git diff --check` — passed

A live companion-pairing device flow was not available in this environment, so runtime screenshot validation remains outstanding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pairing overlay spacing and positioning on devices with navigation bars.
  * Added consistent bottom and horizontal margins to prevent content from being obscured by system UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->