### PR TITLE
fix(tv,phone): focus ownership, return focus, and voice search

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/SiloKeyboardActions.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/SiloKeyboardActions.kt
@@ -1,0 +1,24 @@
+package org.siloserver.silo.android.ui.components
+
+import androidx.compose.foundation.text.KeyboardActions
+
+/**
+ * Keyboard actions for a Silo phone text field.
+ *
+ * Installing `KeyboardActions(onAny = ...)` takes ownership of the IME event.
+ * The shared field families did that unconditionally against a no-op default
+ * callback, which silently replaced Compose's default handling with nothing:
+ * pressing Next on Login, Signup, Setup, Create Profile or Edit Profile ran an
+ * empty lambda and left the cursor where it was, so every multi-field form
+ * needed a tap to advance.
+ *
+ * With a callback supplied the field keeps its explicit behavior and invokes it
+ * once. With none, the platform defaults apply: Next and Previous move focus,
+ * Done closes the IME, and Go, Search and Send do nothing.
+ */
+fun siloKeyboardActions(onImeAction: (() -> Unit)?): KeyboardActions =
+    if (onImeAction == null) {
+        KeyboardActions.Default
+    } else {
+        KeyboardActions(onAny = { onImeAction() })
+    }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/aurora/AuroraChrome.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/aurora/AuroraChrome.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import org.siloserver.silo.android.ui.components.siloKeyboardActions
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -251,7 +252,7 @@ fun AuroraTextField(
     placeholder: String = "",
     keyboardType: KeyboardType = KeyboardType.Text,
     imeAction: ImeAction = ImeAction.Next,
-    onImeAction: () -> Unit = {},
+    onImeAction: (() -> Unit)? = null,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     trailing: (@Composable () -> Unit)? = null,
 ) {
@@ -306,7 +307,7 @@ fun AuroraTextField(
                         cursorBrush = SolidColor(if (isFocused) AuroraActiveInk else AuroraAccent),
                         visualTransformation = visualTransformation,
                         keyboardOptions = KeyboardOptions(keyboardType = keyboardType, imeAction = imeAction),
-                        keyboardActions = KeyboardActions(onAny = { onImeAction() }),
+                        keyboardActions = siloKeyboardActions(onImeAction),
                         interactionSource = interactionSource,
                     )
                 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/AuthComponents.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/AuthComponents.kt
@@ -15,14 +15,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -30,7 +25,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,8 +35,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -163,91 +155,6 @@ fun SiloTextField(
                 imeAction = imeAction,
             ),
             keyboardActions = siloKeyboardActions(onImeAction),
-            shape = RoundedCornerShape(18.dp),
-            colors = OutlinedTextFieldDefaults.colors(
-                focusedTextColor = AuthColors.OnSurface,
-                unfocusedTextColor = AuthColors.OnSurface,
-                focusedBorderColor = AuthColors.FieldBorderFocused,
-                unfocusedBorderColor = AuthColors.FieldBorder,
-                errorBorderColor = AuthColors.Error,
-                focusedLabelColor = AuthColors.Primary,
-                unfocusedLabelColor = AuthColors.OnSurfaceVariant,
-                errorLabelColor = AuthColors.Error,
-                cursorColor = AuthColors.Primary,
-                focusedContainerColor = AuthColors.Surface,
-                unfocusedContainerColor = AuthColors.Surface,
-                errorContainerColor = AuthColors.Surface,
-                focusedPlaceholderColor = AuthColors.OnSurfaceVariant,
-                unfocusedPlaceholderColor = AuthColors.OnSurfaceVariant,
-            ),
-            modifier = Modifier.fillMaxWidth(),
-        )
-        if (error != null) {
-            Text(
-                text = error,
-                color = AuthColors.Error,
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(start = 16.dp, top = 4.dp),
-            )
-        }
-    }
-}
-
-/**
- * Password text field with a visibility toggle icon button.
- *
- * @param value Current password text.
- * @param onValueChange Callback when text changes.
- * @param label Label displayed above and inside the field.
- * @param error Optional error message shown below the field.
- * @param imeAction IME action button (default Done).
- * @param onImeAction Callback invoked when the IME action fires.
- * @param modifier Modifier applied to the outer Column.
- */
-@Composable
-fun SiloPasswordField(
-    value: String,
-    onValueChange: (String) -> Unit,
-    label: String,
-    modifier: Modifier = Modifier,
-    error: String? = null,
-    imeAction: ImeAction = ImeAction.Done,
-    onImeAction: (() -> Unit)? = null,
-) {
-    var passwordVisible by rememberSaveable { mutableStateOf(false) }
-
-    Column(modifier = modifier.fillMaxWidth()) {
-        OutlinedTextField(
-            value = value,
-            onValueChange = onValueChange,
-            label = { Text(label) },
-            isError = error != null,
-            singleLine = true,
-            visualTransformation = if (passwordVisible) {
-                VisualTransformation.None
-            } else {
-                PasswordVisualTransformation()
-            },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Password,
-                imeAction = imeAction,
-            ),
-            keyboardActions = siloKeyboardActions(onImeAction),
-            trailingIcon = {
-                val icon = if (passwordVisible) {
-                    Icons.Filled.VisibilityOff
-                } else {
-                    Icons.Filled.Visibility
-                }
-                val description = if (passwordVisible) "Hide password" else "Show password"
-                IconButton(onClick = { passwordVisible = !passwordVisible }) {
-                    Icon(
-                        imageVector = icon,
-                        contentDescription = description,
-                        tint = AuthColors.OnSurfaceVariant,
-                    )
-                }
-            },
             shape = RoundedCornerShape(18.dp),
             colors = OutlinedTextFieldDefaults.colors(
                 focusedTextColor = AuthColors.OnSurface,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/AuthComponents.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/AuthComponents.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.siloserver.silo.android.ui.components.siloKeyboardActions
 import org.siloserver.silo.android.R
 
 /** Silo brand colors used across auth screens. */
@@ -147,7 +148,7 @@ fun SiloTextField(
     error: String? = null,
     keyboardType: KeyboardType = KeyboardType.Text,
     imeAction: ImeAction = ImeAction.Next,
-    onImeAction: () -> Unit = {},
+    onImeAction: (() -> Unit)? = null,
     singleLine: Boolean = true,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
@@ -161,9 +162,7 @@ fun SiloTextField(
                 keyboardType = keyboardType,
                 imeAction = imeAction,
             ),
-            keyboardActions = KeyboardActions(
-                onAny = { onImeAction() },
-            ),
+            keyboardActions = siloKeyboardActions(onImeAction),
             shape = RoundedCornerShape(18.dp),
             colors = OutlinedTextFieldDefaults.colors(
                 focusedTextColor = AuthColors.OnSurface,
@@ -213,7 +212,7 @@ fun SiloPasswordField(
     modifier: Modifier = Modifier,
     error: String? = null,
     imeAction: ImeAction = ImeAction.Done,
-    onImeAction: () -> Unit = {},
+    onImeAction: (() -> Unit)? = null,
 ) {
     var passwordVisible by rememberSaveable { mutableStateOf(false) }
 
@@ -233,9 +232,7 @@ fun SiloPasswordField(
                 keyboardType = KeyboardType.Password,
                 imeAction = imeAction,
             ),
-            keyboardActions = KeyboardActions(
-                onAny = { onImeAction() },
-            ),
+            keyboardActions = siloKeyboardActions(onImeAction),
             trailingIcon = {
                 val icon = if (passwordVisible) {
                     Icons.Filled.VisibilityOff

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/DevicePairingScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/DevicePairingScreen.kt
@@ -140,7 +140,7 @@ fun DevicePairingScreen(
                     }
                     OutlinedButton(
                         onClick = viewModel::deny,
-                        enabled = state.canSubmit,
+                        enabled = state.canDecide,
                         modifier = Modifier.weight(1f),
                     ) {
                         Icon(Icons.Default.Close, contentDescription = null)
@@ -152,7 +152,7 @@ fun DevicePairingScreen(
 
                 Button(
                     onClick = viewModel::approve,
-                    enabled = state.canSubmit,
+                    enabled = state.canDecide,
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.buttonColors(containerColor = AuthColors.Primary),
                 ) {

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/components/SiloKeyboardActionsTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/components/SiloKeyboardActionsTest.kt
@@ -1,0 +1,71 @@
+package org.siloserver.silo.android.ui.components
+
+import androidx.compose.foundation.text.KeyboardActionScope
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.ui.text.input.ImeAction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class SiloKeyboardActionsTest {
+
+    /** Records whether a field fell through to Compose's default handling. */
+    private class RecordingScope : KeyboardActionScope {
+        val defaulted = mutableListOf<ImeAction>()
+        override fun defaultKeyboardAction(imeAction: ImeAction) {
+            defaulted += imeAction
+        }
+    }
+
+    @Test
+    fun `a field with no callback installs no handler, leaving Compose's defaults`() {
+        // The bug: an unconditional onAny took ownership of the event and ran a
+        // no-op, so Next did nothing at all on every multi-field phone form.
+        // Leaving the slots null is what hands the action back to Compose's
+        // KeyboardActionRunner, which moves focus for Next. That traversal is
+        // Compose's behavior, not this helper's, so it is not asserted here.
+        val actions = siloKeyboardActions(onImeAction = null)
+
+        assertSame(KeyboardActions.Default, actions)
+        assertNull(actions.onNext)
+        assertNull(actions.onDone)
+        assertNull(actions.onGo)
+    }
+
+    @Test
+    fun `a supplied callback is invoked exactly once`() {
+        var invocations = 0
+        val actions = siloKeyboardActions(onImeAction = { invocations++ })
+
+        val onNext = assertNotNull(actions.onNext)
+        val scope = RecordingScope()
+        scope.onNext()
+
+        assertEquals(1, invocations)
+        // An explicit callback owns the event; it must not also fall through.
+        assertEquals(emptyList(), scope.defaulted)
+    }
+
+    @Test
+    fun `the callback owns every action the field can raise`() {
+        // Go, Done and Search all route to the same supplied submit callback,
+        // which is what the auth screens rely on for their final field.
+        var invocations = 0
+        val actions = siloKeyboardActions(onImeAction = { invocations++ })
+        val scope = RecordingScope()
+
+        // onAny fans out to every per-action slot, so no action can fall
+        // through to a default the caller did not ask for.
+        assertNotNull(actions.onGo).invoke(scope)
+        assertNotNull(actions.onDone).invoke(scope)
+        assertNotNull(actions.onSearch).invoke(scope)
+        assertNotNull(actions.onSend).invoke(scope)
+        assertNotNull(actions.onNext).invoke(scope)
+        assertNotNull(actions.onPrevious).invoke(scope)
+
+        assertEquals(6, invocations)
+        assertEquals(emptyList(), scope.defaulted)
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogLetterIndexViewModelTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogLetterIndexViewModelTest.kt
@@ -20,15 +20,18 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -38,7 +41,7 @@ class CatalogLetterIndexViewModelTest {
     @Test
     fun browseLetterSelectionUsesServerNamePrefixAndResetsPagination() = runCatalogTest {
         val requests = mutableListOf<RequestRecord>()
-        val repositories = repositoriesFor(requests)
+        val repositories = repositoriesFor(requests, StandardTestDispatcher(testScheduler))
         val viewModel = BrowseViewModel(
             catalogRepository = repositories.catalog,
             savedStateHandle = SavedStateHandle(mapOf("libraryId" to "1")),
@@ -60,7 +63,7 @@ class CatalogLetterIndexViewModelTest {
     @Test
     fun browseDensitySelectionUpdatesLayoutWithoutReloadingCatalog() = runCatalogTest {
         val requests = mutableListOf<RequestRecord>()
-        val repositories = repositoriesFor(requests)
+        val repositories = repositoriesFor(requests, StandardTestDispatcher(testScheduler))
         val viewModel = BrowseViewModel(
             catalogRepository = repositories.catalog,
             savedStateHandle = SavedStateHandle(mapOf("libraryId" to "1")),
@@ -77,7 +80,7 @@ class CatalogLetterIndexViewModelTest {
     @Test
     fun librariesBrowseLetterSelectionUsesServerNamePrefix() = runCatalogTest {
         val requests = mutableListOf<RequestRecord>()
-        val repositories = repositoriesFor(requests)
+        val repositories = repositoriesFor(requests, StandardTestDispatcher(testScheduler))
         val viewModel = LibrariesViewModel(
             personalDataRepository = repositories.personal,
             sectionRepository = repositories.sections,
@@ -98,7 +101,7 @@ class CatalogLetterIndexViewModelTest {
     @Test
     fun librariesDensitySelectionUpdatesLayoutWithoutReloadingCatalog() = runCatalogTest {
         val requests = mutableListOf<RequestRecord>()
-        val repositories = repositoriesFor(requests)
+        val repositories = repositoriesFor(requests, StandardTestDispatcher(testScheduler))
         val viewModel = LibrariesViewModel(
             personalDataRepository = repositories.personal,
             sectionRepository = repositories.sections,
@@ -118,7 +121,7 @@ class CatalogLetterIndexViewModelTest {
     @Test
     fun readingBrowseLetterSelectionUsesServerNamePrefix() = runCatalogTest {
         val requests = mutableListOf<RequestRecord>()
-        val repositories = repositoriesFor(requests)
+        val repositories = repositoriesFor(requests, StandardTestDispatcher(testScheduler))
         val viewModel = ReadingHubViewModel(
             personalDataRepository = repositories.personal,
             sectionRepository = repositories.sections,
@@ -139,7 +142,7 @@ class CatalogLetterIndexViewModelTest {
     @Test
     fun readingDensitySelectionUpdatesLayoutWithoutReloadingCatalog() = runCatalogTest {
         val requests = mutableListOf<RequestRecord>()
-        val repositories = repositoriesFor(requests)
+        val repositories = repositoriesFor(requests, StandardTestDispatcher(testScheduler))
         val viewModel = ReadingHubViewModel(
             personalDataRepository = repositories.personal,
             sectionRepository = repositories.sections,
@@ -156,7 +159,7 @@ class CatalogLetterIndexViewModelTest {
         assertEquals(catalogRequestCount, requests.catalogRequestCount())
     }
 
-    private fun runCatalogTest(block: suspend () -> Unit) = runTest {
+    private fun runCatalogTest(block: suspend TestScope.() -> Unit) = runTest {
         Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
         try {
             block()
@@ -165,13 +168,35 @@ class CatalogLetterIndexViewModelTest {
         }
     }
 
-    private suspend fun awaitState(predicate: () -> Boolean) {
+    /**
+     * Wait for the view model to reach a state, in REAL time.
+     *
+     * Real time is not a shortcut here, it is forced: the Ktor engine backing
+     * these repositories completes on its own dispatcher, so the work is on
+     * actual threads and the test scheduler can neither see it nor advance it.
+     * Draining the scheduler instead — which is what determinism would
+     * require — returns before any response has arrived.
+     *
+     * The flake this replaces was the budget, not the mechanism. Five seconds
+     * is ample on an idle machine and not always ample when Gradle is running
+     * several test modules in parallel on the same cores, so the failure was
+     * load-dependent rather than logical. The budget below is generous because
+     * the only cost of generosity is how long a genuinely broken test takes to
+     * report, while the cost of tightness is a red build that means nothing.
+     *
+     * Making this properly deterministic needs the engine dispatcher to be
+     * injectable the way SectionRepository's already is — a production-side
+     * change, not a test one.
+     */
+    private suspend fun awaitState(description: String = "expected state", predicate: () -> Boolean) {
         withContext(Dispatchers.Default.limitedParallelism(1)) {
-            withTimeout(5_000) {
+            val deadline = withTimeoutOrNull(AwaitStateBudgetMillis) {
                 while (!predicate()) {
                     delay(10)
                 }
+                true
             }
+            assertTrue(deadline == true, "view model never reached $description")
         }
     }
 
@@ -193,7 +218,16 @@ class CatalogLetterIndexViewModelTest {
     private fun List<RequestRecord>.catalogRequestCount(): Int =
         count { it.path == "/api/v1/catalog" }
 
-    private fun repositoriesFor(requests: MutableList<RequestRecord>): Repositories {
+    /**
+     * [homeRequestDispatcher] is the seam that makes this deterministic.
+     * SectionRepository otherwise fans its library requests out on
+     * Dispatchers.Default, which is a real thread pool the test scheduler
+     * cannot see or wait for.
+     */
+    private fun repositoriesFor(
+        requests: MutableList<RequestRecord>,
+        homeRequestDispatcher: CoroutineDispatcher,
+    ): Repositories {
         val client = HttpClient(
             MockEngine { request ->
                 requests += RequestRecord(
@@ -217,7 +251,7 @@ class CatalogLetterIndexViewModelTest {
         }
         return Repositories(
             personal = PersonalDataRepository(PersonalDataApi(client)),
-            sections = SectionRepository(SectionApi(client)),
+            sections = SectionRepository(SectionApi(client), homeRequestDispatcher = homeRequestDispatcher),
             catalog = CatalogRepository(CatalogApi(client)),
         )
     }
@@ -241,5 +275,13 @@ class CatalogLetterIndexViewModelTest {
               ]
             }
         """.trimIndent()
+    }
+
+    private companion object {
+        /**
+         * Deliberately far beyond what the work needs. It exists to catch a
+         * hang, not to police latency on a loaded build machine.
+         */
+        const val AwaitStateBudgetMillis = 30_000L
     }
 }

--- a/androidTvApp/build.gradle.kts
+++ b/androidTvApp/build.gradle.kts
@@ -232,9 +232,23 @@ android {
     }
 }
 
+// The Robolectric suites need the test ComponentActivity in the merged
+// manifest, and that dependency is deliberately debug-only so it can never
+// reach the release APK. The consequence is that those same tests cannot run
+// against the release variant at all — they fail resolving the activity rather
+// than telling you anything about release.
+//
+// Running them once, on debug, is the whole of their value: unit tests are not
+// minified, so the release variant exercises no different code. This was found
+// by a flaky test in another module aborting `gradlew test` before the release
+// task was ever reached.
+androidComponents {
+    beforeVariants(selector().withBuildType("release")) { variant ->
+        variant.enableUnitTest = false
+    }
+}
+
 dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs)
-    // Robolectric's createComposeRule needs the test ComponentActivity in the
-    // manifest. debug-only: it never reaches the release APK.
     debugImplementation(libs.compose.ui.test.manifest)
 }

--- a/androidTvApp/src/androidMain/AndroidManifest.xml
+++ b/androidTvApp/src/androidMain/AndroidManifest.xml
@@ -10,6 +10,19 @@
         android:name="android.hardware.touchscreen"
         android:required="false" />
 
+    <!--
+        Package visibility for the system speech recogniser. From Android 11 an
+        app cannot see packages it has not declared an interest in, so without
+        this the availability check comes back empty on every modern device and
+        the voice affordance silently never appears. Silo asks the recogniser to
+        listen; it never records audio itself, and so needs no RECORD_AUDIO.
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
+        </intent>
+    </queries>
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
@@ -100,7 +100,13 @@ fun TvCatalogGrid(
     // Callers whose data only appends are unaffected; one that re-sorts in
     // place must re-resolve rather than trust a frozen index.
     onRestoreRequesterAttached: (String?) -> Unit = {},
-    onItemFocusedAtIndex: (BrowseItem, Int) -> Unit = { _, _ -> },
+    /**
+     * Both focus edges, not just the gain. A caller confirming a restoration
+     * has to know what holds focus NOW: reporting only arrivals makes its
+     * record sticky, so a card passed over on the way somewhere else still
+     * looks like the current position long after focus has moved on.
+     */
+    onItemFocusedAtIndex: (item: BrowseItem, index: Int, focused: Boolean) -> Unit = { _, _, _ -> },
     artworkAspectRatioForItem: (BrowseItem) -> Float? = { item ->
         tvArtworkAspectRatioForMediaType(item.type)
     },
@@ -278,7 +284,7 @@ fun TvCatalogGrid(
                         // card's outer Column while the Material Card inside it
                         // owns focus, so isFocused is never true here and the
                         // helper would never see a card take focus at all.
-                        .onFocusChanged { if (it.hasFocus) onItemFocusedAtIndex(item, index) },
+                        .onFocusChanged { onItemFocusedAtIndex(item, index, it.hasFocus) },
                     overlay = OverlayDataExtractor.fromBrowseItem(item),
                     actions = actions,
                 )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
@@ -23,10 +23,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
@@ -74,6 +76,31 @@ fun TvCatalogGrid(
     verticalSpacing: Dp = 32.dp,
     firstItemFocusRequester: FocusRequester? = null,
     firstItemCardModifier: Modifier = Modifier,
+    /**
+     * Return-restoration plumbing, for surfaces that restore focus to the card
+     * a detail page was opened from.
+     *
+     * The requester goes on [restoreItemIndex], and that card reports back
+     * which identity it is bound to — a card can be laid out while its modifier
+     * still carries the previous binding, so nothing else can say. Callers
+     * that do not restore leave these alone and keep the first-item behaviour.
+     */
+    restoreItemIndex: Int = -1,
+    restoreItemFocusRequester: FocusRequester? = null,
+    // Two caveats this component cannot remove on its own.
+    //
+    // The restorer's fallback is chosen during composition while attachment is
+    // only known after it, so there is a one-recomposition window either way:
+    // a just-detached requester still named, or a just-attached one not yet.
+    // Tolerable, because that failure is a call returning false followed by
+    // normal entry rather than focus landing somewhere wrong.
+    //
+    // And restoreItemIndex is a POSITION. If the list reorders after the caller
+    // resolved it, the requester follows the index onto a different item.
+    // Callers whose data only appends are unaffected; one that re-sorts in
+    // place must re-resolve rather than trust a frozen index.
+    onRestoreRequesterAttached: (String?) -> Unit = {},
+    onItemFocusedAtIndex: (BrowseItem, Int) -> Unit = { _, _ -> },
     artworkAspectRatioForItem: (BrowseItem) -> Float? = { item ->
         tvArtworkAspectRatioForMediaType(item.type)
     },
@@ -127,6 +154,23 @@ fun TvCatalogGrid(
     // A page we requested has settled (not loading) without adding items while
     // the server still claims more — treat as a stalled/failed load-more and
     // offer an explicit, focusable retry instead of silently re-firing.
+    // WHICH card is holding the restore requester, not merely whether one is.
+    // A Boolean cannot express ownership, and pagination moves the restore
+    // index while both the old and new cards are briefly composed: if the new
+    // card attaches before the old one disposes, the old disposal erases a live
+    // attachment and the fallback silently reverts.
+    var attachedRestoreItemId by remember { mutableStateOf<String?>(null) }
+    // Tracked the same way for the first item, so the fallback below names a
+    // requester some card is actually holding.
+    //
+    // Worth being accurate about the size of this. An UNATTACHED requester is
+    // benign: it returns false and Compose carries on with normal entry, which
+    // is where Default would have arrived anyway. What is not benign is a
+    // requester attached to the WRONG card, and that is what the identity
+    // ownership above prevents. Gating the fallback on attachment only avoids
+    // a pointless failed call.
+    var attachedFirstItemId by remember { mutableStateOf<String?>(null) }
+
     val loadMoreStalled = hasMore &&
         !isLoading &&
         items.isNotEmpty() &&
@@ -146,7 +190,17 @@ fun TvCatalogGrid(
         // explicit first-item requester (or Compose's default first-focusable
         // search) the very first time, before anything has been remembered.
         modifier = modifier.focusRestorer(
-            firstItemFocusRequester ?: FocusRequester.Default,
+            // The restore requester only once a card is genuinely holding it.
+            // It displaces the first-item requester on its card, so naming that
+            // as the fallback would point the restorer at a requester nothing
+            // is attached to — and an index alone does not prove attachment,
+            // since a deep target sits outside lazy composition until scrolled
+            // to. Compose calls this fallback directly when restoration fails,
+            // and an unattached requester returns false, dropping the whole
+            // thing into an ordinary focus search.
+            restoreItemFocusRequester?.takeIf { attachedRestoreItemId != null }
+                ?: firstItemFocusRequester?.takeIf { attachedFirstItemId != null }
+                ?: FocusRequester.Default,
         ),
     ) {
         if (header != null) {
@@ -173,6 +227,35 @@ fun TvCatalogGrid(
                 contentType = { _, item -> item.type },
             ) { index, item ->
                 val (actions, userState) = rememberTvBrowseItemCardActions(item)
+                val isRestoreTarget =
+                    restoreItemFocusRequester != null && index == restoreItemIndex
+                if (isRestoreTarget) {
+                    // Keyed on the callback as well as the item: an owner
+                    // change while the same card survives has to re-announce
+                    // the existing attachment, or the new owner only ever hears
+                    // about it when it goes away.
+                    DisposableEffect(item.contentId, onRestoreRequesterAttached) {
+                        attachedRestoreItemId = item.contentId
+                        onRestoreRequesterAttached(item.contentId)
+                        onDispose {
+                            // Only if this effect still owns the attachment. A
+                            // successor that attached first must not be undone
+                            // by its predecessor's teardown.
+                            if (attachedRestoreItemId == item.contentId) {
+                                attachedRestoreItemId = null
+                                onRestoreRequesterAttached(null)
+                            }
+                        }
+                    }
+                }
+                if (firstItemFocusRequester != null && index == 0 && !isRestoreTarget) {
+                    DisposableEffect(item.contentId) {
+                        attachedFirstItemId = item.contentId
+                        onDispose {
+                            if (attachedFirstItemId == item.contentId) attachedFirstItemId = null
+                        }
+                    }
+                }
                 TvMediaCard(
                     title = item.title,
                     posterUrl = item.posterUrl,
@@ -183,9 +266,19 @@ fun TvCatalogGrid(
                     onClick = { onBrowseItemClick?.invoke(item) ?: onItemClick(item.contentId) },
                     fillWidth = true,
                     artworkAspectRatio = artworkAspectRatioForItem(item),
-                    focusRequester = firstItemFocusRequester.takeIf { index == 0 },
+                    focusRequester = if (isRestoreTarget) {
+                        restoreItemFocusRequester
+                    } else {
+                        firstItemFocusRequester.takeIf { index == 0 }
+                    },
                     cardModifier = if (index == 0) firstItemCardModifier else Modifier,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        // hasFocus, not isFocused: this modifier lands on the
+                        // card's outer Column while the Material Card inside it
+                        // owns focus, so isFocused is never true here and the
+                        // helper would never see a card take focus at all.
+                        .onFocusChanged { if (it.hasFocus) onItemFocusedAtIndex(item, index) },
                     overlay = OverlayDataExtractor.fromBrowseItem(item),
                     actions = actions,
                 )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvDialogInitialFocus.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvDialogInitialFocus.kt
@@ -45,12 +45,29 @@ internal suspend fun requestTvDialogInitialFocus(
  * enter the overlay by traversal. That works even when [target] never became
  * focusable (an all-disabled option list, a control that left the graph while
  * the request was in flight), which is exactly when the retries run out.
+ *
+ * [reacquireKey] re-runs acquisition when an overlay swaps its own body — a
+ * dialog that replaces its form with a progress view renders zero focusables
+ * for a while, and the form coming back needs focus again or the overlay is
+ * dead to the D-pad. Overlays with one fixed body leave it alone. Re-acquisition
+ * checks focus first, so a viewer already inside the overlay is not dragged back
+ * to the first row by an unrelated key change.
+ *
+ * [enabled] suppresses acquisition for a body that has nothing to focus at all
+ * (an in-flight "Submitting…" message). Without it those phases spend the whole
+ * budget requesting a target that is not in the tree and then ask the focus
+ * system to enter an overlay with nothing in it.
  */
 @Composable
-internal fun rememberTvDialogInitialFocus(target: FocusRequester): Modifier {
+internal fun rememberTvDialogInitialFocus(
+    target: FocusRequester,
+    reacquireKey: Any? = Unit,
+    enabled: Boolean = true,
+): Modifier {
     var overlayHasFocus by remember { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
-    LaunchedEffect(target) {
+    LaunchedEffect(target, reacquireKey, enabled) {
+        if (!enabled || overlayHasFocus) return@LaunchedEffect
         val result = requestTvDialogInitialFocus(
             awaitAttempt = { delay(TvDialogInitialFocusRetryDelayMillis) },
             isOverlayFocused = { overlayHasFocus },

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFilterSheet.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFilterSheet.kt
@@ -29,13 +29,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import org.siloserver.silo.tv.ui.focus.tvModalFocusBoundary
+import org.siloserver.silo.tv.ui.focus.rememberTvContentInitialFocus
 import org.siloserver.silo.tv.ui.theme.Spacing
 
 /**
  * Bottom-anchored slide-up filter sheet for the library detail screen.
  * Mirrors the tvOS TVLibraryFilterSheet pattern: a 60%-height surface
- * with Genre / Year / Sort / Alphabet sections, focus-trapped, Back to
- * dismiss.
+ * with Genre / Year / Sort / Alphabet sections, Back to dismiss.
+ *
+ * The sheet is a modal focus owner: D-pad movement cannot leave it for the
+ * page still composed behind the scrim. Callers are responsible for handing
+ * focus back to the control that opened it, via TvRestoreFocusOnModalDismiss —
+ * the sheet cannot do that itself because its exit animation outlives its own
+ * dismissal.
  *
  * Sections are slotted by the caller via [content] so this component
  * stays generic; the library detail screen composes the actual filter
@@ -82,11 +89,13 @@ fun TvFilterSheet(
                     .align(Alignment.BottomStart),
             ) {
                 val focusRequester = remember { FocusRequester() }
-                LaunchedEffect(visible) {
-                    if (visible) {
-                        runCatching { focusRequester.requestFocus() }
-                    }
-                }
+                // The sheet slides in, so the first request lands before its
+                // controls are placed. Retry until focus is actually observed
+                // inside the sheet rather than firing once and hoping.
+                val sheetFocus = rememberTvContentInitialFocus(
+                    target = focusRequester,
+                    contentKey = visible.takeIf { it },
+                )
 
                 BackHandler(enabled = visible, onBack = onDismiss)
 
@@ -99,7 +108,8 @@ fun TvFilterSheet(
                             horizontal = Spacing.safeArea,
                             vertical = Spacing.xl,
                         )
-                        .focusGroup()
+                        .then(sheetFocus)
+                        .tvModalFocusBoundary()
                         .focusRequester(focusRequester),
                     verticalArrangement = Arrangement.spacedBy(Spacing.lg),
                 ) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -47,6 +47,11 @@ import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.section.ResolvedSection
+import org.siloserver.silo.tv.ui.focus.TvReturnResolution
+import org.siloserver.silo.tv.ui.focus.TvReturnTarget
+import org.siloserver.silo.tv.ui.focus.TvReturnTargetSaver
+import org.siloserver.silo.tv.ui.focus.resolveTvReturnTarget
+import org.siloserver.silo.tv.ui.focus.toTvReturnSections
 import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.CatalogRepository
@@ -54,6 +59,7 @@ import org.siloserver.silo.tv.ui.theme.RowDimens
 import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.TvSkyline
 import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.async
@@ -135,18 +141,51 @@ fun TvSkylineSectionFeed(
     var focusedItemIndex by remember { mutableIntStateOf(-1) }
     var focusedContentId by remember { mutableStateOf<String?>(null) }
     var removalFocusRequest by remember { mutableIntStateOf(0) }
-    // The (row, item) to restore focus to when this feed is recreated after
-    // being removed from composition — saveable so it survives both the outer
-    // Main → ItemDetail → Main round trip and inner-nav trips (Settings,
-    // Search). Disposal drops the shell restorer's saved child NODE, so its
-    // default enter can land on the wrong card; these indices let the
-    // recreation ladder re-target it exactly. Updated continuously from card
-    // focus (and on detail launch, where the clicked card is the focused one).
-    var returnRowIndex by rememberSaveable { mutableIntStateOf(-1) }
-    var returnItemIndex by rememberSaveable { mutableIntStateOf(-1) }
+    // Disposal drops the shell restorer's saved child NODE, so its default
+    // enter can land on the wrong card; this target is what lets the recreation
+    // ladder re-target the launch card exactly. Updated continuously from card
+    // focus (and on detail launch, where the clicked card is the focused one),
+    // except while a restoration is running.
+    // The card a detail page was launched from, by identity. Two saved indices
+    // used to stand in for this, and they only describe the same card while the
+    // data is unchanged: a refresh on resume, Continue Watching reordering
+    // after playback, a finished item leaving its row, or a recreated process
+    // rebuilding from the server all leave the numbers valid and pointing
+    // somewhere else. Saveable so it survives both the outer round trip and
+    // process death, which is exactly when the live focus state below is gone
+    // and indices would be all that was left.
+    var returnTarget by rememberSaveable(stateSaver = TvReturnTargetSaver) {
+        mutableStateOf<TvReturnTarget?>(null)
+    }
     // True while a restore target is armed. Gates the restore requester
     // attachments (and the row restorer's enter-fallback redirect they imply).
     var detailReturnPending by rememberSaveable { mutableStateOf(false) }
+    // True while a ladder is actively driving focus back to the launch card.
+    //
+    // Focus lands on the wrong card first often enough that these ladders exist
+    // for it, and every focus gain re-arms the return target. Without this the
+    // intermediate card's focus callback overwrites the armed identity, the
+    // resolution recomputes around it, and the ladder then declares success
+    // against content the viewer never launched — the identity contract
+    // defeating itself.
+    // Counted, not a flag: the recreation ladder and the shell-request ladder
+    // can both be live at once, and a boolean would let whichever finished
+    // first re-open the window while the other was still driving focus.
+    var restorationsInFlight by remember { mutableIntStateOf(0) }
+    // Bumped every time a new return target is armed. A ladder captures it on
+    // entry and stops the moment it no longer matches, because the driver
+    // deliberately follows the current resolution: without this an older ladder
+    // would pivot onto a newly clicked card, see it already focused, and clear
+    // the NEW trip's pending state — losing restoration for the trip that had
+    // only just started.
+    var returnGeneration by rememberSaveable { mutableIntStateOf(0) }
+    // Bumped when a ladder starts, so the row scrolls its own LazyRow to the
+    // resolved card. Without it the card can sit outside the composed
+    // horizontal window after a reorder, the requester never attaches, and
+    // every retry fails — the contract's obligation to scroll the destination
+    // into composition, unmet.
+    var returnRestoreRequest by remember { mutableIntStateOf(0) }
+
     LaunchedEffect(rows) {
         val previousContentId = focusedContentId
         val focusedItemWasRemoved = previousContentId != null &&
@@ -157,11 +196,20 @@ fun TvSkylineSectionFeed(
         if (focusedRowIndex in rows.indices && focusedItemIndex >= rows[focusedRowIndex].items.size) {
             focusedItemIndex = (rows[focusedRowIndex].items.size - 1).coerceAtLeast(-1)
         }
-        if (focusedItemWasRemoved && focusedRowIndex in rows.indices) {
+        // Same guard as browse re-arming: a refresh that removes whatever
+        // incidental focus happened to land on must not redefine what the
+        // viewer launched from.
+        if (focusedItemWasRemoved && focusedRowIndex in rows.indices && restorationsInFlight == 0) {
             val targetRow = rows[focusedRowIndex]
             if (targetRow.items.isNotEmpty()) {
-                returnRowIndex = focusedRowIndex
-                returnItemIndex = focusedItemIndex.coerceIn(0, targetRow.items.lastIndex)
+                val itemIndex = focusedItemIndex.coerceIn(0, targetRow.items.lastIndex)
+                returnTarget = TvReturnTarget(
+                    sectionId = targetRow.id,
+                    itemId = targetRow.items[itemIndex].contentId,
+                    sectionIndex = focusedRowIndex,
+                    itemIndex = itemIndex,
+                )
+                returnGeneration++
                 detailReturnPending = true
                 removalFocusRequest += 1
             }
@@ -185,9 +233,18 @@ fun TvSkylineSectionFeed(
         // the band is still scrolled rows down. Re-arming on every focus event
         // is safe: the ladder's first check sees the card already focused and
         // breaks immediately whenever nothing was actually lost.
-        returnRowIndex = rowIndex
-        returnItemIndex = itemIndex
-        detailReturnPending = true
+        // Browse movement re-arms; a restoration in progress must not. See
+        // restorationInFlight above.
+        if (restorationsInFlight == 0) {
+            returnTarget = TvReturnTarget(
+                sectionId = rowIdentity,
+                itemId = item.contentId,
+                sectionIndex = rowIndex,
+                itemIndex = itemIndex,
+            )
+            returnGeneration++
+            detailReturnPending = true
+        }
     }
 
     // Keep a small window around RESTED focus hot. A raw D-pad move cancels the
@@ -347,6 +404,41 @@ fun TvSkylineSectionFeed(
     // previously entered card.
     var initialFocusRequested by rememberSaveable { mutableStateOf(false) }
     var firstRowFocusRequest by remember { mutableIntStateOf(0) }
+    // Where the launch card is NOW. Resolved against the rows this feed
+    // actually renders — Skyline drops empty rows before layout, so a
+    // projection taken from further upstream would put these indices in a
+    // different coordinate space from the rows they address.
+    //
+    // Rows are treated as a complete snapshot: an aggregate feed response
+    // arrives whole, and a row trimmed to its item limit is capped rather than
+    // paged, so nothing further will load into it. SameSectionOnly because
+    // Home rows overlap — a title can sit in Continue Watching and Recently
+    // Added at once, and following an id across rows would jump focus to a
+    // copy the viewer never touched.
+    val returnResolution: TvReturnResolution =
+        remember(rows, returnTarget, detailReturnPending) {
+            if (detailReturnPending) {
+                resolveTvReturnTarget(returnTarget, rows.toTvReturnSections())
+            } else {
+                TvReturnResolution.Empty
+            }
+        }
+    // Read fresh inside the retry ladders. The resolution is a plain remembered
+    // value, so a coroutine that captured it keeps working from the rows of the
+    // composition it launched in; a quiet refresh would leave it steering by a
+    // map of a feed that is no longer on screen.
+    val currentResolution by rememberUpdatedState(returnResolution)
+    val locatedReturn = returnResolution as? TvReturnResolution.Located
+
+
+    // Landing is confirmed by identity, not by coordinates. The card at a
+    // given index is not necessarily the card that was resolved, and an
+    // index-only check reports success for whatever now occupies the slot.
+    fun hasLandedOnReturnTarget(): Boolean {
+        val located = currentResolution as? TvReturnResolution.Located ?: return false
+        return focusedRowIndex == located.sectionIndex && focusedContentId == located.itemId
+    }
+
     val detailReturnRowContainerFocusRequester = remember { FocusRequester() }
     val detailReturnItemFocusRequester =
         detailReturnCardFocusRequester ?: remember { FocusRequester() }
@@ -362,27 +454,75 @@ fun TvSkylineSectionFeed(
     val lifecycleOwner = LocalLifecycleOwner.current
     val firstRowId = rows.firstOrNull()?.id
 
+    /**
+     * Walk focus back to the resolved launch card, re-reading where that is on
+     * every attempt.
+     *
+     * Steering has to be as fresh as the success check. A refresh that keeps
+     * the same first row does not restart these effects, so a ladder that
+     * captured its destination up front would keep driving toward a row the
+     * feed has since moved, while the predicate looks for the new one — it
+     * cannot succeed, and for the shell ladder the request token has already
+     * been marked applied, so nothing retries.
+     *
+     * Hops one focus-restorer scope per frame pair — row group, then card —
+     * because a request that crosses a restorer toward a descendant is
+     * cancelled and rolled back. The vertical band is scrolled whenever the
+     * resolved row changes, not once at the start, for the same reason.
+     */
+    suspend fun driveFocusToReturnTarget(generation: Int, attempts: Int, scrollBand: Boolean) {
+        var scrolledToSection = -1
+        repeat(attempts) {
+            withFrameNanos { }
+            // Someone armed a newer target; that trip owns restoration now.
+            if (generation != returnGeneration) return
+            // The real success signal is the card's own focus callback —
+            // requestFocus() can report success yet silently roll back when
+            // the request crosses a restorer scope.
+            if (hasLandedOnReturnTarget()) return
+            val located = currentResolution as? TvReturnResolution.Located ?: return
+            if (scrollBand && located.sectionIndex != scrolledToSection) {
+                val scrolled = runCatching { rowBandState.scrollToItem(located.sectionIndex) }
+                scrolled.exceptionOrNull()?.let { if (it is CancellationException) throw it }
+                // Only remember a scroll that actually happened, or a failure
+                // would be recorded as done and never retried.
+                if (scrolled.isSuccess) scrolledToSection = located.sectionIndex
+            }
+            // Classified from the fresh index rather than a captured
+            // firstRowId: the removal ladder is not keyed on the row list, so
+            // a reorder mid-run would otherwise keep it addressing the row the
+            // target used to be in.
+            val rowRequester = if (located.sectionIndex == 0) {
+                firstRowContainerFocusRequester
+            } else {
+                detailReturnRowContainerFocusRequester
+            }
+            runCatching { rowRequester.requestFocus() }
+            withFrameNanos { }
+            runCatching { detailReturnItemFocusRequester.requestFocus() }
+        }
+    }
+
     LaunchedEffect(removalFocusRequest) {
         if (removalFocusRequest == 0 || !detailReturnPending) return@LaunchedEffect
-        val rowIndex = returnRowIndex
-        val itemIndex = returnItemIndex
-        if (rowIndex !in rows.indices || itemIndex !in rows[rowIndex].items.indices) {
+        // Pending means the answer is not knowable yet; keep the target and
+        // wait for the data rather than spending it on a stand-in.
+        if (returnResolution is TvReturnResolution.Pending) return@LaunchedEffect
+        if (locatedReturn == null) {
             detailReturnPending = false
             return@LaunchedEffect
         }
-        withFrameNanos { }
-        val rowRequester = if (rows[rowIndex].id == firstRowId) {
-            firstRowContainerFocusRequester
-        } else {
-            detailReturnRowContainerFocusRequester
-        }
-        runCatching { rowRequester.requestFocus() }
-        for (attempt in 0 until 8) {
+        val generation = returnGeneration
+        restorationsInFlight++
+        returnRestoreRequest++
+        try {
             withFrameNanos { }
-            if (focusedRowIndex == rowIndex && focusedItemIndex == itemIndex) break
-            runCatching { detailReturnItemFocusRequester.requestFocus() }
+            driveFocusToReturnTarget(generation, attempts = 8, scrollBand = false)
+        } finally {
+            restorationsInFlight--
         }
-        if (focusedRowIndex == rowIndex && focusedItemIndex == itemIndex) {
+        // Only the trip that owns the target may retire it.
+        if (generation == returnGeneration && hasLandedOnReturnTarget()) {
             detailReturnPending = false
         }
     }
@@ -406,30 +546,15 @@ fun TvSkylineSectionFeed(
     // click that sets pending while this feed is still composed and focused.
     LaunchedEffect(firstRowId) {
         if (!detailReturnPending || firstRowId == null) return@LaunchedEffect
-        val rowIndex = returnRowIndex
-        val itemIndex = returnItemIndex
-        if (rowIndex !in rows.indices || itemIndex !in rows[rowIndex].items.indices) {
-            return@LaunchedEffect
-        }
-        runCatching { rowBandState.scrollToItem(rowIndex) }
-        val rowRequester = if (rows[rowIndex].id == firstRowId) {
-            firstRowContainerFocusRequester
-        } else {
-            detailReturnRowContainerFocusRequester
-        }
-        for (attempt in 0 until 40) {
-            withFrameNanos { }
-            // The real success signal is the card's own focus callback —
-            // requestFocus() can report success yet silently roll back when
-            // the request crosses a restorer scope.
-            if (focusedRowIndex == rowIndex && focusedItemIndex == itemIndex) break
-            // Hop one restorer scope per frame pair: row group, then card —
-            // once default focus is anywhere inside the content group these
-            // are honored, and the row restorer's enter fallback is the
-            // launch card itself, so the hop lands directly on it.
-            runCatching { rowRequester.requestFocus() }
-            withFrameNanos { }
-            runCatching { detailReturnItemFocusRequester.requestFocus() }
+        if (returnResolution is TvReturnResolution.Pending) return@LaunchedEffect
+        if (locatedReturn == null) return@LaunchedEffect
+        val generation = returnGeneration
+        restorationsInFlight++
+        returnRestoreRequest++
+        try {
+            driveFocusToReturnTarget(generation, attempts = 40, scrollBand = true)
+        } finally {
+            restorationsInFlight--
         }
     }
 
@@ -447,35 +572,30 @@ fun TvSkylineSectionFeed(
             // loading so the firstRowId key re-runs it once data lands.
             if (detailReturnFocusRequest == lastAppliedDetailReturnRequest) return@LaunchedEffect
             if (!detailReturnPending) return@LaunchedEffect
-            val rowIndex = returnRowIndex
-            val itemIndex = returnItemIndex
-            if (rowIndex !in rows.indices || itemIndex !in rows[rowIndex].items.indices) {
+            // Skip WITHOUT consuming the request while the answer is still
+            // unknowable, so the firstRowId key re-runs this once data lands.
+            if (returnResolution is TvReturnResolution.Pending) return@LaunchedEffect
+            if (locatedReturn == null) {
                 detailReturnPending = false
                 return@LaunchedEffect
             }
             lastAppliedDetailReturnRequest = detailReturnFocusRequest
-            if (focusedRowIndex == rowIndex && focusedItemIndex == itemIndex) {
+            if (hasLandedOnReturnTarget()) {
                 // The early recreation-time ladder already landed the launch
                 // card; re-running the hops would only jiggle focus.
                 detailReturnPending = false
                 return@LaunchedEffect
             }
-            runCatching { rowBandState.scrollToItem(rowIndex) }
-            withFrameNanos { }
-            val rowRequester = if (rows[rowIndex].id == firstRowId) {
-                firstRowContainerFocusRequester
-            } else {
-                detailReturnRowContainerFocusRequester
-            }
-            runCatching { rowRequester.requestFocus() }
-            // The card requester attaches once the row's restored LazyRow
-            // window composes the launch card; retry across a few frames.
-            for (attempt in 0 until 8) {
+            val generation = returnGeneration
+            restorationsInFlight++
+            returnRestoreRequest++
+            try {
                 withFrameNanos { }
-                runCatching { detailReturnItemFocusRequester.requestFocus() }
-                if (focusedRowIndex == rowIndex && focusedItemIndex == itemIndex) break
+                driveFocusToReturnTarget(generation, attempts = 8, scrollBand = true)
+            } finally {
+                restorationsInFlight--
             }
-            if (focusedRowIndex == rowIndex && focusedItemIndex == itemIndex) {
+            if (generation == returnGeneration && hasLandedOnReturnTarget()) {
                 detailReturnPending = false
             }
             return@LaunchedEffect
@@ -601,14 +721,19 @@ fun TvSkylineSectionFeed(
                     ) { rowIndex, section ->
                         val isFirstRow = section.id == firstRowId
                         val showProgress = showProgressForSection(section)
-                        val isReturnRow = detailReturnPending && rowIndex == returnRowIndex
+                        val isReturnRow = locatedReturn?.sectionIndex == rowIndex
                         TvMediaRow(
                             title = section.title,
                             items = section.items,
                             onItemClick = { contentId ->
-                                returnRowIndex = rowIndex
-                                returnItemIndex =
-                                    section.items.indexOfFirst { it.contentId == contentId }
+                                returnTarget = TvReturnTarget(
+                                    sectionId = section.id,
+                                    itemId = contentId,
+                                    sectionIndex = rowIndex,
+                                    itemIndex = section.items
+                                        .indexOfFirst { it.contentId == contentId },
+                                )
+                                returnGeneration++
                                 detailReturnPending = true
                                 onItemClick(contentId)
                             },
@@ -630,7 +755,17 @@ fun TvSkylineSectionFeed(
                                 else -> null
                             },
                             firstItemFocusRequest = if (isFirstRow) firstRowFocusRequest else 0,
-                            restoreFocusIndex = if (isReturnRow) returnItemIndex else -1,
+                            restoreFocusIndex = if (isReturnRow) {
+                                locatedReturn?.itemIndex ?: -1
+                            } else {
+                                -1
+                            },
+                            // Bumped when a ladder starts, so the row scrolls
+                            // its own LazyRow to the resolved card. A card that
+                            // moved horizontally can otherwise sit outside the
+                            // composed window, leaving the requester unattached
+                            // and every retry doomed.
+                            restoreFocusRequest = if (isReturnRow) returnRestoreRequest else 0,
                             restoreFocusRequester = detailReturnItemFocusRequester
                                 .takeIf { isReturnRow },
                             onItemFocusedAtIndex = { item, itemIndex ->

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -79,6 +79,17 @@ fun TvSkylineSectionFeed(
     sections: List<ResolvedSection>,
     onItemClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    /**
+     * False while rows are still being hydrated.
+     *
+     * Without it a launch row that has not arrived yet is indistinguishable
+     * from one that is gone, and resolution settles on the nearest survivor —
+     * driving focus to a card the viewer never opened and retiring the real
+     * target on the way. The rows list cannot answer this itself: it is
+     * filtered to sections that already HAVE items, so an unhydrated
+     * placeholder is dropped before the adapter could mark it incomplete.
+     */
+    sectionsComplete: Boolean = true,
     focusRequest: Int = 0,
     detailReturnFocusRequest: Int = 0,
     /** Shell-owned requester for the card a detail page was launched from.
@@ -418,7 +429,11 @@ fun TvSkylineSectionFeed(
     val returnResolution: TvReturnResolution =
         remember(rows, returnTarget, detailReturnPending) {
             if (detailReturnPending) {
-                resolveTvReturnTarget(returnTarget, rows.toTvReturnSections())
+                resolveTvReturnTarget(
+                    target = returnTarget,
+                    sections = rows.toTvReturnSections(),
+                    sectionsComplete = sectionsComplete,
+                )
             } else {
                 TvReturnResolution.Empty
             }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvStockImeLifecycle.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvStockImeLifecycle.kt
@@ -1,0 +1,28 @@
+package org.siloserver.silo.tv.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+
+/**
+ * Dismiss the stock TV keyboard when the caller leaves composition.
+ *
+ * Android TV does not take the IME down on its own when the surface that
+ * raised it goes away, so without this the keyboard floats over whatever screen
+ * comes next — with the D-pad still feeding it rather than the content behind.
+ *
+ * Every surface that calls `show()` needs this, which is why it is a shared
+ * composable rather than a comment: the two implementations that copied the
+ * focus-and-show half of the policy both omitted the disposal half.
+ * `TvStockKeyboardPolicyTest` pins that pairing.
+ *
+ * Callers that can be covered by the IME also need `Modifier.imePadding()` on
+ * their container; that cannot be enforced from here.
+ */
+@Composable
+internal fun TvHideStockImeOnDispose() {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    DisposableEffect(keyboardController) {
+        onDispose { runCatching { keyboardController?.hide() } }
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvTextInputDialog.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvTextInputDialog.kt
@@ -77,12 +77,7 @@ fun TvTextInputDialog(
         runCatching { fieldFocusRequester.requestFocus() }
         keyboardController?.show()
     }
-    // Dismiss the IME when the dialog leaves composition so the system keyboard
-    // doesn't float over whatever screen follows (Android TV leaves it up
-    // otherwise). Mirrors the fix in TvSearchScreen.
-    DisposableEffect(Unit) {
-        onDispose { runCatching { keyboardController?.hide() } }
-    }
+    TvHideStockImeOnDispose()
 
     Dialog(onDismissRequest = onDismiss) {
         Box(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvContentInitialFocus.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvContentInitialFocus.kt
@@ -1,0 +1,104 @@
+package org.siloserver.silo.tv.ui.focus
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import kotlinx.coroutines.delay
+
+private const val TvContentInitialFocusRetryDelayMillis = 60L
+
+internal const val TvContentInitialFocusMaxAttempts =
+    (TvFocusAcquisitionBudgetMillis / TvContentInitialFocusRetryDelayMillis).toInt()
+
+/**
+ * Bounded retry-until-observed initial focus for a screen whose content arrives
+ * asynchronously.
+ *
+ * Separate from the dialog adapter because the failure it prevents is
+ * different. A dialog is on screen the instant its effect runs; a content
+ * screen composes its first row *during* lazy placement, so the first request
+ * is routinely rejected. Screens that treated "attempted" as "acquired"
+ * latched that rejection permanently and never focused anything.
+ */
+internal suspend fun requestTvContentInitialFocus(
+    awaitAttempt: suspend () -> Unit,
+    isContentFocused: () -> Boolean,
+    requestFocus: () -> Boolean,
+): TvObservedFocusResult = requestFocusUntilObserved(
+    maxAttempts = TvContentInitialFocusMaxAttempts,
+    awaitAttempt = awaitAttempt,
+    requestFocus = requestFocus,
+    isFocused = isContentFocused,
+)
+
+/**
+ * Whether an anchoring pass should run at all.
+ *
+ * Nothing to anchor to yet when there is no content. Nothing to do either when
+ * the content root already holds focus — the viewer is in there and a refresh
+ * must not yank them back to the first item. Checked before the first attempt
+ * rather than inside the retry loop, which delays a frame before looking.
+ */
+internal fun shouldRequestTvContentInitialFocus(
+    contentKey: Any?,
+    contentHasFocus: Boolean,
+): Boolean = contentKey != null && !contentHasFocus
+
+/**
+ * Attach the returned modifier to the content root, and [target] to the first
+ * item. Anchoring re-runs whenever [contentKey] — the stable identity of the
+ * first item — changes, which is what allows a request rejected during lazy
+ * placement to be retried instead of latched as failure.
+ *
+ * "Acquired" here means the content root owns focus, not that [target]
+ * specifically does: the observation is `hasFocus` on an ancestor, so focus
+ * landing on any descendant satisfies it. That is the property worth having —
+ * the failure being prevented is a dead D-pad, and any focused item inside the
+ * content prevents it.
+ *
+ * Refresh does not steal focus, subject to one bound: focus is checked before
+ * the first request, so a viewer already inside the content is left alone. If
+ * they leave the content *during* an anchoring pass the request can still land
+ * and pull them back.
+ *
+ * [onAcquired] fires only on observed acquisition. Shells use it to hand over
+ * content focus, and telling a shell that focus landed when it did not is how
+ * a screen ends up with no focus owner at all.
+ */
+@Composable
+internal fun rememberTvContentInitialFocus(
+    target: FocusRequester,
+    contentKey: Any?,
+    onAcquired: () -> Unit = {},
+): Modifier {
+    var contentHasFocus by remember { mutableStateOf(false) }
+
+    // Deliberately no "already acquired" latch, which is a real trade rather
+    // than a free win. With one, A -> null -> A and A -> B-exhausted -> A
+    // suppress the request while nothing holds focus — the permanent no-focus
+    // state this adapter exists to remove. Without one, those same re-entries
+    // will anchor even when focus legitimately sits outside the content root,
+    // e.g. in a confirmation dialog, and pull it back.
+    //
+    // Dead D-pad is the worse failure, so it loses. Resolving it properly needs
+    // the modal focus-ownership contract (Series C): a modal that owns focus
+    // should suppress content anchoring underneath it, which is knowledge this
+    // adapter cannot have on its own.
+    LaunchedEffect(target, contentKey) {
+        if (!shouldRequestTvContentInitialFocus(contentKey, contentHasFocus)) return@LaunchedEffect
+        val result = requestTvContentInitialFocus(
+            awaitAttempt = { delay(TvContentInitialFocusRetryDelayMillis) },
+            isContentFocused = { contentHasFocus },
+            requestFocus = target::requestFocus,
+        )
+        if (result == TvObservedFocusResult.Focused) onAcquired()
+    }
+
+    return Modifier.onFocusChanged { contentHasFocus = it.hasFocus }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvControlEnablement.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvControlEnablement.kt
@@ -42,8 +42,29 @@ internal data class TvControlState(
     }
 }
 
-/** Keeps transiently gated controls focusable while exposing truthful accessibility state. */
+/**
+ * Wire a [TvControlState] to a control: focus participation and truthful
+ * accessibility state.
+ *
+ * Passing `focusable` to a TV component's `enabled` parameter does NOT achieve
+ * the focus half, which is the trap this exists to close. `tvClickable` — the
+ * shared basis of TV Material's clickable `Surface` and therefore of `Button`
+ * — calls `focusable()` with its *default* `enabled = true` and never forwards
+ * the component's own `enabled`; that flag reaches only the D-pad-enter handler
+ * and the semantics block. A disabled TV button is consequently still a focus
+ * stop: it just refuses to activate. (Verified against the tv-material 1.0.1
+ * bytecode, not inferred from the API shape.)
+ *
+ * So structural exclusion has to be asked for explicitly, and on the control's
+ * own modifier chain ahead of the component's internal focusable — which is
+ * where a `modifier` parameter lands.
+ *
+ * Every call site predating this used [TvControlState.transient], where
+ * `focusable` is always true, so the promise was never tested. It is kept here
+ * rather than at each call site so it cannot be forgotten again.
+ */
 internal fun Modifier.tvControlSemantics(controlState: TvControlState): Modifier =
-    semantics {
-        if (!controlState.actionable) disabled()
-    }
+    tvFocusSuppressed(!controlState.focusable)
+        .semantics {
+            if (!controlState.actionable) disabled()
+        }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
@@ -44,6 +44,17 @@ internal class TvFlatReturnRestoration internal constructor(
      * there is and the live focus state is gone.
      */
     private val targetState: MutableState<TvReturnTarget?>,
+    /**
+     * Whether a target was already saved when this holder was created — the
+     * only honest way to tell "the viewer came back" from "the viewer just
+     * arrived".
+     *
+     * Asking whether a target exists cannot answer it: browsing arms one on
+     * every card focus, so on a fresh entry the answer flips the moment the
+     * grid happens to take focus, and it races whatever else the screen wanted
+     * to focus instead. Captured once, at creation, it cannot race anything.
+     */
+    val isReturning: Boolean,
 ) {
     internal var target: TvReturnTarget?
         get() = targetState.value
@@ -71,6 +82,8 @@ internal class TvFlatReturnRestoration internal constructor(
      * ordinary first entry.
      */
     val requesterItemIndex: Int get() = destination?.itemIndex ?: provisionalItemIndex
+
+
 
     /**
      * Report ordinary browse movement.
@@ -157,12 +170,44 @@ internal fun rememberTvFlatReturnRestoration(
     itemIds: List<String>,
     hasMore: Boolean,
     isLoadingMore: Boolean,
+    /**
+     * True while the surface is REPLACING its list rather than extending it —
+     * a resume refresh that reloads from offset zero.
+     *
+     * This is not the same signal as [isLoadingMore] and cannot be folded into
+     * it. [isLoadingMore] is only consulted once resolution has already come
+     * back Pending, and a stale multi-page list still CONTAINS the target, so
+     * it resolves Exact and that check is never reached. Restoration would then
+     * scroll and acquire against a list the refresh is about to throw away:
+     * either the card vanishes mid-acquisition and the one-shot attempt fails,
+     * or focus lands on a card that is removed a frame later.
+     *
+     * So a replacement gates the FIRST resolution, not the page hunt. Once the
+     * refresh has settled and the truncated list is authoritative, a target
+     * beyond it is genuinely Pending and paging back toward it is the right
+     * answer rather than a race.
+     */
+    isReplacingContent: Boolean = false,
     errorMessage: String?,
     surfaceKey: String,
     onLoadMore: () -> Unit,
     scrollToItem: suspend (itemIndex: Int) -> Unit,
     requestFocus: () -> Boolean,
     onRestored: () -> Unit,
+    /**
+     * What to do on a surface with nothing recorded yet — ordinary first entry.
+     *
+     * True focuses the first item, which is what a surface whose entry point IS
+     * its first card wants, and makes restoration subsume its plain initial
+     * focus. False stands down and leaves entry to the screen: a person page
+     * deliberately opens on its filter chips so the identity header stays
+     * visible, and a restoration that grabbed the first poster instead would
+     * break that on every visit while only being wanted on returns.
+     *
+     * "Fresh arrival" here means no target was saved before this composition —
+     * see [TvFlatReturnRestoration.isReturning].
+     */
+    focusFirstItemWithoutTarget: Boolean = true,
 ): TvFlatReturnRestoration {
     // The key is saved WITH the target and checked on the way back.
     // rememberSaveable does not validate restored values against its inputs, so
@@ -174,11 +219,14 @@ internal fun rememberTvFlatReturnRestoration(
     ) {
         mutableStateOf<TvReturnTarget?>(null)
     }
-    val restoration = remember(surfaceKey, savedTarget) { TvFlatReturnRestoration(savedTarget) }
+    val restoration = remember(surfaceKey, savedTarget) {
+        TvFlatReturnRestoration(savedTarget, isReturning = savedTarget.value != null)
+    }
 
     val currentItemIds by rememberUpdatedState(itemIds)
     val currentHasMore by rememberUpdatedState(hasMore)
     val currentIsLoadingMore by rememberUpdatedState(isLoadingMore)
+    val currentIsReplacing by rememberUpdatedState(isReplacingContent)
     val currentError by rememberUpdatedState(errorMessage)
     val currentLoadMore by rememberUpdatedState(onLoadMore)
     val currentScrollToItem by rememberUpdatedState(scrollToItem)
@@ -204,17 +252,70 @@ internal fun rememberTvFlatReturnRestoration(
     // because one is already in flight — would stall restoration forever.
     LaunchedEffect(surfaceKey, itemIds.isNotEmpty()) {
         if (restoration.completed || currentItemIds.isEmpty()) return@LaunchedEffect
+        // A fresh arrival on a surface that owns its own entry focus. Decided
+        // from state saved before this composition began, so it cannot depend
+        // on whether a card has taken focus yet.
+        if (!restoration.isReturning && !focusFirstItemWithoutTarget) return@LaunchedEffect
         // Claimed before the settle delay, not after: default or restored focus
         // can land during it, and its callback would redefine the launch item.
         restoration.inFlight = true
         try {
             delay(TvFlatReturnSettleDelayMillis)
 
+            // Ordered after the settle delay on purpose: a resume refresh is
+            // usually dispatched a frame or two after the screen recomposes, so
+            // checking on arrival would sail straight past one that has not
+            // raised its flag yet.
+            //
+            // Bounded, because a surface wedged in refresh must not hold
+            // restoration open forever — timing out here simply proceeds
+            // against whatever list exists, which is the old behaviour.
+            val settled = withTimeoutOrNull(TvFlatReturnReplaceWaitMillis) {
+                while (true) {
+                    snapshotFlow { currentIsReplacing }.first { !it }
+                    // Quiet has to be PROVEN, not assumed. Entering this only
+                    // when the flag is already true was the earlier mistake: it
+                    // returned instantly on a false reading, which is exactly
+                    // what a refresh dispatched one frame later also looks
+                    // like. So watch for a restart, and only a window that
+                    // passes without one counts as settled.
+                    val restarted = withTimeoutOrNull(TvFlatReturnSettleDelayMillis) {
+                        snapshotFlow { currentIsReplacing }.first { it }
+                    } != null
+                    if (!restarted) break
+                }
+            } != null
+
+            // Still replacing after the budget. Restoring the recorded target
+            // now is the one genuinely unsafe outcome: focus can land on a card
+            // the imminent replacement removes, and once Compose is relocating
+            // focus away from a disappearing node nothing here controls where
+            // it ends up.
+            //
+            // So retarget to the first item instead of standing down. It is the
+            // one position a replacement cannot invalidate — a reload produces
+            // page one, whose first item is this one — and it keeps the shell
+            // handoff honest, where abandoning would leave the surface with
+            // nothing focused at all.
+            if (!settled) {
+                currentItemIds.firstOrNull()?.let { firstId ->
+                    restoration.target = TvReturnTarget(
+                        sectionId = TvFlatSectionId,
+                        itemId = firstId,
+                        sectionIndex = 0,
+                        itemIndex = 0,
+                    )
+                }
+            }
+
             withTimeoutOrNull(TvFlatReturnHuntBudgetMillis) {
                 var requests = 0
                 while (resolve(final = false) is TvReturnResolution.Pending) {
                     val loadedBefore = currentItemIds.size
-                    if (!currentIsLoadingMore) {
+                    // A refresh in flight is a load too — asking for the next
+                    // page on top of it appends at an offset the refresh is
+                    // about to invalidate.
+                    if (!currentIsLoadingMore && !currentIsReplacing) {
                         // The ceiling stops NEW requests. It must not stop us
                         // waiting for one already in flight, or the last page
                         // is abandoned with budget to spare.
@@ -225,7 +326,7 @@ internal fun rememberTvFlatReturnRestoration(
                     val waited = awaitFlatPageSettled(
                         loadedBefore = loadedBefore,
                         itemCount = { currentItemIds.size },
-                        isLoadingMore = { currentIsLoadingMore },
+                        isLoadingMore = { currentIsLoadingMore || currentIsReplacing },
                     )
 
                     // Judge the OUTCOME, and only when a load actually reached
@@ -328,6 +429,17 @@ private const val TvFlatReturnPageSettleTimeoutMillis: Long = 2_000L
  * hard a struggling endpoint gets pushed. Counting requests alone let one slow
  * fetch spend the entire allowance on a single page and gave no ceiling at all.
  */
+/**
+ * How long restoration will wait for a content REPLACEMENT to settle before it
+ * resolves anyway.
+ *
+ * Generous, because waiting costs nothing visible — the surface is mid-refresh
+ * and has no stable content to focus regardless — while giving up early costs a
+ * restoration against a list that is about to be discarded. It exists only so a
+ * refresh that never completes cannot wedge the surface.
+ */
+private const val TvFlatReturnReplaceWaitMillis: Long = 3_000L
+
 private const val TvFlatReturnHuntBudgetMillis: Long = 6_000L
 
 /** How many pages one restoration may ask for. */

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
@@ -12,8 +12,10 @@ import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
@@ -165,6 +167,7 @@ internal class TvFlatReturnRestoration internal constructor(
  * items converts. [onRestored] fires only on a confirmed landing, so a caller
  * never tells its shell that content took focus when it did not.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 internal fun rememberTvFlatReturnRestoration(
     itemIds: List<String>,
@@ -270,43 +273,40 @@ internal fun rememberTvFlatReturnRestoration(
             // Bounded, because a surface wedged in refresh must not hold
             // restoration open forever — timing out here simply proceeds
             // against whatever list exists, which is the old behaviour.
-            val settled = withTimeoutOrNull(TvFlatReturnReplaceWaitMillis) {
-                while (true) {
-                    snapshotFlow { currentIsReplacing }.first { !it }
-                    // Quiet has to be PROVEN, not assumed. Entering this only
-                    // when the flag is already true was the earlier mistake: it
-                    // returned instantly on a false reading, which is exactly
-                    // what a refresh dispatched one frame later also looks
-                    // like. So watch for a restart, and only a window that
-                    // passes without one counts as settled.
-                    val restarted = withTimeoutOrNull(TvFlatReturnSettleDelayMillis) {
-                        snapshotFlow { currentIsReplacing }.first { it }
-                    } != null
-                    if (!restarted) break
-                }
-            } != null
-
-            // Still replacing after the budget. Restoring the recorded target
-            // now is the one genuinely unsafe outcome: focus can land on a card
-            // the imminent replacement removes, and once Compose is relocating
-            // focus away from a disappearing node nothing here controls where
-            // it ends up.
+            // Quiet has to be PROVEN, not assumed. Checking the flag on
+            // arrival was the first mistake: a false reading is exactly what a
+            // refresh dispatched one frame later also looks like. Watching for
+            // a restart with a SECOND subscription was the next one — a
+            // complete true→false pulse between the two subscriptions slips
+            // past unobserved.
             //
-            // So retarget to the first item instead of standing down. It is the
-            // one position a replacement cannot invalidate — a reload produces
-            // page one, whose first item is this one — and it keeps the shell
-            // handoff honest, where abandoning would leave the surface with
-            // nothing focused at all.
-            if (!settled) {
-                currentItemIds.firstOrNull()?.let { firstId ->
-                    restoration.target = TvReturnTarget(
-                        sectionId = TvFlatSectionId,
-                        itemId = firstId,
-                        sectionIndex = 0,
-                        itemIndex = 0,
-                    )
-                }
+            // One subscription, then. collectLatest restarts the quiet timer on
+            // every change, so the window only elapses if nothing happened
+            // during it, which is what "settled" has to mean.
+            withTimeoutOrNull(TvFlatReturnReplaceWaitMillis) {
+                snapshotFlow { currentIsReplacing }
+                    .transformLatest { replacing ->
+                        if (!replacing) {
+                            delay(TvFlatReturnSettleDelayMillis)
+                            emit(Unit)
+                        }
+                    }
+                    .first()
             }
+
+            // Deliberately nothing on timeout. An earlier version retargeted to
+            // the first item here, reasoning that a reload produces page one so
+            // index zero cannot be invalidated. That was wrong: the id came
+            // from the OUTGOING list, which a replacement can reorder, empty,
+            // or drop that item from entirely — so acquisition would confirm
+            // against an identity that no longer means what it did, and the
+            // real target was overwritten in saved state where no later entry
+            // could ever retry it.
+            //
+            // Falling through instead resolves live against whatever list
+            // exists by then. If the replacement lands mid-flight the identity
+            // check simply fails and restoration ends without a landing, which
+            // is a worse outcome than restoring but not an incorrect one.
 
             withTimeoutOrNull(TvFlatReturnHuntBudgetMillis) {
                 var requests = 0

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
@@ -300,7 +300,7 @@ internal fun rememberTvFlatReturnRestoration(
             // One subscription, then. collectLatest restarts the quiet timer on
             // every change, so the window only elapses if nothing happened
             // during it, which is what "settled" has to mean.
-            withTimeoutOrNull(TvFlatReturnReplaceWaitMillis) {
+            val settled = withTimeoutOrNull(TvFlatReturnReplaceWaitMillis) {
                 snapshotFlow { currentIsReplacing }
                     .transformLatest { replacing ->
                         if (!replacing) {
@@ -309,21 +309,28 @@ internal fun rememberTvFlatReturnRestoration(
                         }
                     }
                     .first()
-            }
+            } != null
 
-            // Deliberately nothing on timeout. An earlier version retargeted to
-            // the first item here, reasoning that a reload produces page one so
-            // index zero cannot be invalidated. That was wrong: the id came
-            // from the OUTGOING list, which a replacement can reorder, empty,
-            // or drop that item from entirely — so acquisition would confirm
-            // against an identity that no longer means what it did, and the
-            // real target was overwritten in saved state where no later entry
-            // could ever retry it.
+            // Abandon rather than proceed. Falling through was the previous
+            // answer, on the reasoning that a replacement landing mid-flight
+            // would fail the identity check and simply not restore — but that
+            // is not guaranteed. A target from the OUTGOING list can resolve
+            // Exact, skip the hunt, take focus and report a landing in the
+            // moment before the replacement removes the card underneath it,
+            // and then focus is somewhere nobody chose and the shell has been
+            // told content owns it.
             //
-            // Falling through instead resolves live against whatever list
-            // exists by then. If the replacement lands mid-flight the identity
-            // check simply fails and restoration ends without a landing, which
-            // is a worse outcome than restoring but not an incorrect one.
+            // The target is deliberately left intact: this restoration is
+            // giving up, not deciding the target was wrong, so a later entry
+            // can still honour it.
+            if (!settled) return@LaunchedEffect
+
+            // An even earlier version retargeted to the first item on timeout,
+            // reasoning that a reload produces page one so index zero cannot be
+            // invalidated. That was wrong twice over: the id came from the
+            // OUTGOING list, which a replacement can reorder, empty or drop
+            // that item from entirely, and it overwrote the real target in
+            // saved state where no later entry could retry it.
 
             withTimeoutOrNull(TvFlatReturnHuntBudgetMillis) {
                 var requests = 0

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
@@ -288,8 +288,10 @@ internal fun rememberTvFlatReturnRestoration(
             // raised its flag yet.
             //
             // Bounded, because a surface wedged in refresh must not hold
-            // restoration open forever — timing out here simply proceeds
-            // against whatever list exists, which is the old behaviour.
+            // restoration open forever. Timing out ABANDONS — see below; an
+            // earlier version proceeded against whatever list existed, and
+            // that was the defect, not the fallback.
+            //
             // Quiet has to be PROVEN, not assumed. Checking the flag on
             // arrival was the first mistake: a false reading is exactly what a
             // refresh dispatched one frame later also looks like. Watching for

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
@@ -1,0 +1,424 @@
+package org.siloserver.silo.tv.ui.focus
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Restores focus to the item a flat, paginated surface was on when it opened a
+ * detail page.
+ *
+ * The orchestration is identical everywhere it is needed — library grids,
+ * personal lists, people, Collections, Requests — and it is not the kind of
+ * thing to write twice. Its difficulty is not the happy path but the order in
+ * which four independent things have to agree: pages arriving, a resolution
+ * that changes as they do, a requester that binds only once its card composes,
+ * and focus that can be requested successfully and still roll back. Each of
+ * those was got wrong at least once while this was being derived on a single
+ * screen; the point of gathering it here is that the next surface inherits the
+ * conclusions rather than the derivation.
+ *
+ * Not for Search, which is not flat: it mixes library results with
+ * request-provider results in separate containers with unrelated identifier
+ * spaces, and needs real section ids and namespaced item ids.
+ */
+internal class TvFlatReturnRestoration internal constructor(
+    /**
+     * Held by the caller's [rememberSaveable] rather than mirrored into it.
+     *
+     * Mirroring meant writing to saveable state from composition and restoring
+     * through a `remember` side effect — two sources of truth for the one value
+     * that has to survive process death, which is exactly when identity is all
+     * there is and the live focus state is gone.
+     */
+    private val targetState: MutableState<TvReturnTarget?>,
+) {
+    internal var target: TvReturnTarget?
+        get() = targetState.value
+        set(value) { targetState.value = value }
+
+    internal var focusedItemId by mutableStateOf<String?>(null)
+    internal var attachedItemId by mutableStateOf<String?>(null)
+    internal var destination by mutableStateOf<TvReturnResolution.Located?>(null)
+    /**
+     * Deliberately a plain field, not snapshot state: it is derived entirely
+     * from the current inputs, so composition already re-runs when it can
+     * change. Making it observable only invited an extra recomposition on
+     * every change, for a value that is recomputed above the read anyway.
+     */
+    internal var provisionalItemIndex: Int = 0
+    internal var inFlight by mutableStateOf(false)
+    internal var completed by mutableStateOf(false)
+
+    /**
+     * The item index the restore requester belongs on.
+     *
+     * The published destination once there is one, so composition and the
+     * watcher below cannot disagree about where focus is going; a provisional
+     * position before that, which is what keeps a requester attached for
+     * ordinary first entry.
+     */
+    val requesterItemIndex: Int get() = destination?.itemIndex ?: provisionalItemIndex
+
+    /**
+     * Report ordinary browse movement.
+     *
+     * Suppressed while a restoration runs: focus lands on other cards on the
+     * way, and letting one of those redefine the launch item makes the
+     * restoration confirm itself against something the viewer never opened.
+     */
+    fun onItemFocused(itemId: String, index: Int) {
+        focusedItemId = itemId
+        if (!inFlight) {
+            target = TvReturnTarget(TvFlatSectionId, itemId, sectionIndex = 0, itemIndex = index)
+        }
+    }
+
+    /**
+     * Report a deliberate opening.
+     *
+     * Always arms, unlike [onItemFocused]. A card focused during a restoration
+     * did not arm and its focus callback will not fire again, so opening it
+     * would otherwise navigate carrying the previous trip's target.
+     */
+    fun onItemClicked(itemId: String, index: Int) {
+        target = TvReturnTarget(
+            TvFlatSectionId,
+            itemId,
+            sectionIndex = 0,
+            // Only a fallback coordinate; keep the last one rather than
+            // inventing the top of the list if the item is not in view.
+            itemIndex = index.takeIf { it >= 0 } ?: target?.itemIndex ?: 0,
+        )
+    }
+
+    /**
+     * Report which item the restore requester is currently bound to.
+     *
+     * The card has to say this, because nothing else can. A card can be laid
+     * out while its modifier still carries the previous binding, so "the slot
+     * is visible" is not evidence that a request will reach the right node.
+     */
+    fun onRequesterAttached(itemId: String?) {
+        attachedItemId = itemId
+    }
+}
+
+/**
+ * Drives one restoration for a flat, paginated surface.
+ *
+ * [itemIds], [hasMore], [isLoadingMore] and [errorMessage] are read live
+ * throughout — a captured snapshot would freeze the hunt, and `snapshotFlow`
+ * would observe nothing at all.
+ *
+ * [surfaceKey] identifies the surface. Changing it starts over completely —
+ * target, landing state and the completion latch — because a different tab or
+ * library is a different surface, not the same one with different contents.
+ *
+ * It is a String, and must be a stable injective one — an enum's `name`, an id,
+ * a canonically encoded composite. It was `Any?` with `toString()`, which is
+ * neither: `1` and `"1"` collide, `null` and `""` collide, and a default
+ * `toString()` can change across process recreation and silently discard a
+ * valid target. A key that quietly means two things is worse than no key.
+ * The screen this was extracted from reset only the target and kept the latch,
+ * which is unsound on its own terms: had its tab branches not disposed and
+ * recreated the whole subtree, a second tab would have found the latch already
+ * set and never restored focus at all.
+ *
+ * A caller changing [surfaceKey] MUST also recreate its item content —
+ * separate composition branches, or `key(surfaceKey) { … }` around the list.
+ * The acknowledgements this depends on come from the cards themselves, and a
+ * card that neither disposes nor moves has no reason to report its attachment
+ * again; the fresh holder then waits for something nobody will send and gives
+ * up, losing restoration on a surface that looks fine.
+ *
+ * That is a precondition, not something this can rescue: see the acquisition
+ * below for why a blind request is unsafe. Existing callers satisfy it by
+ * construction — a new one must check.
+ *
+ * [scrollToItem] receives an ITEM index; a surface with headers ahead of its
+ * items converts. [onRestored] fires only on a confirmed landing, so a caller
+ * never tells its shell that content took focus when it did not.
+ */
+@Composable
+internal fun rememberTvFlatReturnRestoration(
+    itemIds: List<String>,
+    hasMore: Boolean,
+    isLoadingMore: Boolean,
+    errorMessage: String?,
+    surfaceKey: String,
+    onLoadMore: () -> Unit,
+    scrollToItem: suspend (itemIndex: Int) -> Unit,
+    requestFocus: () -> Boolean,
+    onRestored: () -> Unit,
+): TvFlatReturnRestoration {
+    // The key is saved WITH the target and checked on the way back.
+    // rememberSaveable does not validate restored values against its inputs, so
+    // a process that comes back composing a different surface first would
+    // otherwise adopt the previous surface's target as its own.
+    val savedTarget = rememberSaveable(
+        surfaceKey,
+        stateSaver = keyedTvReturnTargetSaver(surfaceKey),
+    ) {
+        mutableStateOf<TvReturnTarget?>(null)
+    }
+    val restoration = remember(surfaceKey, savedTarget) { TvFlatReturnRestoration(savedTarget) }
+
+    val currentItemIds by rememberUpdatedState(itemIds)
+    val currentHasMore by rememberUpdatedState(hasMore)
+    val currentIsLoadingMore by rememberUpdatedState(isLoadingMore)
+    val currentError by rememberUpdatedState(errorMessage)
+    val currentLoadMore by rememberUpdatedState(onLoadMore)
+    val currentScrollToItem by rememberUpdatedState(scrollToItem)
+    val currentRequestFocus by rememberUpdatedState(requestFocus)
+    val currentOnRestored by rememberUpdatedState(onRestored)
+
+    fun resolve(final: Boolean): TvReturnResolution = resolveTvReturnTarget(
+        target = restoration.target,
+        sections = flatTvReturnSections(itemIds = currentItemIds, hasMore = currentHasMore),
+        treatAbsenceAsFinal = final,
+    )
+
+    restoration.provisionalItemIndex = remember(itemIds, hasMore, restoration.target) {
+        (resolve(final = true) as? TvReturnResolution.Located)?.itemIndex ?: 0
+    }
+
+    // One hunt, driven as a loop rather than by re-keying this effect.
+    //
+    // Re-keying cannot work: Pending is a singleton, so a resolution that stays
+    // Pending is an unchanged key and the effect never re-runs. Every way a
+    // page can fail to move the list — a page of hidden or duplicate items, a
+    // failed fetch that leaves hasMore set, a request the surface rejects
+    // because one is already in flight — would stall restoration forever.
+    LaunchedEffect(surfaceKey, itemIds.isNotEmpty()) {
+        if (restoration.completed || currentItemIds.isEmpty()) return@LaunchedEffect
+        // Claimed before the settle delay, not after: default or restored focus
+        // can land during it, and its callback would redefine the launch item.
+        restoration.inFlight = true
+        try {
+            delay(TvFlatReturnSettleDelayMillis)
+
+            withTimeoutOrNull(TvFlatReturnHuntBudgetMillis) {
+                var requests = 0
+                while (resolve(final = false) is TvReturnResolution.Pending) {
+                    val loadedBefore = currentItemIds.size
+                    if (!currentIsLoadingMore) {
+                        // The ceiling stops NEW requests. It must not stop us
+                        // waiting for one already in flight, or the last page
+                        // is abandoned with budget to spare.
+                        if (requests >= TvFlatReturnPageRequests) break
+                        currentLoadMore()
+                        requests++
+                    }
+                    val waited = awaitFlatPageSettled(
+                        loadedBefore = loadedBefore,
+                        itemCount = { currentItemIds.size },
+                        isLoadingMore = { currentIsLoadingMore },
+                    )
+
+                    // Judge the OUTCOME, and only when a load actually reached
+                    // a terminal state. Growth is progress whatever an older
+                    // error still says; a load that finished with nothing to
+                    // show and left an error behind is a real failure —
+                    // including when its message matches the previous one,
+                    // which comparing error values would miss.
+                    //
+                    // NeverActive is why that distinction is needed: the
+                    // request may still be queued, and the idle flag and any
+                    // error then describe the world BEFORE it.
+                    val grew = currentItemIds.size != loadedBefore
+                    if (waited == TvFlatPageWait.Settled &&
+                        !grew &&
+                        !currentIsLoadingMore &&
+                        currentError != null
+                    ) {
+                        break
+                    }
+                }
+            }
+
+            val located = resolve(final = true) as? TvReturnResolution.Located
+            // Published as one value so the requester's position and the
+            // identity being watched for cannot drift apart. They did: a
+            // provisional index tracking live data while the identity stayed
+            // frozen moved the requester onto the real item and left the
+            // watcher waiting for the fallback — focus arriving exactly where
+            // it should and being recorded as a failure.
+            restoration.destination = located
+            val targetItemId = located?.itemId ?: currentItemIds.firstOrNull()
+
+            currentScrollToItem(located?.itemIndex ?: 0)
+            // Readiness is part of the acquisition rather than a wait beside
+            // it. Waiting separately and requesting anyway on timeout only
+            // delays a wrong-node request; reporting NotReady holds the request
+            // until the requester is genuinely bound, and gives up honestly if
+            // it never is.
+            val landed = requestFocusUntilObserved(
+                maxAttempts = TvFlatReturnFocusAttempts,
+                awaitAttempt = { delay(TvFlatReturnFocusRetryMillis) },
+                requestFocus = currentRequestFocus,
+                isFocused = {
+                    targetItemId != null && restoration.focusedItemId == targetItemId
+                },
+                targetState = {
+                    if (targetItemId != null && restoration.attachedItemId == targetItemId) {
+                        TvFocusTargetState.Ready
+                    } else {
+                        TvFocusTargetState.NotReady
+                    }
+                },
+            )
+            // Latch either way — nothing re-keys this effect, so not latching
+            // means never trying again rather than trying later. But only
+            // report success when focus actually landed on the intended item.
+            //
+            // No blind rescue here. One was tried: if the identity-gated
+            // acquisition failed and no card had reported focus, request
+            // anyway and take whatever lands. It is unsound, because "no card
+            // reported focus" is not "nothing has focus" — these surfaces also
+            // hold sort and filter controls, genre chips and an A–Z rail, and
+            // focus can be sitting legitimately on any of them. The rescue
+            // would then steal it, seconds after the viewer arrived, which is
+            // worse than the restoration it was trying to salvage. Making it
+            // safe needs an authoritative "nothing on this screen has focus"
+            // signal that only the caller can provide.
+            if (landed == TvObservedFocusResult.Focused) currentOnRestored()
+        } finally {
+            restoration.inFlight = false
+        }
+        restoration.completed = true
+    }
+
+    return restoration
+}
+
+/** Lets the surface settle before restoration competes with default focus. */
+private const val TvFlatReturnSettleDelayMillis: Long = 120L
+
+/**
+ * How long to wait for a requested page to mark itself active.
+ *
+ * Short, because this only observes a flag set by an already-launched
+ * coroutine. Sizing it like a network round trip made a missed pulse — the load
+ * completing between two snapshot evaluations — cost seconds of frozen focus
+ * for nothing.
+ */
+private const val TvFlatReturnPageActiveTimeoutMillis: Long = 300L
+
+/** How long to wait for an active page to settle. */
+private const val TvFlatReturnPageSettleTimeoutMillis: Long = 2_000L
+
+/**
+ * The whole budget for hunting a target through unloaded pages.
+ *
+ * A wall clock, paired with — not replaced by — [TvFlatReturnPageRequests]. The
+ * two bound different things: this is what the viewer experiences, that is how
+ * hard a struggling endpoint gets pushed. Counting requests alone let one slow
+ * fetch spend the entire allowance on a single page and gave no ceiling at all.
+ */
+private const val TvFlatReturnHuntBudgetMillis: Long = 6_000L
+
+/** How many pages one restoration may ask for. */
+private const val TvFlatReturnPageRequests: Int = 4
+
+private const val TvFlatReturnFocusRetryMillis: Long = 60L
+
+private val TvFlatReturnFocusAttempts: Int =
+    (TvFocusAcquisitionBudgetMillis / TvFlatReturnFocusRetryMillis).toInt()
+
+/**
+ * What a wait for a requested page actually observed.
+ *
+ * The distinction matters because the caller decides whether a page load
+ * failed, and it can only do that honestly for a load it saw reach a terminal
+ * state. [NeverActive] carries no information about any load — the flags it
+ * would otherwise read describe the world before the request.
+ */
+private enum class TvFlatPageWait {
+    /**
+     * A load reached a terminal state, or the list changed. Not necessarily
+     * the load this caller requested — an already-active one can be what
+     * settles — which is fine, because the caller reads this only as "a result
+     * exists to judge".
+     */
+    Settled,
+
+    /** Nothing marked itself active in time — the request may still be queued. */
+    NeverActive,
+
+    /** Observed running, but not finished when the wait expired. */
+    StillActive,
+}
+
+/**
+ * Wait for a requested page, reporting what was observed.
+ *
+ * A surface typically launches its load, so the loading flag is not reliably
+ * set by the time the request returns. Waiting only for "not loading" can
+ * therefore succeed instantly against the state from before the request, and a
+ * caller in a loop fires every request it has before the first fetch marks
+ * itself active — which the surface then accepts, because it also still sees
+ * idle. So this waits for a load to become active first, and only then for it
+ * to settle.
+ *
+ * Settling means the list changed OR loading cleared: a page can legitimately
+ * arrive without changing the visible list, and a failed fetch leaves `hasMore`
+ * set. Both phases time out, so this always returns promptly.
+ */
+private suspend fun awaitFlatPageSettled(
+    loadedBefore: Int,
+    itemCount: () -> Int,
+    isLoadingMore: () -> Boolean,
+): TvFlatPageWait {
+    val became = withTimeoutOrNull(TvFlatReturnPageActiveTimeoutMillis) {
+        snapshotFlow { itemCount() to isLoadingMore() }
+            .first { (count, loading) -> count != loadedBefore || loading }
+    } ?: return TvFlatPageWait.NeverActive
+    if (became.first != loadedBefore) return TvFlatPageWait.Settled
+    val settled = withTimeoutOrNull(TvFlatReturnPageSettleTimeoutMillis) {
+        snapshotFlow { itemCount() to isLoadingMore() }
+            .first { (count, loading) -> count != loadedBefore || !loading }
+    }
+    return if (settled == null) TvFlatPageWait.StillActive else TvFlatPageWait.Settled
+}
+
+/**
+ * [TvReturnTargetSaver], partitioned by the surface that saved it.
+ *
+ * A target restored under a different key is discarded rather than adopted:
+ * it describes somewhere the viewer was in another list entirely.
+ */
+internal fun keyedTvReturnTargetSaver(resetToken: String): Saver<TvReturnTarget?, Any> =
+    listSaver(
+        save = { target ->
+            target?.let {
+                listOf(resetToken, it.sectionId, it.itemId, it.sectionIndex, it.itemIndex)
+            } ?: listOf(resetToken)
+        },
+        restore = { saved ->
+            @Suppress("UNCHECKED_CAST")
+            val values = saved as List<Any>
+            if (values.size < 5 || values[0] != resetToken) {
+                null
+            } else {
+                TvReturnTarget(
+                    sectionId = values[1] as String,
+                    itemId = values[2] as String,
+                    sectionIndex = values[3] as Int,
+                    itemIndex = values[4] as Int,
+                )
+            }
+        },
+    )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
@@ -102,6 +102,23 @@ internal class TvFlatReturnRestoration internal constructor(
     }
 
     /**
+     * Report a card LOSING focus. Callers must send this — without it
+     * [focusedItemId] records what was focused once rather than what is focused
+     * now, and the acquisition below reads it as the latter.
+     *
+     * That distinction is the whole game here: acquisition checks the identity
+     * BEFORE issuing any request, so a stale value lets a restoration report
+     * success without ever asking for focus, while focus sits on a control or
+     * another container entirely.
+     *
+     * Guarded on identity because a gain elsewhere arrives before this loss:
+     * clearing unconditionally would erase the position that just replaced it.
+     */
+    fun onItemFocusLost(itemId: String) {
+        if (focusedItemId == itemId) focusedItemId = null
+    }
+
+    /**
      * Report a deliberate opening.
      *
      * Always arms, unlike [onItemFocused]. A card focused during a restoration

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvModalFocusOwnership.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvModalFocusOwnership.kt
@@ -1,0 +1,85 @@
+package org.siloserver.silo.tv.ui.focus
+
+import androidx.compose.foundation.focusGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import kotlinx.coroutines.delay
+
+/**
+ * A modal's focus boundary.
+ *
+ * `focusGroup()` alone is not one. It prioritises traversal inside the group,
+ * but it does not cancel a focus search at the group's edges — so D-pad
+ * movement from a boundary control walks straight out of a visually modal
+ * surface and into the still-composed page behind it. Cancelling the search on
+ * exit is what actually keeps focus inside.
+ *
+ * Apply to the modal's content root, alongside whatever acquires focus within
+ * it. Callers still need [TvRestoreFocusOnModalDismiss] to hand focus back.
+ */
+@OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+internal fun Modifier.tvModalFocusBoundary(): Modifier = this
+    .focusGroup()
+    // `exit` cancels a focus search that is leaving the group, which is exactly
+    // and only what a modal wants. Cancelling up/down/left/right on this node
+    // instead would also govern movement between the modal's own controls —
+    // trading an escape for a dead D-pad inside the modal. Same idiom as the
+    // shell, the audiobook overlay and the player HUD.
+    .focusProperties { exit = { FocusRequester.Cancel } }
+
+private const val TvModalRestoreRetryDelayMillis = 60L
+
+internal const val TvModalRestoreMaxAttempts =
+    (TvFocusAcquisitionBudgetMillis / TvModalRestoreRetryDelayMillis).toInt()
+
+/**
+ * Hand focus back to whatever opened a modal once it closes.
+ *
+ * Without this the modal's nodes simply disappear and the focus system picks a
+ * geometric successor — which is rarely the control the viewer used to open it,
+ * and on a dimmed page is often something they cannot even see.
+ *
+ * Restoration is deliberately driven from the *caller's* scope rather than the
+ * modal's: an exit animation keeps the modal's nodes alive after `visible` goes
+ * false, so anything hosted inside it cannot reliably outlive its own dismissal.
+ *
+ * Nothing happens on first composition — a modal that has never been open has
+ * nothing to restore, and stealing focus on screen entry is its own bug.
+ *
+ * [isOpenerFocused] must genuinely observe the opener. A request that merely
+ * returns true has not acquired anything, and without observation the retry
+ * cannot tell success from an accepted-but-unfocused request — it would keep
+ * re-requesting for the whole budget after focus had already landed.
+ */
+@Composable
+internal fun TvRestoreFocusOnModalDismiss(
+    visible: Boolean,
+    opener: FocusRequester?,
+    isOpenerFocused: () -> Boolean,
+) {
+    var hasBeenVisible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(visible) {
+        if (visible) {
+            hasBeenVisible = true
+            return@LaunchedEffect
+        }
+        if (!hasBeenVisible || opener == null) return@LaunchedEffect
+        hasBeenVisible = false
+        requestFocusUntilObserved(
+            maxAttempts = TvModalRestoreMaxAttempts,
+            awaitAttempt = { delay(TvModalRestoreRetryDelayMillis) },
+            requestFocus = opener::requestFocus,
+            // The opener sits behind an exit animation that is still tearing
+            // the modal down, so early attempts land before it is focusable.
+            isFocused = isOpenerFocused,
+        )
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvModalFocusOwnership.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvModalFocusOwnership.kt
@@ -34,6 +34,37 @@ internal fun Modifier.tvModalFocusBoundary(): Modifier = this
     // shell, the audiobook overlay and the player HUD.
     .focusProperties { exit = { FocusRequester.Cancel } }
 
+/**
+ * Take a control out of D-pad traversal while a modal owns focus.
+ *
+ * The containment in [tvModalFocusBoundary] only holds focus that is already
+ * inside the modal. It does nothing about focus that never got in — and an
+ * in-window overlay leaves the surface underneath fully composed and fully
+ * focusable, so a covered transport button keeps taking Select while a panel is
+ * open in front of it.
+ *
+ * Apply on the same modifier chain as the control's own focusable, ahead of it.
+ * An ancestor works too, but only conditionally: a focus target resolves its
+ * properties by walking up and applying each `FocusPropertiesModifierNode` it
+ * finds, stopping at the first ancestor that is itself a focus target. Anything
+ * introducing one in between — a `focusGroup()`, a TV `Surface`, another
+ * `focusable()` — swallows the suppression before it arrives, silently. Placing
+ * it on the control's own chain has no such dependency on what sits above.
+ *
+ * (`focusGroup()` is not that mechanism, despite looking like it: it deactivates
+ * its own target through `Focusability.Never` rather than through an inherited
+ * focus property, which is exactly why a focus group's children stay focusable.)
+ *
+ * Suppression alone can strand the viewer. Android TV does not re-home focus
+ * when the focused node stops being focusable: the ring disappears and the
+ * D-pad goes dead until something requests focus. So every surface that
+ * suppresses must also give focus somewhere to land — the modal on the way in
+ * (see the dialog initial-focus adapter) and [TvRestoreFocusOnModalDismiss] on
+ * the way out.
+ */
+internal fun Modifier.tvFocusSuppressed(suppressed: Boolean): Modifier =
+    if (suppressed) focusProperties { canFocus = false } else this
+
 private const val TvModalRestoreRetryDelayMillis = 60L
 
 internal const val TvModalRestoreMaxAttempts =

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTarget.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTarget.kt
@@ -20,14 +20,18 @@ internal enum class TvPairDeviceAction { EnterCode, Check, Approve, Done }
  */
 internal fun tvPairDeviceFocusTarget(
     hasCompleted: Boolean,
+    hasResolvedLookup: Boolean,
     canEnterCode: Boolean,
     canSubmit: Boolean,
     isLoading: Boolean,
     isSubmitting: Boolean,
 ): TvPairDeviceAction? = when {
     hasCompleted -> TvPairDeviceAction.Done
-    canSubmit -> TvPairDeviceAction.Approve
-    canEnterCode -> TvPairDeviceAction.EnterCode
+    // canSubmit only means an identifier exists and nothing is being submitted
+    // — on a token route it is true from construction, before the lookup has
+    // returned anything to approve. The resolved lookup is the real signal.
+    hasResolvedLookup && canSubmit -> TvPairDeviceAction.Approve
+    canEnterCode && !isSubmitting -> TvPairDeviceAction.EnterCode
     // Check is the only remaining control, and only while it is enabled.
     !isLoading && !isSubmitting -> TvPairDeviceAction.Check
     else -> null

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTarget.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTarget.kt
@@ -4,35 +4,35 @@ package org.siloserver.silo.tv.ui.focus
 internal enum class TvPairDeviceAction { EnterCode, Check, Approve, Done }
 
 /**
- * The action that should hold focus right now, or `null` when the panel has
- * nothing actionable and focus must wait.
+ * The action that should hold focus right now.
  *
- * Focus eligibility here is driven entirely by asynchronous state — a token
- * route starts its lookup automatically, which disables Check while it runs and
- * enables Approve/Deny when it resolves — and none of that changes
- * `completedStatus`. Keying initial focus on completion alone therefore
- * requested focus once, against a control that was disabled at that instant,
- * and never asked again: the panel could sit with no focus owner at all.
+ * This answers "which control deserves focus", not "which control is
+ * focusable", and the return is not nullable because every incomplete state
+ * renders Check and every completed one renders Done.
+ *
+ * An earlier version returned null while a token lookup was running, on the
+ * theory that the disabled Check had left the focus graph and nothing was
+ * focusable. It had not: TV Material keeps disabled buttons focusable. So the
+ * null was never a real state — it just meant focus was left whereever
+ * traversal put it, including on controls that could not be used.
  *
  * A resolved lookup outranks Check, because approving is what the viewer came
- * to do. Deny is deliberately not a target: it sits beside Approve and is one
- * D-pad press away, and defaulting focus to the destructive choice is wrong.
+ * to do. It is keyed on the lookup rather than on whether approving is
+ * *currently* actionable, so submitting a decision — which briefly makes it
+ * un-actionable — does not move the target out from under the viewer.
+ *
+ * Deny is deliberately never a target: it sits beside Approve and is one D-pad
+ * press away, and defaulting focus to the destructive choice is wrong.
  */
 internal fun tvPairDeviceFocusTarget(
     hasCompleted: Boolean,
     hasResolvedLookup: Boolean,
     canEnterCode: Boolean,
-    canSubmit: Boolean,
-    isLoading: Boolean,
-    isSubmitting: Boolean,
-): TvPairDeviceAction? = when {
+): TvPairDeviceAction = when {
     hasCompleted -> TvPairDeviceAction.Done
-    // canSubmit only means an identifier exists and nothing is being submitted
-    // — on a token route it is true from construction, before the lookup has
-    // returned anything to approve. The resolved lookup is the real signal.
-    hasResolvedLookup && canSubmit -> TvPairDeviceAction.Approve
-    canEnterCode && !isSubmitting -> TvPairDeviceAction.EnterCode
-    // Check is the only remaining control, and only while it is enabled.
-    !isLoading && !isSubmitting -> TvPairDeviceAction.Check
-    else -> null
+    hasResolvedLookup -> TvPairDeviceAction.Approve
+    canEnterCode -> TvPairDeviceAction.EnterCode
+    // Check is rendered in every incomplete state and gated transiently, so it
+    // is always both present and focusable — which is what makes this total.
+    else -> TvPairDeviceAction.Check
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTarget.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTarget.kt
@@ -1,0 +1,34 @@
+package org.siloserver.silo.tv.ui.focus
+
+/** The actions the pair-device panel can offer, in the order it offers them. */
+internal enum class TvPairDeviceAction { EnterCode, Check, Approve, Done }
+
+/**
+ * The action that should hold focus right now, or `null` when the panel has
+ * nothing actionable and focus must wait.
+ *
+ * Focus eligibility here is driven entirely by asynchronous state — a token
+ * route starts its lookup automatically, which disables Check while it runs and
+ * enables Approve/Deny when it resolves — and none of that changes
+ * `completedStatus`. Keying initial focus on completion alone therefore
+ * requested focus once, against a control that was disabled at that instant,
+ * and never asked again: the panel could sit with no focus owner at all.
+ *
+ * A resolved lookup outranks Check, because approving is what the viewer came
+ * to do. Deny is deliberately not a target: it sits beside Approve and is one
+ * D-pad press away, and defaulting focus to the destructive choice is wrong.
+ */
+internal fun tvPairDeviceFocusTarget(
+    hasCompleted: Boolean,
+    canEnterCode: Boolean,
+    canSubmit: Boolean,
+    isLoading: Boolean,
+    isSubmitting: Boolean,
+): TvPairDeviceAction? = when {
+    hasCompleted -> TvPairDeviceAction.Done
+    canSubmit -> TvPairDeviceAction.Approve
+    canEnterCode -> TvPairDeviceAction.EnterCode
+    // Check is the only remaining control, and only while it is enabled.
+    !isLoading && !isSubmitting -> TvPairDeviceAction.Check
+    else -> null
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvProfileFocusTarget.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvProfileFocusTarget.kt
@@ -1,0 +1,43 @@
+package org.siloserver.silo.tv.ui.focus
+
+/**
+ * Which profile should own focus after the profile list changes.
+ *
+ * The screen reloads on every resume, so "the list changed" is the normal case,
+ * not an exceptional one — returning from an edit, deleting a tile in manage
+ * mode, or simply coming back to the screen all produce a new list. Anchoring
+ * unconditionally on the first tile therefore overrode the viewer's position
+ * every time.
+ *
+ * [previousIds] and [currentIds] are profile IDs in display order.
+ * [focusedId] is the profile that owned focus before the change, if any.
+ *
+ * Returns the profile ID to focus, or `null` to leave focus alone — which is
+ * what an already-correct focus position or an empty list both call for.
+ */
+internal fun tvProfileFocusTarget(
+    previousIds: List<String>,
+    currentIds: List<String>,
+    focusedId: String?,
+    hasMaterialized: Boolean,
+): String? {
+    if (currentIds.isEmpty()) return null
+
+    // First time the list has ever arrived: anchor so the D-pad has a home.
+    if (!hasMaterialized) return currentIds.first()
+
+    // Nothing was focused here — a refresh must not seize focus from wherever
+    // the viewer actually is, which may be another part of the screen entirely.
+    val focused = focusedId ?: return null
+
+    // Still present, possibly at a new index: it keeps focus, and the caller
+    // re-requests it so a reordered tile carries focus with it.
+    if (focused in currentIds) return focused
+
+    // Deleted. Fall to the tile that took its place, or the last one if it was
+    // the tail. Landing on the first tile after deleting the fourth is the
+    // jump this whole function exists to avoid.
+    val removedIndex = previousIds.indexOf(focused)
+    if (removedIndex < 0) return null
+    return currentIds[removedIndex.coerceAtMost(currentIds.lastIndex)]
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnAdapters.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnAdapters.kt
@@ -1,0 +1,40 @@
+package org.siloserver.silo.tv.ui.focus
+
+import org.siloserver.silo.model.section.ResolvedSection
+
+/**
+ * Projects a Skyline row feed into the shape [resolveTvReturnTarget] reads.
+ *
+ * Completeness asks one question: can more items still arrive in this row? Not
+ * whether more exist somewhere. The two look alike and pull in opposite
+ * directions, and a Skyline feed contains both cases:
+ *
+ * - A row with cards is **complete**, even when `totalCount` runs to hundreds.
+ *   Such a row is *capped* — the server trims it to `itemLimit` — and nothing
+ *   will ever fetch the remainder. Calling it incomplete would park every
+ *   unresolved return in [TvReturnResolution.Pending] forever, waiting on a
+ *   page no one requests.
+ * - A row with no cards but a non-zero `totalCount` is **incomplete**. That is
+ *   not an empty row, it is a placeholder: `hydrateHomeSections` fetches those
+ *   separately and fills them in. Calling it complete would read "not fetched
+ *   yet" as "nothing here" and spend the return target on a fallback moments
+ *   before the real row appeared.
+ * - A row with no cards and no total is genuinely empty, and complete.
+ *
+ * The caller supplies the matching container-level answer by passing the
+ * hydration's `fullyResolved` as `sectionsComplete`, which covers rows that had
+ * not arrived at all.
+ *
+ * Project the list the feed actually RENDERS, not an upstream one. Skyline
+ * drops empty rows before laying them out, so a projection taken from further
+ * up carries sections the feed never shows and puts every resolved index in a
+ * different coordinate space from the rows they are meant to address.
+ */
+internal fun List<ResolvedSection>.toTvReturnSections(): List<TvReturnSection> =
+    map { section ->
+        TvReturnSection(
+            id = section.id,
+            itemIds = section.items.map { it.contentId },
+            isComplete = section.items.isNotEmpty() || section.totalCount == 0,
+        )
+    }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnAdapters.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnAdapters.kt
@@ -38,3 +38,25 @@ internal fun List<ResolvedSection>.toTvReturnSections(): List<TvReturnSection> =
             isComplete = section.items.isNotEmpty() || section.totalCount == 0,
         )
     }
+
+/**
+ * Projects a flat, paginated surface — a library grid, personal list, people or
+ * collection — into the shape [resolveTvReturnTarget] reads.
+ *
+ * One implicit section, and [hasMore] is the honest answer to the question
+ * completeness asks. These surfaces load a page at a time, so an item further
+ * in is absent from what is loaded in exactly the way a deleted item is;
+ * reporting complete while pages remain spends the return target on whichever
+ * card happens to be nearby.
+ *
+ * The caller that receives [TvReturnResolution.Pending] owes two things: ask
+ * for the next page, and bound the hunt — by a clock, a request ceiling, or
+ * both — then re-ask with `treatAbsenceAsFinal`. A surface that only waits
+ * waits forever.
+ */
+internal fun flatTvReturnSections(
+    itemIds: List<String>,
+    hasMore: Boolean,
+): List<TvReturnSection> = listOf(
+    TvReturnSection(id = TvFlatSectionId, itemIds = itemIds, isComplete = !hasMore),
+)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnTarget.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnTarget.kt
@@ -1,0 +1,375 @@
+package org.siloserver.silo.tv.ui.focus
+
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import kotlin.math.abs
+
+/**
+ * The section id a surface with no sections uses.
+ *
+ * Library grids, personal lists and people have exactly one implicit section,
+ * and it is spelled out rather than left null so that "same section" means the
+ * same thing everywhere. A nullable section id looked tidier and was a trap:
+ * nothing in the section list could ever equal null, so a flat surface could
+ * never match its own launch section and every surviving item resolved as a
+ * positional fallback — the exact behaviour this contract exists to replace.
+ *
+ * Search is NOT one of these, despite looking like a list of results: it mixes
+ * library items with request-provider results in separate containers, which
+ * carry unrelated identifier spaces. It uses real section ids per container and
+ * namespaced item ids, as below.
+ *
+ * Surfaces whose identity is composite must namespace and encode it the same
+ * way on both sides — `catalog:<contentId>` versus `request:<mediaType>:<tmdbId>`
+ * — so that two identifier spaces cannot collide on a bare number. Ids are
+ * opaque to this contract, which is exactly why the encoding has to be
+ * deliberate at the surface.
+ *
+ * The encoding must be stable, canonical and injective: every domain on a
+ * heterogeneous surface tagged, and any component that could itself contain the
+ * separator escaped or length-prefixed. Reserving a separator by convention is
+ * not enough — a title or provider key containing it silently forges a
+ * different identity.
+ */
+internal const val TvFlatSectionId: String = ""
+
+/**
+ * Where a surface was when it opened a detail page, and how to find that place
+ * again afterwards.
+ *
+ * Restoration used to be a pair of saved indices, which is only correct while
+ * the data is identical on the way back. It rarely is: a feed refreshes on
+ * resume, Continue Watching reorders the moment something is played, a finished
+ * item leaves the row it was in, a grid is re-sorted, and a recreated process
+ * rebuilds from whatever the server says now. Saved indices survive all of that
+ * syntactically and point at different content, so focus lands on something the
+ * viewer never chose — the failure being removed here.
+ *
+ * Identity is therefore the item itself, qualified by the section it was in.
+ * The pair is the *occurrence*: feeds routinely carry the same item in more
+ * than one row, and "the copy in Continue Watching" is not the same place as
+ * "the copy in Recently Added". Indices are kept, but only as coordinates for
+ * the fallback: they answer "roughly where was I" once the occurrence is gone,
+ * and nothing else.
+ *
+ * [itemId] is deliberately not called a content id. Surfaces restore to
+ * profiles, libraries, people and requests as well as media, and each brings
+ * its own identifier. Where a surface's natural identity is composite (a
+ * request's provider and id, say), it composes one string and uses it
+ * consistently on both sides.
+ */
+internal data class TvReturnTarget(
+    /** The row/section the item was in; [TvFlatSectionId] on a flat surface. */
+    val sectionId: String,
+    val itemId: String,
+    /** Fallback coordinate only. Never the primary identity. */
+    val sectionIndex: Int,
+    /** Fallback coordinate only. Never the primary identity. */
+    val itemIndex: Int,
+)
+
+/**
+ * Persists a [TvReturnTarget] across process death.
+ *
+ * Recreation is the case that most needs identity and least has it: the saved
+ * *node* the focus restorer would have used is gone, live state like the
+ * currently focused item id was never saveable, and what comes back is whatever
+ * the server says now. Indices alone survive that, and are least trustworthy
+ * exactly when they would otherwise be all that is left.
+ */
+internal val TvReturnTargetSaver: Saver<TvReturnTarget?, Any> = listSaver(
+    save = { target ->
+        target?.let { listOf(it.sectionId, it.itemId, it.sectionIndex, it.itemIndex) } ?: emptyList()
+    },
+    restore = { saved ->
+        @Suppress("UNCHECKED_CAST")
+        val values = saved as List<Any>
+        if (values.isEmpty()) {
+            null
+        } else {
+            TvReturnTarget(
+                sectionId = values[0] as String,
+                itemId = values[1] as String,
+                sectionIndex = values[2] as Int,
+                itemIndex = values[3] as Int,
+            )
+        }
+    },
+)
+
+/** A section of restorable content, as it stands *now*. */
+internal data class TvReturnSection(
+    val id: String,
+    val itemIds: List<String>,
+    /**
+     * Whether [itemIds] is everything this section will hold *for the load in
+     * progress* — not for all time. A later refresh is a new snapshot, and a
+     * complete section can come back different.
+     *
+     * False while pages are still loading. Most surfaces here paginate, and an
+     * item on page four is missing from page one in exactly the way a deleted
+     * item is — so without this the resolver reads "not loaded yet" as "gone"
+     * and burns the target on a positional fallback before the real answer
+     * arrives.
+     */
+    val isComplete: Boolean = true,
+)
+
+/**
+ * Whether an item found in a *different* section counts as the same place.
+ *
+ * Off by default, because the two situations that produce it are
+ * indistinguishable from the data: an item genuinely moved between rows, or the
+ * launched occurrence disappeared while a copy that was always there sits
+ * elsewhere. Treating the second as a match throws focus vertically across the
+ * feed to a card the viewer never touched, which is worse than landing where
+ * they were.
+ *
+ * Overlapping feeds — Home, where a title can sit in Continue Watching and
+ * Recently Added at once — must stay on [SameSectionOnly]. Once the occurrence
+ * is defined as the pair, an item leaving its row means that occurrence is
+ * gone, and the positional fallback is the honest answer. Only surfaces whose
+ * sections are disjoint by construction can opt in.
+ */
+internal enum class TvReturnRelocation { SameSectionOnly, FollowAcrossSections }
+
+/** Where a surface should put focus when it comes back. */
+internal sealed interface TvReturnResolution {
+    /** A destination, carrying what it resolved to and not only where. */
+    sealed interface Located : TvReturnResolution {
+        val sectionIndex: Int
+        val itemIndex: Int
+        val sectionId: String
+        val itemId: String
+    }
+
+    /** The occurrence the viewer launched from is still here. */
+    data class Exact(
+        override val sectionIndex: Int,
+        override val itemIndex: Int,
+        override val sectionId: String,
+        override val itemId: String,
+    ) : Located
+
+    /**
+     * The occurrence is gone. This is the closest surviving position — what
+     * the viewer would reasonably expect under the cursor instead.
+     */
+    data class Nearest(
+        override val sectionIndex: Int,
+        override val itemIndex: Int,
+        override val sectionId: String,
+        override val itemId: String,
+    ) : Located
+
+    /**
+     * Not found, but its absence is not authoritative — something that could
+     * still produce it has not finished loading. Keep the target and ask again;
+     * do not consume it.
+     *
+     * Two caller obligations come with this, and neither can live in the
+     * resolver. It must *drive* the loading it is waiting on, because a
+     * demand-paged surface that only waits will wait forever. And it must bound
+     * the wait, then re-ask with `treatAbsenceAsFinal = true`, because pages can
+     * fail, `hasMore` can stay stuck true, and an unbounded wait leaves focus
+     * unrestored — the dead D-pad this campaign exists to remove.
+     */
+    data object Pending : TvReturnResolution
+
+    /** There is nothing focusable to return to. */
+    data object Empty : TvReturnResolution
+}
+
+/**
+ * Resolve a recorded [target] against the content as it stands now.
+ *
+ * Preference order:
+ *
+ * 1. The same occurrence — same section identity, same item. Matched on
+ *    identity rather than index, so a reordered feed or a re-sorted grid still
+ *    finds it.
+ * 2. The same item in another section, only when [relocation] allows it.
+ * 3. Its old position in its section, if that section survives: whatever took
+ *    the slot. Clamped, because it may have been last.
+ * 4. The nearest surviving section, if the section went too.
+ *
+ * Absence is only acted on once it is authoritative — see
+ * [TvReturnSection.isComplete], [sectionsComplete] and [treatAbsenceAsFinal].
+ * Sections with no items are never chosen, since there is nothing in them to
+ * focus.
+ *
+ * This says *where*, not *when*. A caller still has to scroll the destination
+ * into composition, attach a requester, and request focus under the observed
+ * policy; the identities in the result are what let it confirm afterwards that
+ * it landed on the thing that was resolved, rather than on whatever now
+ * occupies those coordinates.
+ *
+ * Section ids are REQUIRED to be unique and stable within a surface. That is
+ * not a stylistic preference: the no-stall rule below reads a present, finished
+ * launch section as the final word, which is only sound if no second section
+ * could later arrive bearing the same id. A surface that cannot guarantee
+ * unique ids must namespace them until it can.
+ *
+ * Duplicates are nonetheless handled deterministically rather than left to list
+ * order, so a data bug degrades predictably instead of moving focus about on
+ * every refresh: every namesake is searched, the one nearest the remembered
+ * coordinate wins, and within a section a repeated item resolves to the copy
+ * nearest the remembered position — an exact tie taking the earlier copy. That
+ * is damage control for a shape the contract does not support, and it is only
+ * meaningful once the section list is complete.
+ */
+internal fun resolveTvReturnTarget(
+    target: TvReturnTarget?,
+    sections: List<TvReturnSection>,
+    relocation: TvReturnRelocation = TvReturnRelocation.SameSectionOnly,
+    /**
+     * Whether [sections] is every section this surface will have.
+     *
+     * The same problem as [TvReturnSection.isComplete], one level up: a feed
+     * still loading its rows is missing the launch row in exactly the way a
+     * deleted row is. A per-section flag cannot express that, because a section
+     * that has not arrived yet is not in the list to carry one.
+     */
+    sectionsComplete: Boolean = true,
+    /**
+     * Stop waiting and answer from what is here.
+     *
+     * The terminal half of [TvReturnResolution.Pending]. A caller that has
+     * exhausted its budget sets this instead of misreporting completeness, so
+     * the fallback stays inside the contract rather than being reimplemented,
+     * differently, at each of the surfaces.
+     */
+    treatAbsenceAsFinal: Boolean = false,
+): TvReturnResolution {
+    if (target == null) return TvReturnResolution.Empty
+
+    // Every section carrying the launch id, not merely the first: a duplicated
+    // section id could otherwise shadow the real one with an empty namesake.
+    val sameSections = sections.withIndex().filter { it.value.id == target.sectionId }
+    val populated = sections.withIndex().filter { it.value.itemIds.isNotEmpty() }
+
+    // 1 — the occurrence, wherever its section has moved to. When a section id
+    // appears more than once, the nearest namesake holding the item wins: the
+    // same nearest-coordinate policy relocation uses, rather than whichever the
+    // list happens to reach first.
+    val sameSectionHit = sameSections
+        .filter { it.value.itemIds.contains(target.itemId) }
+        .minWithOrNull(nearestTo(target.sectionIndex))
+    if (sameSectionHit != null) {
+        return TvReturnResolution.Exact(
+            sectionIndex = sameSectionHit.index,
+            itemIndex = sameSectionHit.value.itemIds.nearestIndexOf(target.itemId, target.itemIndex),
+            sectionId = sameSectionHit.value.id,
+            itemId = target.itemId,
+        )
+    }
+
+    // 2 — the item elsewhere, for surfaces that have said that is meaningful.
+    // Ties go to the section nearest where it was, so a duplicate three rows
+    // away does not win over one adjacent.
+    if (relocation == TvReturnRelocation.FollowAcrossSections) {
+        val relocated = populated
+            .filter { it.value.id != target.sectionId && it.value.itemIds.contains(target.itemId) }
+            .minWithOrNull(nearestTo(target.sectionIndex))
+        if (relocated != null) {
+            return TvReturnResolution.Exact(
+                sectionIndex = relocated.index,
+                itemIndex = relocated.value.itemIds.nearestIndexOf(target.itemId, target.itemIndex),
+                sectionId = relocated.value.id,
+                itemId = target.itemId,
+            )
+        }
+    }
+
+    // Nothing found. Before falling back, decide whether "not here" is final —
+    // consuming the target early strands focus on a stand-in for good.
+    if (!treatAbsenceAsFinal && couldStillArrive(sections, sameSections, relocation, sectionsComplete)) {
+        return TvReturnResolution.Pending
+    }
+
+    if (populated.isEmpty()) return TvReturnResolution.Empty
+
+    // 3 — the slot it used to occupy, in the section that outlived it.
+    val survivingSameSection = sameSections
+        .filter { it.value.itemIds.isNotEmpty() }
+        .minWithOrNull(nearestTo(target.sectionIndex))
+    if (survivingSameSection != null) {
+        val itemIndex = target.itemIndex.coerceIn(0, survivingSameSection.value.itemIds.lastIndex)
+        return TvReturnResolution.Nearest(
+            sectionIndex = survivingSameSection.index,
+            itemIndex = itemIndex,
+            sectionId = survivingSameSection.value.id,
+            itemId = survivingSameSection.value.itemIds[itemIndex],
+        )
+    }
+
+    // 4 — the section is gone or empty. Nearest survivor by the remembered
+    // coordinate, then the remembered position inside it.
+    val fallbackSection = populated.minWithOrNull(nearestTo(target.sectionIndex))
+        ?: return TvReturnResolution.Empty
+    val itemIndex = target.itemIndex.coerceIn(0, fallbackSection.value.itemIds.lastIndex)
+    return TvReturnResolution.Nearest(
+        sectionIndex = fallbackSection.index,
+        itemIndex = itemIndex,
+        sectionId = fallbackSection.value.id,
+        itemId = fallbackSection.value.itemIds[itemIndex],
+    )
+}
+
+/**
+ * Whether anything still loading could yet produce the target.
+ *
+ * Deliberately policy-sensitive. Waiting on data that could not change the
+ * answer is not caution, it is a stall: under [TvReturnRelocation.SameSectionOnly]
+ * a present, finished launch section has already settled the question, and
+ * sections yet to load are irrelevant to it.
+ */
+private fun couldStillArrive(
+    sections: List<TvReturnSection>,
+    sameSections: List<IndexedValue<TvReturnSection>>,
+    relocation: TvReturnRelocation,
+    sectionsComplete: Boolean,
+): Boolean = when (relocation) {
+    // Any section still filling could carry the item, and a section not yet
+    // loaded could arrive carrying it.
+    TvReturnRelocation.FollowAcrossSections -> !sectionsComplete || sections.any { !it.isComplete }
+    // Only the launch section can answer. If it is here, its own pages decide
+    // and sections yet to load are irrelevant — which relies on section ids
+    // being unique, as the contract requires. If it is absent, it may still be
+    // on its way.
+    TvReturnRelocation.SameSectionOnly ->
+        if (sameSections.isEmpty()) !sectionsComplete else sameSections.any { !it.value.isComplete }
+}
+
+/**
+ * Index of [itemId], preferring the copy closest to [preferredIndex].
+ *
+ * Ids are expected to be unique within a section, but a feed that repeats one
+ * should land the viewer near where they were rather than at whichever copy
+ * comes first.
+ */
+private fun List<String>.nearestIndexOf(itemId: String, preferredIndex: Int): Int =
+    withIndex()
+        .filter { it.value == itemId }
+        .minByOrNull { abs(it.index - preferredIndex) }
+        ?.index
+        ?: -1
+
+/**
+ * Closest to [sectionIndex], preferring the later section when two are equally
+ * close.
+ *
+ * A forward bias, chosen because moving focus backwards lands the viewer in
+ * content they have already scrolled past.
+ *
+ * Not "the row that slid up": for the positional fallback a removed section
+ * makes its successor land at distance zero, which is no tie at all, so the tie
+ * there is only reachable around a section that is present but empty. The other
+ * callers can tie for their own reasons — two equidistant namesakes, or two
+ * equidistant relocation candidates — and the same bias applies to them.
+ */
+private fun nearestTo(sectionIndex: Int): Comparator<IndexedValue<TvReturnSection>> =
+    compareBy(
+        { candidate -> abs(candidate.index - sectionIndex) },
+        { candidate -> if (candidate.index >= sectionIndex) 0 else 1 },
+    )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookBookmarksPanel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookBookmarksPanel.kt
@@ -35,7 +35,6 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 import org.siloserver.silo.model.audiobook.AudiobookBookmark
-import org.siloserver.silo.tv.ui.components.rememberTvDialogInitialFocus
 
 /**
  * TV audiobook Bookmarks overlay. Mirrors the phone's bookmarks sheet over the
@@ -51,12 +50,15 @@ fun TvAudiobookBookmarksPanel(
     onJumpTo: (AudiobookBookmark) -> Unit,
     onDelete: (AudiobookBookmark) -> Unit,
     modifier: Modifier = Modifier,
+    onFocusAcquisitionFailed: () -> Unit = {},
 ) {
     val addFocus = remember { FocusRequester() }
 
     TvAudiobookOverlayScaffold(
         title = "Bookmarks",
-        modifier = modifier.then(rememberTvDialogInitialFocus(addFocus)),
+        initialFocus = addFocus,
+        modifier = modifier,
+        onAcquisitionFailed = onFocusAcquisitionFailed,
     ) {
         BookmarkActionRow(
             label = "Bookmark here",

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookChaptersPanel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookChaptersPanel.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import org.siloserver.silo.audiobook.audiobookChapterLabel
 import org.siloserver.silo.model.catalog.VersionChapter
-import kotlinx.coroutines.delay
 
 /**
  * Full-screen, focusable chapters overlay. Auto-scrolls to + highlights the
@@ -25,21 +24,27 @@ fun TvAudiobookChaptersPanel(
     currentChapterIndex: Int,
     onSelectChapter: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    onFocusAcquisitionFailed: () -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     val focusRequester = remember { FocusRequester() }
     val focusIndex = currentChapterIndex.coerceIn(0, (chapters.size - 1).coerceAtLeast(0))
 
+    // Scroll only. Focus acquisition is the scaffold's, because the current
+    // chapter can sit hundreds of rows down: it is not laid out until the scroll
+    // lands, and a fixed sleep-then-request-once raced that every time.
     LaunchedEffect(Unit) {
         if (focusIndex in chapters.indices) {
             runCatching { listState.scrollToItem(focusIndex) }
         }
-        // Let the scrolled row compose/lay out before grabbing focus.
-        delay(100)
-        runCatching { focusRequester.requestFocus() }
     }
 
-    TvAudiobookOverlayScaffold(title = "Chapters", modifier = modifier) {
+    TvAudiobookOverlayScaffold(
+        title = "Chapters",
+        initialFocus = focusRequester,
+        modifier = modifier,
+        onAcquisitionFailed = onFocusAcquisitionFailed,
+    ) {
         LazyColumn(state = listState, modifier = Modifier.fillMaxWidth()) {
             itemsIndexed(chapters) { index, chapter ->
                 TvAudiobookOverlayRow(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookOverlay.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookOverlay.kt
@@ -18,13 +18,20 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalFocusManager
+import kotlinx.coroutines.delay
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -35,19 +42,91 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import org.siloserver.silo.tv.ui.focus.TvFocusAcquisitionBudgetMillis
+import org.siloserver.silo.tv.ui.focus.TvFocusRelocationBudgetMillis
+import org.siloserver.silo.tv.ui.focus.TvObservedFocusResult
+import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
+
+private const val TvAudiobookPanelFocusRetryDelayMillis = 60L
+
+private val TvAudiobookPanelFocusMaxAttempts =
+    (TvFocusAcquisitionBudgetMillis / TvAudiobookPanelFocusRetryDelayMillis).toInt()
+
+/**
+ * Confirming that a traversal landed is a relocation, not an acquisition: focus
+ * has already moved and we are only waiting to see where. The short budget is
+ * the right one — a long wait here just delays the fail-open.
+ */
+private val TvAudiobookPanelFocusConfirmAttempts =
+    (TvFocusRelocationBudgetMillis / TvAudiobookPanelFocusRetryDelayMillis).toInt()
 
 /**
  * Right-aligned full-screen overlay panel over a dimming scrim, shared by the
  * chapters / speed / sleep audiobook panels (spec §4.9 — focusable overlays,
  * not phone bottom sheets). Back is handled by the host screen.
+ *
+ * Acquisition lives here rather than in each panel because every panel needs it
+ * and the ones that hand-rolled it got it wrong in the same way: a single
+ * unobserved `requestFocus()`, some of them fired before the target row had
+ * been laid out. A rejected request was indistinguishable from a successful
+ * one, so the panel opened with focus still on the transport pill behind the
+ * scrim — and the containment below cannot help with focus that never entered.
+ *
+ * [initialFocus] is required, not optional: a panel with nothing focusable in
+ * it cannot own focus, and while it is open the covered player is suppressed,
+ * so "no focus target" means a dead D-pad rather than a cosmetic problem.
+ *
+ * [onAcquisitionFailed] is the escape hatch for when that still does not work.
+ * Acquisition is retried until observed, but "retried until observed" is not
+ * the same as "guaranteed", and the shared dialog adapter's last resort — ask
+ * the focus system to enter the overlay by traversal — returns a Boolean that
+ * can be false, with nothing left to try. Suppressing the player behind an
+ * overlay that then fails to take focus is strictly worse than the escape bug
+ * this replaces, so the failure is reported instead of swallowed and the host
+ * hands the player back.
  */
 @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
 internal fun TvAudiobookOverlayScaffold(
     title: String,
+    initialFocus: FocusRequester,
     modifier: Modifier = Modifier,
+    onAcquisitionFailed: () -> Unit = {},
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    var panelHasFocus by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
+
+    LaunchedEffect(initialFocus) {
+        val result = requestFocusUntilObserved(
+            maxAttempts = TvAudiobookPanelFocusMaxAttempts,
+            awaitAttempt = { delay(TvAudiobookPanelFocusRetryDelayMillis) },
+            requestFocus = initialFocus::requestFocus,
+            isFocused = { panelHasFocus },
+        )
+        if (result == TvObservedFocusResult.Focused || panelHasFocus) return@LaunchedEffect
+
+        // Traversal, in case the named row never became focusable but something
+        // else in the panel did. `exit` cancels searches *leaving* the group and
+        // does not block entering it.
+        //
+        // A true return is not success. `moveFocus` is a global directional
+        // move: it reports that focus moved, not that it moved into this panel.
+        // Observed panel focus is the criterion for the request above, and
+        // abandoning it here would be how a "focus went somewhere else entirely"
+        // outcome gets recorded as a win while the player stays suppressed. So
+        // the move is confirmed the same way, and an unconfirmed move is a
+        // failure like any other.
+        val entered = runCatching { focusManager.moveFocus(FocusDirection.Enter) }.getOrDefault(false)
+        if (entered) {
+            repeat(TvAudiobookPanelFocusConfirmAttempts) {
+                delay(TvAudiobookPanelFocusRetryDelayMillis)
+                if (panelHasFocus) return@LaunchedEffect
+            }
+        }
+        if (!panelHasFocus) onAcquisitionFailed()
+    }
+
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -65,6 +144,7 @@ internal fun TvAudiobookOverlayScaffold(
                 // stays open. Same recipe as the player HUD picker.
                 .focusGroup()
                 .focusProperties { exit = { FocusRequester.Cancel } }
+                .onFocusChanged { panelHasFocus = it.hasFocus }
                 .padding(horizontal = 18.dp, vertical = 22.dp),
         ) {
             Text(text = title, style = MaterialTheme.typography.titleLarge, color = Color.White)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookPlayerScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -77,12 +78,21 @@ import org.siloserver.silo.common.player.SiloPlaybackService
 import org.siloserver.silo.model.catalog.VersionChapter
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvPoster
+import org.siloserver.silo.tv.ui.focus.TvFocusAcquisitionBudgetMillis
+import org.siloserver.silo.tv.ui.focus.TvObservedFocusResult
+import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
+import org.siloserver.silo.tv.ui.focus.tvFocusSuppressed
 import com.google.common.util.concurrent.MoreExecutors
 import kotlinx.coroutines.delay
 import org.koin.compose.viewmodel.koinViewModel
 import kotlin.math.max
 
 private enum class AudiobookPanel { None, Chapters, Speed, Sleep, More, Skip, Bookmarks, About }
+
+private const val TvAudiobookTransportFocusRetryDelayMillis = 60L
+
+private val TvAudiobookTransportFocusMaxAttempts =
+    (TvFocusAcquisitionBudgetMillis / TvAudiobookTransportFocusRetryDelayMillis).toInt()
 
 /**
  * 10-foot, D-pad audiobook player for Android TV. A thin focus/layout view over
@@ -222,9 +232,48 @@ fun TvAudiobookPlayerScreen(
     }
 
     // Initial / restored focus lands on play/pause when no panel is open.
-    LaunchedEffect(state.isLoading, activePanel) {
-        if (!state.isLoading && activePanel == AudiobookPanel.None) {
-            runCatching { playPauseFocus.requestFocus() }
+    //
+    // Observed, because both moments this covers request focus at a target that
+    // may not be focusable yet: on first load the transport is composed in the
+    // same pass, and on panel close the panel is still being torn down. A
+    // one-shot request that lands early is silently dropped, and with the
+    // covered controls suppressed while a panel is open there is nothing else
+    // holding focus to fall back on — the screen would simply go dead.
+    var transportHasFocus by remember { mutableStateOf(false) }
+    // Set when an open panel reports that it could not take focus. Suppressing
+    // the player behind a panel that then holds no focus is worse than the
+    // escape this whole change is about, so that case hands the player back.
+    var panelFocusFailed by remember(activePanel) { mutableStateOf(false) }
+    LaunchedEffect(state.isLoading, state.error != null, activePanel, panelFocusFailed) {
+        // The error branch replaces the transport entirely, so there is nothing
+        // to acquire and retrying just burns the budget. Keyed, not just
+        // guarded, so clearing an error re-runs acquisition.
+        if (state.isLoading || state.error != null) return@LaunchedEffect
+        if (activePanel != AudiobookPanel.None && !panelFocusFailed) return@LaunchedEffect
+        if (transportHasFocus) return@LaunchedEffect
+        val result = requestFocusUntilObserved(
+            maxAttempts = TvAudiobookTransportFocusMaxAttempts,
+            awaitAttempt = { delay(TvAudiobookTransportFocusRetryDelayMillis) },
+            requestFocus = playPauseFocus::requestFocus,
+            isFocused = { transportHasFocus },
+        )
+        // Last rung of the ladder. Handing the player back is only useful if
+        // the player can actually take focus, and by here it has not: the panel
+        // reported failure and the transport did not answer either. (Strictly
+        // that says these two places lack focus, not that nothing anywhere has
+        // it — but a panel that never took focus with the player suppressed
+        // behind it leaves nothing else plausible.) Another request is not a
+        // new idea at that point. The one remaining move that changes the tree
+        // rather than re-asking the same question is dropping the overlay: it
+        // removes the panel's containment and the scrim, and re-keys this
+        // effect against an unobstructed player. That is also the terminating
+        // step — with no panel open the branch cannot fire again, so this
+        // escalates at most once.
+        if (result != TvObservedFocusResult.Focused &&
+            !transportHasFocus &&
+            activePanel != AudiobookPanel.None
+        ) {
+            activePanel = AudiobookPanel.None
         }
     }
 
@@ -238,6 +287,23 @@ fun TvAudiobookPlayerScreen(
             onExit()
         }
     }
+
+    // A runtime failure can set `error` after playback is already up. That swaps
+    // the whole content branch for TvErrorScreen, which has no actions in it —
+    // so an open panel would be left floating over a screen with nothing to
+    // return focus to once it closes. Close the panel with the content it
+    // belonged to.
+    LaunchedEffect(state.error != null) {
+        if (state.error != null) activePanel = AudiobookPanel.None
+    }
+
+    // The panels are in-window overlays, so the player stays composed and
+    // focusable behind them. Containment inside a panel cannot stop Select
+    // reaching a covered transport button when focus never entered the panel,
+    // and it cannot stop a panel row's Down walking into the pills below the
+    // scrim — the covered controls have to leave the focus graph outright.
+    val panelIsOpen = activePanel != AudiobookPanel.None
+    val playerFocusSuppressed = panelIsOpen && !panelFocusFailed
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val metrics = tvAudiobookPlayerMetrics(maxWidth.value.toInt(), maxHeight.value.toInt())
@@ -332,7 +398,10 @@ fun TvAudiobookPlayerScreen(
                             )
                             Spacer(Modifier.height(metrics.transportTopGapDp.dp))
                             TvAudiobookTransportRow(
-                                modifier = Modifier.focusProperties { down = speedChipFocus },
+                                modifier = Modifier
+                                    .focusProperties { down = speedChipFocus }
+                                    .onFocusChanged { transportHasFocus = it.hasFocus },
+                                focusSuppressed = playerFocusSuppressed,
                                 // Pause intent, not transient isPlaying, so the icon
                                 // stays stable through a seek's rebuffer.
                                 isPlaying = !state.isPaused,
@@ -353,6 +422,7 @@ fun TvAudiobookPlayerScreen(
                             Spacer(Modifier.height(metrics.utilityTopGapDp.dp))
                             TvAudiobookSecondaryControls(
                                 modifier = Modifier.focusProperties { up = playPauseFocus },
+                                focusSuppressed = playerFocusSuppressed,
                                 speedLabel = tvAudiobookSpeedLabel(state.playbackSpeed),
                                 sleepLabel = tvAudiobookSleepLabel(
                                     minutesLeft = state.sleepTimerMinutesLeft,
@@ -379,6 +449,7 @@ fun TvAudiobookPlayerScreen(
 
             when (activePanel) {
                 AudiobookPanel.Chapters -> TvAudiobookChaptersPanel(
+                    onFocusAcquisitionFailed = { panelFocusFailed = true },
                     chapters = state.chapters,
                     currentChapterIndex = currentChapterIndex,
                     onSelectChapter = { idx ->
@@ -387,6 +458,7 @@ fun TvAudiobookPlayerScreen(
                     },
                 )
                 AudiobookPanel.Speed -> TvAudiobookSpeedPanel(
+                    onFocusAcquisitionFailed = { panelFocusFailed = true },
                     currentSpeed = state.playbackSpeed,
                     // Fine-adjust / presets apply live and stay open so the user
                     // can keep tuning; "Set as default" persists and closes.
@@ -394,16 +466,19 @@ fun TvAudiobookPlayerScreen(
                     onSetDefault = { viewModel.setDefaultSpeed(it); activePanel = AudiobookPanel.None },
                 )
                 AudiobookPanel.Skip -> TvAudiobookSkipIntervalPanel(
+                    onFocusAcquisitionFailed = { panelFocusFailed = true },
                     skipBackSeconds = state.skipBackSeconds,
                     skipForwardSeconds = state.skipForwardSeconds,
                     onSelectSkipBack = { viewModel.setSkipBackSeconds(it) },
                     onSelectSkipForward = { viewModel.setSkipForwardSeconds(it) },
                 )
                 AudiobookPanel.Sleep -> TvAudiobookSleepPanel(
+                    onFocusAcquisitionFailed = { panelFocusFailed = true },
                     currentChoice = sleepChoice,
                     onSelectSleep = { viewModel.applySleepTimer(it); activePanel = AudiobookPanel.None },
                 )
                 AudiobookPanel.More -> TvAudiobookMorePanel(
+                    onFocusAcquisitionFailed = { panelFocusFailed = true },
                     skipLabel = tvAudiobookSkipLabel(
                         skipBackSeconds = state.skipBackSeconds,
                         skipForwardSeconds = state.skipForwardSeconds,
@@ -416,6 +491,7 @@ fun TvAudiobookPlayerScreen(
                 AudiobookPanel.Bookmarks -> {
                     val bookmarks by viewModel.bookmarks.collectAsState()
                     TvAudiobookBookmarksPanel(
+                        onFocusAcquisitionFailed = { panelFocusFailed = true },
                         bookmarks = bookmarks,
                         onAddCurrent = { viewModel.addBookmark() },
                         onJumpTo = { bookmark ->
@@ -425,18 +501,13 @@ fun TvAudiobookPlayerScreen(
                         onDelete = { viewModel.removeBookmark(it.id) },
                     )
                 }
-                AudiobookPanel.About -> TvAudiobookOverlayScaffold(title = "About") {
-                    Spacer(Modifier.height(12.dp))
-                    Text(
-                        text = state.overview.orEmpty(),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = Color.White.copy(alpha = 0.82f),
-                        // Generous cap: a description fits the full-height panel; TV
-                        // can't D-pad-scroll an inner text box.
-                        maxLines = 30,
-                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                    )
-                }
+                AudiobookPanel.About -> TvAudiobookAboutPanel(
+                    onFocusAcquisitionFailed = { panelFocusFailed = true },
+                    overview = state.overview.orEmpty(),
+                    // Same destination as Back from any panel, so the two ways
+                    // out of About do not disagree.
+                    onClose = { activePanel = AudiobookPanel.None },
+                )
                 AudiobookPanel.None -> Unit
             }
         }
@@ -616,6 +687,7 @@ private fun TvAudiobookSecondaryControls(
     onStop: () -> Unit,
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester? = null,
+    focusSuppressed: Boolean = false,
     buttonHeight: Dp = 58.dp,
     buttonSpacing: Dp = 16.dp,
 ) {
@@ -628,12 +700,14 @@ private fun TvAudiobookSecondaryControls(
             label = speedLabel,
             icon = Icons.Filled.Speed,
             focusRequester = focusRequester,
+            focusSuppressed = focusSuppressed,
             height = buttonHeight,
             onClick = onSpeed,
         )
         TvAudiobookPillButton(
             label = sleepLabel,
             icon = Icons.Filled.Bedtime,
+            focusSuppressed = focusSuppressed,
             height = buttonHeight,
             onClick = onSleep,
         )
@@ -641,6 +715,7 @@ private fun TvAudiobookSecondaryControls(
             TvAudiobookPillButton(
                 label = "Chapters",
                 icon = Icons.AutoMirrored.Filled.FormatListBulleted,
+                focusSuppressed = focusSuppressed,
                 height = buttonHeight,
                 onClick = onChapters,
             )
@@ -648,14 +723,53 @@ private fun TvAudiobookSecondaryControls(
         TvAudiobookPillButton(
             label = "More",
             icon = Icons.Filled.MoreHoriz,
+            focusSuppressed = focusSuppressed,
             height = buttonHeight,
             onClick = onMore,
         )
         TvAudiobookPillButton(
             label = "Stop",
             icon = Icons.Filled.Close,
+            focusSuppressed = focusSuppressed,
             height = buttonHeight,
             onClick = onStop,
+        )
+    }
+}
+
+/**
+ * The book description. Its only action is leaving, but it still needs one:
+ * with the covered player suppressed, a panel holding no focusable at all
+ * leaves the D-pad dead until Back, and nothing on screen says so.
+ */
+@Composable
+private fun TvAudiobookAboutPanel(
+    overview: String,
+    onClose: () -> Unit,
+    onFocusAcquisitionFailed: () -> Unit,
+) {
+    val closeFocus = remember { FocusRequester() }
+    TvAudiobookOverlayScaffold(
+        title = "About",
+        initialFocus = closeFocus,
+        onAcquisitionFailed = onFocusAcquisitionFailed,
+    ) {
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = overview,
+            style = MaterialTheme.typography.bodyLarge,
+            color = Color.White.copy(alpha = 0.82f),
+            // Generous cap: a description fits the full-height panel; TV
+            // can't D-pad-scroll an inner text box.
+            maxLines = 30,
+            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+        )
+        Spacer(Modifier.height(16.dp))
+        TvAudiobookOverlayRow(
+            label = "Close",
+            isCurrent = false,
+            onSelect = onClose,
+            focusRequester = closeFocus,
         )
     }
 }
@@ -667,14 +781,21 @@ private fun TvAudiobookMorePanel(
     onSkip: () -> Unit,
     onBookmarks: () -> Unit,
     onAbout: () -> Unit,
+    onFocusAcquisitionFailed: () -> Unit,
 ) {
-    TvAudiobookOverlayScaffold(title = "More") {
+    val firstRowFocus = remember { FocusRequester() }
+    TvAudiobookOverlayScaffold(
+        title = "More",
+        initialFocus = firstRowFocus,
+        onAcquisitionFailed = onFocusAcquisitionFailed,
+    ) {
         Spacer(Modifier.height(12.dp))
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             TvAudiobookMoreRow(
                 icon = Icons.Filled.Tune,
                 title = "Skip interval",
                 subtitle = skipLabel,
+                focusRequester = firstRowFocus,
                 onClick = onSkip,
             )
             TvAudiobookMoreRow(
@@ -701,6 +822,7 @@ private fun TvAudiobookMoreRow(
     title: String,
     subtitle: String,
     onClick: () -> Unit,
+    focusRequester: FocusRequester? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
@@ -711,6 +833,7 @@ private fun TvAudiobookMoreRow(
             .fillMaxWidth()
             .clip(RoundedCornerShape(14.dp))
             .background(bg)
+            .let { mod -> if (focusRequester != null) mod.focusRequester(focusRequester) else mod }
             .focusable(interactionSource = interactionSource)
             .onPreviewKeyEvent { e ->
                 if (e.type != KeyEventType.KeyUp) return@onPreviewKeyEvent false
@@ -741,6 +864,7 @@ private fun TvAudiobookPillButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester? = null,
+    focusSuppressed: Boolean = false,
     height: Dp = 58.dp,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -753,6 +877,8 @@ private fun TvAudiobookPillButton(
             .clip(RoundedCornerShape(height / 2))
             .background(bg)
             .let { mod -> if (focusRequester != null) mod.focusRequester(focusRequester) else mod }
+            // Ahead of the focusable, so it binds to this pill's own focus target.
+            .tvFocusSuppressed(focusSuppressed)
             .focusable(interactionSource = interactionSource)
             .onPreviewKeyEvent { e ->
                 if (e.type != KeyEventType.KeyUp) return@onPreviewKeyEvent false

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookPlayerScreen.kt
@@ -249,7 +249,18 @@ fun TvAudiobookPlayerScreen(
         // to acquire and retrying just burns the budget. Keyed, not just
         // guarded, so clearing an error re-runs acquisition.
         if (state.isLoading || state.error != null) return@LaunchedEffect
-        if (activePanel != AudiobookPanel.None && !panelFocusFailed) return@LaunchedEffect
+        // A panel that could not take focus has to CLOSE, not merely hand the
+        // player back. Unsuppressing the transport while the panel and its
+        // scrim are still drawn puts focus on controls the viewer cannot see —
+        // D-pad and Select land behind the modal — and the escalation below
+        // never rescues that, because it only fires when the transport also
+        // fails to take focus. Closing first re-keys this effect against an
+        // unobstructed player, which then acquires normally.
+        if (activePanel != AudiobookPanel.None && panelFocusFailed) {
+            activePanel = AudiobookPanel.None
+            return@LaunchedEffect
+        }
+        if (activePanel != AudiobookPanel.None) return@LaunchedEffect
         if (transportHasFocus) return@LaunchedEffect
         val result = requestFocusUntilObserved(
             maxAttempts = TvAudiobookTransportFocusMaxAttempts,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookSkipIntervalPanel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookSkipIntervalPanel.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -26,12 +25,20 @@ fun TvAudiobookSkipIntervalPanel(
     onSelectSkipBack: (Int) -> Unit,
     onSelectSkipForward: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    onFocusAcquisitionFailed: () -> Unit = {},
 ) {
     val focusRequester = remember { FocusRequester() }
-    val focusValue = skipBackSeconds
-    LaunchedEffect(Unit) { runCatching { focusRequester.requestFocus() } }
+    // A persisted interval outside the allowed set would attach the requester to
+    // no row at all, leaving the panel with nothing to acquire.
+    val focusValue = skipBackSeconds.takeIf { it in AudiobookSettingsStore.ALLOWED_SKIP }
+        ?: AudiobookSettingsStore.ALLOWED_SKIP.first()
 
-    TvAudiobookOverlayScaffold(title = "Skip interval", modifier = modifier) {
+    TvAudiobookOverlayScaffold(
+        title = "Skip interval",
+        initialFocus = focusRequester,
+        modifier = modifier,
+        onAcquisitionFailed = onFocusAcquisitionFailed,
+    ) {
         SectionLabel("Skip back")
         AudiobookSettingsStore.ALLOWED_SKIP.forEach { seconds ->
             TvAudiobookOverlayRow(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookSleepPanel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookSleepPanel.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import org.siloserver.silo.common.player.SleepTimerChoice
-import kotlinx.coroutines.delay
 
 private data class SleepOption(val label: String, val choice: SleepTimerChoice)
 
@@ -31,18 +30,20 @@ fun TvAudiobookSleepPanel(
     currentChoice: SleepTimerChoice,
     onSelectSleep: (SleepTimerChoice) -> Unit,
     modifier: Modifier = Modifier,
+    onFocusAcquisitionFailed: () -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     val focusRequester = remember { FocusRequester() }
     val focusIndex = SLEEP_OPTIONS.indexOfFirst { it.choice == currentChoice }.coerceAtLeast(0)
-    LaunchedEffect(Unit) {
-        listState.scrollToItem(focusIndex)
-        // Let the target row compose/measure after the scroll before grabbing focus.
-        delay(100)
-        runCatching { focusRequester.requestFocus() }
-    }
+    // Scroll only; the scaffold retries until focus is observed on the row.
+    LaunchedEffect(Unit) { listState.scrollToItem(focusIndex) }
 
-    TvAudiobookOverlayScaffold(title = "Sleep timer", modifier = modifier) {
+    TvAudiobookOverlayScaffold(
+        title = "Sleep timer",
+        initialFocus = focusRequester,
+        modifier = modifier,
+        onAcquisitionFailed = onFocusAcquisitionFailed,
+    ) {
         LazyColumn(
             state = listState,
             modifier = Modifier

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookSpeedPanel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookSpeedPanel.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -46,11 +45,16 @@ fun TvAudiobookSpeedPanel(
     onSelectSpeed: (Float) -> Unit,
     onSetDefault: (Float) -> Unit,
     modifier: Modifier = Modifier,
+    onFocusAcquisitionFailed: () -> Unit = {},
 ) {
     val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { runCatching { focusRequester.requestFocus() } }
 
-    TvAudiobookOverlayScaffold(title = "Speed", modifier = modifier) {
+    TvAudiobookOverlayScaffold(
+        title = "Speed",
+        initialFocus = focusRequester,
+        modifier = modifier,
+        onAcquisitionFailed = onFocusAcquisitionFailed,
+    ) {
         // Fine adjust grabs initial focus so ◀/▶ work immediately.
         SpeedFineAdjustRow(
             speed = currentSpeed,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookTransportRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookTransportRow.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Icon
+import org.siloserver.silo.tv.ui.focus.tvFocusSuppressed
 
 /**
  * Five-button audiobook transport, D-pad navigable. Mirrors the video player's
@@ -68,6 +69,7 @@ fun TvAudiobookTransportRow(
     onNextChapter: () -> Unit,
     playPauseFocus: FocusRequester,
     modifier: Modifier = Modifier,
+    focusSuppressed: Boolean = false,
     buttonSize: Dp = 68.dp,
     primaryButtonWidth: Dp = 112.dp,
     primaryButtonHeight: Dp = 58.dp,
@@ -82,12 +84,14 @@ fun TvAudiobookTransportRow(
             icon = Icons.Filled.SkipPrevious,
             description = "Previous chapter",
             enabled = chaptersEnabled,
+            focusSuppressed = focusSuppressed,
             buttonSize = buttonSize,
             onClick = onPrevChapter,
         )
         TransportIconButton(
             icon = skipBackIcon(skipBackSeconds),
             description = "Skip back $skipBackSeconds seconds",
+            focusSuppressed = focusSuppressed,
             buttonSize = buttonSize,
             onClick = onSkipBack,
         )
@@ -96,6 +100,7 @@ fun TvAudiobookTransportRow(
             description = if (isPlaying) "Pause" else "Play",
             isPrimary = true,
             focusRequester = playPauseFocus,
+            focusSuppressed = focusSuppressed,
             buttonSize = buttonSize,
             primaryButtonWidth = primaryButtonWidth,
             primaryButtonHeight = primaryButtonHeight,
@@ -104,6 +109,7 @@ fun TvAudiobookTransportRow(
         TransportIconButton(
             icon = skipForwardIcon(skipForwardSeconds),
             description = "Skip forward $skipForwardSeconds seconds",
+            focusSuppressed = focusSuppressed,
             buttonSize = buttonSize,
             onClick = onSkipForward,
         )
@@ -111,6 +117,7 @@ fun TvAudiobookTransportRow(
             icon = Icons.Filled.SkipNext,
             description = "Next chapter",
             enabled = chaptersEnabled,
+            focusSuppressed = focusSuppressed,
             buttonSize = buttonSize,
             onClick = onNextChapter,
         )
@@ -125,6 +132,7 @@ private fun TransportIconButton(
     enabled: Boolean = true,
     isPrimary: Boolean = false,
     focusRequester: FocusRequester? = null,
+    focusSuppressed: Boolean = false,
     buttonSize: Dp = 68.dp,
     primaryButtonWidth: Dp = 112.dp,
     primaryButtonHeight: Dp = 58.dp,
@@ -160,6 +168,9 @@ private fun TransportIconButton(
                 shape = buttonShape,
             )
             .let { mod -> if (focusRequester != null) mod.focusRequester(focusRequester) else mod }
+            // Ahead of the focusable, so it binds to this button's own focus
+            // target rather than being inherited from somewhere up the tree.
+            .tvFocusSuppressed(focusSuppressed)
             .focusable(interactionSource = interactionSource)
             .onPreviewKeyEvent { event ->
                 if (event.type != KeyEventType.KeyUp) return@onPreviewKeyEvent false

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvPairDeviceScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvPairDeviceScreen.kt
@@ -40,7 +40,9 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import org.siloserver.silo.model.auth.DeviceLoginLookupResponse
+import org.siloserver.silo.tv.ui.focus.TvControlState
 import org.siloserver.silo.tv.ui.focus.rememberTvContentInitialFocus
+import org.siloserver.silo.tv.ui.focus.tvControlSemantics
 import org.siloserver.silo.tv.ui.focus.tvPairDeviceFocusTarget
 import org.siloserver.silo.tv.ui.focus.TvPairDeviceAction
 import org.siloserver.silo.tv.ui.components.TvTextInputDialog
@@ -82,23 +84,37 @@ fun TvPairDeviceScreen(
     // before a decision lands; matches the phone's editable-field gating.
     val canEnterCode = state.token.isNullOrBlank() && state.completedStatus == null
 
-    // Which control is actionable changes with isLoading, isSubmitting and
-    // canSubmit, none of which alter completedStatus — so focus is keyed on the
-    // eligible action itself and re-acquired whenever that changes.
+    // Approve and Deny exist to act on a specific request, and the request only
+    // exists once the lookup resolves — a deep link arrives with its token
+    // already set, so "there is an identifier" was never the right gate.
+    //
+    // The two halves are separated because they are different kinds of
+    // disabled. With no lookup the decision cannot apply at all, so the buttons
+    // leave the focus graph rather than sitting there as dead stops the D-pad
+    // walks onto (TV Material keeps disabled buttons focusable, so `enabled`
+    // alone would not do that — see tvControlSemantics). A decision already in
+    // flight is momentary, so those stay focusable and merely refuse to act,
+    // which is what keeps focus from being dropped mid-submit.
+    val decisionState = TvControlState(
+        focusable = state.lookup != null,
+        actionable = state.canDecide,
+    )
+    // Check is gated transiently: it is the only control on a token route
+    // before the lookup resolves, and it is what the focus target falls back
+    // to, so it has to stay in the focus graph while its own lookup runs.
+    val checkState = TvControlState.transient(!state.isLoading && !state.isSubmitting)
+
     val focusTarget = tvPairDeviceFocusTarget(
         hasCompleted = state.completedStatus != null,
         hasResolvedLookup = state.lookup != null,
         canEnterCode = canEnterCode,
-        canSubmit = state.canSubmit,
-        isLoading = state.isLoading,
-        isSubmitting = state.isSubmitting,
     )
     val actionFocus = rememberTvContentInitialFocus(
         target = when (focusTarget) {
             TvPairDeviceAction.EnterCode -> enterCodeFocus
             TvPairDeviceAction.Check -> checkFocus
             TvPairDeviceAction.Approve -> approveFocus
-            TvPairDeviceAction.Done, null -> doneFocus
+            TvPairDeviceAction.Done -> doneFocus
         },
         contentKey = focusTarget,
     )
@@ -191,9 +207,11 @@ fun TvPairDeviceScreen(
                         }
                     }
                     Button(
-                        onClick = { viewModel.lookup() },
-                        enabled = !state.isLoading && !state.isSubmitting,
-                        modifier = Modifier.focusRequester(checkFocus),
+                        onClick = { checkState.perform { viewModel.lookup() } },
+                        enabled = checkState.focusable,
+                        modifier = Modifier
+                            .focusRequester(checkFocus)
+                            .tvControlSemantics(checkState),
                     ) {
                         Icon(Icons.Default.Refresh, contentDescription = null)
                         Spacer(Modifier.width(8.dp))
@@ -204,15 +222,21 @@ fun TvPairDeviceScreen(
                 Spacer(Modifier.height(16.dp))
 
                 Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                    Button(onClick = viewModel::deny, enabled = state.canSubmit) {
+                    Button(
+                        onClick = { decisionState.perform(viewModel::deny) },
+                        enabled = decisionState.focusable,
+                        modifier = Modifier.tvControlSemantics(decisionState),
+                    ) {
                         Icon(Icons.Default.Close, contentDescription = null)
                         Spacer(Modifier.width(8.dp))
                         Text("Deny")
                     }
                     Button(
-                        onClick = viewModel::approve,
-                        enabled = state.canSubmit,
-                        modifier = Modifier.focusRequester(approveFocus),
+                        onClick = { decisionState.perform(viewModel::approve) },
+                        enabled = decisionState.focusable,
+                        modifier = Modifier
+                            .focusRequester(approveFocus)
+                            .tvControlSemantics(decisionState),
                     ) {
                         Icon(Icons.Default.Check, contentDescription = null)
                         Spacer(Modifier.width(8.dp))

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvPairDeviceScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvPairDeviceScreen.kt
@@ -40,6 +40,9 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import org.siloserver.silo.model.auth.DeviceLoginLookupResponse
+import org.siloserver.silo.tv.ui.focus.rememberTvContentInitialFocus
+import org.siloserver.silo.tv.ui.focus.tvPairDeviceFocusTarget
+import org.siloserver.silo.tv.ui.focus.TvPairDeviceAction
 import org.siloserver.silo.tv.ui.components.TvTextInputDialog
 import org.siloserver.silo.viewmodel.DevicePairingViewModel
 import org.koin.compose.viewmodel.koinViewModel
@@ -68,21 +71,41 @@ fun TvPairDeviceScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     var showCodeEntry by remember { mutableStateOf(false) }
-    val firstActionFocus = remember { FocusRequester() }
+    val enterCodeFocus = remember { FocusRequester() }
+    val checkFocus = remember { FocusRequester() }
+    val approveFocus = remember { FocusRequester() }
+    val doneFocus = remember { FocusRequester() }
 
     BackHandler(enabled = true) { onDone() }
-
-    LaunchedEffect(state.completedStatus) {
-        runCatching { firstActionFocus.requestFocus() }
-    }
 
     // Manual code entry is only meaningful before a token-driven lookup and
     // before a decision lands; matches the phone's editable-field gating.
     val canEnterCode = state.token.isNullOrBlank() && state.completedStatus == null
 
+    // Which control is actionable changes with isLoading, isSubmitting and
+    // canSubmit, none of which alter completedStatus — so focus is keyed on the
+    // eligible action itself and re-acquired whenever that changes.
+    val focusTarget = tvPairDeviceFocusTarget(
+        hasCompleted = state.completedStatus != null,
+        canEnterCode = canEnterCode,
+        canSubmit = state.canSubmit,
+        isLoading = state.isLoading,
+        isSubmitting = state.isSubmitting,
+    )
+    val actionFocus = rememberTvContentInitialFocus(
+        target = when (focusTarget) {
+            TvPairDeviceAction.EnterCode -> enterCodeFocus
+            TvPairDeviceAction.Check -> checkFocus
+            TvPairDeviceAction.Approve -> approveFocus
+            TvPairDeviceAction.Done, null -> doneFocus
+        },
+        contentKey = focusTarget,
+    )
+
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .then(actionFocus)
             .background(MaterialTheme.colorScheme.background),
         contentAlignment = Alignment.Center,
     ) {
@@ -159,7 +182,7 @@ fun TvPairDeviceScreen(
                     if (canEnterCode) {
                         Button(
                             onClick = { showCodeEntry = true },
-                            modifier = Modifier.focusRequester(firstActionFocus),
+                            modifier = Modifier.focusRequester(enterCodeFocus),
                         ) {
                             Icon(Icons.Default.Edit, contentDescription = null)
                             Spacer(Modifier.width(8.dp))
@@ -169,7 +192,7 @@ fun TvPairDeviceScreen(
                     Button(
                         onClick = { viewModel.lookup() },
                         enabled = !state.isLoading && !state.isSubmitting,
-                        modifier = if (canEnterCode) Modifier else Modifier.focusRequester(firstActionFocus),
+                        modifier = Modifier.focusRequester(checkFocus),
                     ) {
                         Icon(Icons.Default.Refresh, contentDescription = null)
                         Spacer(Modifier.width(8.dp))
@@ -185,7 +208,11 @@ fun TvPairDeviceScreen(
                         Spacer(Modifier.width(8.dp))
                         Text("Deny")
                     }
-                    Button(onClick = viewModel::approve, enabled = state.canSubmit) {
+                    Button(
+                        onClick = viewModel::approve,
+                        enabled = state.canSubmit,
+                        modifier = Modifier.focusRequester(approveFocus),
+                    ) {
                         Icon(Icons.Default.Check, contentDescription = null)
                         Spacer(Modifier.width(8.dp))
                         Text(if (state.isSubmitting) "Approving…" else "Approve")
@@ -194,7 +221,7 @@ fun TvPairDeviceScreen(
             } else {
                 Button(
                     onClick = onDone,
-                    modifier = Modifier.focusRequester(firstActionFocus),
+                    modifier = Modifier.focusRequester(doneFocus),
                 ) {
                     Text("Done")
                 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvPairDeviceScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvPairDeviceScreen.kt
@@ -87,6 +87,7 @@ fun TvPairDeviceScreen(
     // eligible action itself and re-acquired whenever that changes.
     val focusTarget = tvPairDeviceFocusTarget(
         hasCompleted = state.completedStatus != null,
+        hasResolvedLookup = state.lookup != null,
         canEnterCode = canEnterCode,
         canSubmit = state.canSubmit,
         isLoading = state.isLoading,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt
@@ -73,6 +73,7 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import org.siloserver.silo.tv.ui.components.TvHideStockImeOnDispose
 import org.siloserver.silo.tv.R
 import org.siloserver.silo.common.pairing.PairingReceiver
 import org.siloserver.silo.common.pairing.PairingReceiverStatus
@@ -397,6 +398,7 @@ private fun ManualEntryCard(
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    TvHideStockImeOnDispose()
     Column(
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
         modifier = modifier

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/browse/TvBrowseScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/browse/TvBrowseScreen.kt
@@ -39,6 +39,9 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import org.siloserver.silo.tv.ui.focus.TvRestoreFocusOnModalDismiss
 import org.siloserver.silo.tv.ui.components.TvCatalogEmptyState
 import org.siloserver.silo.tv.ui.components.TvCatalogGrid
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
@@ -71,6 +74,19 @@ fun TvBrowseScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     var showFilterSheet by remember { mutableStateOf(false) }
+    // The sheet is a modal focus owner, so something has to hand focus back
+    // when it closes. Left to the focus system, the successor is picked
+    // geometrically and lands on whatever the dimmed page happened to have.
+    val filterOpenerFocus = remember { FocusRequester() }
+    var filterOpenerFocused by remember { mutableStateOf(false) }
+    val filterOpenerModifier = Modifier
+        .focusRequester(filterOpenerFocus)
+        .onFocusChanged { filterOpenerFocused = it.isFocused }
+    TvRestoreFocusOnModalDismiss(
+        visible = showFilterSheet,
+        opener = filterOpenerFocus,
+        isOpenerFocused = { filterOpenerFocused },
+    )
 
     val firstItemFocusRequester = remember { FocusRequester() }
     var initialFocusRequested by remember { mutableStateOf(false) }
@@ -99,6 +115,7 @@ fun TvBrowseScreen(
                     sortLabel = sortLabel,
                     filter = state.filter,
                     onOpenFilters = { showFilterSheet = true },
+                    filterOpenerModifier = filterOpenerModifier,
                     modifier = Modifier.padding(
                         top = TvTopMenuLayout.contentTopInset,
                         start = Spacing.safeArea,
@@ -122,6 +139,7 @@ fun TvBrowseScreen(
                     sortLabel = sortLabel,
                     filter = state.filter,
                     onOpenFilters = { showFilterSheet = true },
+                    filterOpenerModifier = filterOpenerModifier,
                     modifier = Modifier.padding(
                         top = TvTopMenuLayout.contentTopInset,
                         start = Spacing.safeArea,
@@ -136,6 +154,7 @@ fun TvBrowseScreen(
                     onItemClick = onOpenItemDetail,
                     onLoadMore = viewModel::loadMore,
                     onOpenFilters = { showFilterSheet = true },
+                    filterOpenerModifier = filterOpenerModifier,
                     firstItemFocusRequester = firstItemFocusRequester,
                 )
             }
@@ -251,6 +270,7 @@ private fun BrowseGrid(
     onItemClick: (String) -> Unit,
     onLoadMore: () -> Unit,
     onOpenFilters: () -> Unit,
+    filterOpenerModifier: Modifier,
     firstItemFocusRequester: FocusRequester,
 ) {
     // Shared catalog grid: pagination, focus-restorer, header + empty state.
@@ -282,6 +302,7 @@ private fun BrowseGrid(
                 sortLabel = sortLabel,
                 filter = state.filter,
                 onOpenFilters = onOpenFilters,
+                filterOpenerModifier = filterOpenerModifier,
             )
         },
         emptyState = {
@@ -300,6 +321,7 @@ private fun BrowseHeader(
     sortLabel: String,
     filter: TvBrowseFilter,
     onOpenFilters: () -> Unit,
+    filterOpenerModifier: Modifier,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -330,6 +352,7 @@ private fun BrowseHeader(
             filter = filter,
             sortLabel = sortLabel,
             onOpenFilters = onOpenFilters,
+            filterOpenerModifier = filterOpenerModifier,
         )
     }
 }
@@ -344,6 +367,7 @@ private fun FilterRow(
     filter: TvBrowseFilter,
     sortLabel: String,
     onOpenFilters: () -> Unit,
+    filterOpenerModifier: Modifier,
     modifier: Modifier = Modifier,
 ) {
     FlowRow(
@@ -353,7 +377,11 @@ private fun FilterRow(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
-        FilterEntryButton(label = "Filter", onClick = onOpenFilters)
+        FilterEntryButton(
+            label = "Filter",
+            onClick = onOpenFilters,
+            modifier = filterOpenerModifier,
+        )
 
         if (filter.genre != null) {
             ActiveFilterPill(label = "Genre: ${filter.genre}")

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
@@ -722,6 +722,13 @@ internal fun calendarUpFallbackAction(
     focusedControlZone: CalendarControlFocusZone?,
     isRepeat: Boolean = false,
 ): CalendarUpFallbackAction = when {
+    // A return to the controls is already in flight. It stays in flight until
+    // the controls actually take focus, and for those frames the shelf still
+    // reports its own index — so neither the null-index check below nor
+    // shouldReturnCalendarFocusToControls (which goes false the instant the
+    // return starts) can hold a held key. Without this, the same press that
+    // began the handoff leaks straight into geometric movement.
+    isRepeat && isReturningToControls -> CalendarUpFallbackAction.StayInContent
     shouldReturnCalendarFocusToControls(
         focusedShelfIndex = focusedShelfIndex,
         firstFocusableShelfIndex = firstFocusableShelfIndex,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
@@ -27,6 +27,17 @@ import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.foundation.lazy.itemsIndexed
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.siloserver.silo.tv.ui.focus.TvFocusAcquisitionBudgetMillis
+import org.siloserver.silo.tv.ui.focus.TvReturnRelocation
+import org.siloserver.silo.tv.ui.focus.TvReturnResolution
+import org.siloserver.silo.tv.ui.focus.TvReturnSection
+import org.siloserver.silo.tv.ui.focus.TvReturnTarget
+import org.siloserver.silo.tv.ui.focus.TvReturnTargetSaver
+import org.siloserver.silo.tv.ui.focus.resolveTvReturnTarget
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -47,6 +58,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
@@ -120,7 +133,7 @@ import java.util.Locale
  * Mirrors [org.siloserver.silo.tv.ui.screens.recommendations.TvRecommendationsScreen]
  * for the koinViewModel + initial-focus-once pattern.
  */
-@OptIn(ExperimentalTvMaterial3Api::class)
+@OptIn(ExperimentalTvMaterial3Api::class, kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @Composable
 fun TvCalendarScreen(
     onOpenItemDetail: (contentId: String) -> Unit,
@@ -148,13 +161,154 @@ fun TvCalendarScreen(
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
 
+    var shelfFocusDay by remember { mutableStateOf<String?>(null) }
+    var shelfFocusRequest by remember { mutableIntStateOf(0) }
+    var shelfFocusItemIndex by remember { mutableIntStateOf(0) }
+
+    // Where the viewer was when they opened something. The day is the section
+    // and the item's own contentId is its identity — NOT detailContentId, which
+    // several episodes of one show share and which would therefore send focus
+    // to whichever of them the week happens to list first.
+    var returnTarget by rememberSaveable(stateSaver = TvReturnTargetSaver) {
+        mutableStateOf<TvReturnTarget?>(null)
+    }
+    // Recorded by a CLICK and by nothing else, which is what makes a target
+    // mean "I opened something and I am coming back".
+    //
+    // The pending flag is saveable and is the actual return signal. Inferring
+    // it from "a target survived this composition" required Calendar to have
+    // been disposed and recreated, which a fast Back during the outgoing
+    // transition does not do — the target would then sit unconsumed and make
+    // some later, ordinary tab re-selection look like a return instead.
+    //
+    // The flat surfaces also record on focus, and that is right for them: they
+    // are pushed routes where Back is the only way in, so a saved target can
+    // only have come from a trip. Calendar is a root tab. Browsing a card,
+    // switching to Home, and selecting Calendar again would look identical to a
+    // detail return, and restoring there would quietly defeat the shell's
+    // documented reset to the controls. The cost is that process death while
+    // merely browsing forgets the position — which is the lesser of the two.
+    var returnPending by rememberSaveable { mutableStateOf(false) }
+    // Bumped when the destination resumes, whether or not it was recreated.
+    var resumeGeneration by remember { mutableIntStateOf(0) }
+    CalendarResumeSignal { resumeGeneration++ }
+    // What the restoration is waiting to see take focus, and what last did.
+    // Confirmation is by identity: having called requestFocus() is not evidence
+    // that anything received it.
+    var focusedItemId by remember { mutableStateOf<String?>(null) }
+
+    val recordReturnTarget: (String, CalendarItem, Int) -> Unit = { date, item, index ->
+        returnPending = true
+        returnTarget = TvReturnTarget(
+            sectionId = date,
+            itemId = item.contentId,
+            sectionIndex = state.weekDates.indexOf(date).coerceAtLeast(0),
+            itemIndex = index,
+        )
+    }
+
     // Explicit shell-to-screen handoff. The shell bumps this token whenever
     // Calendar is selected, including re-selection after a restored route.
     // Target the active segment directly instead of asking the parent content
     // group to guess a descendant (which falls back to Home while navigating).
-    LaunchedEffect(focusRequest, state.isLoading) {
+    // A return owns entry. The shell bumps its token on every Calendar
+    // selection, a Back out of item detail included, so without this the shell
+    // handoff would scroll to the top and claim the controls while the
+    // restoration was still working — two claimants, and the later one wins by
+    // accident rather than by decision.
+    // Keyed on state.days, not just the week's dates. A refresh keeps the same
+    // seven dates while replacing everything inside them, so weekDates alone
+    // could not tell a completed refresh from no change at all — and the effect
+    // would never re-resolve.
+    LaunchedEffect(resumeGeneration, state.isLoading, state.isRefreshing, state.days) {
+        // isRefreshing as well as isLoading. Resolving mid-refresh answers
+        // against cards the refresh is about to replace, and both
+        // FollowAcrossSections and treatAbsenceAsFinal are claims about a FINAL
+        // snapshot — applying them to a provisional one consumes the target on
+        // an answer that was never authoritative.
+        if (!returnPending || state.isLoading || state.isRefreshing) return@LaunchedEffect
+        val sections = state.weekDates.map { date ->
+            TvReturnSection(id = date, itemIds = state.itemsFor(date).map { it.contentId })
+        }
+        val located = resolveTvReturnTarget(
+            target = returnTarget,
+            sections = sections,
+            // A calendar item can legitimately change day when an air date is
+            // corrected. The viewer went to see that item, not that slot, so
+            // following it is what they meant.
+            relocation = TvReturnRelocation.FollowAcrossSections,
+            // The week is fixed and nothing pages, so absence is already final
+            // — there is no later arrival to wait for.
+            treatAbsenceAsFinal = true,
+        ) as? TvReturnResolution.Located
+        if (located == null) {
+            // A week that renders no cards has nothing to restore to, and the
+            // shell handoff is the right answer for it — waiting for a later
+            // load would hold entry open on a screen already showing the viewer
+            // its empty or error state.
+            returnTarget = null
+            returnPending = false
+            // Release the claim, exactly as the timeout path does. Waking the
+            // shell effect is no use if it then finds the token already
+            // applied and stands down again, which in the retained case leaves
+            // the screen with nothing focused.
+            lastAppliedFocusRequest = -1
+            return@LaunchedEffect
+        }
+        // Claim the shell handoff before driving, so the effect below treats it
+        // as already applied rather than racing this one.
+        lastAppliedFocusRequest = focusRequest
+        listState.scrollToItem(located.sectionIndex + CalendarShelfIndexOffset)
+        // Let the shelf compose and attach before the token names it.
+        androidx.compose.runtime.withFrameNanos { }
+        shelfFocusItemIndex = located.itemIndex
+        shelfFocusDay = located.sectionId
+        shelfFocusRequest += 1
+
+        // Wait to SEE the card take focus. requestFocus() can be dropped — an
+        // unattached requester, a shelf still composing, a focus transaction
+        // that rolls back — and every one of those returns without telling us.
+        val landed = withTimeoutOrNull(TvFocusAcquisitionBudgetMillis) {
+            // Settled on the target, not merely seen there. focusedItemId now
+            // tracks CURRENT focus, but a snapshot of it is still only a moment
+            // — focus traversal can pass through the target on its way
+            // somewhere else, and a bare first { } would call that a landing.
+            // Holding the value across a short window is what distinguishes
+            // arriving from passing by.
+            snapshotFlow { focusedItemId }
+                .transformLatest { id ->
+                    if (id == located.itemId) {
+                        delay(TvCalendarReturnSettleMillis)
+                        emit(Unit)
+                    }
+                }
+                .first()
+        } != null
+
+        returnTarget = null
+        returnPending = false
+        if (landed) {
+            // Only now. Reporting the handoff on having ASKED would leave the
+            // shell believing content owns focus while nothing does, and the
+            // top menu suppressed behind it.
+            onInitialContentFocus()
+        } else {
+            // Give entry back. Releasing the claim re-arms the shell effect,
+            // which returnPending has just re-keyed.
+            lastAppliedFocusRequest = -1
+        }
+    }
+
+    // returnPending is a key, not just a condition. Standing aside is only safe
+    // if standing down wakes this again: a return that resolves to nothing —
+    // the week failed to load, or came back empty — would otherwise leave the
+    // screen with no claimant at all, because this effect had already run and
+    // returned early. When the restoration does drive, it claims the token
+    // first, so the re-run stops at the line above instead.
+    LaunchedEffect(focusRequest, state.isLoading, returnPending) {
         if (focusRequest == lastAppliedFocusRequest) return@LaunchedEffect
         if (state.isLoading) return@LaunchedEffect
+        if (returnPending) return@LaunchedEffect
         val layoutInfo = listState.layoutInfo
         val itemExtent = (layoutInfo.visibleItemsInfo.firstOrNull()?.size ?: 0) +
             layoutInfo.mainAxisItemSpacing
@@ -195,8 +349,6 @@ fun TvCalendarScreen(
     val snapControlsToInitialPosition: () -> Unit = {
         scope.launch { listState.animateScrollToItem(0) }
     }
-    var shelfFocusDay by remember { mutableStateOf<String?>(null) }
-    var shelfFocusRequest by remember { mutableIntStateOf(0) }
     val tintState = rememberAmbientBackdropTintState()
     val initialTintItem = state.weekDates
         .asSequence()
@@ -240,6 +392,13 @@ fun TvCalendarScreen(
                         }
                         if (state.itemsFor(date).isNotEmpty()) {
                             shelfFocusDay = date
+                            // Explicitly zero. Relying on the consume callback
+                            // to have reset it makes this depend on the
+                            // previous request having run to completion — and a
+                            // shelf effect cancelled while its scroll suspends
+                            // never reaches that reset, leaving a day selection
+                            // to inherit the restoration's card index.
+                            shelfFocusItemIndex = 0
                             shelfFocusRequest += 1
                         }
                     },
@@ -271,11 +430,26 @@ fun TvCalendarScreen(
                 selectedDayFocusRequester = selectedDayFocusRequester,
                 shelfFocusDay = shelfFocusDay,
                 shelfFocusRequest = shelfFocusRequest,
+                shelfFocusItemIndex = shelfFocusItemIndex,
                 onShelfFocusConsumed = {
                     shelfFocusDay = null
                     shelfFocusRequest = 0
+                    shelfFocusItemIndex = 0
                 },
-                onItemFocused = { item -> tintState.set(null, item.posterUrl) },
+                onItemFocused = { _, item, _, focused ->
+                    if (focused) {
+                        tintState.set(null, item.posterUrl)
+                        focusedItemId = item.contentId
+                    } else if (focusedItemId == item.contentId) {
+                        // Only if this card is still the one on record. A gain
+                        // elsewhere lands before this loss arrives, and an
+                        // unconditional clear would wipe the new position.
+                        focusedItemId = null
+                    }
+                },
+                onItemClicked = { date, item, index ->
+                    recordReturnTarget(date, item, index)
+                },
                 onOpenItemDetail = onOpenItemDetail,
             )
         }
@@ -758,8 +932,10 @@ private fun CalendarList(
     selectedDayFocusRequester: FocusRequester,
     shelfFocusDay: String?,
     shelfFocusRequest: Int,
+    shelfFocusItemIndex: Int,
     onShelfFocusConsumed: () -> Unit,
-    onItemFocused: (CalendarItem) -> Unit,
+    onItemFocused: (date: String, item: CalendarItem, index: Int, focused: Boolean) -> Unit,
+    onItemClicked: (date: String, item: CalendarItem, index: Int) -> Unit,
     onOpenItemDetail: (contentId: String) -> Unit,
 ) {
     val snapScope = rememberCoroutineScope()
@@ -908,8 +1084,12 @@ private fun CalendarList(
                 isToday = date == state.today,
                 items = state.itemsFor(date),
                 focusRequest = if (date == shelfFocusDay) shelfFocusRequest else 0,
+                focusItemIndex = if (date == shelfFocusDay) shelfFocusItemIndex else 0,
                 onFocusApplied = onShelfFocusConsumed,
-                onItemFocused = onItemFocused,
+                onItemFocusChanged = { item, itemIndex, focused ->
+                    onItemFocused(date, item, itemIndex, focused)
+                },
+                onItemClicked = { item, itemIndex -> onItemClicked(date, item, itemIndex) },
                 // Snap the day whose shelf owns focus to the top of the list
                 // (QA 2026-07-08: default bring-into-view revealed only the
                 // focused CARD, stranding the previous day's caption strip
@@ -939,13 +1119,20 @@ private fun DayShelf(
     isToday: Boolean,
     items: List<CalendarItem>,
     focusRequest: Int,
+    /**
+     * Which card the token should land on. Zero for a week-strip day
+     * selection, which means "this day" and nothing finer; the card actually
+     * left behind when a return is being restored.
+     */
+    focusItemIndex: Int = 0,
     onFocusApplied: () -> Unit = {},
-    onItemFocused: (CalendarItem) -> Unit,
+    onItemFocusChanged: (item: CalendarItem, index: Int, focused: Boolean) -> Unit,
+    onItemClicked: (item: CalendarItem, index: Int) -> Unit = { _, _ -> },
     onShelfFocused: () -> Unit = {},
     onShelfFocusChanged: (Boolean) -> Unit = {},
     onOpenItemDetail: (contentId: String) -> Unit,
 ) {
-    val firstCardFocusRequester = remember { FocusRequester() }
+    val targetCardFocusRequester = remember { FocusRequester() }
     val rowState = rememberLazyListState()
 
     // A changing, non-zero focus token (from a week-strip day selection) kicks
@@ -956,10 +1143,11 @@ private fun DayShelf(
     // item 0 first so the first card is composed and its FocusRequester attached
     // — otherwise, after the shelf has been scrolled horizontally, the first
     // card may be off-screen and the request is dropped.
+    val targetCardIndex = focusItemIndex.coerceIn(0, (items.size - 1).coerceAtLeast(0))
     LaunchedEffect(focusRequest) {
         if (focusRequest > 0 && items.isNotEmpty()) {
-            rowState.scrollToItem(0)
-            runCatching { firstCardFocusRequester.requestFocus() }
+            rowState.scrollToItem(targetCardIndex)
+            runCatching { targetCardFocusRequester.requestFocus() }
             onFocusApplied()
         }
     }
@@ -998,14 +1186,22 @@ private fun DayShelf(
                 ),
                 horizontalArrangement = Arrangement.spacedBy(CalendarCardSpacing),
             ) {
-                items(items, key = { "$date-${it.contentId}" }) { item ->
+                itemsIndexed(items, key = { _, it -> "$date-${it.contentId}" }) { index, item ->
                     CalendarEventCard(
                         item = item,
-                        // First card holds the focus requester so a week-strip
-                        // day selection can hand focus down to this shelf.
-                        focusRequester = if (item == items.first()) firstCardFocusRequester else null,
-                        onFocused = { onItemFocused(item) },
-                        onClick = { onOpenItemDetail(item.detailContentId) },
+                        // The card the pending token names holds the requester,
+                        // so one mechanism serves both a week-strip day
+                        // selection and a restored return.
+                        focusRequester = targetCardFocusRequester.takeIf { index == targetCardIndex },
+                        onFocusChanged = { focused -> onItemFocusChanged(item, index, focused) },
+                        onClick = {
+                            onItemClicked(item, index)
+                            // detailContentId is where the card GOES; contentId
+                            // is what the card IS. Several episodes of one show
+                            // share a destination, so identity has to come from
+                            // the item, not from the route.
+                            onOpenItemDetail(item.detailContentId)
+                        },
                     )
                 }
             }
@@ -1073,14 +1269,17 @@ private val posterShape = RoundedCornerShape(10.dp)
 private fun CalendarEventCard(
     item: CalendarItem,
     focusRequester: FocusRequester?,
-    onFocused: () -> Unit,
+    onFocusChanged: (Boolean) -> Unit,
     onClick: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
 
+    // Both edges. Gain alone made the screen's record of "what has focus"
+    // sticky, so a card focus passed over on the way somewhere else still
+    // looked like the current position long after focus had moved on.
     LaunchedEffect(isFocused, item.contentId) {
-        if (isFocused) onFocused()
+        onFocusChanged(isFocused)
     }
 
     // tvOS FocusableCalendarCard: the poster alone is the focus-lifted
@@ -1342,3 +1541,30 @@ private fun emptyCopy(filter: String): String = when (filter) {
     CalendarFilter.Trending -> "No trending releases this week."
     else -> "No movie releases or episode airings in this week."
 }
+
+/** The filter/week control shell occupies list slot zero, ahead of every day. */
+private const val CalendarShelfIndexOffset: Int = 1
+
+/**
+ * Fires whenever this destination resumes — coming back from a detail route,
+ * and also from the app being foregrounded.
+ *
+ * The signal has to be the lifecycle rather than composition identity: a Back
+ * pressed during the outgoing transition can leave the destination composed,
+ * and then "was I recreated?" answers a question nobody asked.
+ */
+@Composable
+private fun CalendarResumeSignal(onResume: () -> Unit) {
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    val currentOnResume by rememberUpdatedState(onResume)
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) currentOnResume()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+}
+
+/** Focus must hold the target this long to count as arrived rather than passing. */
+private const val TvCalendarReturnSettleMillis: Long = 120L

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/collections/TvCollectionDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/collections/TvCollectionDetailScreen.kt
@@ -14,14 +14,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.ui.focus.FocusRequester
+import org.siloserver.silo.tv.ui.focus.rememberTvFlatReturnRestoration
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
-import org.siloserver.silo.tv.ui.focus.rememberTvContentInitialFocus
 import org.siloserver.silo.tv.ui.components.TvCatalogEmptyState
 import org.siloserver.silo.tv.ui.components.TvCatalogGrid
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
@@ -40,20 +41,36 @@ fun TvCollectionDetailScreen(
     ),
 ) {
     val state by viewModel.uiState.collectAsState()
+    val gridState = rememberLazyGridState()
 
     BackHandler(enabled = true) { onBack() }
 
-    val firstItemFocusRequester = remember { FocusRequester() }
-    // Same rejected-during-placement latch as the collections grid.
-    val contentInitialFocus = rememberTvContentInitialFocus(
-        target = firstItemFocusRequester,
-        contentKey = state.items.firstOrNull()?.contentId,
+    val restoreItemFocusRequester = remember { FocusRequester() }
+    // Returns land on the card the viewer opened, not the top of the
+    // collection. This also covers first entry, where no target is recorded and
+    // the resolution is the first item — the same place the plain initial focus
+    // put it.
+    //
+    // Not quite the same lifecycle, though: the old adapter re-armed whenever
+    // the first item's identity changed, whereas this runs once. Harmless here,
+    // because loading only appends pages so the first item does not move, but a
+    // surface that replaces its contents in place would need the difference
+    // thought about rather than assumed.
+    val restoration = rememberTvFlatReturnRestoration(
+        itemIds = state.items.map { it.contentId },
+        hasMore = state.hasMore,
+        isLoadingMore = state.isLoadingMore,
+        errorMessage = state.error,
+        surfaceKey = collectionId,
+        onLoadMore = viewModel::loadMore,
+        scrollToItem = { itemIndex -> gridState.scrollToItem(itemIndex) },
+        requestFocus = restoreItemFocusRequester::requestFocus,
+        onRestored = {},
     )
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .then(contentInitialFocus)
             .background(MaterialTheme.colorScheme.background),
     ) {
         Text(
@@ -75,9 +92,21 @@ fun TvCollectionDetailScreen(
                 items = state.items,
                 isLoading = state.isLoadingMore,
                 hasMore = state.hasMore,
-                onItemClick = onItemClick,
+                onItemClick = { contentId ->
+                    restoration.onItemClicked(
+                        itemId = contentId,
+                        index = state.items.indexOfFirst { it.contentId == contentId },
+                    )
+                    onItemClick(contentId)
+                },
                 onLoadMore = viewModel::loadMore,
-                firstItemFocusRequester = firstItemFocusRequester,
+                gridState = gridState,
+                restoreItemIndex = restoration.requesterItemIndex,
+                restoreItemFocusRequester = restoreItemFocusRequester,
+                onRestoreRequesterAttached = restoration::onRequesterAttached,
+                onItemFocusedAtIndex = { item, index ->
+                    restoration.onItemFocused(item.contentId, index)
+                },
                 emptyState = {
                     TvCatalogEmptyState(message = "This collection is empty.")
                 },

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/collections/TvCollectionDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/collections/TvCollectionDetailScreen.kt
@@ -104,8 +104,12 @@ fun TvCollectionDetailScreen(
                 restoreItemIndex = restoration.requesterItemIndex,
                 restoreItemFocusRequester = restoreItemFocusRequester,
                 onRestoreRequesterAttached = restoration::onRequesterAttached,
-                onItemFocusedAtIndex = { item, index ->
+                onItemFocusedAtIndex = { item, index, focused ->
+                    if (focused) {
                     restoration.onItemFocused(item.contentId, index)
+                } else {
+                    restoration.onItemFocusLost(item.contentId)
+                }
                 },
                 emptyState = {
                     TvCatalogEmptyState(message = "This collection is empty.")

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/collections/TvCollectionDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/collections/TvCollectionDetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
+import org.siloserver.silo.tv.ui.focus.rememberTvContentInitialFocus
 import org.siloserver.silo.tv.ui.components.TvCatalogEmptyState
 import org.siloserver.silo.tv.ui.components.TvCatalogGrid
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
@@ -43,16 +44,16 @@ fun TvCollectionDetailScreen(
     BackHandler(enabled = true) { onBack() }
 
     val firstItemFocusRequester = remember { FocusRequester() }
-    var initialFocusRequested by remember { mutableStateOf(false) }
-    LaunchedEffect(state.items.firstOrNull()?.contentId) {
-        if (initialFocusRequested || state.items.isEmpty()) return@LaunchedEffect
-        runCatching { firstItemFocusRequester.requestFocus() }
-        initialFocusRequested = true
-    }
+    // Same rejected-during-placement latch as the collections grid.
+    val contentInitialFocus = rememberTvContentInitialFocus(
+        target = firstItemFocusRequester,
+        contentKey = state.items.firstOrNull()?.contentId,
+    )
 
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .then(contentInitialFocus)
             .background(MaterialTheme.colorScheme.background),
     ) {
         Text(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/collections/TvCollectionsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/collections/TvCollectionsScreen.kt
@@ -43,6 +43,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import org.koin.compose.viewmodel.koinViewModel
 import org.siloserver.silo.model.personal.Collection
+import org.siloserver.silo.tv.ui.focus.rememberTvContentInitialFocus
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvLoadingScreen
 import org.siloserver.silo.tv.ui.theme.Spacing
@@ -62,13 +63,14 @@ fun TvCollectionsScreen(
     val firstCollectionFocusRequester = remember { FocusRequester() }
     val firstCollectionId = state.sections.firstNotNullOfOrNull { it.collections.firstOrNull()?.id }
 
-    var initialFocusRequested by remember { mutableStateOf(false) }
-    LaunchedEffect(firstCollectionId) {
-        if (initialFocusRequested || firstCollectionId == null) return@LaunchedEffect
-        runCatching { firstCollectionFocusRequester.requestFocus() }
-        onInitialContentFocus()
-        initialFocusRequested = true
-    }
+    // Latching "attempted" as "acquired" left the grid with no focus owner when
+    // the first request landed during lazy placement, and told the shell that
+    // content focus had succeeded anyway.
+    val contentInitialFocus = rememberTvContentInitialFocus(
+        target = firstCollectionFocusRequester,
+        contentKey = firstCollectionId,
+        onAcquired = onInitialContentFocus,
+    )
 
     val lifecycleOwner = LocalLifecycleOwner.current
     var skippedFirstResume by remember { mutableStateOf(false) }
@@ -85,6 +87,7 @@ fun TvCollectionsScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .then(contentInitialFocus)
             .background(MaterialTheme.colorScheme.background),
     ) {
         Header()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/collections/TvCreateCollectionDialog.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/collections/TvCreateCollectionDialog.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.tv.ui.screens.collections
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,12 +37,14 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.tv.material3.Button
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import org.siloserver.silo.tv.ui.components.TvHideStockImeOnDispose
 import org.siloserver.silo.tv.ui.components.TvFilterChip
 import org.siloserver.silo.tv.ui.components.tvOutlinedTextFieldColors
 
@@ -71,11 +74,18 @@ fun TvCreateCollectionDialog(
             keyboardController?.show()
         }
     }
+    TvHideStockImeOnDispose()
 
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        // imePadding below is inert without this: a Dialog gets its own window,
+        // which by default fits system windows itself and reports no IME inset.
+        properties = DialogProperties(decorFitsSystemWindows = false),
+    ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .imePadding()
                 .background(Color.Black.copy(alpha = 0.85f)),
             contentAlignment = Alignment.Center,
         ) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeScreen.kt
@@ -94,6 +94,7 @@ fun TvHomeScreen(
             )
         else -> TvHomeContent(
             sections = visibleSections,
+            sectionsFullyResolved = state.sectionsFullyResolved,
             onItemClick = onItemClick,
             onSeeAll = onSeeAll,
             onOpenForYou = onOpenForYou,
@@ -175,9 +176,11 @@ private fun TvHomeContent(
     onToggleWatchlist: (String, Boolean) -> Unit = { _, _ -> },
     onDismissContinueWatching: (String, String) -> Unit = { _, _ -> },
     onDismissNextUp: (String, String) -> Unit = { _, _ -> },
+    sectionsFullyResolved: Boolean = true,
 ) {
     TvSkylineSectionFeed(
         sections = sections,
+        sectionsComplete = sectionsFullyResolved,
         onItemClick = onItemClick,
         focusRequest = focusRequest,
         detailReturnFocusRequest = detailReturnFocusRequest,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
@@ -38,19 +38,8 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
-import org.siloserver.silo.tv.ui.focus.TvFocusAcquisitionBudgetMillis
-import org.siloserver.silo.tv.ui.focus.TvFlatSectionId
-import org.siloserver.silo.tv.ui.focus.TvFocusTargetState
-import org.siloserver.silo.tv.ui.focus.TvObservedFocusResult
-import org.siloserver.silo.tv.ui.focus.TvReturnResolution
-import org.siloserver.silo.tv.ui.focus.TvReturnTarget
-import org.siloserver.silo.tv.ui.focus.TvReturnTargetSaver
-import org.siloserver.silo.tv.ui.focus.flatTvReturnSections
-import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
-import org.siloserver.silo.tv.ui.focus.resolveTvReturnTarget
-import androidx.compose.runtime.snapshotFlow
+import org.siloserver.silo.tv.ui.focus.rememberTvFlatReturnRestoration
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -82,8 +71,6 @@ import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.SubtleSurface
 import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
 import org.siloserver.silo.tv.ui.theme.monoGroupHeader
-import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.flow.first
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -310,105 +297,6 @@ private enum class TvBrowsePanel { Sort, Filter }
 internal fun libraryLazyGridIndex(itemIndex: Int, headerCount: Int): Int =
     itemIndex.coerceAtLeast(0) + headerCount.coerceAtLeast(0)
 
-/**
- * How long to wait for a requested page to mark itself active.
- *
- * Short, because this only observes a flag the view model sets before its first
- * suspension. Sizing it like a network round trip made a missed pulse — the
- * load completing between two snapshot evaluations — cost seconds of frozen
- * focus for nothing.
- */
-private const val LibraryReturnPageActiveTimeoutMillis: Long = 300L
-
-/** How long to wait for an active page to settle. */
-private const val LibraryReturnPageSettleTimeoutMillis: Long = 2_000L
-
-/**
- * The whole budget for hunting a target through unloaded pages.
- *
- * A wall clock, paired with — not replaced by — [LibraryReturnPageRequests].
- * The two bound different things: this is what the viewer experiences, that is
- * how hard a struggling endpoint gets pushed. Counting attempts alone let one
- * slow fetch spend the entire allowance on a single page and gave no ceiling
- * at all on the hunt.
- */
-private const val LibraryReturnHuntBudgetMillis: Long = 6_000L
-
-/**
- * How many pages one restoration may ask for.
- *
- * A ceiling on requests, separate from the viewer-facing clock: the two bound
- * different things, and using the clock alone let a fast-failing endpoint be
- * asked over and over for its whole duration.
- */
-private const val LibraryReturnPageRequests: Int = 4
-
-private const val LibraryReturnFocusRetryMillis: Long = 60L
-
-private val LibraryReturnFocusAttempts: Int =
-    (TvFocusAcquisitionBudgetMillis / LibraryReturnFocusRetryMillis).toInt()
-
-/**
- * What a wait for a requested page actually observed.
- *
- * The distinction matters because the caller decides whether a page load
- * failed, and it can only do that honestly for a load it saw reach a terminal
- * state. [NeverActive] carries no information about any load at all — the flags
- * it would otherwise read describe the world before the request.
- */
-private enum class LibraryPageWait {
-    /**
-     * A load reached a terminal state, or the list changed. Not necessarily
-     * the load this caller requested — an already-active one can be what
-     * settles — which is fine, because the caller only reads this as "a
-     * result exists to judge".
-     */
-    Settled,
-
-    /** Nothing marked itself active in time — the request may still be queued. */
-    NeverActive,
-
-    /** Observed running, but it had not finished when the wait expired. */
-    StillActive,
-}
-
-/**
- * Wait for a requested page, reporting what was observed.
- *
- * `loadMoreBrowse` launches its work, and while that normally reaches the
- * loading flag synchronously on the main dispatcher, it is not guaranteed to.
- * Waiting only for "not loading" can therefore succeed instantly against the
- * state from before the request, and a caller in a loop fires every request it
- * has before the first fetch marks itself active — which the view model then
- * accepts, because it also still sees idle.
- *
- * So this waits for the request to become active first, and only then for it to
- * settle. Settling means the list changed OR loading cleared: a page can
- * legitimately arrive without changing the visible list (every item hidden on
- * TV, or duplicates the view model dedupes away), and a failed fetch leaves
- * `hasMore` set.
- *
- * Both phases time out, so this always returns promptly. A timeout is not proof
- * the page is dead — deciding that is the caller's job, and the outcome
- * returned here is what lets it avoid blaming a request it never actually saw
- * start.
- */
-private suspend fun awaitLibraryPageSettled(
-    loadedBefore: Int,
-    state: () -> TvLibraryDetailViewModel.UiState,
-): LibraryPageWait {
-    val became = withTimeoutOrNull(LibraryReturnPageActiveTimeoutMillis) {
-        snapshotFlow { state().browseItems.size to state().browseLoadingMore }
-            .first { (size, loadingMore) -> size != loadedBefore || loadingMore }
-    } ?: return LibraryPageWait.NeverActive
-    if (became.first != loadedBefore) return LibraryPageWait.Settled
-    val settled = withTimeoutOrNull(LibraryReturnPageSettleTimeoutMillis) {
-        snapshotFlow { state().browseItems.size to state().browseLoadingMore }
-            .first { (size, loadingMore) -> size != loadedBefore || !loadingMore }
-    }
-    return if (settled == null) LibraryPageWait.StillActive else LibraryPageWait.Settled
-}
-
 @Composable
 private fun LibraryTab(
     state: TvLibraryDetailViewModel.UiState,
@@ -429,21 +317,6 @@ private fun LibraryTab(
 ) {
     val restoredGridItemFocusRequester = remember { FocusRequester() }
     val gridState = rememberLazyGridState()
-    // The card this grid was on, by identity. A saved index survives a re-sort,
-    // a filter change and a page arriving above it while addressing entirely
-    // different content — which is what returning from a detail page used to
-    // land on.
-    var returnTarget by rememberSaveable(state.selectedTab, stateSaver = TvReturnTargetSaver) {
-        mutableStateOf<TvReturnTarget?>(null)
-    }
-    // The card focus is on right now, used to confirm a restoration actually
-    // landed rather than trusting that requestFocus held.
-    var focusedItemId by remember { mutableStateOf<String?>(null) }
-    // Guards the armed identity while a restoration is running: focus can land
-    // on another card first, and its callback would otherwise redefine what the
-    // viewer launched from and make that card an exact match.
-    var restorationInFlight by remember { mutableStateOf(false) }
-    var initialFocusRequested by remember { mutableStateOf(false) }
     var openPanel by remember { mutableStateOf<TvBrowsePanel?>(null) }
     val gridHeaderCount = listOf(
         showBrowseControls,
@@ -451,138 +324,23 @@ private fun LibraryTab(
         state.selectedAudiobookGroup != null && onClearAudiobookGroup != null,
     ).count { it }
 
-    // LibraryTab receives state as a plain value, so everything the hunt below
-    // reads has to come through here — a captured UiState would freeze the item
-    // list, the loading flags and every resolution, and snapshotFlow would
-    // observe no state reads at all.
-    val currentState by rememberUpdatedState(state)
-
-    fun resolveReturn(
-        snapshot: TvLibraryDetailViewModel.UiState,
-        final: Boolean,
-    ): TvReturnResolution = resolveTvReturnTarget(
-        target = returnTarget,
-        sections = flatTvReturnSections(
-            itemIds = snapshot.browseItems.map { it.contentId },
-            hasMore = snapshot.browseHasMore,
-        ),
-        treatAbsenceAsFinal = final,
+    val restoration = rememberTvFlatReturnRestoration(
+        itemIds = state.browseItems.map { it.contentId },
+        hasMore = state.browseHasMore,
+        isLoadingMore = state.browseLoadingMore,
+        errorMessage = state.browseError,
+        surfaceKey = state.selectedTab.name,
+        onLoadMore = onLoadMore,
+        // Headers occupy full-span slots ahead of the cards, so the grid's own
+        // index runs ahead of the item index by however many are showing.
+        scrollToItem = { itemIndex ->
+            gridState.scrollToItem(
+                libraryLazyGridIndex(itemIndex = itemIndex, headerCount = gridHeaderCount),
+            )
+        },
+        requestFocus = restoredGridItemFocusRequester::requestFocus,
+        onRestored = onInitialContentFocus,
     )
-
-    // Provisional placement for the requester, remembered rather than rescanned
-    // on every recomposition.
-    // Where the restoration decided to go, published once so composition and
-    // the focus watcher agree. Null until then, when a provisional position
-    // keeps a requester attached for ordinary first entry.
-    var focusTarget by remember { mutableStateOf<TvReturnResolution.Located?>(null) }
-    // Which item the restore requester is currently bound to, as reported by
-    // the card itself after composition applies.
-    var attachedRestoreItemId by remember { mutableStateOf<String?>(null) }
-    val provisionalItemIndex = remember(state.browseItems, state.browseHasMore, returnTarget) {
-        (resolveReturn(state, final = true) as? TvReturnResolution.Located)?.itemIndex ?: 0
-    }
-    val restoredItemIndex = focusTarget?.itemIndex ?: provisionalItemIndex
-
-    // One hunt, driven as a loop rather than by re-keying this effect.
-    //
-    // Re-keying cannot work here: Pending is a singleton, so a resolution that
-    // stays Pending is an unchanged key and the effect never re-runs. Every way
-    // a page can fail to move the list — a page of hidden or duplicate items, a
-    // failed fetch that leaves hasMore set, a request the view model rejects
-    // because one is already in flight — would then stall restoration forever
-    // with nothing ever setting initialFocusRequested.
-    LaunchedEffect(state.selectedTab, state.browseItems.isNotEmpty()) {
-        if (initialFocusRequested || currentState.browseItems.isEmpty()) return@LaunchedEffect
-        // Claimed before the settle delay, not after: default or restored focus
-        // can land during it, and its callback would redefine the launch card.
-        restorationInFlight = true
-        try {
-            kotlinx.coroutines.delay(120)
-
-            // Hunt the target through unloaded pages, bounded by one clock.
-            withTimeoutOrNull(LibraryReturnHuntBudgetMillis) {
-                var requests = 0
-                while (resolveReturn(currentState, final = false) is TvReturnResolution.Pending) {
-                    val loadedBefore = currentState.browseItems.size
-                    if (!currentState.browseLoadingMore) {
-                        // The ceiling stops NEW requests. It must not stop us
-                        // waiting for one already in flight, or a fourth page
-                        // still loading is abandoned with budget to spare.
-                        if (requests >= LibraryReturnPageRequests) break
-                        onLoadMore()
-                        requests++
-                    }
-                    // A slow page is not a dead one. The clock above decides
-                    // when to stop waiting; a settle timeout here only means
-                    // this iteration learned nothing, and abandoning on it
-                    // threw away seconds of remaining budget.
-                    val waited = awaitLibraryPageSettled(loadedBefore) { currentState }
-
-                    // Judge the OUTCOME, and only when a load actually reached
-                    // a terminal state. A load that grew the list made progress
-                    // whatever an older error still says; one that finished
-                    // with nothing to show and left an error behind is a real
-                    // failure — including when its message matches the previous
-                    // one, which comparing error values would miss.
-                    //
-                    // NeverActive is the case this guard exists for: the
-                    // request may simply still be queued, and the idle flag and
-                    // stale error then describe the world BEFORE it, not its
-                    // result.
-                    val grew = currentState.browseItems.size != loadedBefore
-                    val settledInFailure = waited == LibraryPageWait.Settled &&
-                        !grew &&
-                        !currentState.browseLoadingMore &&
-                        currentState.browseError != null
-                    if (settledInFailure) break
-                }
-            }
-
-            // Whatever was found — or the fallback, once the clock ran out.
-            val located = resolveReturn(currentState, final = true) as? TvReturnResolution.Located
-            // Published as one value so the requester's position and the
-            // identity being watched for cannot drift apart. They did: the
-            // provisional index tracked live data while the identity was
-            // frozen, so a page landing mid-attempt moved the requester onto
-            // the real card and left the watcher waiting for the fallback —
-            // focus arriving exactly where it should and being called a
-            // failure.
-            focusTarget = located
-            val targetItemId = located?.itemId
-                ?: currentState.browseItems.firstOrNull()?.contentId
-            val gridIndex = libraryLazyGridIndex(
-                itemIndex = located?.itemIndex ?: 0,
-                headerCount = gridHeaderCount,
-            )
-
-            gridState.scrollToItem(gridIndex)
-            // Readiness is part of the acquisition rather than a wait beside
-            // it. Waiting separately and then requesting anyway on timeout just
-            // delays the wrong-node request by a second; reporting NotReady
-            // makes the loop hold its request until the requester is genuinely
-            // bound to this card, and give up honestly if it never is.
-            val landed = requestFocusUntilObserved(
-                maxAttempts = LibraryReturnFocusAttempts,
-                awaitAttempt = { kotlinx.coroutines.delay(LibraryReturnFocusRetryMillis) },
-                requestFocus = restoredGridItemFocusRequester::requestFocus,
-                isFocused = { targetItemId != null && focusedItemId == targetItemId },
-                targetState = {
-                    if (targetItemId != null && attachedRestoreItemId == targetItemId) {
-                        TvFocusTargetState.Ready
-                    } else {
-                        TvFocusTargetState.NotReady
-                    }
-                },
-            )
-            // Latch either way — nothing re-keys this effect, so not latching
-            // means never trying again rather than trying later. But only tell
-            // the shell that content took focus when it actually did.
-            if (landed == TvObservedFocusResult.Focused) onInitialContentFocus()
-        } finally {
-            restorationInFlight = false
-        }
-        initialFocusRequested = true
-    }
 
     if (state.browseError != null && state.browseItems.isEmpty()) {
         TvErrorScreen(
@@ -604,44 +362,20 @@ private fun LibraryTab(
             LibraryGrid(
                 state = state,
                 onItemClick = { contentId ->
-                    // Arm the clicked card explicitly. A card that took focus
-                    // during a restoration deliberately did not re-arm the
-                    // target, and its focus callback will not fire again — so
-                    // opening it straight away would navigate with nothing
-                    // recorded, or worse, with the previous trip's card.
-                    val index = state.browseItems.indexOfFirst { it.contentId == contentId }
-                    returnTarget = TvReturnTarget(
-                        sectionId = TvFlatSectionId,
+                    restoration.onItemClicked(
                         itemId = contentId,
-                        sectionIndex = 0,
-                        // Only a fallback coordinate, so keep the last known
-                        // one rather than inventing the top of the grid if the
-                        // card somehow is not in the list we can see.
-                        itemIndex = index.takeIf { it >= 0 }
-                            ?: returnTarget?.itemIndex
-                            ?: 0,
+                        index = state.browseItems.indexOfFirst { it.contentId == contentId },
                     )
                     onItemClick(contentId)
                 },
                 onLoadMore = onLoadMore,
                 gridState = gridState,
                 restoredItemFocusRequester = restoredGridItemFocusRequester,
-                restoredItemIndex = restoredItemIndex,
-                onRestoreRequesterAttached = { attachedRestoreItemId = it },
+                restoredItemIndex = restoration.requesterItemIndex,
+                onRestoreRequesterAttached = restoration::onRequesterAttached,
                 onItemFocused = { index ->
                     state.browseItems.getOrNull(index)?.let { item ->
-                        focusedItemId = item.contentId
-                        // Browse movement re-arms; a restoration in progress
-                        // must not, or the card focus happens to touch on the
-                        // way becomes what the viewer "launched from".
-                        if (!restorationInFlight) {
-                            returnTarget = TvReturnTarget(
-                                sectionId = TvFlatSectionId,
-                                itemId = item.contentId,
-                                sectionIndex = 0,
-                                itemIndex = index,
-                            )
-                        }
+                        restoration.onItemFocused(item.contentId, index)
                     }
                 },
                 showGenreChips = showGenreChips,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
@@ -373,9 +373,13 @@ private fun LibraryTab(
                 restoredItemFocusRequester = restoredGridItemFocusRequester,
                 restoredItemIndex = restoration.requesterItemIndex,
                 onRestoreRequesterAttached = restoration::onRequesterAttached,
-                onItemFocused = { index ->
+                onItemFocused = { index, focused ->
                     state.browseItems.getOrNull(index)?.let { item ->
-                        restoration.onItemFocused(item.contentId, index)
+                        if (focused) {
+                            restoration.onItemFocused(item.contentId, index)
+                        } else {
+                            restoration.onItemFocusLost(item.contentId)
+                        }
                     }
                 },
                 showGenreChips = showGenreChips,
@@ -432,7 +436,11 @@ private fun LibraryGrid(
     restoredItemFocusRequester: FocusRequester,
     restoredItemIndex: Int?,
     onRestoreRequesterAttached: (String?) -> Unit,
-    onItemFocused: (Int) -> Unit,
+    /**
+     * Both edges. Gain alone makes the caller's record of what holds focus
+     * sticky, and the restoration reads that record as CURRENT focus.
+     */
+    onItemFocused: (index: Int, focused: Boolean) -> Unit,
     showGenreChips: Boolean,
     onGenreChanged: (String?) -> Unit,
     onClearAudiobookGroup: (() -> Unit)?,
@@ -583,7 +591,7 @@ private fun LibraryGrid(
                         focusRequester = restoredItemFocusRequester.takeIf { index == restoredItemIndex },
                         modifier = Modifier
                             .fillMaxWidth()
-                            .onFocusChanged { if (it.hasFocus) onItemFocused(index) },
+                            .onFocusChanged { onItemFocused(index, it.hasFocus) },
                         overlay = org.siloserver.silo.overlays.OverlayDataExtractor.fromBrowseItem(item),
                         actions = actions,
                     )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
@@ -31,13 +31,26 @@ import androidx.compose.material.icons.filled.VideoLibrary
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
+import org.siloserver.silo.tv.ui.focus.TvFocusAcquisitionBudgetMillis
+import org.siloserver.silo.tv.ui.focus.TvFlatSectionId
+import org.siloserver.silo.tv.ui.focus.TvFocusTargetState
+import org.siloserver.silo.tv.ui.focus.TvObservedFocusResult
+import org.siloserver.silo.tv.ui.focus.TvReturnResolution
+import org.siloserver.silo.tv.ui.focus.TvReturnTarget
+import org.siloserver.silo.tv.ui.focus.TvReturnTargetSaver
+import org.siloserver.silo.tv.ui.focus.flatTvReturnSections
+import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
+import org.siloserver.silo.tv.ui.focus.resolveTvReturnTarget
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -69,6 +82,8 @@ import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.SubtleSurface
 import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
 import org.siloserver.silo.tv.ui.theme.monoGroupHeader
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.flow.first
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -286,14 +301,113 @@ private fun RecommendedTab(
 /** Which browse overlay panel is open over the grid (tvOS `TVBrowsePanel`). */
 private enum class TvBrowsePanel { Sort, Filter }
 
-internal fun restoredLibraryFocusIndex(savedIndex: Int, itemCount: Int): Int? =
-    if (itemCount <= 0) null else savedIndex.coerceIn(0, itemCount - 1)
+/**
+ * The LazyGrid position of the [itemIndex]th card.
+ *
+ * Headers occupy full-span slots ahead of the cards, so the grid's own index
+ * runs ahead of the item index by however many are showing.
+ */
+internal fun libraryLazyGridIndex(itemIndex: Int, headerCount: Int): Int =
+    itemIndex.coerceAtLeast(0) + headerCount.coerceAtLeast(0)
 
-internal fun restoredLibraryLazyGridIndex(
-    savedIndex: Int,
-    itemCount: Int,
-    headerCount: Int,
-): Int? = restoredLibraryFocusIndex(savedIndex, itemCount)?.plus(headerCount.coerceAtLeast(0))
+/**
+ * How long to wait for a requested page to mark itself active.
+ *
+ * Short, because this only observes a flag the view model sets before its first
+ * suspension. Sizing it like a network round trip made a missed pulse — the
+ * load completing between two snapshot evaluations — cost seconds of frozen
+ * focus for nothing.
+ */
+private const val LibraryReturnPageActiveTimeoutMillis: Long = 300L
+
+/** How long to wait for an active page to settle. */
+private const val LibraryReturnPageSettleTimeoutMillis: Long = 2_000L
+
+/**
+ * The whole budget for hunting a target through unloaded pages.
+ *
+ * A wall clock, paired with — not replaced by — [LibraryReturnPageRequests].
+ * The two bound different things: this is what the viewer experiences, that is
+ * how hard a struggling endpoint gets pushed. Counting attempts alone let one
+ * slow fetch spend the entire allowance on a single page and gave no ceiling
+ * at all on the hunt.
+ */
+private const val LibraryReturnHuntBudgetMillis: Long = 6_000L
+
+/**
+ * How many pages one restoration may ask for.
+ *
+ * A ceiling on requests, separate from the viewer-facing clock: the two bound
+ * different things, and using the clock alone let a fast-failing endpoint be
+ * asked over and over for its whole duration.
+ */
+private const val LibraryReturnPageRequests: Int = 4
+
+private const val LibraryReturnFocusRetryMillis: Long = 60L
+
+private val LibraryReturnFocusAttempts: Int =
+    (TvFocusAcquisitionBudgetMillis / LibraryReturnFocusRetryMillis).toInt()
+
+/**
+ * What a wait for a requested page actually observed.
+ *
+ * The distinction matters because the caller decides whether a page load
+ * failed, and it can only do that honestly for a load it saw reach a terminal
+ * state. [NeverActive] carries no information about any load at all — the flags
+ * it would otherwise read describe the world before the request.
+ */
+private enum class LibraryPageWait {
+    /**
+     * A load reached a terminal state, or the list changed. Not necessarily
+     * the load this caller requested — an already-active one can be what
+     * settles — which is fine, because the caller only reads this as "a
+     * result exists to judge".
+     */
+    Settled,
+
+    /** Nothing marked itself active in time — the request may still be queued. */
+    NeverActive,
+
+    /** Observed running, but it had not finished when the wait expired. */
+    StillActive,
+}
+
+/**
+ * Wait for a requested page, reporting what was observed.
+ *
+ * `loadMoreBrowse` launches its work, and while that normally reaches the
+ * loading flag synchronously on the main dispatcher, it is not guaranteed to.
+ * Waiting only for "not loading" can therefore succeed instantly against the
+ * state from before the request, and a caller in a loop fires every request it
+ * has before the first fetch marks itself active — which the view model then
+ * accepts, because it also still sees idle.
+ *
+ * So this waits for the request to become active first, and only then for it to
+ * settle. Settling means the list changed OR loading cleared: a page can
+ * legitimately arrive without changing the visible list (every item hidden on
+ * TV, or duplicates the view model dedupes away), and a failed fetch leaves
+ * `hasMore` set.
+ *
+ * Both phases time out, so this always returns promptly. A timeout is not proof
+ * the page is dead — deciding that is the caller's job, and the outcome
+ * returned here is what lets it avoid blaming a request it never actually saw
+ * start.
+ */
+private suspend fun awaitLibraryPageSettled(
+    loadedBefore: Int,
+    state: () -> TvLibraryDetailViewModel.UiState,
+): LibraryPageWait {
+    val became = withTimeoutOrNull(LibraryReturnPageActiveTimeoutMillis) {
+        snapshotFlow { state().browseItems.size to state().browseLoadingMore }
+            .first { (size, loadingMore) -> size != loadedBefore || loadingMore }
+    } ?: return LibraryPageWait.NeverActive
+    if (became.first != loadedBefore) return LibraryPageWait.Settled
+    val settled = withTimeoutOrNull(LibraryReturnPageSettleTimeoutMillis) {
+        snapshotFlow { state().browseItems.size to state().browseLoadingMore }
+            .first { (size, loadingMore) -> size != loadedBefore || !loadingMore }
+    }
+    return if (settled == null) LibraryPageWait.StillActive else LibraryPageWait.Settled
+}
 
 @Composable
 private fun LibraryTab(
@@ -315,7 +429,20 @@ private fun LibraryTab(
 ) {
     val restoredGridItemFocusRequester = remember { FocusRequester() }
     val gridState = rememberLazyGridState()
-    var lastFocusedItemIndex by rememberSaveable(state.selectedTab) { mutableStateOf(0) }
+    // The card this grid was on, by identity. A saved index survives a re-sort,
+    // a filter change and a page arriving above it while addressing entirely
+    // different content — which is what returning from a detail page used to
+    // land on.
+    var returnTarget by rememberSaveable(state.selectedTab, stateSaver = TvReturnTargetSaver) {
+        mutableStateOf<TvReturnTarget?>(null)
+    }
+    // The card focus is on right now, used to confirm a restoration actually
+    // landed rather than trusting that requestFocus held.
+    var focusedItemId by remember { mutableStateOf<String?>(null) }
+    // Guards the armed identity while a restoration is running: focus can land
+    // on another card first, and its callback would otherwise redefine what the
+    // viewer launched from and make that card an exact match.
+    var restorationInFlight by remember { mutableStateOf(false) }
     var initialFocusRequested by remember { mutableStateOf(false) }
     var openPanel by remember { mutableStateOf<TvBrowsePanel?>(null) }
     val gridHeaderCount = listOf(
@@ -324,18 +451,136 @@ private fun LibraryTab(
         state.selectedAudiobookGroup != null && onClearAudiobookGroup != null,
     ).count { it }
 
-    LaunchedEffect(state.selectedTab, state.browseItems.isNotEmpty(), gridHeaderCount) {
-        if (initialFocusRequested || state.browseItems.isEmpty()) return@LaunchedEffect
-        kotlinx.coroutines.delay(120)
-        val restoreIndex = restoredLibraryFocusIndex(lastFocusedItemIndex, state.browseItems.size) ?: 0
-        val lazyGridIndex = restoredLibraryLazyGridIndex(
-            savedIndex = restoreIndex,
-            itemCount = state.browseItems.size,
-            headerCount = gridHeaderCount,
-        ) ?: 0
-        gridState.scrollToItem(lazyGridIndex)
-        runCatching { restoredGridItemFocusRequester.requestFocus() }
-        onInitialContentFocus()
+    // LibraryTab receives state as a plain value, so everything the hunt below
+    // reads has to come through here — a captured UiState would freeze the item
+    // list, the loading flags and every resolution, and snapshotFlow would
+    // observe no state reads at all.
+    val currentState by rememberUpdatedState(state)
+
+    fun resolveReturn(
+        snapshot: TvLibraryDetailViewModel.UiState,
+        final: Boolean,
+    ): TvReturnResolution = resolveTvReturnTarget(
+        target = returnTarget,
+        sections = flatTvReturnSections(
+            itemIds = snapshot.browseItems.map { it.contentId },
+            hasMore = snapshot.browseHasMore,
+        ),
+        treatAbsenceAsFinal = final,
+    )
+
+    // Provisional placement for the requester, remembered rather than rescanned
+    // on every recomposition.
+    // Where the restoration decided to go, published once so composition and
+    // the focus watcher agree. Null until then, when a provisional position
+    // keeps a requester attached for ordinary first entry.
+    var focusTarget by remember { mutableStateOf<TvReturnResolution.Located?>(null) }
+    // Which item the restore requester is currently bound to, as reported by
+    // the card itself after composition applies.
+    var attachedRestoreItemId by remember { mutableStateOf<String?>(null) }
+    val provisionalItemIndex = remember(state.browseItems, state.browseHasMore, returnTarget) {
+        (resolveReturn(state, final = true) as? TvReturnResolution.Located)?.itemIndex ?: 0
+    }
+    val restoredItemIndex = focusTarget?.itemIndex ?: provisionalItemIndex
+
+    // One hunt, driven as a loop rather than by re-keying this effect.
+    //
+    // Re-keying cannot work here: Pending is a singleton, so a resolution that
+    // stays Pending is an unchanged key and the effect never re-runs. Every way
+    // a page can fail to move the list — a page of hidden or duplicate items, a
+    // failed fetch that leaves hasMore set, a request the view model rejects
+    // because one is already in flight — would then stall restoration forever
+    // with nothing ever setting initialFocusRequested.
+    LaunchedEffect(state.selectedTab, state.browseItems.isNotEmpty()) {
+        if (initialFocusRequested || currentState.browseItems.isEmpty()) return@LaunchedEffect
+        // Claimed before the settle delay, not after: default or restored focus
+        // can land during it, and its callback would redefine the launch card.
+        restorationInFlight = true
+        try {
+            kotlinx.coroutines.delay(120)
+
+            // Hunt the target through unloaded pages, bounded by one clock.
+            withTimeoutOrNull(LibraryReturnHuntBudgetMillis) {
+                var requests = 0
+                while (resolveReturn(currentState, final = false) is TvReturnResolution.Pending) {
+                    val loadedBefore = currentState.browseItems.size
+                    if (!currentState.browseLoadingMore) {
+                        // The ceiling stops NEW requests. It must not stop us
+                        // waiting for one already in flight, or a fourth page
+                        // still loading is abandoned with budget to spare.
+                        if (requests >= LibraryReturnPageRequests) break
+                        onLoadMore()
+                        requests++
+                    }
+                    // A slow page is not a dead one. The clock above decides
+                    // when to stop waiting; a settle timeout here only means
+                    // this iteration learned nothing, and abandoning on it
+                    // threw away seconds of remaining budget.
+                    val waited = awaitLibraryPageSettled(loadedBefore) { currentState }
+
+                    // Judge the OUTCOME, and only when a load actually reached
+                    // a terminal state. A load that grew the list made progress
+                    // whatever an older error still says; one that finished
+                    // with nothing to show and left an error behind is a real
+                    // failure — including when its message matches the previous
+                    // one, which comparing error values would miss.
+                    //
+                    // NeverActive is the case this guard exists for: the
+                    // request may simply still be queued, and the idle flag and
+                    // stale error then describe the world BEFORE it, not its
+                    // result.
+                    val grew = currentState.browseItems.size != loadedBefore
+                    val settledInFailure = waited == LibraryPageWait.Settled &&
+                        !grew &&
+                        !currentState.browseLoadingMore &&
+                        currentState.browseError != null
+                    if (settledInFailure) break
+                }
+            }
+
+            // Whatever was found — or the fallback, once the clock ran out.
+            val located = resolveReturn(currentState, final = true) as? TvReturnResolution.Located
+            // Published as one value so the requester's position and the
+            // identity being watched for cannot drift apart. They did: the
+            // provisional index tracked live data while the identity was
+            // frozen, so a page landing mid-attempt moved the requester onto
+            // the real card and left the watcher waiting for the fallback —
+            // focus arriving exactly where it should and being called a
+            // failure.
+            focusTarget = located
+            val targetItemId = located?.itemId
+                ?: currentState.browseItems.firstOrNull()?.contentId
+            val gridIndex = libraryLazyGridIndex(
+                itemIndex = located?.itemIndex ?: 0,
+                headerCount = gridHeaderCount,
+            )
+
+            gridState.scrollToItem(gridIndex)
+            // Readiness is part of the acquisition rather than a wait beside
+            // it. Waiting separately and then requesting anyway on timeout just
+            // delays the wrong-node request by a second; reporting NotReady
+            // makes the loop hold its request until the requester is genuinely
+            // bound to this card, and give up honestly if it never is.
+            val landed = requestFocusUntilObserved(
+                maxAttempts = LibraryReturnFocusAttempts,
+                awaitAttempt = { kotlinx.coroutines.delay(LibraryReturnFocusRetryMillis) },
+                requestFocus = restoredGridItemFocusRequester::requestFocus,
+                isFocused = { targetItemId != null && focusedItemId == targetItemId },
+                targetState = {
+                    if (targetItemId != null && attachedRestoreItemId == targetItemId) {
+                        TvFocusTargetState.Ready
+                    } else {
+                        TvFocusTargetState.NotReady
+                    }
+                },
+            )
+            // Latch either way — nothing re-keys this effect, so not latching
+            // means never trying again rather than trying later. But only tell
+            // the shell that content took focus when it actually did.
+            if (landed == TvObservedFocusResult.Focused) onInitialContentFocus()
+        } finally {
+            restorationInFlight = false
+        }
         initialFocusRequested = true
     }
 
@@ -358,12 +603,47 @@ private fun LibraryTab(
         Box(modifier = Modifier.weight(1f)) {
             LibraryGrid(
                 state = state,
-                onItemClick = onItemClick,
+                onItemClick = { contentId ->
+                    // Arm the clicked card explicitly. A card that took focus
+                    // during a restoration deliberately did not re-arm the
+                    // target, and its focus callback will not fire again — so
+                    // opening it straight away would navigate with nothing
+                    // recorded, or worse, with the previous trip's card.
+                    val index = state.browseItems.indexOfFirst { it.contentId == contentId }
+                    returnTarget = TvReturnTarget(
+                        sectionId = TvFlatSectionId,
+                        itemId = contentId,
+                        sectionIndex = 0,
+                        // Only a fallback coordinate, so keep the last known
+                        // one rather than inventing the top of the grid if the
+                        // card somehow is not in the list we can see.
+                        itemIndex = index.takeIf { it >= 0 }
+                            ?: returnTarget?.itemIndex
+                            ?: 0,
+                    )
+                    onItemClick(contentId)
+                },
                 onLoadMore = onLoadMore,
                 gridState = gridState,
                 restoredItemFocusRequester = restoredGridItemFocusRequester,
-                restoredItemIndex = restoredLibraryFocusIndex(lastFocusedItemIndex, state.browseItems.size),
-                onItemFocused = { lastFocusedItemIndex = it },
+                restoredItemIndex = restoredItemIndex,
+                onRestoreRequesterAttached = { attachedRestoreItemId = it },
+                onItemFocused = { index ->
+                    state.browseItems.getOrNull(index)?.let { item ->
+                        focusedItemId = item.contentId
+                        // Browse movement re-arms; a restoration in progress
+                        // must not, or the card focus happens to touch on the
+                        // way becomes what the viewer "launched from".
+                        if (!restorationInFlight) {
+                            returnTarget = TvReturnTarget(
+                                sectionId = TvFlatSectionId,
+                                itemId = item.contentId,
+                                sectionIndex = 0,
+                                itemIndex = index,
+                            )
+                        }
+                    }
+                },
                 showGenreChips = showGenreChips,
                 onGenreChanged = onGenreChanged,
                 onClearAudiobookGroup = onClearAudiobookGroup,
@@ -417,6 +697,7 @@ private fun LibraryGrid(
     gridState: LazyGridState,
     restoredItemFocusRequester: FocusRequester,
     restoredItemIndex: Int?,
+    onRestoreRequesterAttached: (String?) -> Unit,
     onItemFocused: (Int) -> Unit,
     showGenreChips: Boolean,
     onGenreChanged: (String?) -> Unit,
@@ -543,6 +824,18 @@ private fun LibraryGrid(
                     contentType = { _, item -> item.type },
                 ) { index, item ->
                     val (actions, userState) = org.siloserver.silo.tv.ui.components.rememberTvBrowseItemCardActions(item)
+                    if (index == restoredItemIndex) {
+                        // Report which identity the restore requester is
+                        // actually bound to, once composition has applied.
+                        // "The slot is visible" does not prove that: a card can
+                        // be laid out while the modifier still carries the
+                        // previous binding, so a restoration gated on layout
+                        // alone can request focus at the wrong card.
+                        DisposableEffect(item.contentId) {
+                            onRestoreRequesterAttached(item.contentId)
+                            onDispose { onRestoreRequesterAttached(null) }
+                        }
+                    }
                     TvMediaCard(
                         title = item.title,
                         posterUrl = item.posterUrl,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
@@ -449,6 +449,7 @@ private fun LibraryGrid(
     onOpenFilterPanel: () -> Unit = {},
     onClearFilters: () -> Unit = {},
 ) {
+    var attachedRestoreItemId by remember { mutableStateOf<String?>(null) }
     val nearEnd by remember(
         gridState,
         state.browseHasMore,
@@ -574,8 +575,20 @@ private fun LibraryGrid(
                         // previous binding, so a restoration gated on layout
                         // alone can request focus at the wrong card.
                         DisposableEffect(item.contentId) {
+                            attachedRestoreItemId = item.contentId
                             onRestoreRequesterAttached(item.contentId)
-                            onDispose { onRestoreRequesterAttached(null) }
+                            onDispose {
+                                // Only when this card is still the owner. When
+                                // the requester moves, the new card attaches
+                                // before the old one disposes, so an
+                                // unconditional clear wipes the live attachment
+                                // and the restoration is reported NotReady
+                                // against a requester that is in fact bound.
+                                if (attachedRestoreItemId == item.contentId) {
+                                    attachedRestoreItemId = null
+                                    onRestoreRequesterAttached(null)
+                                }
+                            }
                         }
                     }
                     TvMediaCard(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -38,6 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
+import org.siloserver.silo.tv.ui.focus.rememberTvFlatReturnRestoration
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
@@ -133,7 +135,8 @@ private fun TvPersonDetailContent(
     onRetryItems: () -> Unit,
     onOpenItemDetail: (contentId: String) -> Unit,
 ) {
-    val firstFilterFocusRequester = remember { FocusRequester() }
+    val selectedFilterFocusRequester = remember { FocusRequester() }
+    var lastRefocusedFilter by remember { mutableStateOf(state.selectedFilter) }
     val bioFocusRequester = remember { FocusRequester() }
     val gridState = rememberLazyGridState()
     val scope = rememberCoroutineScope()
@@ -153,75 +156,136 @@ private fun TvPersonDetailContent(
         Unit
     }
 
+    val restoreItemFocusRequester = remember { FocusRequester() }
+    // Returns land on the poster the viewer opened. Entry does not: this page
+    // opens on the filter row so the identity header stays visible, so on a
+    // fresh arrival the restoration stands down and the effect below is
+    // untouched.
+    val restoration = rememberTvFlatReturnRestoration(
+        itemIds = state.items.map { it.contentId },
+        hasMore = state.hasMore,
+        isLoadingMore = state.isLoadingItems,
+        errorMessage = state.pagingError,
+        surfaceKey = "person-${person.id}-${state.selectedFilter.name}",
+        onLoadMore = onLoadMore,
+        // The header is one full-span slot ahead of the posters, so the grid's
+        // own index runs one past the item index.
+        scrollToItem = { itemIndex -> gridState.scrollToItem(itemIndex + PersonGridHeaderSlots) },
+        requestFocus = restoreItemFocusRequester::requestFocus,
+        onRestored = {},
+        focusFirstItemWithoutTarget = false,
+    )
+
     // Enter on the filter row so the full identity header remains visible.
     // Moving down into the posters then scrolls the whole header away naturally.
+    // A return owns entry instead, so this stands aside for one.
     LaunchedEffect(state.availableFilters.isNotEmpty()) {
         if (initialFocusRequested || state.availableFilters.isEmpty()) return@LaunchedEffect
+        if (restoration.isReturning) return@LaunchedEffect
         kotlinx.coroutines.delay(120)
-        runCatching { firstFilterFocusRequester.requestFocus() }
+        runCatching { selectedFilterFocusRequester.requestFocus() }
         initialFocusRequested = true
     }
 
-    TvCatalogGrid(
-        items = state.items,
-        isLoading = state.isLoadingItems,
-        hasMore = state.hasMore,
-        onItemClick = onOpenItemDetail,
-        onLoadMore = onLoadMore,
-        modifier = Modifier.fillMaxSize(),
-        gridState = gridState,
-        fixedColumnCount = PersonGridColumns,
-        // tvOS `TVPersonDetailContent`: 48pt page top, 72pt bottom, 40pt grid
-        // column spacing, 48pt header → filmography gap (all halved to dp).
-        contentPadding = PaddingValues(
-            start = Spacing.safeArea,
-            top = 24.dp,
-            end = Spacing.safeArea,
-            bottom = 36.dp,
-        ),
-        horizontalSpacing = PersonGridItemSpacing,
-        verticalSpacing = Spacing.sectionSpacing,
-        artworkAspectRatioForItem = ::personWorkCardAspectRatio,
-        header = {
-            Column(verticalArrangement = Arrangement.spacedBy(24.dp)) {
-                PersonHeader(person = person, bioFocusRequester = bioFocusRequester)
-                FilmographyHeader(
-                    selected = state.selectedFilter,
-                    availableFilters = state.availableFilters,
-                    totalLoaded = state.items.size,
-                    totalItems = state.totalItems,
-                    hasMore = state.hasMore,
-                    firstFilterFocusRequester = firstFilterFocusRequester,
-                    onMoveUp = if (hasBio) focusBio else restoreHeaderTop,
-                    onSelect = onFilterSelected,
+    // key() below disposes the whole grid on a filter change, filter row and
+    // all — including the chip the viewer just pressed. Nothing else would put
+    // focus back on it.
+    //
+    // Every change refocuses, whether a press caused it or an async gate fell
+    // back to All on its own. Distinguishing the two was the earlier design and
+    // it was wrong: it existed to avoid yanking focus off a poster the viewer
+    // was reading, but the key change has already destroyed that poster by the
+    // time this runs. There is no focus left to preserve — only focus to lose.
+    //
+    // The first composition is not a change. Seeding from the current value is
+    // what makes that true even on a return, where entry belongs to the
+    // restoration rather than to the chips.
+    LaunchedEffect(state.selectedFilter) {
+        if (state.selectedFilter == lastRefocusedFilter) return@LaunchedEffect
+        lastRefocusedFilter = state.selectedFilter
+        runCatching { selectedFilterFocusRequester.requestFocus() }
+    }
+
+    // The surface key includes the filter, and the helper requires item
+    // content to be recreated when it changes. applyFilter usually empties
+    // the list first, which disposes the cards anyway — but not on every
+    // path: an asynchronous filter gate can fall back to All without
+    // clearing. Keying it here makes the precondition hold by construction
+    // rather than by timing.
+    key(state.selectedFilter) {
+        TvCatalogGrid(
+            items = state.items,
+            isLoading = state.isLoadingItems,
+            hasMore = state.hasMore,
+            onItemClick = { contentId ->
+                restoration.onItemClicked(
+                    itemId = contentId,
+                    index = state.items.indexOfFirst { it.contentId == contentId },
                 )
-                state.pagingError?.let { error ->
-                    Text(
-                        text = error,
-                        style = MaterialTheme.typography.bodyMedium.copy(
-                            fontSize = 14.sp,
-                            lineHeight = 17.sp,
-                        ),
-                        color = Color.White.copy(alpha = 0.62f),
+                onOpenItemDetail(contentId)
+            },
+            onLoadMore = onLoadMore,
+            restoreItemIndex = restoration.requesterItemIndex,
+            restoreItemFocusRequester = restoreItemFocusRequester,
+            onRestoreRequesterAttached = restoration::onRequesterAttached,
+            onItemFocusedAtIndex = { item, index ->
+                restoration.onItemFocused(item.contentId, index)
+            },
+            modifier = Modifier.fillMaxSize(),
+            gridState = gridState,
+            fixedColumnCount = PersonGridColumns,
+            // tvOS `TVPersonDetailContent`: 48pt page top, 72pt bottom, 40pt grid
+            // column spacing, 48pt header → filmography gap (all halved to dp).
+            contentPadding = PaddingValues(
+                start = Spacing.safeArea,
+                top = 24.dp,
+                end = Spacing.safeArea,
+                bottom = 36.dp,
+            ),
+            horizontalSpacing = PersonGridItemSpacing,
+            verticalSpacing = Spacing.sectionSpacing,
+            artworkAspectRatioForItem = ::personWorkCardAspectRatio,
+            header = {
+                Column(verticalArrangement = Arrangement.spacedBy(24.dp)) {
+                    PersonHeader(person = person, bioFocusRequester = bioFocusRequester)
+                    FilmographyHeader(
+                        selected = state.selectedFilter,
+                        availableFilters = state.availableFilters,
+                        totalLoaded = state.items.size,
+                        totalItems = state.totalItems,
+                        hasMore = state.hasMore,
+                        selectedFilterFocusRequester = selectedFilterFocusRequester,
+                        onMoveUp = if (hasBio) focusBio else restoreHeaderTop,
+                        onSelect = onFilterSelected,
                     )
-                    // A failed page-0 load leaves the grid with nothing
-                    // focusable below the chips. Keep retry in the scrolling
-                    // header instead of dead-ending on the empty state.
-                    if (state.items.isEmpty()) {
-                        Button(
-                            onClick = onRetryItems,
-                            contentPadding = PaddingValues(horizontal = 32.dp, vertical = 12.dp),
-                        ) {
-                            Text("Retry", style = MaterialTheme.typography.labelLarge)
+                    state.pagingError?.let { error ->
+                        Text(
+                            text = error,
+                            style = MaterialTheme.typography.bodyMedium.copy(
+                                fontSize = 14.sp,
+                                lineHeight = 17.sp,
+                            ),
+                            color = Color.White.copy(alpha = 0.62f),
+                        )
+                        // A failed page-0 load leaves the grid with nothing
+                        // focusable below the chips. Keep retry in the scrolling
+                        // header instead of dead-ending on the empty state.
+                        if (state.items.isEmpty()) {
+                            Button(
+                                onClick = onRetryItems,
+                                contentPadding = PaddingValues(horizontal = 32.dp, vertical = 12.dp),
+                            ) {
+                                Text("Retry", style = MaterialTheme.typography.labelLarge)
+                            }
                         }
                     }
                 }
-            }
-        },
-        emptyState = {
-            TvCatalogEmptyState(message = "No titles found.")
-        },
-    )
+            },
+            emptyState = {
+                TvCatalogEmptyState(message = "No titles found.")
+            },
+        )
+    }
 }
 
 // ============================================================================
@@ -497,7 +561,11 @@ private fun FilmographyHeader(
     totalLoaded: Int,
     totalItems: Int,
     hasMore: Boolean,
-    firstFilterFocusRequester: FocusRequester,
+    /**
+     * Attaches to the SELECTED chip — the entry point on a fresh arrival, and
+     * the chip to restore after a filter change recreates this row.
+     */
+    selectedFilterFocusRequester: FocusRequester,
     onMoveUp: () -> Unit,
     onSelect: (TvPersonMediaFilter) -> Unit,
 ) {
@@ -557,8 +625,14 @@ private fun FilmographyHeader(
                     label = filter.title,
                     selected = filter == selected,
                     onClick = { onSelect(filter) },
-                    modifier = if (index == 0) {
-                        Modifier.focusRequester(firstFilterFocusRequester)
+                    // Falls back to the first chip when the selection is not
+                    // among the available filters, so the requester is never
+                    // left unattached.
+                    modifier = if (
+                        filter == selected ||
+                        (index == 0 && selected !in availableFilters)
+                    ) {
+                        Modifier.focusRequester(selectedFilterFocusRequester)
                     } else {
                         Modifier
                     },
@@ -690,3 +764,6 @@ private fun personWorkCardAspectRatio(item: BrowseItem): Float? =
     } else {
         null
     }
+
+/** The person header is a single full-span slot ahead of the poster grid. */
+private const val PersonGridHeaderSlots: Int = 1

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailScreen.kt
@@ -228,8 +228,12 @@ private fun TvPersonDetailContent(
             restoreItemIndex = restoration.requesterItemIndex,
             restoreItemFocusRequester = restoreItemFocusRequester,
             onRestoreRequesterAttached = restoration::onRequesterAttached,
-            onItemFocusedAtIndex = { item, index ->
-                restoration.onItemFocused(item.contentId, index)
+            onItemFocusedAtIndex = { item, index, focused ->
+                if (focused) {
+                    restoration.onItemFocused(item.contentId, index)
+                } else {
+                    restoration.onItemFocusLost(item.contentId)
+                }
             },
             modifier = Modifier.fillMaxSize(),
             gridState = gridState,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
@@ -24,7 +24,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.ui.focus.FocusRequester
+import org.siloserver.silo.tv.ui.focus.rememberTvFlatReturnRestoration
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.ExperimentalTvMaterial3Api
@@ -68,6 +70,7 @@ fun TvFavoritesScreen(
     PersonalListResumeRefresh(viewModel)
     PersonalGrid(
         title = "Favorites",
+        surfaceKey = "personal-favorites",
         icon = Icons.Filled.Favorite,
         emptyMessage = "No favorites yet",
         state = state,
@@ -89,6 +92,7 @@ fun TvWatchlistScreen(
     PersonalListResumeRefresh(viewModel)
     PersonalGrid(
         title = "Watchlist",
+        surfaceKey = "personal-watchlist",
         icon = Icons.Outlined.BookmarkBorder,
         emptyMessage = "Your watchlist is empty",
         state = state,
@@ -150,6 +154,7 @@ fun TvHistoryScreen(
     PersonalListResumeRefresh(viewModel)
     PersonalGrid(
         title = "Watch History",
+        surfaceKey = "personal-history",
         icon = Icons.Filled.History,
         emptyMessage = "No watch history yet",
         state = state,
@@ -195,6 +200,7 @@ private fun PersonalGrid(
     title: String,
     icon: ImageVector,
     emptyMessage: String,
+    surfaceKey: String,
     state: PersonalListUiState,
     onItemClick: (contentId: String) -> Unit,
     onLoadMore: () -> Unit,
@@ -202,14 +208,37 @@ private fun PersonalGrid(
     onInitialContentFocus: () -> Unit,
 ) {
     val startPadding = tvPageStartPadding()
+    val gridState = rememberLazyGridState()
     val firstItemFocusRequester = remember { FocusRequester() }
+    val restoreItemFocusRequester = remember { FocusRequester() }
     val firstItemId = state.items.firstOrNull()?.contentId
+
+    val restoration = rememberTvFlatReturnRestoration(
+        itemIds = state.items.map { it.contentId },
+        hasMore = state.hasMore,
+        isLoadingMore = state.isLoadingMore,
+        // These lists refresh on every resume — exactly when a viewer comes
+        // back from a detail page — and a refresh REPLACES the items with page
+        // one rather than appending. Folding it into isLoadingMore was not
+        // enough: a stale multi-page list still contains the target, so it
+        // resolves before that flag is ever consulted.
+        isReplacingContent = state.isRefreshing,
+        errorMessage = state.error,
+        surfaceKey = surfaceKey,
+        onLoadMore = onLoadMore,
+        scrollToItem = { itemIndex -> gridState.scrollToItem(itemIndex) },
+        requestFocus = restoreItemFocusRequester::requestFocus,
+        onRestored = onInitialContentFocus,
+    )
 
     // One-shot guard so pagination, retries, or any other ViewModel re-emission
     // doesn't yank focus back to the first card after the user has scrolled.
     var initialFocusRequested by remember { mutableStateOf(false) }
     LaunchedEffect(firstItemId) {
         if (initialFocusRequested || firstItemId == null) return@LaunchedEffect
+        // A pending return owns entry; the restoration reports the handoff
+        // itself once it has actually landed.
+        if (restoration.isReturning) return@LaunchedEffect
         runCatching { firstItemFocusRequester.requestFocus() }
         onInitialContentFocus()
         initialFocusRequested = true
@@ -266,16 +295,34 @@ private fun PersonalGrid(
             )
             else -> TvCatalogGrid(
                 items = state.items,
-                isLoading = state.isLoadingMore,
+                // A restored deep scroll position sits at the paging threshold,
+                // so the grid would ask for the next page the moment it lands.
+                // During a refresh that page is fetched at an offset the
+                // refresh is about to invalidate — it either gets discarded or
+                // lands after page one and leaves a hole.
+                isLoading = state.isLoadingMore || state.isRefreshing,
                 hasMore = state.hasMore,
-                onItemClick = onItemClick,
+                onItemClick = { contentId ->
+                    restoration.onItemClicked(
+                        itemId = contentId,
+                        index = state.items.indexOfFirst { it.contentId == contentId },
+                    )
+                    onItemClick(contentId)
+                },
                 onLoadMore = onLoadMore,
                 contentPadding = tvPageContentPadding(top = Spacing.lg),
                 // Match every other catalog grid (browse/person/collections):
                 // the adaptive default rendered ~5 oversized columns here
                 // (QA 2026-07-08).
                 fixedColumnCount = 6,
+                gridState = gridState,
                 firstItemFocusRequester = firstItemFocusRequester,
+                restoreItemIndex = restoration.requesterItemIndex,
+                restoreItemFocusRequester = restoreItemFocusRequester,
+                onRestoreRequesterAttached = restoration::onRequesterAttached,
+                onItemFocusedAtIndex = { item, index ->
+                    restoration.onItemFocused(item.contentId, index)
+                },
             )
         }
     }
@@ -308,7 +355,12 @@ private fun PersonalInlineGrid(
             )
             else -> TvCatalogGrid(
                 items = state.items,
-                isLoading = state.isLoadingMore,
+                // A restored deep scroll position sits at the paging threshold,
+                // so the grid would ask for the next page the moment it lands.
+                // During a refresh that page is fetched at an offset the
+                // refresh is about to invalidate — it either gets discarded or
+                // lands after page one and leaves a hole.
+                isLoading = state.isLoadingMore || state.isRefreshing,
                 hasMore = state.hasMore,
                 onItemClick = onItemClick,
                 onLoadMore = onLoadMore,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
@@ -209,9 +209,7 @@ private fun PersonalGrid(
 ) {
     val startPadding = tvPageStartPadding()
     val gridState = rememberLazyGridState()
-    val firstItemFocusRequester = remember { FocusRequester() }
     val restoreItemFocusRequester = remember { FocusRequester() }
-    val firstItemId = state.items.firstOrNull()?.contentId
 
     val restoration = rememberTvFlatReturnRestoration(
         itemIds = state.items.map { it.contentId },
@@ -231,18 +229,11 @@ private fun PersonalGrid(
         onRestored = onInitialContentFocus,
     )
 
-    // One-shot guard so pagination, retries, or any other ViewModel re-emission
-    // doesn't yank focus back to the first card after the user has scrolled.
-    var initialFocusRequested by remember { mutableStateOf(false) }
-    LaunchedEffect(firstItemId) {
-        if (initialFocusRequested || firstItemId == null) return@LaunchedEffect
-        // A pending return owns entry; the restoration reports the handoff
-        // itself once it has actually landed.
-        if (restoration.isReturning) return@LaunchedEffect
-        runCatching { firstItemFocusRequester.requestFocus() }
-        onInitialContentFocus()
-        initialFocusRequested = true
-    }
+    // No separate first-entry path. On a fresh arrival the restoration already
+    // targets index zero, so the grid gives that slot to the restore requester
+    // and this one was never attached — it requested focus on nothing and then
+    // told the shell content had taken focus. One claimant, reporting only
+    // once focus is confirmed.
 
     Column(
         modifier = Modifier
@@ -316,7 +307,6 @@ private fun PersonalGrid(
                 // (QA 2026-07-08).
                 fixedColumnCount = 6,
                 gridState = gridState,
-                firstItemFocusRequester = firstItemFocusRequester,
                 restoreItemIndex = restoration.requesterItemIndex,
                 restoreItemFocusRequester = restoreItemFocusRequester,
                 onRestoreRequesterAttached = restoration::onRequesterAttached,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
@@ -310,8 +310,12 @@ private fun PersonalGrid(
                 restoreItemIndex = restoration.requesterItemIndex,
                 restoreItemFocusRequester = restoreItemFocusRequester,
                 onRestoreRequesterAttached = restoration::onRequesterAttached,
-                onItemFocusedAtIndex = { item, index ->
-                    restoration.onItemFocused(item.contentId, index)
+                onItemFocusedAtIndex = { item, index, focused ->
+                    if (focused) {
+                        restoration.onItemFocused(item.contentId, index)
+                    } else {
+                        restoration.onItemFocusLost(item.contentId)
+                    }
                 },
             )
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvAiTranslateDialog.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvAiTranslateDialog.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -35,8 +34,8 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
-import kotlinx.coroutines.delay
 import org.siloserver.silo.model.playback.PlayerSubtitleInfo
+import org.siloserver.silo.tv.ui.components.rememberTvDialogInitialFocus
 import org.siloserver.silo.tv.ui.theme.DarkBackground
 
 /** Which capture mode the dialog is in — availability comes from AiStatus. */
@@ -92,14 +91,42 @@ fun TvAiTranslateDialog(
     // when the Failed/Idle form (or the Running Cancel row) comes back —
     // otherwise the dialog is dead to the d-pad. Submitting itself has nothing
     // to focus, so it is skipped.
-    var overlayHasFocus by remember { mutableStateOf(false) }
-    LaunchedEffect(aiState.phase) {
-        if (aiState.phase is AiJobPhase.Submitting) return@LaunchedEffect
-        while (!overlayHasFocus) {
-            runCatching { firstRowFocus.requestFocus() }
-            delay(60)
-        }
+    //
+    // Bounded, via the shared adapter. The loop this replaces was `while
+    // (!overlayHasFocus)` with no exit: on the empty state, where nothing at all
+    // was focusable, it re-requested a target that was not in the tree every
+    // 60 ms for as long as the dialog stayed open. Bounding it alone would not
+    // have saved that state — with no focus target in the tree the traversal
+    // fallback has nothing to find either. The Close row below is what makes
+    // the empty state recoverable; the bound is what stops the spinning.
+    //
+    // Keyed on the shape of the focus graph, not on the phase value. Two
+    // separate reasons:
+    //   - Running carries a progress percentage that changes several times a
+    //     second, so keying on the phase itself would restart acquisition
+    //     throughout the job.
+    //   - Phase alone is not enough. Track availability is derived from the
+    //     player's session tracks and can change under an open dialog, which
+    //     swaps the empty state for the picker form (or back) without the phase
+    //     moving at all. That removes the focused row and composes new ones, so
+    //     it has to re-key or the dialog goes dead in place.
+    // Row *enablement* deliberately does not appear here: a quota-exhausted
+    // submit row stays focusable and only refuses to act, so it never strands
+    // focus.
+    val bodyKey = when {
+        aiState.phase is AiJobPhase.Running -> "running"
+        aiState.phase == AiJobPhase.Submitting -> "submitting"
+        !subtitlesAvailable && !audioAvailable -> "form-empty"
+        // Both modes available adds the Mode row, which is where firstRowFocus
+        // attaches; with one mode it moves to the source row instead.
+        subtitlesAvailable && audioAvailable -> "form-both-modes"
+        else -> "form-single-mode"
     }
+    val initialFocusModifier = rememberTvDialogInitialFocus(
+        target = firstRowFocus,
+        reacquireKey = bodyKey,
+        enabled = aiState.phase !is AiJobPhase.Submitting,
+    )
     LaunchedEffect(aiState.completedNonce) {
         if (aiState.completedNonce != initialNonce) onDismiss()
     }
@@ -127,7 +154,7 @@ fun TvAiTranslateDialog(
                     .background(color = DarkBackground.copy(alpha = 0.68f), shape = panelShape)
                     .border(0.6.dp, Color.White.copy(alpha = 0.20f), panelShape)
                     .padding(horizontal = 14.dp, vertical = 14.dp)
-                    .onFocusChanged { overlayHasFocus = it.hasFocus },
+                    .then(initialFocusModifier),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 Text(
@@ -169,6 +196,16 @@ fun TvAiTranslateDialog(
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = Color.White.copy(alpha = 0.66f),
                                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+                            )
+                            // The empty state used to render explanatory text and
+                            // nothing else: no focusable, so `firstRowFocus` was
+                            // attached to nothing and the dialog opened with the
+                            // d-pad dead and no visible way out. Back dismissed it,
+                            // but nothing on screen said so.
+                            TvDialogActionRow(
+                                title = "Close",
+                                onClick = onDismiss,
+                                modifier = Modifier.focusRequester(firstRowFocus),
                             )
                         } else {
                             if (subtitlesAvailable && audioAvailable) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionScreen.kt
@@ -100,9 +100,9 @@ private val AddProfilePlusSize = 44.dp
 private val AddProfilePlusStrokeWidth = 2.dp
 private val ProfileUtilityChromeTop = 40.dp
 private val ProfileUtilityChromeEnd = 64.dp
-private val ProfileUtilityChangeServerWidth = 164.dp
-private val ProfileUtilityManageWidth = 104.dp
-private val ProfileUtilitySignOutWidth = 100.dp
+// The utility pills size to their own labels. Fixed widths clipped them:
+// "Sign Out" rendered as "Sign" at 100dp, and the label a control shows is the
+// one thing about it that cannot be allowed to be wrong.
 private val ProfileUtilityChipHeight = 28.dp
 private val ProfileHeaderTop = 92.dp
 private val ProfileGridWidth = 772.dp
@@ -164,7 +164,6 @@ fun TvProfileSelectionScreen(
                         label = if (state.isManageMode) "Done" else "Manage",
                         icon = Icons.Filled.Edit,
                         variant = TvPillVariant.Hollow,
-                        modifier = Modifier.width(ProfileUtilityManageWidth),
                         heightOverride = ProfileUtilityChipHeight,
                         horizontalPaddingOverride = 10.dp,
                         labelStyle = MaterialTheme.typography.labelMedium,
@@ -174,7 +173,6 @@ fun TvProfileSelectionScreen(
                         label = "Change Server",
                         icon = Icons.Filled.Dns,
                         variant = TvPillVariant.Hollow,
-                        modifier = Modifier.width(ProfileUtilityChangeServerWidth),
                         heightOverride = ProfileUtilityChipHeight,
                         horizontalPaddingOverride = 10.dp,
                         labelStyle = MaterialTheme.typography.labelMedium,
@@ -184,7 +182,6 @@ fun TvProfileSelectionScreen(
                         label = "Sign Out",
                         icon = Icons.Filled.Logout,
                         variant = TvPillVariant.Hollow,
-                        modifier = Modifier.width(ProfileUtilitySignOutWidth),
                         heightOverride = ProfileUtilityChipHeight,
                         horizontalPaddingOverride = 10.dp,
                         labelStyle = MaterialTheme.typography.labelMedium,
@@ -197,21 +194,14 @@ fun TvProfileSelectionScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .align(Alignment.TopCenter)
-                        // The journey row adds 40dp above the legacy title band;
-                        // offset that addition so the title/grid keep their
-                        // established vertical footprint and utility chips stay
-                        // isolated in the top chrome.
+                        // No journey row here any more, so the title band sits
+                        // at its own top inset rather than offsetting one.
                         .padding(
-                            top = ProfileHeaderTop - 40.dp,
+                            top = ProfileHeaderTop,
                             start = Spacing.safeArea,
                             end = Spacing.safeArea,
                         ),
                 ) {
-                    AuroraJourneyProgress(
-                        currentStep = 3,
-                        modifier = Modifier.width(230.dp),
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
                     Text(
                         text = "Who's watching?",
                         style = MaterialTheme.typography.displayLarge,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionScreen.kt
@@ -69,6 +69,15 @@ import org.siloserver.silo.common.ui.components.profileAvatarDisplayText
 import org.siloserver.silo.common.ui.components.rememberProfileServerUrl
 import org.siloserver.silo.common.ui.components.resolveAvatarUrl
 import org.siloserver.silo.model.profile.Profile
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import org.siloserver.silo.tv.ui.focus.TvObservedFocusResult
+import org.siloserver.silo.tv.ui.focus.TvFocusTargetState
+import org.siloserver.silo.tv.ui.focus.tvProfileFocusTarget
+import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
+import org.siloserver.silo.tv.ui.focus.TvFrameRelocationMaxAttempts
 import org.siloserver.silo.tv.ui.components.TvAuroraBackdrop
 import org.siloserver.silo.tv.ui.components.AuroraJourneyProgress
 import org.siloserver.silo.tv.ui.components.TvAuroraVariant
@@ -217,15 +226,60 @@ fun TvProfileSelectionScreen(
 
                     Spacer(modifier = Modifier.height(32.dp))
 
-                    val firstCardFocus = remember { FocusRequester() }
-                    LaunchedEffect(state.profiles) {
-                        if (state.profiles.isNotEmpty()) {
-                            runCatching { firstCardFocus.requestFocus() }
-                        }
+                    // The screen reloads on every resume, so re-anchoring on
+                    // the first tile overrode the viewer's position on every
+                    // return. Keep a requester per profile ID and move focus
+                    // only where tvProfileFocusTarget says it belongs.
+                    val tileFocusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+                    var focusedProfileId by remember { mutableStateOf<String?>(null) }
+                    var previousProfileIds by remember { mutableStateOf(emptyList<String>()) }
+                    var hasAnchored by remember { mutableStateOf(false) }
+                    val profileIds = state.profiles.map { it.id }
+
+                    LaunchedEffect(profileIds) {
+                        val target = tvProfileFocusTarget(
+                            previousIds = previousProfileIds,
+                            currentIds = profileIds,
+                            focusedId = focusedProfileId,
+                            hasMaterialized = hasAnchored,
+                        )
+                        previousProfileIds = profileIds
+                        // Requesters are keyed by ID, so a deleted profile's
+                        // would otherwise be retained for the screen's lifetime.
+                        tileFocusRequesters.keys.retainAll(profileIds.toSet())
+                        if (target == null) return@LaunchedEffect
+                        // Placement can trail the data by a frame or two.
+                        val result = requestFocusUntilObserved(
+                            maxAttempts = TvFrameRelocationMaxAttempts,
+                            awaitAttempt = { withFrameNanos { } },
+                            requestFocus = {
+                                tileFocusRequesters[target]?.requestFocus() ?: false
+                            },
+                            isFocused = { focusedProfileId == target },
+                            targetState = {
+                                // The viewer moved to another tile themselves
+                                // while we were retrying. Stop chasing rather
+                                // than fight them for the rest of the budget.
+                                val focused = focusedProfileId
+                                if (focused != null && focused != target) {
+                                    TvFocusTargetState.Disposed
+                                } else {
+                                    TvFocusTargetState.Ready
+                                }
+                            },
+                        )
+                        // Only a landed anchor counts. Setting this up front
+                        // meant a second list arriving mid-retry cancelled the
+                        // first pass and left the replacement believing the
+                        // screen was already anchored, so it never anchored.
+                        if (result == TvObservedFocusResult.Focused) hasAnchored = true
                     }
                     ProfileTileGrid(
                         profiles = state.profiles,
-                        firstCardFocus = firstCardFocus,
+                        focusRequesterFor = { id ->
+                            tileFocusRequesters.getOrPut(id) { FocusRequester() }
+                        },
+                        onProfileFocused = { focusedProfileId = it },
                         isManageMode = state.isManageMode,
                         onProfileSelected = viewModel::onProfileSelected,
                         onEditProfile = { onEditProfile(it.id) },
@@ -285,7 +339,10 @@ fun TvProfileSelectionScreen(
 @Composable
 private fun ProfileTileGrid(
     profiles: List<Profile>,
-    firstCardFocus: FocusRequester,
+    focusRequesterFor: (String) -> FocusRequester,
+    // Null means no profile tile owns focus — the Add tile has it, or focus
+    // left the grid entirely. Restoration must not re-request a tile then.
+    onProfileFocused: (String?) -> Unit,
     isManageMode: Boolean,
     onProfileSelected: (Profile) -> Unit,
     onEditProfile: (Profile) -> Unit,
@@ -295,7 +352,9 @@ private fun ProfileTileGrid(
     val itemCount = profiles.size + 1
     val rowCount = (itemCount + ProfileGridColumns - 1) / ProfileGridColumns
     Column(
-        modifier = Modifier.width(ProfileGridWidth),
+        modifier = Modifier
+            .width(ProfileGridWidth)
+            .onFocusChanged { if (!it.hasFocus) onProfileFocused(null) },
         verticalArrangement = Arrangement.spacedBy(56.dp),
     ) {
         repeat(rowCount) { rowIndex ->
@@ -326,14 +385,19 @@ private fun ProfileTileGrid(
                                         }
                                     },
                                     onDelete = { onDeleteProfile(profile) },
-                                    modifier = if (itemIndex == 0) {
-                                        Modifier.focusRequester(firstCardFocus)
-                                    } else {
-                                        Modifier
-                                    },
+                                    modifier = Modifier
+                                        .focusRequester(focusRequesterFor(profile.id))
+                                        .onFocusChanged {
+                                            if (it.isFocused) onProfileFocused(profile.id)
+                                        },
                                 )
                             }
-                            itemIndex == profiles.size -> TvAddProfileCard(onClick = onAddProfile)
+                            itemIndex == profiles.size -> TvAddProfileCard(
+                                onClick = onAddProfile,
+                                modifier = Modifier.onFocusChanged {
+                                    if (it.isFocused) onProfileFocused(null)
+                                },
+                            )
                         }
                     }
                 }
@@ -491,14 +555,14 @@ private fun TvProfileCard(
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun TvAddProfileCard(onClick: () -> Unit) {
+private fun TvAddProfileCard(onClick: () -> Unit, modifier: Modifier = Modifier) {
     val shape = RoundedCornerShape(ProfileTileCornerRadius)
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
     val surfaceAlpha = if (isFocused) 0.14f else 0.06f
     val strokeAlpha = if (isFocused) 0.70f else 0.28f
     val plusAlpha = if (isFocused) 1.0f else 0.60f
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         Surface(
             onClick = onClick,
             interactionSource = interactionSource,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvMyRequestsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvMyRequestsScreen.kt
@@ -27,7 +27,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import org.siloserver.silo.tv.ui.focus.rememberTvFlatReturnRestoration
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.ExperimentalTvMaterial3Api
@@ -53,16 +57,43 @@ fun TvMyRequestsScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     val visibleRequests = state.requests.filterTvMediaRequests()
-    val firstItemFocusRequester = remember { FocusRequester() }
-    val firstRequestId = visibleRequests.firstOrNull()?.id
-    var initialFocusRequested by remember { mutableStateOf(false) }
+    val restoreItemFocusRequester = remember { FocusRequester() }
+    var attachedRequesterId by remember { mutableStateOf<String?>(null) }
+    val listState = rememberLazyListState()
 
-    LaunchedEffect(firstRequestId) {
-        if (initialFocusRequested || firstRequestId == null) return@LaunchedEffect
-        runCatching { firstItemFocusRequester.requestFocus() }
-        onInitialContentFocus()
-        initialFocusRequested = true
-    }
+    // Rows are identified by the REQUEST, not by what they open. A row with a
+    // library item opens that item while every other row opens the request
+    // detail, so two rows can share a navigation target; keying restoration on
+    // it would send focus to whichever came first. request.id is the row.
+    //
+    // Projected from the FILTERED list, because that is what is rendered — the
+    // view model's unfiltered list would put every index in a different
+    // coordinate space from the rows these indices address.
+    //
+    // Nothing here paginates, so hasMore is false and the page hunt never runs;
+    // the restoration is purely resolve, scroll, confirm.
+    val restoration = rememberTvFlatReturnRestoration(
+        itemIds = visibleRequests.map { it.id },
+        hasMore = false,
+        isLoadingMore = false,
+        // Refresh here is a button rather than a resume hook, so it cannot
+        // collide with entry the way the personal lists' does — but it still
+        // REPLACES the list, and a viewer who presses it and opens a row
+        // before it lands would otherwise restore against the outgoing one.
+        isReplacingContent = state.isRefreshing,
+        errorMessage = state.error,
+        surfaceKey = "my-requests",
+        onLoadMore = {},
+        scrollToItem = { itemIndex -> listState.scrollToItem(itemIndex + requestsHeaderSlots(state.error)) },
+        requestFocus = restoreItemFocusRequester::requestFocus,
+        onRestored = onInitialContentFocus,
+    )
+
+    // No separate first-entry path. On a fresh arrival the restoration already
+    // targets row zero, so a second requester would race it — and worse, the
+    // one that ran first was UNATTACHED whenever restoration owned row zero,
+    // meaning it reported a content handoff it had not actually made. One
+    // claimant, and it only reports once focus is confirmed.
 
     Column(
         modifier = Modifier
@@ -81,6 +112,7 @@ fun TvMyRequestsScreen(
             )
             visibleRequests.isEmpty() -> EmptyMyRequests()
             else -> LazyColumn(
+                state = listState,
                 modifier = Modifier
                     .fillMaxSize()
                     .focusGroup(),
@@ -101,9 +133,27 @@ fun TvMyRequestsScreen(
                     }
                 }
                 itemsIndexed(visibleRequests, key = { _, request -> request.id }) { index, request ->
+                    if (index == restoration.requesterItemIndex) {
+                        DisposableEffect(request.id) {
+                            attachedRequesterId = request.id
+                            restoration.onRequesterAttached(request.id)
+                            onDispose {
+                                // Only if this row is still the owner. When the
+                                // requester moves, the new row can attach
+                                // before the old one disposes, and an
+                                // unconditional clear would erase the live
+                                // attachment and lose the restore.
+                                if (attachedRequesterId == request.id) {
+                                    attachedRequesterId = null
+                                    restoration.onRequesterAttached(null)
+                                }
+                            }
+                        }
+                    }
                     TvRequestListCard(
                         request = request,
                         onClick = {
+                            restoration.onItemClicked(itemId = request.id, index = index)
                             // In-library items open library detail; everything else
                             // opens the request detail (phone parity — rows are always
                             // actionable, not only when a library item exists).
@@ -111,7 +161,14 @@ fun TvMyRequestsScreen(
                             if (contentId != null) onOpenLibraryItem(contentId)
                             else onOpenRequestDetail(request.mediaType, request.tmdbId)
                         },
-                        focusRequester = firstItemFocusRequester.takeIf { index == 0 },
+                        focusRequester = restoreItemFocusRequester
+                            .takeIf { index == restoration.requesterItemIndex },
+                        // hasFocus, not isFocused: the card's own Surface owns
+                        // focus below this modifier, so isFocused never fires
+                        // here and the restoration could never confirm.
+                        modifier = Modifier.onFocusChanged {
+                            if (it.hasFocus) restoration.onItemFocused(request.id, index)
+                        },
                         trailing = {
                             if (request.canCancel()) {
                                 TvRequestActionPill(
@@ -195,3 +252,6 @@ private fun EmptyMyRequests() {
         }
     }
 }
+
+/** The error banner, when shown, is one list slot ahead of the request rows. */
+private fun requestsHeaderSlots(error: String?): Int = if (error != null) 1 else 0

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvMyRequestsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvMyRequestsScreen.kt
@@ -167,7 +167,11 @@ fun TvMyRequestsScreen(
                         // focus below this modifier, so isFocused never fires
                         // here and the restoration could never confirm.
                         modifier = Modifier.onFocusChanged {
-                            if (it.hasFocus) restoration.onItemFocused(request.id, index)
+                            if (it.hasFocus) {
+                                restoration.onItemFocused(request.id, index)
+                            } else {
+                                restoration.onItemFocusLost(request.id)
+                            }
                         },
                         trailing = {
                             if (request.canCancel()) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchReturnProjection.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchReturnProjection.kt
@@ -1,0 +1,77 @@
+package org.siloserver.silo.tv.ui.screens.search
+
+import org.siloserver.silo.model.catalog.BrowseItem
+import org.siloserver.silo.model.request.RequestMediaResult
+import org.siloserver.silo.model.request.RequestMediaType
+import org.siloserver.silo.tv.ui.focus.TvReturnSection
+
+/**
+ * Search is the one surface where two different kinds of thing sit on the same
+ * screen, so the return target has to say WHICH.
+ *
+ * The catalog grid holds library items keyed by content id; the footer row
+ * holds requestable titles keyed by (mediaType, tmdbId). Those id spaces are
+ * unrelated, and a requestable title that is already in the library carries
+ * BOTH — it opens the library item while still being a request card. Left
+ * un-namespaced, a return could resolve a content id against the request row,
+ * or match the library twin of the request card the viewer actually opened and
+ * put focus in the wrong section entirely.
+ */
+internal const val TvSearchCatalogSectionId: String = "search-catalog"
+
+internal const val TvSearchRequestSectionId: String = "search-requests"
+
+/** Namespaced so a content id can never collide with a request id. */
+internal fun tvSearchCatalogItemId(contentId: String): String = "catalog:$contentId"
+
+/**
+ * Namespaced on the request's OWN identity, not on the library item it may
+ * open. Two request cards can point at the same library item; the card is what
+ * the viewer left.
+ *
+ * The media type is canonicalised first. The rendering pipeline already
+ * accepts case and whitespace variants, and treats "audiobooks" as
+ * "audiobook" — so the same result can arrive spelled differently across two
+ * responses. Encoding it raw would give one card two identities and quietly
+ * lose the return whenever the spelling changed under it.
+ */
+internal fun tvSearchRequestItemId(mediaType: String, tmdbId: Int): String =
+    "request:${canonicalTvRequestMediaType(mediaType)}:$tmdbId"
+
+private fun canonicalTvRequestMediaType(mediaType: String): String =
+    when (val normalized = mediaType.trim().lowercase()) {
+        "audiobooks" -> RequestMediaType.Audiobook
+        else -> normalized
+    }
+
+/**
+ * Sections in rendered order: the grid, then the footer row beneath it.
+ *
+ * [catalogComplete] is false while more pages can still arrive, which is what
+ * lets a target deeper than the loaded results wait rather than settle for a
+ * near miss.
+ *
+ * [requestsComplete] is not the same thing and cannot be assumed from "this
+ * row does not paginate". Request search CLEARS its results when a query
+ * starts and installs the response later, so there is a window where the row
+ * is empty and not yet answered. Resolving then would read absence as final
+ * and consume the target on a card that was about to come back. Modelled here
+ * rather than left to the driver, so it cannot be forgotten at the call site.
+ */
+internal fun tvSearchReturnSections(
+    catalogItems: List<BrowseItem>,
+    requestResults: List<RequestMediaResult>,
+    catalogComplete: Boolean,
+    requestsComplete: Boolean,
+): List<TvReturnSection> = listOf(
+    TvReturnSection(
+        id = TvSearchCatalogSectionId,
+        itemIds = catalogItems.map { tvSearchCatalogItemId(it.contentId) },
+        isComplete = catalogComplete,
+    ),
+    TvReturnSection(
+        id = TvSearchRequestSectionId,
+        itemIds = requestResults.map { tvSearchRequestItemId(it.mediaType, it.tmdbId) },
+        isComplete = requestsComplete,
+    ),
+)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
@@ -125,6 +125,11 @@ fun TvSearchScreen(
         mutableStateOf<TvReturnTarget?>(null)
     }
     var returnPending by rememberSaveable { mutableStateOf(false) }
+    // One refresh per return, and a hard ceiling on how many times a return may
+    // stand down waiting for content. Both exist because this effect is keyed
+    // on state its own body changes.
+    var returnRefreshed by rememberSaveable { mutableStateOf(false) }
+    var returnStandDowns by remember { mutableIntStateOf(0) }
     var resumeGeneration by remember { mutableIntStateOf(0) }
     TvSearchResumeSignal { resumeGeneration++ }
     var focusedReturnItemId by remember { mutableStateOf<String?>(null) }
@@ -136,6 +141,8 @@ fun TvSearchScreen(
 
     val recordReturn: (String, String, Int, Int) -> Unit = { sectionId, itemId, sectionIndex, itemIndex ->
         returnPending = true
+        returnRefreshed = false
+        returnStandDowns = 0
         // Consumed, not deferred. Merely holding the submit handoff back until
         // the return finishes means it becomes eligible the moment restoration
         // clears returnPending — and then steals focus off the card that was
@@ -181,16 +188,28 @@ fun TvSearchScreen(
     // typed one does — including handing focus to the results afterwards,
     // which is the whole point of speaking: nobody dictates a title in order
     // to then be left on the search field.
-    val voiceSearch = rememberTvVoiceSearch(prompt = "Speak a title") { spoken ->
-        viewModel.onQueryChanged(spoken)
-        pendingSearchFocus = true
-        if (requestsEnabled && spoken.length >= 2) {
-            requestSearchViewModel.onMediaTypeChanged(requestMediaType)
-            requestSearchViewModel.onQueryChanged(spoken)
-            requestSearchViewModel.search()
-        }
-        viewModel.submitSearch()
-    }
+    var voiceUnavailableMessage by remember { mutableStateOf<String?>(null) }
+    val voiceSearch = rememberTvVoiceSearch(
+        prompt = "Speak a title",
+        onResult = { spoken ->
+            // The same cap typing obeys. A noisy recognition can run long, and
+            // the field's own limit does not apply to text that never went
+            // through it.
+            val query = spoken.take(TV_SEARCH_QUERY_MAX_LENGTH)
+            voiceUnavailableMessage = null
+            viewModel.onQueryChanged(query)
+            pendingSearchFocus = true
+            if (requestsEnabled && query.length >= 2) {
+                requestSearchViewModel.onMediaTypeChanged(requestMediaType)
+                requestSearchViewModel.onQueryChanged(query)
+                requestSearchViewModel.search()
+            }
+            viewModel.submitSearch()
+        },
+        onUnavailable = {
+            voiceUnavailableMessage = "Voice search isn't available on this device."
+        },
+    )
 
     LaunchedEffect(requestsEnabled, state.query, requestMediaType) {
         val query = state.query.trim()
@@ -253,8 +272,31 @@ fun TvSearchScreen(
         // status these cards show — so a return is exactly when this row is
         // stale, and it is stale whether or not the screen stayed composed.
         // In place, so the cards a restoration is aiming at stay put.
-        if (canSearchRequests && requestState.hasSubmittedQuery && !requestState.isLoading) {
+        //
+        // ONCE per return. Refreshing flips requestSearchSettled, which is a
+        // key of this very effect, so an unguarded call relaunches the effect
+        // and refreshes again — forever, whenever resolution does not finish
+        // on the first pass.
+        //
+        // Skipped while an error is showing: there the query-keyed effect owns
+        // recovery and runs a full search, and two refetches racing would have
+        // one cancel the other and blank the row underneath the restoration.
+        if (!returnRefreshed &&
+            canSearchRequests &&
+            requestState.hasSubmittedQuery &&
+            !requestState.isLoading &&
+            requestState.error == null
+        ) {
+            returnRefreshed = true
             requestSearchViewModel.refreshInPlace()
+            // A request card must be resolved against the REFRESHED row.
+            // Preserved results still contain it, so it would otherwise match
+            // Exact, take focus and disarm before the response lands — and if
+            // that response drops the card, focus goes with it. Incomplete
+            // only yields Pending when the target is ABSENT, so completeness
+            // alone does not hold this back. A catalog target is unaffected by
+            // the request row and carries on immediately.
+            if (returnTarget?.sectionId == TvSearchRequestSectionId) return@LaunchedEffect
         }
 
         val sections = tvSearchReturnSections(
@@ -302,7 +344,13 @@ fun TvSearchScreen(
                     snapshotFlow { requestState.isLoading || state.isLoadingMore }
                         .first { !it }
                 } != null
-                if (!settled) {
+                returnStandDowns++
+                // Absolute, not per-attempt. A timeout that restarts with the
+                // effect bounds one stuck fetch and nothing else — a sequence
+                // of quick successful ones would keep re-arming it while the
+                // return never resolved and went on suppressing the ordinary
+                // submit handoff.
+                if (!settled || returnStandDowns >= TvSearchReturnMaxStandDowns) {
                     returnTarget = null
                     returnPending = false
                 }
@@ -483,6 +531,7 @@ fun TvSearchScreen(
                     },
                     onMediaTypeChanged = viewModel::onMediaTypeChanged,
                     voiceSearch = voiceSearch,
+                    voiceUnavailableMessage = voiceUnavailableMessage,
                 )
             },
             footer = {
@@ -665,7 +714,9 @@ private fun SearchStage(
     onSearch: () -> Unit,
     onMediaTypeChanged: (TvSearchMediaType) -> Unit,
     voiceSearch: TvVoiceSearchController,
+    voiceUnavailableMessage: String?,
 ) {
+    val voiceFocusRequester = remember { FocusRequester() }
     val mediaTypes = availableMediaTypes
     val fieldShape = RoundedCornerShape(14.dp)
 
@@ -689,11 +740,15 @@ private fun SearchStage(
         if (voiceSearch.isAvailable) {
             TvVoiceSearchButton(
                 onClick = voiceSearch::start,
-                // DOWN joins the same rail the field uses, so the mic is not a
-                // dead end, and UP is left alone so the top menu stays
-                // reachable from here exactly as it is from the field. RIGHT
-                // falls through to the field beside it.
-                modifier = Modifier.focusProperties { down = firstFilterChipFocusRequester },
+                modifier = Modifier
+                    .focusRequester(voiceFocusRequester)
+                    // RIGHT is stated rather than left to geometry, because the
+                    // route INTO this button comes from below and the way back
+                    // out has to be certain.
+                    .focusProperties {
+                        right = searchFieldFocusRequester
+                        down = firstFilterChipFocusRequester
+                    },
             )
         }
         OutlinedTextField(
@@ -740,6 +795,14 @@ private fun SearchStage(
         )
         }
 
+        voiceUnavailableMessage?.let { message ->
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.White.copy(alpha = 0.72f),
+            )
+        }
+
         LazyRow(
             modifier = Modifier.focusRestorer(firstFilterChipFocusRequester),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -751,13 +814,26 @@ private fun SearchStage(
                 contentType = { _, _ -> "media-type-chip" },
             ) { index, type ->
                 val chipModifier = Modifier
-                    // UP returns to the search field, stated rather than left
-                    // to geometry. The field used to be the nearest thing above
-                    // this rail and is not any more — the mic sits to its left,
-                    // directly over the first chip — so spatial search would
-                    // now land there instead. The field is the control this row
-                    // belongs to, wherever it happens to be drawn.
-                    .focusProperties { up = searchFieldFocusRequester }
+                    // UP is stated rather than left to geometry, and the first
+                    // chip deliberately goes somewhere different.
+                    //
+                    // The mic sits directly above chip zero, and it is the ONLY
+                    // way in: Compose Foundation's text field consumes D-pad
+                    // Left as character navigation even when the cursor cannot
+                    // move, so Field → Left → Mic is not a route that can be
+                    // relied on. Sending chip zero up to the mic gives the
+                    // button an entry path that never crosses the field, and
+                    // the mic's own Right leads back to it.
+                    //
+                    // Every other chip goes to the field, which is the control
+                    // this row belongs to.
+                    .focusProperties {
+                        up = if (index == 0 && voiceSearch.isAvailable) {
+                            voiceFocusRequester
+                        } else {
+                            searchFieldFocusRequester
+                        }
+                    }
                     .then(
                         if (index == 0) {
                             Modifier.focusRequester(firstFilterChipFocusRequester)
@@ -954,6 +1030,9 @@ private const val TvSearchReturnPendingBudgetMillis: Long = 1_200L
  * thing it guards against is a request that never returns at all.
  */
 private const val TvSearchReturnInFlightBudgetMillis: Long = 10_000L
+
+/** How many times a return may stand down before it gives up for good. */
+private const val TvSearchReturnMaxStandDowns: Int = 4
 
 /** Focus must hold the card this long to count as arrived rather than passing. */
 private const val TvSearchReturnSettleMillis: Long = 120L

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.graphics.Color
+import androidx.activity.compose.BackHandler
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -167,6 +168,18 @@ fun TvSearchScreen(
     val activeSearchFieldFocusRequester = searchFieldFocusRequester ?: internalSearchFieldFocusRequester
     val keyboardController = LocalSoftwareKeyboardController.current
     var hasEnteredSearch by rememberSaveable { mutableStateOf(false) }
+    var isKeyboardOpen by remember { mutableStateOf(false) }
+
+    // Back closes the keyboard rather than leaving the screen.
+    //
+    // Without this, Back from a raised keyboard fell through to the shell and
+    // popped Search entirely — so the only way to put the keyboard away was
+    // also the way out, and anyone reaching for the mic lost the screen instead.
+    BackHandler(enabled = isKeyboardOpen) {
+        isKeyboardOpen = false
+        keyboardController?.hide()
+        runCatching { activeSearchFieldFocusRequester.requestFocus() }
+    }
     val requestMediaType = state.mediaType.toRequestMediaType()
     val visibleRequestResults = requestState.results
         .filterTvRequestResults()
@@ -412,7 +425,6 @@ fun TvSearchScreen(
         searchGridState.animateScrollToItem(0)
         androidx.compose.runtime.withFrameNanos { }
         runCatching { activeSearchFieldFocusRequester.requestFocus() }
-        keyboardController?.show()
     }
     LaunchedEffect(
         pendingSearchFocus,
@@ -519,10 +531,7 @@ fun TvSearchScreen(
                     searchFieldFocusRequester = activeSearchFieldFocusRequester,
                     firstFilterChipFocusRequester = firstFilterChipFocusRequester,
                     firstContentFocusRequester = firstContentFocusRequester,
-                    onSearchFieldFocusChanged = { focused ->
-                        onSearchFieldFocusChanged(focused)
-                        if (focused) keyboardController?.show()
-                    },
+                    onSearchFieldFocusChanged = onSearchFieldFocusChanged,
                     onQueryChanged = viewModel::onQueryChanged,
                     onSearch = {
                         pendingSearchFocus = true
@@ -537,6 +546,8 @@ fun TvSearchScreen(
                     onMediaTypeChanged = viewModel::onMediaTypeChanged,
                     voiceSearch = voiceSearch,
                     voiceUnavailableMessage = voiceUnavailableMessage,
+                    isKeyboardOpen = isKeyboardOpen,
+                    onKeyboardOpenChanged = { isKeyboardOpen = it },
                 )
             },
             footer = {
@@ -720,8 +731,11 @@ private fun SearchStage(
     onMediaTypeChanged: (TvSearchMediaType) -> Unit,
     voiceSearch: TvVoiceSearchController,
     voiceUnavailableMessage: String?,
+    isKeyboardOpen: Boolean,
+    onKeyboardOpenChanged: (Boolean) -> Unit,
 ) {
     val voiceFocusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
     val mediaTypes = availableMediaTypes
     val fieldShape = RoundedCornerShape(14.dp)
 
@@ -759,6 +773,15 @@ private fun SearchStage(
         OutlinedTextField(
             value = query,
             onValueChange = { onQueryChanged(it.take(TV_SEARCH_QUERY_MAX_LENGTH)) },
+            // Read-only until Select. This is what actually keeps the keyboard
+            // down — not withholding a show() call, which was the earlier
+            // mistake: Compose raises the IME itself whenever an editable field
+            // takes focus, so the only way to hold a focused field without a
+            // keyboard is for it not to be editable yet.
+            //
+            // Focus can then rest here harmlessly, the D-pad still belongs to
+            // the screen, and everything beside the field stays reachable.
+            readOnly = !isKeyboardOpen,
             singleLine = true,
             placeholder = {
                 Text(
@@ -789,26 +812,49 @@ private fun SearchStage(
                 // the search field onto the All/Movies/Series filters,
                 // regardless of whether result cards are also rendered below.
                 .focusRequester(searchFieldFocusRequester)
-                .onFocusChanged { onSearchFieldFocusChanged(it.isFocused) }
-                // LEFT reaches the mic, and it has to be taken in the PREVIEW
-                // phase to get there. Compose's text field consumes Left as
-                // cursor movement even when the caret cannot move, so both a
-                // plain key handler and a focusProperties destination lose the
-                // race — the key never becomes a focus move at all. Previewing
-                // it is the same mechanism the shell uses to claim Up.
+                .onFocusChanged { state ->
+                    onSearchFieldFocusChanged(state.isFocused)
+                    // Leaving the field puts it back to read-only, so returning
+                    // to it later does not silently raise the keyboard again.
+                    if (!state.isFocused && isKeyboardOpen) onKeyboardOpenChanged(false)
+                }
+                // Select opens the keyboard; focus alone does not.
                 //
-                // The cost is that Left no longer walks the caret. On a TV that
-                // is a fair trade: text arrives through the on-screen keyboard,
-                // which carries its own cursor keys, whereas the mic has no
-                // other way in.
+                // Raising it on focus is what made everything beside this field
+                // unreachable: the IME is a separate window that owns the
+                // D-pad, so with it up no key ever reaches this app and the mic
+                // to the left may as well not exist. Nothing an app can do wins
+                // that race — the earlier attempt to preview Left here was
+                // fighting a window that had already taken the event.
+                //
+                // With the keyboard closed the D-pad belongs to the screen
+                // again, and ordinary focus movement reaches the mic with no
+                // routing at all. Typing costs one Select first, which is the
+                // trade, and it is the one the Wholphin client makes.
                 .onPreviewKeyEvent { event ->
-                    if (voiceSearch.isAvailable &&
+                    val opensKeyboard = event.key == Key.DirectionCenter || event.key == Key.Enter
+                    when {
+                        event.type == KeyEventType.KeyUp && opensKeyboard && !isKeyboardOpen -> {
+                            onKeyboardOpenChanged(true)
+                            keyboardController?.show()
+                            true
+                        }
+                        // LEFT has to be taken from the field as well. Keeping
+                        // the keyboard down was necessary but not sufficient:
+                        // the text field still consumes Left as caret movement,
+                        // even read-only and even with nowhere for the caret to
+                        // go, so the key never becomes a focus move.
+                        //
+                        // Only while the keyboard is closed. Once it is open the
+                        // IME owns the D-pad and this never runs — and Left
+                        // genuinely should walk the caret then.
                         event.type == KeyEventType.KeyDown &&
-                        event.key == Key.DirectionLeft
-                    ) {
-                        runCatching { voiceFocusRequester.requestFocus() }.getOrDefault(false)
-                    } else {
-                        false
+                            event.key == Key.DirectionLeft &&
+                            !isKeyboardOpen &&
+                            voiceSearch.isAvailable -> {
+                            runCatching { voiceFocusRequester.requestFocus() }.getOrDefault(false)
+                        }
+                        else -> false
                     }
                 }
                 .focusProperties { down = firstFilterChipFocusRequester },

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
@@ -22,6 +22,12 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.filled.Mic
+import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.tv.material3.Surface
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Icon as M3Icon
@@ -32,6 +38,18 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.snapshotFlow
+import org.siloserver.silo.tv.ui.focus.TvReturnTarget
+import org.siloserver.silo.tv.ui.focus.TvReturnTargetSaver
+import org.siloserver.silo.tv.ui.focus.TvReturnRelocation
+import org.siloserver.silo.tv.ui.focus.TvReturnResolution
+import org.siloserver.silo.tv.ui.focus.resolveTvReturnTarget
+import org.siloserver.silo.tv.ui.focus.TvFocusAcquisitionBudgetMillis
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.withTimeoutOrNull
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -76,7 +94,7 @@ internal fun shouldFocusSearchField(
     explicitFieldRequest: Boolean,
 ): Boolean = explicitFieldRequest || (!hasEnteredSearch && !hasResults)
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+@OptIn(ExperimentalTvMaterial3Api::class, kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @Composable
 fun TvSearchScreen(
     onResultClick: (BrowseItem) -> Unit,
@@ -94,13 +112,48 @@ fun TvSearchScreen(
     val requestsEnabled by requestsFeatureStore.isEnabled.collectAsState()
     val firstResultFocusRequester = remember { FocusRequester() }
     val firstRequestResultFocusRequester = remember { FocusRequester() }
+    // One requester per section, addressed by index rather than pinned to the
+    // first card. The two sections are separate focus containers, so a single
+    // shared requester could not name a position in both.
+    val restoreCatalogFocusRequester = remember { FocusRequester() }
+    val restoreRequestFocusRequester = remember { FocusRequester() }
+
+    // Search is a root tab, like Calendar: "a target exists" cannot mean
+    // "returning", because browsing a result and re-selecting Search would look
+    // identical. The click is the signal, the lifecycle says when.
+    var returnTarget by rememberSaveable(stateSaver = TvReturnTargetSaver) {
+        mutableStateOf<TvReturnTarget?>(null)
+    }
+    var returnPending by rememberSaveable { mutableStateOf(false) }
+    var resumeGeneration by remember { mutableIntStateOf(0) }
+    TvSearchResumeSignal { resumeGeneration++ }
+    var focusedReturnItemId by remember { mutableStateOf<String?>(null) }
+    var restoreCatalogIndex by remember { mutableIntStateOf(-1) }
+    var restoreRequestIndex by remember { mutableIntStateOf(-1) }
+
+    var pendingSearchFocus by remember { mutableStateOf(false) }
+
+
+    val recordReturn: (String, String, Int, Int) -> Unit = { sectionId, itemId, sectionIndex, itemIndex ->
+        returnPending = true
+        // Consumed, not deferred. Merely holding the submit handoff back until
+        // the return finishes means it becomes eligible the moment restoration
+        // clears returnPending — and then steals focus off the card that was
+        // just restored. Opening something ends that handoff's claim outright.
+        pendingSearchFocus = false
+        returnTarget = TvReturnTarget(
+            sectionId = sectionId,
+            itemId = itemId,
+            sectionIndex = sectionIndex,
+            itemIndex = itemIndex,
+        )
+    }
     val feedbackActionFocusRequester = remember { FocusRequester() }
     val firstFilterChipFocusRequester = remember { FocusRequester() }
     val internalSearchFieldFocusRequester = remember { FocusRequester() }
     val searchGridState = rememberLazyGridState()
     val activeSearchFieldFocusRequester = searchFieldFocusRequester ?: internalSearchFieldFocusRequester
     val keyboardController = LocalSoftwareKeyboardController.current
-    var pendingSearchFocus by remember { mutableStateOf(false) }
     var hasEnteredSearch by rememberSaveable { mutableStateOf(false) }
     val requestMediaType = state.mediaType.toRequestMediaType()
     val visibleRequestResults = requestState.results
@@ -124,12 +177,45 @@ fun TvSearchScreen(
         visibleRequestResults.isNotEmpty() ||
         state.error != null
 
+    // A spoken query is a submitted query. It goes through exactly the path a
+    // typed one does — including handing focus to the results afterwards,
+    // which is the whole point of speaking: nobody dictates a title in order
+    // to then be left on the search field.
+    val voiceSearch = rememberTvVoiceSearch(prompt = "Speak a title") { spoken ->
+        viewModel.onQueryChanged(spoken)
+        pendingSearchFocus = true
+        if (requestsEnabled && spoken.length >= 2) {
+            requestSearchViewModel.onMediaTypeChanged(requestMediaType)
+            requestSearchViewModel.onQueryChanged(spoken)
+            requestSearchViewModel.search()
+        }
+        viewModel.submitSearch()
+    }
+
     LaunchedEffect(requestsEnabled, state.query, requestMediaType) {
         val query = state.query.trim()
         if (!requestsEnabled || query.length < 2) {
             requestSearchViewModel.onQueryChanged("")
             return@LaunchedEffect
         }
+        // Same query as the view model already answered. This effect re-runs on
+        // every re-entry, a Back out of a request detail included — and there
+        // the results are BOTH still on screen and genuinely stale, because
+        // creating a request in the detail changes the status these cards show.
+        //
+        // So refresh rather than skip, and refresh in place rather than through
+        // the ordinary path, which blanks the row before refetching: a viewer
+        // would watch it empty and refill, and a return restoration would lose
+        // the card it was aiming at partway through.
+        val alreadyAnswered = requestState.submittedQuery == query &&
+            requestState.mediaType == requestMediaType &&
+            !requestState.isLoading &&
+            requestState.error == null
+        // Nothing to do: the answer on screen is for this exact query. Staleness
+        // after a return is handled by the restoration effect, which is the only
+        // place that knows a return happened — this effect is keyed on the query
+        // and cannot tell a re-entry from a recomposition.
+        if (alreadyAnswered) return@LaunchedEffect
         delay(300)
         requestSearchViewModel.onMediaTypeChanged(requestMediaType)
         requestSearchViewModel.onQueryChanged(query)
@@ -143,6 +229,127 @@ fun TvSearchScreen(
         }
         hasEnteredSearch = true
     }
+    // Return restoration. Deliberately separate from the pendingSearchFocus
+    // handoff above: that one belongs to an explicit search submission, and
+    // this screen goes out of its way NOT to jump focus when results merely
+    // appear, because doing so yanks the viewer out of text entry mid-query.
+    // A return is the one case where moving focus onto a result is what was
+    // asked for.
+    LaunchedEffect(
+        resumeGeneration,
+        state.isLoading,
+        state.isLoadingMore,
+        state.items,
+        visibleRequestResults,
+        requestSearchSettled,
+    ) {
+        // Deliberately NOT gated on requestSearchSettled. A catalog return has
+        // no reason to wait for the request row, and a request return is held
+        // by the section's own completeness below — which is what makes that
+        // flag mean something instead of being unreachable.
+        if (!returnPending || state.isLoading) return@LaunchedEffect
+
+        // Opening a request detail can create a request, which changes the
+        // status these cards show — so a return is exactly when this row is
+        // stale, and it is stale whether or not the screen stayed composed.
+        // In place, so the cards a restoration is aiming at stay put.
+        if (canSearchRequests && requestState.hasSubmittedQuery && !requestState.isLoading) {
+            requestSearchViewModel.refreshInPlace()
+        }
+
+        val sections = tvSearchReturnSections(
+            catalogItems = state.items,
+            requestResults = visibleRequestResults,
+            // More pages can still arrive, so a target beyond the loaded
+            // results is not yet absent.
+            catalogComplete = !state.hasMore,
+            requestsComplete = requestSearchSettled,
+        )
+        fun resolve(final: Boolean) = resolveTvReturnTarget(
+            target = returnTarget,
+            sections = sections,
+            // A library item and a requestable title are different things even
+            // when they are the same film, and namespacing already means an id
+            // cannot appear in the other section. Following would only buy
+            // pointless waits.
+            relocation = TvReturnRelocation.SameSectionOnly,
+            treatAbsenceAsFinal = final,
+        )
+
+        var resolution = resolve(final = false)
+        if (resolution is TvReturnResolution.Pending) {
+            // Not loaded yet is not the same as not there, and consuming the
+            // target on the difference loses a return that was about to become
+            // possible. Search does not page TOWARD a target the way the flat
+            // surfaces do, but work already in flight deserves the wait.
+            //
+            // If content arrives first this coroutine is cancelled and the
+            // effect re-resolves against it, which is the outcome we want; the
+            // delay only elapses when nothing came.
+            delay(TvSearchReturnPendingBudgetMillis)
+            // Still fetching. Standing down WITHOUT consuming is the safe move:
+            // a timer expiring is not evidence that nothing is coming, and no
+            // latency figure would make it one. This effect is keyed on the
+            // very signals that change when the fetch lands, so it re-runs and
+            // resolves properly then.
+            //
+            // Bounded all the same. A fetch that never completes would
+            // otherwise leave the screen armed for good, and an armed return
+            // keeps suppressing the explicit-submit handoff — so the failure
+            // would outlive the return and quietly break ordinary searching.
+            if (requestState.isLoading || state.isLoadingMore) {
+                val settled = withTimeoutOrNull(TvSearchReturnInFlightBudgetMillis) {
+                    snapshotFlow { requestState.isLoading || state.isLoadingMore }
+                        .first { !it }
+                } != null
+                if (!settled) {
+                    returnTarget = null
+                    returnPending = false
+                }
+                return@LaunchedEffect
+            }
+            resolution = resolve(final = true)
+        }
+        val located = resolution as? TvReturnResolution.Located
+
+        if (located == null) {
+            returnTarget = null
+            returnPending = false
+            return@LaunchedEffect
+        }
+
+        when (located.sectionId) {
+            TvSearchCatalogSectionId -> {
+                restoreCatalogIndex = located.itemIndex
+                searchGridState.scrollToItem(located.itemIndex)
+                androidx.compose.runtime.withFrameNanos { }
+                runCatching { restoreCatalogFocusRequester.requestFocus() }
+            }
+            TvSearchRequestSectionId -> {
+                restoreRequestIndex = located.itemIndex
+                androidx.compose.runtime.withFrameNanos { }
+                runCatching { restoreRequestFocusRequester.requestFocus() }
+            }
+        }
+
+        // Confirmed by watching focus hold the card, not by having asked.
+        withTimeoutOrNull(TvFocusAcquisitionBudgetMillis) {
+            snapshotFlow { focusedReturnItemId }
+                .transformLatest { id ->
+                    if (id == located.itemId) {
+                        delay(TvSearchReturnSettleMillis)
+                        emit(Unit)
+                    }
+                }
+                .first()
+        }
+
+        returnTarget = null
+        returnPending = false
+        restoreCatalogIndex = -1
+        restoreRequestIndex = -1
+    }
+
     // The search field auto-shows the soft keyboard on focus; leaving Search
     // without dismissing it left the system IME floating over the next screen
     // (e.g. over the video when starting playback from a result).
@@ -156,12 +363,19 @@ fun TvSearchScreen(
     }
     LaunchedEffect(
         pendingSearchFocus,
+        returnPending,
         state.isLoading,
         requestSearchSettled,
         state.items.size,
         visibleRequestResults.size,
     ) {
         if (!pendingSearchFocus || state.isLoading || !requestSearchSettled) return@LaunchedEffect
+        // A return outranks a stale submit. Submitting, walking down to a card
+        // that the reset had not yet cleared, and opening it leaves this armed
+        // on a retained composition — and on the way back both effects would
+        // otherwise be eligible, one aiming at the restored card and the other
+        // at the first result.
+        if (returnPending) return@LaunchedEffect
         pendingSearchFocus = false
         runCatching {
             if (state.items.isNotEmpty()) {
@@ -196,7 +410,15 @@ fun TvSearchScreen(
             isLoading = state.isLoadingMore,
             hasMore = state.hasMore,
             onItemClick = { },
-            onBrowseItemClick = onResultClick,
+            onBrowseItemClick = { item ->
+                recordReturn(
+                    TvSearchCatalogSectionId,
+                    tvSearchCatalogItemId(item.contentId),
+                    0,
+                    state.items.indexOfFirst { it.contentId == item.contentId },
+                )
+                onResultClick(item)
+            },
             onLoadMore = viewModel::loadMore,
             modifier = Modifier
                 .fillMaxWidth()
@@ -212,6 +434,16 @@ fun TvSearchScreen(
             horizontalSpacing = 14.dp,
             verticalSpacing = 20.dp,
             firstItemFocusRequester = firstResultFocusRequester,
+            restoreItemIndex = restoreCatalogIndex,
+            restoreItemFocusRequester = restoreCatalogFocusRequester,
+            onItemFocusedAtIndex = { item, _, focused ->
+                val id = tvSearchCatalogItemId(item.contentId)
+                if (focused) {
+                    focusedReturnItemId = id
+                } else if (focusedReturnItemId == id) {
+                    focusedReturnItemId = null
+                }
+            },
             // UP from the first card always lands back on the filter chip rail.
             // Without this Compose's spatial focus search can prefer the wider
             // search field above and skip over the smaller chip row.
@@ -250,6 +482,7 @@ fun TvSearchScreen(
                         viewModel.submitSearch()
                     },
                     onMediaTypeChanged = viewModel::onMediaTypeChanged,
+                    voiceSearch = voiceSearch,
                 )
             },
             footer = {
@@ -262,6 +495,24 @@ fun TvSearchScreen(
                     results = visibleRequestResults,
                     shouldShow = shouldShowRequestSection,
                     firstItemFocusRequester = firstRequestResultFocusRequester,
+                    restoreItemIndex = restoreRequestIndex,
+                    restoreItemFocusRequester = restoreRequestFocusRequester,
+                    onItemFocusChanged = { item, _, focused ->
+                        val id = tvSearchRequestItemId(item.mediaType, item.tmdbId)
+                        if (focused) {
+                            focusedReturnItemId = id
+                        } else if (focusedReturnItemId == id) {
+                            focusedReturnItemId = null
+                        }
+                    },
+                    onItemClicked = { item, index ->
+                        recordReturn(
+                            TvSearchRequestSectionId,
+                            tvSearchRequestItemId(item.mediaType, item.tmdbId),
+                            1,
+                            index,
+                        )
+                    },
                     firstItemCardModifier = Modifier.focusProperties {
                         up = if (state.items.isNotEmpty()) firstResultFocusRequester else firstFilterChipFocusRequester
                     },
@@ -305,6 +556,10 @@ private fun TvRequestSearchSection(
     shouldShow: Boolean,
     firstItemFocusRequester: FocusRequester,
     firstItemCardModifier: Modifier,
+    restoreItemIndex: Int = -1,
+    restoreItemFocusRequester: FocusRequester? = null,
+    onItemFocusChanged: (RequestMediaResult, Int, Boolean) -> Unit = { _, _, _ -> },
+    onItemClicked: (RequestMediaResult, Int) -> Unit = { _, _ -> },
     onOpenRequestDetail: (mediaType: String, tmdbId: Int) -> Unit,
     onOpenLibraryItem: (contentId: String) -> Unit,
 ) {
@@ -338,17 +593,28 @@ private fun TvRequestSearchSection(
                         key = { _, item -> "${item.mediaType}-${item.tmdbId}" },
                         contentType = { _, _ -> "request-search-result" },
                     ) { index, item ->
+                        val isRestoreTarget = restoreItemFocusRequester != null &&
+                            index == restoreItemIndex
                         TvRequestCard(
                             result = item,
                             onClick = {
+                                onItemClicked(item, index)
                                 if (item.canOpenLibraryDetail()) {
                                     onOpenLibraryItem(item.libraryContentId.orEmpty())
                                 } else {
                                     onOpenRequestDetail(item.mediaType, item.tmdbId)
                                 }
                             },
-                            focusRequester = firstItemFocusRequester.takeIf { index == 0 },
-                            cardModifier = if (index == 0) firstItemCardModifier else Modifier,
+                            // The restore target wins the slot when it is this
+                            // card: index zero can be both, and two requesters
+                            // on one node is one requester too many.
+                            focusRequester = if (isRestoreTarget) {
+                                restoreItemFocusRequester
+                            } else {
+                                firstItemFocusRequester.takeIf { index == 0 }
+                            },
+                            cardModifier = (if (index == 0) firstItemCardModifier else Modifier)
+                                .onFocusChanged { onItemFocusChanged(item, index, it.hasFocus) },
                         )
                     }
                 }
@@ -398,6 +664,7 @@ private fun SearchStage(
     onQueryChanged: (String) -> Unit,
     onSearch: () -> Unit,
     onMediaTypeChanged: (TvSearchMediaType) -> Unit,
+    voiceSearch: TvVoiceSearchController,
 ) {
     val mediaTypes = availableMediaTypes
     val fieldShape = RoundedCornerShape(14.dp)
@@ -413,6 +680,10 @@ private fun SearchStage(
             ),
         verticalArrangement = Arrangement.spacedBy(Spacing.sm),
     ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
         OutlinedTextField(
             value = query,
             onValueChange = { onQueryChanged(it.take(TV_SEARCH_QUERY_MAX_LENGTH)) },
@@ -455,6 +726,19 @@ private fun SearchStage(
                 unfocusedBorderColor = Color.White.copy(alpha = 0.12f),
             ),
         )
+
+        // Hidden outright when nothing can service it, rather than shown and
+        // inert: a mic that does nothing when pressed is worse than no mic.
+        if (voiceSearch.isAvailable) {
+            TvVoiceSearchButton(
+                onClick = voiceSearch::start,
+                // DOWN joins the same rail the field uses, so the mic is not a
+                // dead end, and UP is left alone so the top menu stays
+                // reachable from here exactly as it is from the field.
+                modifier = Modifier.focusProperties { down = firstFilterChipFocusRequester },
+            )
+        }
+        }
 
         LazyRow(
             modifier = Modifier.focusRestorer(firstFilterChipFocusRequester),
@@ -635,3 +919,75 @@ private fun TvSearchMediaType.allowsRequestResult(item: RequestMediaResult): Boo
         TvSearchMediaType.Series -> item.mediaType == RequestMediaType.Series
         TvSearchMediaType.Audiobooks -> item.mediaType == RequestMediaType.Audiobook
     }
+
+/**
+ * Fires when this destination resumes — a Back out of a result, and also an
+ * app foregrounding. Composition identity cannot answer this: a Back during
+ * the outgoing transition can leave the screen composed.
+ */
+@Composable
+private fun TvSearchResumeSignal(onResume: () -> Unit) {
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    val currentOnResume by rememberUpdatedState(onResume)
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) currentOnResume()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+}
+
+/** How long a not-yet-loaded target waits on work already in flight. */
+private const val TvSearchReturnPendingBudgetMillis: Long = 1_200L
+
+/**
+ * How long a return waits on a fetch that is genuinely still running before it
+ * gives up and disarms. Long, because the wait itself is harmless and the only
+ * thing it guards against is a request that never returns at all.
+ */
+private const val TvSearchReturnInFlightBudgetMillis: Long = 10_000L
+
+/** Focus must hold the card this long to count as arrived rather than passing. */
+private const val TvSearchReturnSettleMillis: Long = 120L
+
+/**
+ * The mic beside the search field.
+ *
+ * Deliberately a peer of the field rather than an icon inside it: a trailing
+ * icon in a text field is not focusable, and on a remote a control you cannot
+ * reach with the D-pad may as well not exist.
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun TvVoiceSearchButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    Surface(
+        onClick = onClick,
+        interactionSource = interactionSource,
+        shape = ClickableSurfaceDefaults.shape(CircleShape),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = Color.White.copy(alpha = 0.055f),
+            focusedContainerColor = Color.White,
+            contentColor = Color.White,
+            focusedContentColor = Color.Black,
+        ),
+        modifier = modifier.size(52.dp),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            M3Icon(
+                imageVector = Icons.Filled.Mic,
+                contentDescription = "Search by voice",
+                tint = if (isFocused) Color.Black else Color.White.copy(alpha = 0.82f),
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
@@ -684,6 +684,18 @@ private fun SearchStage(
             horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+        // Hidden outright when nothing can service it, rather than shown and
+        // inert: a mic that does nothing when pressed is worse than no mic.
+        if (voiceSearch.isAvailable) {
+            TvVoiceSearchButton(
+                onClick = voiceSearch::start,
+                // DOWN joins the same rail the field uses, so the mic is not a
+                // dead end, and UP is left alone so the top menu stays
+                // reachable from here exactly as it is from the field. RIGHT
+                // falls through to the field beside it.
+                modifier = Modifier.focusProperties { down = firstFilterChipFocusRequester },
+            )
+        }
         OutlinedTextField(
             value = query,
             onValueChange = { onQueryChanged(it.take(TV_SEARCH_QUERY_MAX_LENGTH)) },
@@ -726,18 +738,6 @@ private fun SearchStage(
                 unfocusedBorderColor = Color.White.copy(alpha = 0.12f),
             ),
         )
-
-        // Hidden outright when nothing can service it, rather than shown and
-        // inert: a mic that does nothing when pressed is worse than no mic.
-        if (voiceSearch.isAvailable) {
-            TvVoiceSearchButton(
-                onClick = voiceSearch::start,
-                // DOWN joins the same rail the field uses, so the mic is not a
-                // dead end, and UP is left alone so the top menu stays
-                // reachable from here exactly as it is from the field.
-                modifier = Modifier.focusProperties { down = firstFilterChipFocusRequester },
-            )
-        }
         }
 
         LazyRow(
@@ -751,6 +751,13 @@ private fun SearchStage(
                 contentType = { _, _ -> "media-type-chip" },
             ) { index, type ->
                 val chipModifier = Modifier
+                    // UP returns to the search field, stated rather than left
+                    // to geometry. The field used to be the nearest thing above
+                    // this rail and is not any more — the mic sits to its left,
+                    // directly over the first chip — so spatial search would
+                    // now land there instead. The field is the control this row
+                    // belongs to, wherever it happens to be drawn.
+                    .focusProperties { up = searchFieldFocusRequester }
                     .then(
                         if (index == 0) {
                             Modifier.focusRequester(firstFilterChipFocusRequester)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
@@ -55,6 +55,7 @@ import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.model.feature.RequestsFeatureStore
 import org.siloserver.silo.model.request.RequestMediaResult
 import org.siloserver.silo.model.request.RequestMediaType
+import org.siloserver.silo.tv.ui.components.TvHideStockImeOnDispose
 import org.siloserver.silo.tv.ui.components.TvCatalogGrid
 import org.siloserver.silo.tv.ui.components.TvFilterChip
 import org.siloserver.silo.tv.ui.components.tvOutlinedTextFieldColors
@@ -142,13 +143,10 @@ fun TvSearchScreen(
         }
         hasEnteredSearch = true
     }
-    // The search field auto-shows the soft keyboard on focus, but nothing hid
-    // it when leaving Search — on Android TV the system IME then floats over
-    // the next screen (e.g. starting playback from a search result left the
-    // keyboard on top of the video). Dismiss it when Search leaves composition.
-    DisposableEffect(Unit) {
-        onDispose { runCatching { keyboardController?.hide() } }
-    }
+    // The search field auto-shows the soft keyboard on focus; leaving Search
+    // without dismissing it left the system IME floating over the next screen
+    // (e.g. over the video when starting playback from a result).
+    TvHideStockImeOnDispose()
     LaunchedEffect(backToSearchFieldRequest) {
         if (backToSearchFieldRequest <= 0) return@LaunchedEffect
         searchGridState.animateScrollToItem(0)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
@@ -59,6 +59,11 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
@@ -785,6 +790,27 @@ private fun SearchStage(
                 // regardless of whether result cards are also rendered below.
                 .focusRequester(searchFieldFocusRequester)
                 .onFocusChanged { onSearchFieldFocusChanged(it.isFocused) }
+                // LEFT reaches the mic, and it has to be taken in the PREVIEW
+                // phase to get there. Compose's text field consumes Left as
+                // cursor movement even when the caret cannot move, so both a
+                // plain key handler and a focusProperties destination lose the
+                // race — the key never becomes a focus move at all. Previewing
+                // it is the same mechanism the shell uses to claim Up.
+                //
+                // The cost is that Left no longer walks the caret. On a TV that
+                // is a fair trade: text arrives through the on-screen keyboard,
+                // which carries its own cursor keys, whereas the mic has no
+                // other way in.
+                .onPreviewKeyEvent { event ->
+                    if (voiceSearch.isAvailable &&
+                        event.type == KeyEventType.KeyDown &&
+                        event.key == Key.DirectionLeft
+                    ) {
+                        runCatching { voiceFocusRequester.requestFocus() }.getOrDefault(false)
+                    } else {
+                        false
+                    }
+                }
                 .focusProperties { down = firstFilterChipFocusRequester },
             colors = tvOutlinedTextFieldColors(
                 focusedContainerColor = ElevatedSurface,
@@ -814,26 +840,17 @@ private fun SearchStage(
                 contentType = { _, _ -> "media-type-chip" },
             ) { index, type ->
                 val chipModifier = Modifier
-                    // UP is stated rather than left to geometry, and the first
-                    // chip deliberately goes somewhere different.
-                    //
-                    // The mic sits directly above chip zero, and it is the ONLY
-                    // way in: Compose Foundation's text field consumes D-pad
-                    // Left as character navigation even when the cursor cannot
-                    // move, so Field → Left → Mic is not a route that can be
-                    // relied on. Sending chip zero up to the mic gives the
-                    // button an entry path that never crosses the field, and
-                    // the mic's own Right leads back to it.
-                    //
-                    // Every other chip goes to the field, which is the control
-                    // this row belongs to.
-                    .focusProperties {
-                        up = if (index == 0 && voiceSearch.isAvailable) {
-                            voiceFocusRequester
-                        } else {
-                            searchFieldFocusRequester
-                        }
-                    }
+                    // UP returns to the search field — every chip, no
+                    // exceptions. An earlier attempt sent chip zero to the mic
+                    // instead, to give the button a route that avoided the text
+                    // field. It did not work and made things worse: the shell
+                    // claims DirectionUp in its own preview handler above this
+                    // row, so the chip's property never decides anything, and
+                    // when the move it performs fails the shell hands focus to
+                    // the top menu. Chip zero's Up therefore left the screen
+                    // entirely instead of reaching the field. The mic is
+                    // reached from the field itself now, below.
+                    .focusProperties { up = searchFieldFocusRequester }
                     .then(
                         if (index == 0) {
                             Modifier.focusRequester(firstFilterChipFocusRequester)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvVoiceSearch.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvVoiceSearch.kt
@@ -1,0 +1,105 @@
+package org.siloserver.silo.tv.ui.screens.search
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.speech.RecognizerIntent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Voice search on TV, spoken into the remote.
+ *
+ * This deliberately hands off to the system recogniser rather than recording
+ * anything itself. On a Shield the recogniser listens through the remote's
+ * microphone, which is the hardware the viewer expects to be talking into, and
+ * because the recording happens in that app rather than this one Silo needs no
+ * RECORD_AUDIO permission at all — nothing here can listen, only ask.
+ *
+ * The remote's own mic BUTTON cannot be used to start this: Android TV binds it
+ * to the system assistant before any app sees it. An on-screen affordance is
+ * the only way an app can offer voice, which is why the mic lives beside the
+ * search field.
+ */
+internal class TvVoiceSearchController(
+    /**
+     * False when no recogniser is installed, which is ordinary on a bare AOSP
+     * TV box. Callers hide the affordance rather than offering a button that
+     * cannot do anything.
+     */
+    val isAvailable: Boolean,
+    private val launch: () -> Unit,
+) {
+    fun start() {
+        if (isAvailable) launch()
+    }
+}
+
+@Composable
+internal fun rememberTvVoiceSearch(
+    prompt: String,
+    onResult: (String) -> Unit,
+): TvVoiceSearchController {
+    val context = LocalContext.current
+    val currentOnResult by rememberUpdatedState(onResult)
+
+    // Resolved once. Installing a recogniser mid-session is not a case worth
+    // recomposing for, and re-querying the package manager on every frame is.
+    val isAvailable = remember(context) { isTvSpeechRecognitionAvailable(context) }
+
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode != Activity.RESULT_OK) return@rememberLauncherForActivityResult
+        val spoken = result.data
+            ?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+            // The list is ordered by confidence, so the first entry is the
+            // recogniser's own best guess. Silo has no better way to choose
+            // between alternates than the engine that produced them.
+            ?.firstOrNull()
+            ?.trim()
+            .orEmpty()
+        // A cancelled or empty recognition must not wipe a query the viewer
+        // already typed.
+        if (spoken.isNotEmpty()) currentOnResult(spoken)
+    }
+
+    return remember(isAvailable, prompt, launcher) {
+        TvVoiceSearchController(isAvailable = isAvailable) {
+            runCatching { launcher.launch(tvSpeechRecognizerIntent(prompt)) }
+        }
+    }
+}
+
+private fun tvSpeechRecognizerIntent(prompt: String): Intent =
+    Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+        // Free-form rather than web search: these are film, series and book
+        // titles, not queries, and the web-search model rewrites them toward
+        // whatever it thinks you meant to google.
+        putExtra(
+            RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+            RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+        )
+        putExtra(RecognizerIntent.EXTRA_PROMPT, prompt)
+        // One result is all the caller uses; asking for more only makes the
+        // recogniser work harder for output that gets discarded.
+        putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
+    }
+
+/**
+ * Whether anything on this device can handle a recognition request.
+ *
+ * Needs the matching `<queries>` element in the manifest — from Android 11 an
+ * app cannot see packages it has not declared an interest in, so without it
+ * this returns false on every modern device and the mic silently never appears.
+ */
+private fun isTvSpeechRecognitionAvailable(context: Context): Boolean =
+    context.packageManager
+        .queryIntentActivities(Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH), 0)
+        .isNotEmpty()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvVoiceSearch.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvVoiceSearch.kt
@@ -2,9 +2,10 @@ package org.siloserver.silo.tv.ui.screens.search
 
 import android.app.Activity
 import android.content.Context
+import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.speech.RecognizerIntent
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
@@ -34,10 +35,16 @@ internal class TvVoiceSearchController(
      * cannot do anything.
      */
     val isAvailable: Boolean,
-    private val launch: () -> Unit,
+    private val launch: () -> Boolean,
+    private val onUnavailable: () -> Unit,
 ) {
     fun start() {
-        if (isAvailable) launch()
+        // Availability was resolved earlier and can be wrong by now — the
+        // recogniser may have been disabled or uninstalled since. Say so
+        // instead of doing nothing: a visible mic that silently ignores a
+        // press is the worst outcome for someone who does not know what an
+        // intent is.
+        if (!isAvailable || !launch()) onUnavailable()
     }
 }
 
@@ -45,9 +52,11 @@ internal class TvVoiceSearchController(
 internal fun rememberTvVoiceSearch(
     prompt: String,
     onResult: (String) -> Unit,
+    onUnavailable: () -> Unit,
 ): TvVoiceSearchController {
     val context = LocalContext.current
     val currentOnResult by rememberUpdatedState(onResult)
+    val currentOnUnavailable by rememberUpdatedState(onUnavailable)
 
     // Resolved once. Installing a recogniser mid-session is not a case worth
     // recomposing for, and re-querying the package manager on every frame is.
@@ -71,11 +80,26 @@ internal fun rememberTvVoiceSearch(
     }
 
     return remember(isAvailable, prompt, launcher) {
-        TvVoiceSearchController(isAvailable = isAvailable) {
-            runCatching { launcher.launch(tvSpeechRecognizerIntent(prompt)) }
-        }
+        TvVoiceSearchController(
+            isAvailable = isAvailable,
+            launch = {
+                // Narrow, and reported. A blanket runCatching here swallowed
+                // every reason a launch could fail and left the caller unable
+                // to tell success from silence.
+                try {
+                    launcher.launch(tvSpeechRecognizerIntent(prompt))
+                    true
+                } catch (e: ActivityNotFoundException) {
+                    Log.w(TvVoiceSearchTag, "No activity accepted the speech recognition intent", e)
+                    false
+                }
+            },
+            onUnavailable = { currentOnUnavailable() },
+        )
     }
 }
+
+private const val TvVoiceSearchTag = "TvVoiceSearch"
 
 private fun tvSpeechRecognizerIntent(prompt: String): Intent =
     Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
@@ -87,9 +111,14 @@ private fun tvSpeechRecognizerIntent(prompt: String): Intent =
             RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
         )
         putExtra(RecognizerIntent.EXTRA_PROMPT, prompt)
-        // One result is all the caller uses; asking for more only makes the
-        // recogniser work harder for output that gets discarded.
-        putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
+        // EXTRA_MAX_RESULTS is deliberately unset. Only the first result is
+        // used either way, and leaving the cap off asks nothing unusual of a
+        // third-party recogniser.
+        //
+        // EXTRA_LANGUAGE is deliberately unset too. Unset means the device's
+        // own speech locale, which is what a household actually configured;
+        // pinning the app's UI locale would make an English UI work and break
+        // a family that speaks Dutch.
     }
 
 /**
@@ -100,6 +129,13 @@ private fun tvSpeechRecognizerIntent(prompt: String): Intent =
  * this returns false on every modern device and the mic silently never appears.
  */
 private fun isTvSpeechRecognitionAvailable(context: Context): Boolean =
-    context.packageManager
-        .queryIntentActivities(Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH), 0)
-        .isNotEmpty()
+    // resolveActivity, not queryIntentActivities(intent, 0). The latter also
+    // returns handlers whose filter lacks CATEGORY_DEFAULT, which
+    // startActivityForResult will not launch — so the mic could appear for a
+    // recogniser that cannot actually be started.
+    //
+    // SpeechRecognizer.isRecognitionAvailable is not the check either: it
+    // reports a recognition SERVICE, and what this needs is an exported
+    // ACTIVITY. A device can have one without the other.
+    Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
+        .resolveActivity(context.packageManager) != null

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvVoiceSearch.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvVoiceSearch.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Context
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.provider.Settings
 import android.speech.RecognizerIntent
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -61,6 +63,7 @@ internal fun rememberTvVoiceSearch(
     // Resolved once. Installing a recogniser mid-session is not a case worth
     // recomposing for, and re-querying the package manager on every frame is.
     val isAvailable = remember(context) { isTvSpeechRecognitionAvailable(context) }
+    val recognizerPackage = remember(context) { preferredRecognizerPackage(context) }
 
     val launcher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
@@ -79,7 +82,7 @@ internal fun rememberTvVoiceSearch(
         if (spoken.isNotEmpty()) currentOnResult(spoken)
     }
 
-    return remember(isAvailable, prompt, launcher) {
+    return remember(isAvailable, prompt, recognizerPackage, launcher) {
         TvVoiceSearchController(
             isAvailable = isAvailable,
             launch = {
@@ -87,7 +90,7 @@ internal fun rememberTvVoiceSearch(
                 // every reason a launch could fail and left the caller unable
                 // to tell success from silence.
                 try {
-                    launcher.launch(tvSpeechRecognizerIntent(prompt))
+                    launcher.launch(tvSpeechRecognizerIntent(prompt, recognizerPackage))
                     true
                 } catch (e: ActivityNotFoundException) {
                     Log.w(TvVoiceSearchTag, "No activity accepted the speech recognition intent", e)
@@ -101,8 +104,54 @@ internal fun rememberTvVoiceSearch(
 
 private const val TvVoiceSearchTag = "TvVoiceSearch"
 
-private fun tvSpeechRecognizerIntent(prompt: String): Intent =
+/**
+ * Which package should service the recognition request, or null to leave it to
+ * the system.
+ *
+ * More than one activity commonly claims this intent — a Google TV Streamer
+ * offers both the TV search app and the text-to-speech package — and with no
+ * default the launch becomes a disambiguation chooser. Asking someone to pick
+ * an app with a remote before they can say a film title is not voice search.
+ *
+ * The order matters and is not the obvious one. The device's configured
+ * VOICE_RECOGNITION_SERVICE names a service for programmatic recognition, not
+ * necessarily the best ACTIVITY to show someone: on a Streamer it points at the
+ * text-to-speech package, whose activity is not the ten-foot voice UI anyone
+ * wants. The voice-interaction/assistant package is the system's designated
+ * spoken front end, and on a TV that is the one with the microphone UI built
+ * for a remote. So it is asked first, and the recognition service only after.
+ *
+ * When nothing matches, null leaves the intent implicit and the system shows
+ * its chooser — worse, but honest, and better than silently picking whichever
+ * handler happened to be listed first.
+ */
+private fun preferredRecognizerPackage(context: Context): String? {
+    val candidates = context.packageManager.queryIntentActivities(
+        Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH),
+        PackageManager.MATCH_DEFAULT_ONLY,
+    )
+    if (candidates.size <= 1) {
+        return candidates.firstOrNull()?.activityInfo?.packageName
+    }
+    val resolver = context.contentResolver
+    val preferred = listOf(
+        "voice_interaction_service",
+        "assistant",
+        // Read by key: the constant is not public API.
+        "voice_recognition_service",
+    ).mapNotNull { key ->
+        Settings.Secure.getString(resolver, key)
+            ?.substringBefore('/')
+            ?.takeIf { it.isNotBlank() }
+    }
+    return preferred.firstOrNull { pkg ->
+        candidates.any { it.activityInfo?.packageName == pkg }
+    }
+}
+
+private fun tvSpeechRecognizerIntent(prompt: String, recognizerPackage: String?): Intent =
     Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+        recognizerPackage?.let(::setPackage)
         // Free-form rather than web search: these are film, series and book
         // titles, not queries, and the web-search model rewrites them toward
         // whatever it thinks you meant to google.

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/servers/TvServerListScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/servers/TvServerListScreen.kt
@@ -47,6 +47,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 import org.siloserver.silo.model.server.ServerEntry
+import org.siloserver.silo.tv.ui.focus.rememberTvContentInitialFocus
 import org.siloserver.silo.tv.ui.components.TvDialogOption
 import org.siloserver.silo.tv.ui.components.TvOptionDialog
 import org.siloserver.silo.tv.ui.theme.Spacing
@@ -94,20 +95,19 @@ fun TvServerListScreen(
         }
     }
 
-    LaunchedEffect(state.servers.size) {
-        // Anchor focus on the first row whenever the list materializes so
-        // d-pad navigation has somewhere to land.
-        if (state.servers.isNotEmpty()) {
-            repeat(TvInitialFocusRetryCount) {
-                if (runCatching { firstFocus.requestFocus() }.isSuccess) return@LaunchedEffect
-                delay(TvInitialFocusRetryDelayMs)
-            }
-        }
-    }
+    // Anchor focus on the first row whenever the list materializes so d-pad
+    // navigation has somewhere to land. The rows are lazy, so the first request
+    // lands before placement and is rejected — this retries until focus is
+    // actually observed rather than until a call merely returns.
+    val contentInitialFocus = rememberTvContentInitialFocus(
+        target = firstFocus,
+        contentKey = state.servers.firstOrNull()?.id,
+    )
 
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .then(contentInitialFocus)
             .background(ServerSettingsBackground)
             .padding(start = 44.dp, top = Spacing.safeArea, end = 44.dp, bottom = Spacing.xxxl),
     ) {
@@ -210,8 +210,6 @@ fun TvServerListScreen(
 
 }
 
-private const val TvInitialFocusRetryCount = 4
-private const val TvInitialFocusRetryDelayMs = 50L
 private val ServerSettingsBackground = Color(0xFF17181A)
 private val ServerListMaxWidth = 620.dp
 private val ServerRowShape = RoundedCornerShape(8.dp)

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvStockKeyboardPolicyTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvStockKeyboardPolicyTest.kt
@@ -3,6 +3,7 @@ package org.siloserver.silo.tv.ui.components
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class TvStockKeyboardPolicyTest {
     @Test
@@ -17,5 +18,37 @@ class TvStockKeyboardPolicyTest {
         removedFiles.forEach { path ->
             assertFalse(File(path).exists(), "$path should not remain as a production text-entry path")
         }
+    }
+
+    @Test
+    fun everySurfaceThatRaisesTheStockKeyboardAlsoDismissesIt() {
+        // Android TV leaves the IME up when the surface that raised it goes
+        // away, so it floats over the next screen and keeps eating the D-pad.
+        // Two implementations copied the focus-and-show half of the policy and
+        // omitted the disposal half.
+        //
+        // Being a source check, this catches the copy — a file that takes the
+        // keyboard controller and shows it — not every conceivable way of
+        // raising the IME. It is also per file rather than per composable, so
+        // one helper call blesses everything in that file.
+        val sources = File("src/androidMain/kotlin")
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+
+        val showsTheKeyboard = Regex("""\w+\??\.show\(\)""")
+        val offenders = sources
+            .map { it to it.readText() }
+            .filter { (_, text) ->
+                text.contains("LocalSoftwareKeyboardController") &&
+                    showsTheKeyboard.containsMatchIn(text)
+            }
+            .filterNot { (_, text) -> text.contains("TvHideStockImeOnDispose()") }
+            .map { (file, _) -> file.path }
+            .toList()
+
+        assertTrue(
+            offenders.isEmpty(),
+            "these raise the stock TV keyboard without dismissing it on disposal: $offenders",
+        )
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvContentInitialFocusTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvContentInitialFocusTest.kt
@@ -1,0 +1,118 @@
+package org.siloserver.silo.tv.ui.focus
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TvContentInitialFocusTest {
+
+    @Test
+    fun `a request rejected during placement is retried until focus is observed`() {
+        runTest {
+            var requests = 0
+            var focused = false
+
+            val result = requestTvContentInitialFocus(
+                awaitAttempt = {},
+                isContentFocused = { focused },
+                requestFocus = {
+                    requests++
+                    // The lazy grid places the first item on the third frame.
+                    if (requests < 3) false else true.also { focused = true }
+                },
+            )
+
+            assertEquals(TvObservedFocusResult.Focused, result)
+            assertEquals(3, requests)
+        }
+    }
+
+    @Test
+    fun `a request that is accepted but never observed exhausts rather than latching success`() {
+        runTest {
+            var requests = 0
+
+            val result = requestTvContentInitialFocus(
+                awaitAttempt = {},
+                isContentFocused = { false },
+                requestFocus = { true.also { requests++ } },
+            )
+
+            // The old code treated this exact case as success and latched it.
+            assertEquals(TvObservedFocusResult.Exhausted, result)
+            assertEquals(TvContentInitialFocusMaxAttempts, requests)
+        }
+    }
+
+    @Test
+    fun `content that already owns focus is never asked again, so refresh cannot steal it`() {
+        runTest {
+            var requests = 0
+
+            val result = requestTvContentInitialFocus(
+                awaitAttempt = {},
+                isContentFocused = { true },
+                requestFocus = { true.also { requests++ } },
+            )
+
+            assertEquals(TvObservedFocusResult.Focused, result)
+            assertEquals(0, requests)
+        }
+    }
+
+    @Test
+    fun `a throwing requester does not end acquisition`() {
+        runTest {
+            var requests = 0
+            var focused = false
+
+            val result = requestTvContentInitialFocus(
+                awaitAttempt = {},
+                isContentFocused = { focused },
+                requestFocus = {
+                    requests++
+                    // A detached requester throws rather than returning false.
+                    if (requests == 1) error("not attached")
+                    true.also { focused = true }
+                },
+            )
+
+            assertEquals(TvObservedFocusResult.Focused, result)
+            assertEquals(2, requests)
+        }
+    }
+
+    @Test
+    fun `no anchoring pass runs without content`() {
+        assertEquals(false, shouldRequestTvContentInitialFocus(contentKey = null, contentHasFocus = false))
+        assertEquals(false, shouldRequestTvContentInitialFocus(contentKey = null, contentHasFocus = true))
+    }
+
+    @Test
+    fun `a viewer already inside the content is never pulled back by a refresh`() {
+        assertEquals(false, shouldRequestTvContentInitialFocus(contentKey = "collection-1", contentHasFocus = true))
+    }
+
+    @Test
+    fun `content that arrives with nothing focused is anchored`() {
+        assertEquals(true, shouldRequestTvContentInitialFocus(contentKey = "collection-1", contentHasFocus = false))
+    }
+
+    @Test
+    fun `returning to content that was focused before is anchored again, not suppressed`() {
+        // The wedge an "already acquired" latch would create: after the first
+        // item goes away and comes back, or after a different key exhausts in
+        // between, nothing holds focus and the pass must still run.
+        assertEquals(true, shouldRequestTvContentInitialFocus(contentKey = "collection-1", contentHasFocus = false))
+        assertEquals(true, shouldRequestTvContentInitialFocus(contentKey = "collection-2", contentHasFocus = false))
+        assertEquals(true, shouldRequestTvContentInitialFocus(contentKey = "collection-1", contentHasFocus = false))
+    }
+
+    @Test
+    fun `the attempt budget covers the acquisition window`() {
+        assertEquals(
+            TvFocusAcquisitionBudgetMillis,
+            TvContentInitialFocusMaxAttempts * 60L,
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTargetTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTargetTest.kt
@@ -4,49 +4,75 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
+/**
+ * States here mirror `DevicePairingUiState`, whose `canSubmit` is
+ * `!isSubmitting && (token or code is non-blank)` — it means "there is an
+ * identifier to submit", NOT "the lookup resolved". A token route therefore has
+ * canSubmit true from construction, before anything has come back to approve.
+ */
 class TvPairDeviceFocusTargetTest {
 
     private fun target(
         hasCompleted: Boolean = false,
+        hasResolvedLookup: Boolean = false,
         canEnterCode: Boolean = false,
         canSubmit: Boolean = false,
         isLoading: Boolean = false,
         isSubmitting: Boolean = false,
-    ) = tvPairDeviceFocusTarget(hasCompleted, canEnterCode, canSubmit, isLoading, isSubmitting)
+    ) = tvPairDeviceFocusTarget(
+        hasCompleted, hasResolvedLookup, canEnterCode, canSubmit, isLoading, isSubmitting,
+    )
 
     @Test
-    fun `the token route has nothing to focus while its automatic lookup runs`() {
-        // Deep-linked with a token: no code entry, Check disabled by isLoading.
-        assertNull(target(isLoading = true))
+    fun `a token route offers Check while its automatic lookup is still running`() {
+        // canSubmit is already true here purely because a token exists. Treating
+        // that as "resolved" would focus Approve before there is anything to
+        // approve; Check is disabled mid-lookup, so nothing is focusable.
+        assertNull(target(canSubmit = true, isLoading = true))
     }
 
     @Test
-    fun `when that lookup resolves, focus moves to Approve`() {
-        // The bug: completedStatus never changed across this transition, so the
-        // effect keyed on it never re-ran and the panel stayed unfocused.
-        assertEquals(TvPairDeviceAction.Approve, target(canSubmit = true))
+    fun `once the lookup resolves, focus moves to Approve`() {
+        // completedStatus does not change across this transition, which is why
+        // keying focus on it left the panel unfocused.
+        assertEquals(
+            TvPairDeviceAction.Approve,
+            target(hasResolvedLookup = true, canSubmit = true),
+        )
     }
 
     @Test
-    fun `when that lookup fails, focus falls to the re-enabled Check`() {
-        assertEquals(TvPairDeviceAction.Check, target(isLoading = false, canSubmit = false))
+    fun `a failed lookup keeps the identifier but falls to the re-enabled Check`() {
+        // Error path: lookup stays null, isLoading clears, canSubmit is still
+        // true because the token was never discarded.
+        assertEquals(
+            TvPairDeviceAction.Check,
+            target(canSubmit = true, isLoading = false),
+        )
     }
 
     @Test
     fun `nothing is focusable while a decision is being submitted`() {
-        assertNull(target(isSubmitting = true))
+        // Submission disables every action, and canSubmit is false throughout.
+        assertNull(target(hasResolvedLookup = true, isSubmitting = true))
+        assertNull(target(canEnterCode = true, isSubmitting = true))
     }
 
     @Test
-    fun `the manual route offers code entry first`() {
+    fun `the manual route offers code entry before any lookup exists`() {
         assertEquals(TvPairDeviceAction.EnterCode, target(canEnterCode = true))
     }
 
     @Test
-    fun `a resolved lookup outranks manual code entry`() {
+    fun `a typed code does not become Approve until the lookup resolves`() {
+        // canEnterCode and canSubmit are both true once a code is typed.
+        assertEquals(
+            TvPairDeviceAction.EnterCode,
+            target(canEnterCode = true, canSubmit = true),
+        )
         assertEquals(
             TvPairDeviceAction.Approve,
-            target(canEnterCode = true, canSubmit = true),
+            target(canEnterCode = true, canSubmit = true, hasResolvedLookup = true),
         )
     }
 
@@ -54,7 +80,12 @@ class TvPairDeviceFocusTargetTest {
     fun `completion outranks everything`() {
         assertEquals(
             TvPairDeviceAction.Done,
-            target(hasCompleted = true, canEnterCode = true, canSubmit = true),
+            target(
+                hasCompleted = true,
+                hasResolvedLookup = true,
+                canEnterCode = true,
+                canSubmit = true,
+            ),
         )
     }
 
@@ -64,11 +95,12 @@ class TvPairDeviceFocusTargetTest {
         // destructive choice would be wrong.
         val everyReachableTarget = listOf(
             target(hasCompleted = true),
-            target(canSubmit = true),
+            target(hasResolvedLookup = true, canSubmit = true),
             target(canEnterCode = true),
-            target(),
-            target(isLoading = true),
-            target(isSubmitting = true),
+            target(canSubmit = true),
+            target(canSubmit = true, isLoading = true),
+            // canSubmit is false while submitting, by construction.
+            target(hasResolvedLookup = true, isSubmitting = true),
         )
         assertEquals(
             listOf(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTargetTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTargetTest.kt
@@ -2,13 +2,15 @@ package org.siloserver.silo.tv.ui.focus
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 /**
- * States here mirror `DevicePairingUiState`, whose `canSubmit` is
- * `!isSubmitting && (token or code is non-blank)` — it means "there is an
- * identifier to submit", NOT "the lookup resolved". A token route therefore has
- * canSubmit true from construction, before anything has come back to approve.
+ * Focus here is keyed on which control deserves focus, not on which control
+ * happens to be enabled. The panel keeps something focusable in every state —
+ * Check is gated transiently — so there is always an answer.
+ *
+ * Deny is absent from [TvPairDeviceAction] entirely rather than merely
+ * unreachable, so "focus never defaults to the destructive choice" is a
+ * compile-time property and not something asserted here.
  */
 class TvPairDeviceFocusTargetTest {
 
@@ -16,63 +18,39 @@ class TvPairDeviceFocusTargetTest {
         hasCompleted: Boolean = false,
         hasResolvedLookup: Boolean = false,
         canEnterCode: Boolean = false,
-        canSubmit: Boolean = false,
-        isLoading: Boolean = false,
-        isSubmitting: Boolean = false,
-    ) = tvPairDeviceFocusTarget(
-        hasCompleted, hasResolvedLookup, canEnterCode, canSubmit, isLoading, isSubmitting,
-    )
+    ) = tvPairDeviceFocusTarget(hasCompleted, hasResolvedLookup, canEnterCode)
 
     @Test
-    fun `a token route offers Check while its automatic lookup is still running`() {
-        // canSubmit is already true here purely because a token exists. Treating
-        // that as "resolved" would focus Approve before there is anything to
-        // approve; Check is disabled mid-lookup, so nothing is focusable.
-        assertNull(target(canSubmit = true, isLoading = true))
+    fun `a token route waits on Check until its automatic lookup resolves`() {
+        // The deep-link route has no code to enter and nothing to approve yet.
+        // Check is the only control on screen, and it stays focusable while its
+        // own lookup runs — which is why this is Check and not "nothing".
+        assertEquals(TvPairDeviceAction.Check, target())
     }
 
     @Test
-    fun `once the lookup resolves, focus moves to Approve`() {
-        // completedStatus does not change across this transition, which is why
-        // keying focus on it left the panel unfocused.
-        assertEquals(
-            TvPairDeviceAction.Approve,
-            target(hasResolvedLookup = true, canSubmit = true),
-        )
+    fun `a resolved lookup moves focus to Approve`() {
+        assertEquals(TvPairDeviceAction.Approve, target(hasResolvedLookup = true))
     }
 
     @Test
-    fun `a failed lookup keeps the identifier but falls to the re-enabled Check`() {
-        // Error path: lookup stays null, isLoading clears, canSubmit is still
-        // true because the token was never discarded.
-        assertEquals(
-            TvPairDeviceAction.Check,
-            target(canSubmit = true, isLoading = false),
-        )
+    fun `a failed lookup falls back to Check rather than to Approve`() {
+        // The error path clears the lookup while the token stays set. Keying on
+        // the identifier instead put focus on an Approve that could act on a
+        // request the server had just rejected.
+        assertEquals(TvPairDeviceAction.Check, target(hasResolvedLookup = false))
     }
 
     @Test
-    fun `nothing is focusable while a decision is being submitted`() {
-        // Submission disables every action, and canSubmit is false throughout.
-        assertNull(target(hasResolvedLookup = true, isSubmitting = true))
-        assertNull(target(canEnterCode = true, isSubmitting = true))
-    }
-
-    @Test
-    fun `the manual route offers code entry before any lookup exists`() {
+    fun `the manual route offers code entry before any lookup resolves`() {
         assertEquals(TvPairDeviceAction.EnterCode, target(canEnterCode = true))
     }
 
     @Test
-    fun `a typed code does not become Approve until the lookup resolves`() {
-        // canEnterCode and canSubmit are both true once a code is typed.
-        assertEquals(
-            TvPairDeviceAction.EnterCode,
-            target(canEnterCode = true, canSubmit = true),
-        )
+    fun `a resolved lookup outranks code entry`() {
         assertEquals(
             TvPairDeviceAction.Approve,
-            target(canEnterCode = true, canSubmit = true, hasResolvedLookup = true),
+            target(hasResolvedLookup = true, canEnterCode = true),
         )
     }
 
@@ -80,38 +58,7 @@ class TvPairDeviceFocusTargetTest {
     fun `completion outranks everything`() {
         assertEquals(
             TvPairDeviceAction.Done,
-            target(
-                hasCompleted = true,
-                hasResolvedLookup = true,
-                canEnterCode = true,
-                canSubmit = true,
-            ),
-        )
-    }
-
-    @Test
-    fun `Deny is never the default target`() {
-        // It sits next to Approve, one press away. Defaulting focus to the
-        // destructive choice would be wrong.
-        val everyReachableTarget = listOf(
-            target(hasCompleted = true),
-            target(hasResolvedLookup = true, canSubmit = true),
-            target(canEnterCode = true),
-            target(canSubmit = true),
-            target(canSubmit = true, isLoading = true),
-            // canSubmit is false while submitting, by construction.
-            target(hasResolvedLookup = true, isSubmitting = true),
-        )
-        assertEquals(
-            listOf(
-                TvPairDeviceAction.Done,
-                TvPairDeviceAction.Approve,
-                TvPairDeviceAction.EnterCode,
-                TvPairDeviceAction.Check,
-                null,
-                null,
-            ),
-            everyReachableTarget,
+            target(hasCompleted = true, hasResolvedLookup = true, canEnterCode = true),
         )
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTargetTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvPairDeviceFocusTargetTest.kt
@@ -1,0 +1,85 @@
+package org.siloserver.silo.tv.ui.focus
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TvPairDeviceFocusTargetTest {
+
+    private fun target(
+        hasCompleted: Boolean = false,
+        canEnterCode: Boolean = false,
+        canSubmit: Boolean = false,
+        isLoading: Boolean = false,
+        isSubmitting: Boolean = false,
+    ) = tvPairDeviceFocusTarget(hasCompleted, canEnterCode, canSubmit, isLoading, isSubmitting)
+
+    @Test
+    fun `the token route has nothing to focus while its automatic lookup runs`() {
+        // Deep-linked with a token: no code entry, Check disabled by isLoading.
+        assertNull(target(isLoading = true))
+    }
+
+    @Test
+    fun `when that lookup resolves, focus moves to Approve`() {
+        // The bug: completedStatus never changed across this transition, so the
+        // effect keyed on it never re-ran and the panel stayed unfocused.
+        assertEquals(TvPairDeviceAction.Approve, target(canSubmit = true))
+    }
+
+    @Test
+    fun `when that lookup fails, focus falls to the re-enabled Check`() {
+        assertEquals(TvPairDeviceAction.Check, target(isLoading = false, canSubmit = false))
+    }
+
+    @Test
+    fun `nothing is focusable while a decision is being submitted`() {
+        assertNull(target(isSubmitting = true))
+    }
+
+    @Test
+    fun `the manual route offers code entry first`() {
+        assertEquals(TvPairDeviceAction.EnterCode, target(canEnterCode = true))
+    }
+
+    @Test
+    fun `a resolved lookup outranks manual code entry`() {
+        assertEquals(
+            TvPairDeviceAction.Approve,
+            target(canEnterCode = true, canSubmit = true),
+        )
+    }
+
+    @Test
+    fun `completion outranks everything`() {
+        assertEquals(
+            TvPairDeviceAction.Done,
+            target(hasCompleted = true, canEnterCode = true, canSubmit = true),
+        )
+    }
+
+    @Test
+    fun `Deny is never the default target`() {
+        // It sits next to Approve, one press away. Defaulting focus to the
+        // destructive choice would be wrong.
+        val everyReachableTarget = listOf(
+            target(hasCompleted = true),
+            target(canSubmit = true),
+            target(canEnterCode = true),
+            target(),
+            target(isLoading = true),
+            target(isSubmitting = true),
+        )
+        assertEquals(
+            listOf(
+                TvPairDeviceAction.Done,
+                TvPairDeviceAction.Approve,
+                TvPairDeviceAction.EnterCode,
+                TvPairDeviceAction.Check,
+                null,
+                null,
+            ),
+            everyReachableTarget,
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvProfileFocusTargetTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvProfileFocusTargetTest.kt
@@ -1,0 +1,163 @@
+package org.siloserver.silo.tv.ui.focus
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TvProfileFocusTargetTest {
+
+    private val abc = listOf("a", "b", "c", "d")
+
+    @Test
+    fun `the first arrival of the list is anchored`() {
+        assertEquals(
+            "a",
+            tvProfileFocusTarget(
+                previousIds = emptyList(),
+                currentIds = abc,
+                focusedId = null,
+                hasMaterialized = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `deleting the first profile falls to the one that replaced it`() {
+        assertEquals(
+            "b",
+            tvProfileFocusTarget(
+                previousIds = abc,
+                currentIds = listOf("b", "c", "d"),
+                focusedId = "a",
+                hasMaterialized = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `deleting the only profile anchors nothing`() {
+        assertNull(
+            tvProfileFocusTarget(
+                previousIds = listOf("a"),
+                currentIds = emptyList(),
+                focusedId = "a",
+                hasMaterialized = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `adding a profile leaves the focused one alone`() {
+        assertEquals(
+            "b",
+            tvProfileFocusTarget(
+                previousIds = abc,
+                currentIds = abc + "e",
+                focusedId = "b",
+                hasMaterialized = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `a list that changed but kept the focused profile keeps focus on it`() {
+        // Note the caller keys its effect on the ID list, so an *identical*
+        // list never reaches here — this is the changed-list case, which is
+        // what an edit or a deletion elsewhere in the grid produces.
+        assertEquals(
+            "c",
+            tvProfileFocusTarget(
+                previousIds = abc,
+                currentIds = listOf("a", "c", "d"),
+                focusedId = "c",
+                hasMaterialized = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `an edited profile keeps focus even after it moves position`() {
+        assertEquals(
+            "c",
+            tvProfileFocusTarget(
+                previousIds = abc,
+                currentIds = listOf("c", "a", "b", "d"),
+                focusedId = "c",
+                hasMaterialized = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `deleting the focused profile falls to the tile that took its place`() {
+        assertEquals(
+            "d",
+            tvProfileFocusTarget(
+                previousIds = abc,
+                currentIds = listOf("a", "b", "d"),
+                focusedId = "c",
+                hasMaterialized = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `deleting the last profile falls back to the new last one`() {
+        assertEquals(
+            "c",
+            tvProfileFocusTarget(
+                previousIds = abc,
+                currentIds = listOf("a", "b", "c"),
+                focusedId = "d",
+                hasMaterialized = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `a refresh with focus elsewhere on the screen is left alone`() {
+        // Focus may be on Add Profile, Change Server or Sign Out. A profile
+        // reload has no business pulling it into the grid.
+        assertNull(
+            tvProfileFocusTarget(
+                previousIds = abc,
+                currentIds = abc,
+                focusedId = null,
+                hasMaterialized = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `an empty list has nothing to anchor`() {
+        assertNull(
+            tvProfileFocusTarget(
+                previousIds = abc,
+                currentIds = emptyList(),
+                focusedId = "a",
+                hasMaterialized = true,
+            ),
+        )
+        assertNull(
+            tvProfileFocusTarget(
+                previousIds = emptyList(),
+                currentIds = emptyList(),
+                focusedId = null,
+                hasMaterialized = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `a focused profile that was never in the previous list is left alone`() {
+        // No index to fall back from, so guessing would be worse than nothing.
+        assertNull(
+            tvProfileFocusTarget(
+                previousIds = listOf("a", "b"),
+                currentIds = listOf("a", "b"),
+                focusedId = "ghost",
+                hasMaterialized = true,
+            ),
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnAdaptersTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnAdaptersTest.kt
@@ -1,0 +1,108 @@
+package org.siloserver.silo.tv.ui.focus
+
+import org.siloserver.silo.model.section.ResolvedSection
+import org.siloserver.silo.model.section.SectionItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TvReturnAdaptersTest {
+
+    private fun item(contentId: String) = SectionItem(
+        contentId = contentId,
+        type = "movie",
+        title = "Title $contentId",
+    )
+
+    private fun section(id: String, ids: List<String>, totalCount: Int = 0) = ResolvedSection(
+        id = id,
+        sectionType = "row",
+        title = id,
+        totalCount = totalCount,
+        items = ids.map(::item),
+    )
+
+    @Test
+    fun `rows project to their section id and card content ids in order`() {
+        val feed = listOf(
+            section("continue", listOf("a", "b")),
+            section("recent", listOf("c")),
+        )
+
+        assertEquals(
+            listOf(
+                TvReturnSection("continue", listOf("a", "b")),
+                TvReturnSection("recent", listOf("c")),
+            ),
+            feed.toTvReturnSections(),
+        )
+    }
+
+    @Test
+    fun `a capped row is complete even though the server says more exist`() {
+        // The distinction that matters: totalCount above the card count means
+        // the row was TRIMMED, not that a page is still coming. Nothing will
+        // ever load the remainder, so reporting it incomplete would leave every
+        // unresolved return waiting forever for a request nobody makes.
+        val capped = listOf(
+            section("recent", listOf("a", "b"), totalCount = 500).copy(itemLimit = 2),
+        )
+
+        assertTrue(capped.toTvReturnSections().single().isComplete)
+    }
+
+    @Test
+    fun `an unhydrated placeholder row is incomplete, not empty`() {
+        // The distinction this pins: hydrateHomeSections fetches rows that
+        // arrive with no cards but a non-zero total, then fills them in.
+        // Reading that as "nothing here" spends the return target on a
+        // fallback moments before the real row appears.
+        val placeholder = listOf(section("recent", emptyList(), totalCount = 20))
+
+        assertTrue(!placeholder.toTvReturnSections().single().isComplete)
+        assertEquals(
+            TvReturnResolution.Pending,
+            resolveTvReturnTarget(
+                TvReturnTarget("recent", "e", 0, 1),
+                placeholder.toTvReturnSections(),
+            ),
+        )
+    }
+
+    @Test
+    fun `a genuinely empty row is complete`() {
+        val empty = listOf(section("recent", emptyList(), totalCount = 0))
+        assertTrue(empty.toTvReturnSections().single().isComplete)
+    }
+
+    @Test
+    fun `an empty feed projects to no sections`() {
+        assertEquals(emptyList(), emptyList<ResolvedSection>().toTvReturnSections())
+    }
+
+    @Test
+    fun `a projected feed resolves a launch card by identity`() {
+        // End to end through the contract, so the projection is exercised the
+        // way the feed will use it rather than only compared field by field.
+        val feed = listOf(
+            section("continue", listOf("a", "b")),
+            section("recent", listOf("c", "d")),
+        )
+        val launched = TvReturnTarget("recent", "d", sectionIndex = 1, itemIndex = 1)
+
+        // The feed reorders and the launch row moves; identity still finds it.
+        val reordered = listOf(
+            section("recent", listOf("new", "c", "d")),
+            section("continue", listOf("a", "b")),
+        )
+
+        assertEquals(
+            TvReturnResolution.Exact(1, 1, "recent", "d"),
+            resolveTvReturnTarget(launched, feed.toTvReturnSections()),
+        )
+        assertEquals(
+            TvReturnResolution.Exact(0, 2, "recent", "d"),
+            resolveTvReturnTarget(launched, reordered.toTvReturnSections()),
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnAdaptersTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnAdaptersTest.kt
@@ -105,4 +105,51 @@ class TvReturnAdaptersTest {
             resolveTvReturnTarget(launched, reordered.toTvReturnSections()),
         )
     }
+
+    // ── Flat paginated surfaces ──────────────────────────────────────────
+
+    @Test
+    fun `a flat page still loading reports incomplete`() {
+        val page = flatTvReturnSections(listOf("a", "b"), hasMore = true)
+
+        assertTrue(!page.single().isComplete)
+        assertEquals(TvFlatSectionId, page.single().id)
+    }
+
+    @Test
+    fun `a fully loaded flat surface reports complete`() {
+        assertTrue(flatTvReturnSections(listOf("a"), hasMore = false).single().isComplete)
+    }
+
+    @Test
+    fun `a target beyond the loaded page waits rather than settling nearby`() {
+        // The regression this pins for every paginated surface: an item on a
+        // later page is missing exactly as a deleted one is, and settling here
+        // strands focus on whatever card the first page happens to end with.
+        val launched = TvReturnTarget(TvFlatSectionId, "z", sectionIndex = 0, itemIndex = 60)
+
+        assertEquals(
+            TvReturnResolution.Pending,
+            resolveTvReturnTarget(launched, flatTvReturnSections(listOf("a", "b"), hasMore = true)),
+        )
+        // Once the page carrying it arrives, identity finds it wherever it sits.
+        assertEquals(
+            TvReturnResolution.Exact(0, 2, TvFlatSectionId, "z"),
+            resolveTvReturnTarget(launched, flatTvReturnSections(listOf("a", "b", "z"), hasMore = true)),
+        )
+    }
+
+    @Test
+    fun `a caller out of patience settles on the nearest loaded card`() {
+        val launched = TvReturnTarget(TvFlatSectionId, "z", sectionIndex = 0, itemIndex = 60)
+
+        assertEquals(
+            TvReturnResolution.Nearest(0, 1, TvFlatSectionId, "b"),
+            resolveTvReturnTarget(
+                launched,
+                flatTvReturnSections(listOf("a", "b"), hasMore = true),
+                treatAbsenceAsFinal = true,
+            ),
+        )
+    }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnTargetTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnTargetTest.kt
@@ -644,4 +644,31 @@ class TvReturnTargetTest {
             resolveTvReturnTarget(target(sectionIndex = 1, itemIndex = 0), namesakes),
         )
     }
+
+    // ── Targets are partitioned by the surface that saved them ───────────
+
+    @Test
+    fun `a saved target is discarded when it comes back on a different surface`() {
+        // rememberSaveable does not validate restored values against its keys,
+        // so a process returning on a different tab would otherwise adopt the
+        // previous surface's target and restore focus to somewhere the viewer
+        // was in another list entirely.
+        val saver = keyedTvReturnTargetSaver("browse")
+        val scope = SaverScope { true }
+        val saved = with(saver) { scope.save(TvReturnTarget(TvFlatSectionId, "q", 0, 3)) }
+
+        assertEquals(null, keyedTvReturnTargetSaver("genres").restore(saved!!))
+        assertEquals(
+            TvReturnTarget(TvFlatSectionId, "q", 0, 3),
+            keyedTvReturnTargetSaver("browse").restore(saved),
+        )
+    }
+
+    @Test
+    fun `an empty target round-trips as empty on its own surface`() {
+        val saver = keyedTvReturnTargetSaver("browse")
+        val scope = SaverScope { true }
+        val saved = with(saver) { scope.save(null) }
+        assertEquals(null, saved?.let { saver.restore(it) })
+    }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnTargetTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnTargetTest.kt
@@ -1,0 +1,647 @@
+package org.siloserver.silo.tv.ui.focus
+
+import androidx.compose.runtime.saveable.SaverScope
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The cases here are the ones saved indices got wrong. Each names the real
+ * event that produces it, because "the data changed while you were away" is the
+ * normal state of a feed, not an edge case.
+ */
+class TvReturnTargetTest {
+
+    private val continueWatching = TvReturnSection("continue", listOf("a", "b", "c"))
+    private val recentlyAdded = TvReturnSection("recent", listOf("d", "e"))
+    private val because = TvReturnSection("because", listOf("f", "g", "h"))
+    private val feed = listOf(continueWatching, recentlyAdded, because)
+
+    private fun target(
+        sectionId: String = "recent",
+        itemId: String = "e",
+        sectionIndex: Int = 1,
+        itemIndex: Int = 1,
+    ) = TvReturnTarget(sectionId, itemId, sectionIndex, itemIndex)
+
+    // ── The occurrence is still there ────────────────────────────────────
+
+    @Test
+    fun `an unchanged feed returns to the launch card`() {
+        assertEquals(
+            TvReturnResolution.Exact(1, 1, "recent", "e"),
+            resolveTvReturnTarget(target(), feed),
+        )
+    }
+
+    @Test
+    fun `a feed that reordered its rows follows the row, not the saved index`() {
+        // The launch row moves from index 1 to index 2. A resolver trusting the
+        // saved index would land in a different row entirely.
+        val reordered = listOf(because, continueWatching, recentlyAdded)
+        assertEquals(
+            TvReturnResolution.Exact(2, 1, "recent", "e"),
+            resolveTvReturnTarget(target(), reordered),
+        )
+    }
+
+    @Test
+    fun `items inserted ahead of the launch card do not drag focus along`() {
+        val shifted = listOf(
+            continueWatching,
+            recentlyAdded.copy(itemIds = listOf("new", "d", "e")),
+            because,
+        )
+        assertEquals(
+            TvReturnResolution.Exact(1, 2, "recent", "e"),
+            resolveTvReturnTarget(target(), shifted),
+        )
+    }
+
+    @Test
+    fun `an item removed from the front of the row shifts the target left`() {
+        val shifted = listOf(continueWatching, recentlyAdded.copy(itemIds = listOf("e")), because)
+        assertEquals(
+            TvReturnResolution.Exact(1, 0, "recent", "e"),
+            resolveTvReturnTarget(target(), shifted),
+        )
+    }
+
+    @Test
+    fun `a flat grid resolves by identity after a sort changes the order`() {
+        val grid = listOf(TvReturnSection(TvFlatSectionId, listOf("r", "q", "p")))
+        val launched = TvReturnTarget(TvFlatSectionId, itemId = "p", sectionIndex = 0, itemIndex = 0)
+
+        assertEquals(
+            TvReturnResolution.Exact(0, 2, TvFlatSectionId, "p"),
+            resolveTvReturnTarget(launched, grid),
+        )
+    }
+
+    // ── Duplicates and relocation ────────────────────────────────────────
+
+    @Test
+    fun `a duplicate elsewhere is not mistaken for the launch card`() {
+        // Feeds routinely carry the same item in several rows. "b" leaves
+        // Continue Watching while a copy that was ALWAYS in Recently Added
+        // stays put. Jumping to that copy throws focus across the feed to a
+        // card the viewer never touched.
+        val duplicated = listOf(
+            continueWatching.copy(itemIds = listOf("a", "c")),
+            recentlyAdded.copy(itemIds = listOf("d", "b", "e")),
+            because,
+        )
+        val launched = target(sectionId = "continue", itemId = "b", sectionIndex = 0, itemIndex = 1)
+
+        assertEquals(
+            TvReturnResolution.Nearest(0, 1, "continue", "c"),
+            resolveTvReturnTarget(launched, duplicated),
+        )
+    }
+
+    @Test
+    fun `a surface with disjoint rows can opt into following the item`() {
+        val moved = listOf(
+            continueWatching.copy(itemIds = listOf("a", "c")),
+            recentlyAdded,
+            because.copy(itemIds = listOf("f", "b", "g", "h")),
+        )
+        val launched = target(sectionId = "continue", itemId = "b", sectionIndex = 0, itemIndex = 1)
+
+        assertEquals(
+            TvReturnResolution.Exact(2, 1, "because", "b"),
+            resolveTvReturnTarget(launched, moved, TvReturnRelocation.FollowAcrossSections),
+        )
+    }
+
+    @Test
+    fun `following the item prefers the copy nearest the original row`() {
+        // With several copies, display order must not decide: a refresh that
+        // merely reorders those rows would change where focus lands.
+        val everywhere = listOf(
+            TvReturnSection("s0", listOf("x")),
+            TvReturnSection("s1", listOf("b")),
+            TvReturnSection("gone-from", listOf("y")),
+            TvReturnSection("s3", listOf("b")),
+        )
+        val launched = target(sectionId = "gone-from", itemId = "b", sectionIndex = 2, itemIndex = 0)
+
+        assertEquals(
+            TvReturnResolution.Exact(3, 0, "s3", "b"),
+            resolveTvReturnTarget(launched, everywhere, TvReturnRelocation.FollowAcrossSections),
+        )
+    }
+
+    // ── Incomplete data ──────────────────────────────────────────────────
+
+    @Test
+    fun `a half-loaded section does not count as proof the item is gone`() {
+        // Grids, Search, personal lists, Collections and people all paginate.
+        // An item on page four is missing from page one in exactly the way a
+        // deleted item is, and consuming the target here strands focus on a
+        // stand-in permanently.
+        val firstPage = listOf(TvReturnSection(TvFlatSectionId, listOf("p", "q"), isComplete = false))
+        val launched = TvReturnTarget(TvFlatSectionId, itemId = "z", sectionIndex = 0, itemIndex = 40)
+
+        assertEquals(TvReturnResolution.Pending, resolveTvReturnTarget(launched, firstPage))
+    }
+
+    @Test
+    fun `a fully loaded section that lacks the item is proof enough`() {
+        val complete = listOf(TvReturnSection(TvFlatSectionId, listOf("p", "q"), isComplete = true))
+        val launched = TvReturnTarget(TvFlatSectionId, itemId = "z", sectionIndex = 0, itemIndex = 40)
+
+        assertEquals(
+            TvReturnResolution.Nearest(0, 1, TvFlatSectionId, "q"),
+            resolveTvReturnTarget(launched, complete),
+        )
+    }
+
+    @Test
+    fun `an empty but still loading surface waits rather than giving up`() {
+        val loading = listOf(TvReturnSection("recent", emptyList(), isComplete = false))
+        assertEquals(TvReturnResolution.Pending, resolveTvReturnTarget(target(), loading))
+    }
+
+    @Test
+    fun `a loading sibling does not hold up a section that has finished`() {
+        // The launch row is complete and does not list the item, so its absence
+        // is already authoritative — another row still loading is irrelevant
+        // unless the surface follows items across rows.
+        val mixed = listOf(
+            continueWatching.copy(isComplete = false),
+            recentlyAdded.copy(itemIds = listOf("d"), isComplete = true),
+            because,
+        )
+        assertEquals(
+            TvReturnResolution.Nearest(1, 0, "recent", "d"),
+            resolveTvReturnTarget(target(), mixed),
+        )
+    }
+
+    @Test
+    fun `a vanished row waits on a loading sibling only when following items`() {
+        // With the row gone, a cross-section match is the only thing that could
+        // still turn up — so completeness matters only to a surface that would
+        // accept one.
+        val loading = listOf(continueWatching.copy(isComplete = false), because)
+        val launched = target(sectionId = "gone", itemId = "e", sectionIndex = 1, itemIndex = 0)
+
+        assertEquals(
+            TvReturnResolution.Pending,
+            resolveTvReturnTarget(launched, loading, TvReturnRelocation.FollowAcrossSections),
+        )
+        assertEquals(
+            TvReturnResolution.Nearest(1, 0, "because", "f"),
+            resolveTvReturnTarget(launched, loading),
+        )
+    }
+
+    @Test
+    fun `a feed still loading its rows waits before falling back`() {
+        // The launch row may simply not have arrived yet. A per-section flag
+        // cannot say so — a section that has not loaded is not in the list to
+        // carry one — which is why completeness is also asked of the list.
+        val partialFeed = listOf(continueWatching)
+        assertEquals(
+            TvReturnResolution.Pending,
+            resolveTvReturnTarget(target(), partialFeed, sectionsComplete = false),
+        )
+        // Once the feed says that is all the rows there are, the launch row is
+        // genuinely gone and the fallback is honest.
+        assertEquals(
+            TvReturnResolution.Nearest(0, 1, "continue", "b"),
+            resolveTvReturnTarget(target(), partialFeed, sectionsComplete = true),
+        )
+    }
+
+    @Test
+    fun `following items waits on any loading row even when the launch row is done`() {
+        // The launch row has finished and does not list the item, but a surface
+        // that accepts the item from anywhere could still see it arrive in the
+        // row that is still filling.
+        val mixed = listOf(
+            continueWatching.copy(isComplete = false),
+            recentlyAdded.copy(itemIds = listOf("d"), isComplete = true),
+            because,
+        )
+        assertEquals(
+            TvReturnResolution.Pending,
+            resolveTvReturnTarget(target(), mixed, TvReturnRelocation.FollowAcrossSections),
+        )
+        // A surface that only looks in its own row has its answer already.
+        assertEquals(
+            TvReturnResolution.Nearest(1, 0, "recent", "d"),
+            resolveTvReturnTarget(target(), mixed),
+        )
+    }
+
+    // ── The occurrence is gone ───────────────────────────────────────────
+
+    @Test
+    fun `a removed item leaves focus on whatever took its place`() {
+        val without = listOf(continueWatching, recentlyAdded.copy(itemIds = listOf("d", "x")), because)
+        assertEquals(
+            TvReturnResolution.Nearest(1, 1, "recent", "x"),
+            resolveTvReturnTarget(target(), without),
+        )
+    }
+
+    @Test
+    fun `a removed last item falls back inside its row rather than off the end`() {
+        val shorter = listOf(continueWatching, recentlyAdded.copy(itemIds = listOf("d")), because)
+        assertEquals(
+            TvReturnResolution.Nearest(1, 0, "recent", "d"),
+            resolveTvReturnTarget(target(), shorter),
+        )
+    }
+
+    @Test
+    fun `a removed row falls back to the row that slid into its place`() {
+        val without = listOf(continueWatching, because)
+        assertEquals(
+            TvReturnResolution.Nearest(1, 1, "because", "g"),
+            resolveTvReturnTarget(target(), without),
+        )
+    }
+
+    @Test
+    fun `a removed row with no exact successor picks the nearest by distance`() {
+        // The launch row was index 3 of a longer feed; only earlier rows
+        // survive, so the fallback has to measure distance rather than reuse
+        // the saved index.
+        val survivors = listOf(continueWatching, recentlyAdded)
+        val launched = target(sectionId = "gone", itemId = "z", sectionIndex = 3, itemIndex = 0)
+
+        assertEquals(
+            TvReturnResolution.Nearest(1, 0, "recent", "d"),
+            resolveTvReturnTarget(launched, survivors),
+        )
+    }
+
+    @Test
+    fun `an emptied row is never chosen as a fallback`() {
+        val emptied = listOf(
+            continueWatching,
+            recentlyAdded.copy(itemIds = emptyList()),
+            because,
+        )
+        assertEquals(
+            TvReturnResolution.Nearest(2, 1, "because", "g"),
+            resolveTvReturnTarget(target(), emptied),
+        )
+    }
+
+    @Test
+    fun `a tie between the row above and below goes to the one below`() {
+        // Only reachable for an emptied-but-present row: a removed row makes
+        // its successor land at distance zero, which is no tie. This is a plain
+        // forward bias — moving focus backwards lands the viewer in content
+        // they have already scrolled past.
+        val emptiedInPlace = listOf(
+            continueWatching,
+            recentlyAdded.copy(itemIds = emptyList()),
+            because,
+        )
+        assertEquals(
+            TvReturnResolution.Nearest(2, 0, "because", "f"),
+            resolveTvReturnTarget(target(itemIndex = 0), emptiedInPlace),
+        )
+    }
+
+    @Test
+    fun `an entirely empty feed has nothing to restore`() {
+        assertEquals(TvReturnResolution.Empty, resolveTvReturnTarget(target(), emptyList()))
+        assertEquals(
+            TvReturnResolution.Empty,
+            resolveTvReturnTarget(target(), listOf(TvReturnSection("recent", emptyList()))),
+        )
+    }
+
+    @Test
+    fun `no recorded target restores nothing`() {
+        assertEquals(TvReturnResolution.Empty, resolveTvReturnTarget(null, feed))
+    }
+
+    // ── Surviving process death ──────────────────────────────────────────
+
+    private fun roundTrip(target: TvReturnTarget?): TvReturnTarget? {
+        val scope = SaverScope { true }
+        val saved = with(TvReturnTargetSaver) { scope.save(target) }
+        return saved?.let { TvReturnTargetSaver.restore(it) }
+    }
+
+    @Test
+    fun `a target survives process death intact`() {
+        val launched = target()
+        assertEquals(launched, roundTrip(launched))
+    }
+
+    @Test
+    fun `a flat surface's target survives process death`() {
+        val flat = TvReturnTarget(TvFlatSectionId, itemId = "r", sectionIndex = 0, itemIndex = 2)
+        assertEquals(flat, roundTrip(flat))
+    }
+
+    @Test
+    fun `a flat surface restores a surviving item by identity, not by position`() {
+        // The defect this replaces: the flat section id used to be null while
+        // no section could ever BE null, so a flat surface never matched its
+        // own launch section and every surviving item came back as a positional
+        // fallback. An earlier version of this test asserted that behaviour and
+        // so made the bug look intended.
+        val grid = listOf(TvReturnSection(TvFlatSectionId, listOf("r", "q", "p")))
+        val launched = TvReturnTarget(TvFlatSectionId, itemId = "q", sectionIndex = 0, itemIndex = 2)
+
+        assertEquals(
+            TvReturnResolution.Exact(0, 1, TvFlatSectionId, "q"),
+            resolveTvReturnTarget(launched, grid),
+        )
+    }
+
+    @Test
+    fun `no target survives as no target`() {
+        assertEquals(null, roundTrip(null))
+    }
+
+    // ── Waiting, and stopping waiting ────────────────────────────────────
+
+    @Test
+    fun `a finished launch row does not wait on rows that have not loaded`() {
+        // Under SameSectionOnly only the launch row can answer, so once it is
+        // here and complete the question is settled. Waiting on rows that
+        // could not change the answer is a stall, not caution.
+        val partial = listOf(recentlyAdded.copy(itemIds = listOf("d"), isComplete = true))
+        val launched = target(sectionIndex = 0)
+
+        assertEquals(
+            TvReturnResolution.Nearest(0, 0, "recent", "d"),
+            resolveTvReturnTarget(launched, partial, sectionsComplete = false),
+        )
+    }
+
+    @Test
+    fun `identity still wins while the surface is loading`() {
+        // Finding it ends the question immediately; completeness only governs
+        // how absence is read.
+        val partial = listOf(recentlyAdded.copy(isComplete = false))
+        assertEquals(
+            TvReturnResolution.Exact(0, 1, "recent", "e"),
+            resolveTvReturnTarget(target(sectionIndex = 0), partial, sectionsComplete = false),
+        )
+    }
+
+    @Test
+    fun `a pending target resolves once the page carrying it arrives`() {
+        val launched = TvReturnTarget(TvFlatSectionId, itemId = "z", sectionIndex = 0, itemIndex = 40)
+        val firstPage = listOf(TvReturnSection(TvFlatSectionId, listOf("p", "q"), isComplete = false))
+        assertEquals(TvReturnResolution.Pending, resolveTvReturnTarget(launched, firstPage))
+
+        val withNextPage = listOf(
+            TvReturnSection(TvFlatSectionId, listOf("p", "q", "y", "z"), isComplete = false),
+        )
+        assertEquals(
+            TvReturnResolution.Exact(0, 3, TvFlatSectionId, "z"),
+            resolveTvReturnTarget(launched, withNextPage),
+        )
+    }
+
+    @Test
+    fun `a caller that has waited long enough can force an answer`() {
+        // The terminal half of Pending. Without it a caller has to either lie
+        // about completeness or rebuild the fallback itself at every surface.
+        val launched = TvReturnTarget(TvFlatSectionId, itemId = "z", sectionIndex = 0, itemIndex = 40)
+        val stillLoading = listOf(TvReturnSection(TvFlatSectionId, listOf("p", "q"), isComplete = false))
+
+        assertEquals(TvReturnResolution.Pending, resolveTvReturnTarget(launched, stillLoading))
+        assertEquals(
+            TvReturnResolution.Nearest(0, 1, TvFlatSectionId, "q"),
+            resolveTvReturnTarget(launched, stillLoading, treatAbsenceAsFinal = true),
+        )
+    }
+
+    @Test
+    fun `forcing an answer on an empty loading surface gives up rather than waiting`() {
+        val nothingYet = listOf(TvReturnSection("recent", emptyList(), isComplete = false))
+        assertEquals(
+            TvReturnResolution.Empty,
+            resolveTvReturnTarget(target(), nothingYet, treatAbsenceAsFinal = true),
+        )
+    }
+
+    // ── Duplicate ids ────────────────────────────────────────────────────
+
+    @Test
+    fun `a repeated item within a row resolves to the copy nearest the viewer`() {
+        val repeated = listOf(TvReturnSection("recent", listOf("e", "d", "x", "e")))
+        assertEquals(
+            TvReturnResolution.Exact(0, 3, "recent", "e"),
+            resolveTvReturnTarget(target(sectionIndex = 0, itemIndex = 3), repeated),
+        )
+        assertEquals(
+            TvReturnResolution.Exact(0, 0, "recent", "e"),
+            resolveTvReturnTarget(target(sectionIndex = 0, itemIndex = 0), repeated),
+        )
+    }
+
+    @Test
+    fun `a duplicated section id does not shadow the row actually holding the item`() {
+        // An empty namesake appearing first would otherwise hide the real row
+        // and send focus to a positional fallback.
+        val shadowed = listOf(
+            TvReturnSection("recent", emptyList()),
+            TvReturnSection("recent", listOf("d", "e")),
+        )
+        assertEquals(
+            TvReturnResolution.Exact(1, 1, "recent", "e"),
+            resolveTvReturnTarget(target(sectionIndex = 0), shadowed),
+        )
+    }
+
+    @Test
+    fun `following the item prefers a nearer copy over a further one`() {
+        val everywhere = listOf(
+            TvReturnSection("s0", listOf("b")),
+            TvReturnSection("s1", listOf("x")),
+            TvReturnSection("gone-from", listOf("y")),
+            TvReturnSection("s3", listOf("b")),
+        )
+        val launched = target(sectionId = "gone-from", itemId = "b", sectionIndex = 3, itemIndex = 0)
+
+        // s3 is adjacent to the remembered coordinate; s0 is three rows away.
+        assertEquals(
+            TvReturnResolution.Exact(3, 0, "s3", "b"),
+            resolveTvReturnTarget(launched, everywhere, TvReturnRelocation.FollowAcrossSections),
+        )
+    }
+
+    // ── Duplicate section ids, disambiguated ─────────────────────────────
+
+    @Test
+    fun `the nearest namesake holding the item wins, not the first`() {
+        // Matching every namesake but taking the first contradicts the same
+        // nearest-coordinate policy used everywhere else, and sends focus to
+        // the far end of the feed.
+        val namesakes = listOf(
+            TvReturnSection("recent", listOf("d", "e")),
+            TvReturnSection("filler", listOf("x")),
+            TvReturnSection("recent", listOf("d", "e")),
+        )
+        assertEquals(
+            TvReturnResolution.Exact(2, 1, "recent", "e"),
+            resolveTvReturnTarget(target(sectionIndex = 2), namesakes),
+        )
+        assertEquals(
+            TvReturnResolution.Exact(0, 1, "recent", "e"),
+            resolveTvReturnTarget(target(sectionIndex = 0), namesakes),
+        )
+    }
+
+    @Test
+    fun `the nearest populated namesake wins the positional fallback too`() {
+        val namesakes = listOf(
+            TvReturnSection("recent", listOf("p")),
+            TvReturnSection("filler", listOf("x")),
+            TvReturnSection("recent", listOf("q")),
+        )
+        assertEquals(
+            TvReturnResolution.Nearest(2, 0, "recent", "q"),
+            resolveTvReturnTarget(target(sectionIndex = 2, itemIndex = 0), namesakes),
+        )
+    }
+
+    @Test
+    fun `a namesake still loading keeps the target waiting`() {
+        val namesakes = listOf(
+            TvReturnSection("recent", listOf("p"), isComplete = true),
+            TvReturnSection("recent", listOf("q"), isComplete = false),
+        )
+        assertEquals(TvReturnResolution.Pending, resolveTvReturnTarget(target(), namesakes))
+    }
+
+    @Test
+    fun `equidistant repeated items resolve to the earlier copy`() {
+        // Deterministic rather than arbitrary: a refresh must not move focus
+        // between two equally close copies.
+        val repeated = listOf(TvReturnSection("recent", listOf("e", "x", "e")))
+        assertEquals(
+            TvReturnResolution.Exact(0, 0, "recent", "e"),
+            resolveTvReturnTarget(target(sectionIndex = 0, itemIndex = 1), repeated),
+        )
+    }
+
+    // ── Forcing an answer never skips one that exists ────────────────────
+
+    @Test
+    fun `forcing an answer still returns an exact match that is present`() {
+        assertEquals(
+            TvReturnResolution.Exact(1, 1, "recent", "e"),
+            resolveTvReturnTarget(target(), feed, treatAbsenceAsFinal = true),
+        )
+    }
+
+    @Test
+    fun `forcing an answer still returns a relocated match that is present`() {
+        val moved = listOf(
+            continueWatching.copy(itemIds = listOf("a", "c")),
+            recentlyAdded,
+            because.copy(itemIds = listOf("f", "b")),
+        )
+        val launched = target(sectionId = "continue", itemId = "b", sectionIndex = 0, itemIndex = 1)
+
+        assertEquals(
+            TvReturnResolution.Exact(2, 1, "because", "b"),
+            resolveTvReturnTarget(
+                launched,
+                moved,
+                TvReturnRelocation.FollowAcrossSections,
+                treatAbsenceAsFinal = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `following items waits on an unloaded row even when every present row is done`() {
+        val allComplete = listOf(continueWatching, because)
+        val launched = target(sectionId = "gone", itemId = "e", sectionIndex = 1, itemIndex = 0)
+
+        assertEquals(
+            TvReturnResolution.Pending,
+            resolveTvReturnTarget(
+                launched,
+                allComplete,
+                TvReturnRelocation.FollowAcrossSections,
+                sectionsComplete = false,
+            ),
+        )
+    }
+
+    // ── Heterogeneous surfaces ───────────────────────────────────────────
+
+    @Test
+    fun `namespaced identities keep two identifier spaces from colliding`() {
+        // Search mixes library results with request-provider results, where a
+        // bare "1234" is a content id in one space and a TMDB id in the other.
+        // The domains have to be made to COMPETE for this to prove anything:
+        // the launch section is gone and relocation is on, so an unnamespaced
+        // id would match the unrelated library card and throw focus to it.
+        val results = listOf(TvReturnSection("search:library", listOf("catalog:1234")))
+
+        val namespaced = TvReturnTarget("search:requests", "request:movie:1234", 1, 0)
+        assertEquals(
+            TvReturnResolution.Nearest(0, 0, "search:library", "catalog:1234"),
+            resolveTvReturnTarget(namespaced, results, TvReturnRelocation.FollowAcrossSections),
+        )
+
+        // The same shape with bare ids resolves as an Exact match on a wholly
+        // unrelated item — what the namespacing prevents.
+        val collidingResults = listOf(TvReturnSection("search:library", listOf("1234")))
+        val bare = TvReturnTarget("search:requests", "1234", 1, 0)
+        assertEquals(
+            TvReturnResolution.Exact(0, 0, "search:library", "1234"),
+            resolveTvReturnTarget(bare, collidingResults, TvReturnRelocation.FollowAcrossSections),
+        )
+    }
+
+    @Test
+    fun `a duplicate section id degrades predictably but is not a supported shape`() {
+        // Section ids are required to be unique: the no-stall rule treats a
+        // present, finished launch section as final, which only holds if no
+        // second section can later arrive bearing the same id. This pins the
+        // known consequence rather than pretending it away — with a namesake
+        // still unloaded, the present one settles the question and the target
+        // is spent.
+        val onePresent = listOf(TvReturnSection("recent", listOf("d"), isComplete = true))
+
+        assertEquals(
+            TvReturnResolution.Nearest(0, 0, "recent", "d"),
+            resolveTvReturnTarget(target(sectionIndex = 0), onePresent, sectionsComplete = false),
+        )
+    }
+
+    @Test
+    fun `equidistant namesakes resolve forward, like every other tie`() {
+        val namesakes = listOf(
+            TvReturnSection("recent", listOf("d", "e")),
+            TvReturnSection("filler", listOf("x")),
+            TvReturnSection("recent", listOf("d", "e")),
+        )
+        // Remembered at index 1, so both namesakes are one row away.
+        assertEquals(
+            TvReturnResolution.Exact(2, 1, "recent", "e"),
+            resolveTvReturnTarget(target(sectionIndex = 1), namesakes),
+        )
+    }
+
+    @Test
+    fun `equidistant populated namesakes fall back forward too`() {
+        val namesakes = listOf(
+            TvReturnSection("recent", listOf("p")),
+            TvReturnSection("filler", listOf("x")),
+            TvReturnSection("recent", listOf("q")),
+        )
+        assertEquals(
+            TvReturnResolution.Nearest(2, 0, "recent", "q"),
+            resolveTvReturnTarget(target(sectionIndex = 1, itemIndex = 0), namesakes),
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
@@ -72,4 +72,51 @@ class TvCalendarFocusRoutingTest {
             ),
         )
     }
+
+    @Test
+    fun heldUpFreezesWhileTheReturnToControlsIsStillInFlight() {
+        // The handoff is under way but the shelf has not yet given up focus,
+        // so it still reports its own index. Previously this fell through to
+        // geometric movement and the held key walked back into the content.
+        assertEquals(
+            CalendarUpFallbackAction.StayInContent,
+            calendarUpFallbackAction(
+                focusedShelfIndex = 2,
+                firstFocusableShelfIndex = 2,
+                isReturningToControls = true,
+                focusedControlZone = null,
+                isRepeat = true,
+            ),
+        )
+    }
+
+    @Test
+    fun heldUpFreezesInFlightEvenFromALowerShelf() {
+        assertEquals(
+            CalendarUpFallbackAction.StayInContent,
+            calendarUpFallbackAction(
+                focusedShelfIndex = 5,
+                firstFocusableShelfIndex = 2,
+                isReturningToControls = true,
+                focusedControlZone = null,
+                isRepeat = true,
+            ),
+        )
+    }
+
+    @Test
+    fun aFreshUpDuringAnInFlightReturnStillMovesWithinContent() {
+        // Only held repeats are frozen. A deliberate new press is the viewer
+        // acting again, not the tail of the press that started the handoff.
+        assertEquals(
+            CalendarUpFallbackAction.MoveWithinContent,
+            calendarUpFallbackAction(
+                focusedShelfIndex = 5,
+                firstFocusableShelfIndex = 2,
+                isReturningToControls = true,
+                focusedControlZone = null,
+                isRepeat = false,
+            ),
+        )
+    }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryFocusRestoreTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryFocusRestoreTest.kt
@@ -2,27 +2,30 @@ package org.siloserver.silo.tv.ui.screens.library
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
+/**
+ * Restoring the grid used to be a saved index clamped to the current size,
+ * which is why these once asserted "17 comes back as 17". Identity resolution
+ * lives in the shared contract now; what remains here is the grid's own
+ * arithmetic — turning an item position into a LazyGrid position.
+ */
 class TvLibraryFocusRestoreTest {
     @Test
-    fun restoresSavedItemWhenStillPresent() {
-        assertEquals(17, restoredLibraryFocusIndex(17, 40))
-    }
-
-    @Test
-    fun clampsAfterLibraryShrinks() {
-        assertEquals(4, restoredLibraryFocusIndex(17, 5))
-    }
-
-    @Test
-    fun emptyGridHasNoRestoreTarget() {
-        assertNull(restoredLibraryFocusIndex(3, 0))
-    }
-
-    @Test
     fun lazyGridTargetIncludesFullSpanHeaders() {
-        assertEquals(19, restoredLibraryLazyGridIndex(17, 40, 2))
-        assertNull(restoredLibraryLazyGridIndex(0, 0, 2))
+        // Sort/filter controls and genre chips occupy full-span slots ahead of
+        // the cards, so the grid runs ahead of the item index by however many
+        // are showing.
+        assertEquals(19, libraryLazyGridIndex(itemIndex = 17, headerCount = 2))
+    }
+
+    @Test
+    fun aGridWithNoHeadersAddressesCardsDirectly() {
+        assertEquals(17, libraryLazyGridIndex(itemIndex = 17, headerCount = 0))
+    }
+
+    @Test
+    fun negativeInputsClampRatherThanAddressingBeforeTheGrid() {
+        assertEquals(0, libraryLazyGridIndex(itemIndex = -1, headerCount = 0))
+        assertEquals(3, libraryLazyGridIndex(itemIndex = 3, headerCount = -2))
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchReturnProjectionTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchReturnProjectionTest.kt
@@ -1,0 +1,161 @@
+package org.siloserver.silo.tv.ui.screens.search
+
+import org.siloserver.silo.model.catalog.BrowseItem
+import org.siloserver.silo.model.request.RequestAvailability
+import org.siloserver.silo.model.request.RequestMediaResult
+import org.siloserver.silo.tv.ui.focus.TvReturnRelocation
+import org.siloserver.silo.tv.ui.focus.TvReturnResolution
+import org.siloserver.silo.tv.ui.focus.TvReturnTarget
+import org.siloserver.silo.tv.ui.focus.resolveTvReturnTarget
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Search puts library items and requestable titles on one screen, and a
+ * requestable title that is already in the library carries both identities.
+ * These cover the collision that namespacing exists to prevent.
+ */
+class TvSearchReturnProjectionTest {
+
+    private fun catalogItem(id: String) = BrowseItem(contentId = id, type = "movie", title = id)
+
+    private fun requestResult(
+        mediaType: String,
+        tmdbId: Int,
+        libraryContentId: String? = null,
+    ) = RequestMediaResult(
+        mediaType = mediaType,
+        tmdbId = tmdbId,
+        title = "t$tmdbId",
+        availability = if (libraryContentId != null) RequestAvailability.Available else RequestAvailability.Missing,
+        libraryContentId = libraryContentId,
+    )
+
+    @Test
+    fun aRequestCardsLibraryTwinDoesNotStealTheReturn() {
+        // The same title in both places: content id "m1" in the grid, and a
+        // request card that opens that very item.
+        val sections = tvSearchReturnSections(
+            catalogItems = listOf(catalogItem("m0"), catalogItem("m1")),
+            requestResults = listOf(requestResult("movie", 55, libraryContentId = "m1")),
+            catalogComplete = true,
+            requestsComplete = true,
+        )
+
+        // The viewer opened the REQUEST card, so the return belongs in the
+        // request row — not on the grid card it happens to navigate to.
+        val resolved = resolveTvReturnTarget(
+            target = TvReturnTarget(
+                sectionId = TvSearchRequestSectionId,
+                itemId = tvSearchRequestItemId("movie", 55),
+                sectionIndex = 1,
+                itemIndex = 0,
+            ),
+            sections = sections,
+        )
+
+        val located = resolved as TvReturnResolution.Exact
+        assertEquals(TvSearchRequestSectionId, located.sectionId)
+        assertEquals(0, located.itemIndex)
+    }
+
+    @Test
+    fun aCatalogIdIsNeverMatchedAgainstTheRequestRow() {
+        val sections = tvSearchReturnSections(
+            catalogItems = emptyList(),
+            requestResults = listOf(requestResult("movie", 55, libraryContentId = "m1")),
+            catalogComplete = true,
+            requestsComplete = true,
+        )
+
+        // "m1" exists on screen — as the request card's library id. An
+        // un-namespaced projection would match it here.
+        val resolved = resolveTvReturnTarget(
+            target = TvReturnTarget(
+                sectionId = TvSearchCatalogSectionId,
+                itemId = tvSearchCatalogItemId("m1"),
+                sectionIndex = 0,
+                itemIndex = 0,
+            ),
+            sections = sections,
+            relocation = TvReturnRelocation.FollowAcrossSections,
+        )
+
+        assertTrue(
+            resolved !is TvReturnResolution.Exact,
+            "a catalog id must not resolve exactly against a request card",
+        )
+    }
+
+    @Test
+    fun aRequestSearchStillInFlightLetsTheTargetWait() {
+        // Request search clears its results when a query starts, so an empty
+        // row is not evidence that the card is gone.
+        val sections = tvSearchReturnSections(
+            catalogItems = listOf(catalogItem("m0")),
+            requestResults = emptyList(),
+            catalogComplete = true,
+            requestsComplete = false,
+        )
+
+        val resolved = resolveTvReturnTarget(
+            target = TvReturnTarget(
+                sectionId = TvSearchRequestSectionId,
+                itemId = tvSearchRequestItemId("movie", 55),
+                sectionIndex = 1,
+                itemIndex = 0,
+            ),
+            sections = sections,
+        )
+
+        assertEquals(TvReturnResolution.Pending, resolved)
+    }
+
+    @Test
+    fun aCatalogIdSpelledLikeARequestIdIsStillDistinct() {
+        // Proves the catalog namespace independently: without it, this content
+        // id would BE the request row's id.
+        val encoded = tvSearchRequestItemId("movie", 55)
+        assertTrue(tvSearchCatalogItemId(encoded) != encoded)
+    }
+
+    @Test
+    fun mediaTypeAliasesResolveToOneIdentity() {
+        // The rendering pipeline accepts all of these for the same card, so
+        // they must not become different saved identities.
+        val canonical = tvSearchRequestItemId("audiobook", 9)
+        assertEquals(canonical, tvSearchRequestItemId("audiobooks", 9))
+        assertEquals(canonical, tvSearchRequestItemId("  AudioBook ", 9))
+        assertEquals(tvSearchRequestItemId("movie", 9), tvSearchRequestItemId("MOVIE", 9))
+    }
+
+    @Test
+    fun theSameTmdbIdUnderDifferentMediaTypesStaysDistinct() {
+        assertTrue(tvSearchRequestItemId("movie", 7) != tvSearchRequestItemId("tv", 7))
+    }
+
+    @Test
+    fun anIncompleteCatalogLetsADeepTargetWait() {
+        val sections = tvSearchReturnSections(
+            catalogItems = listOf(catalogItem("m0")),
+            requestResults = emptyList(),
+            catalogComplete = false,
+            requestsComplete = true,
+        )
+
+        // Not yet loaded rather than not there: settling for a near miss here
+        // would strand focus on a stand-in for good.
+        val resolved = resolveTvReturnTarget(
+            target = TvReturnTarget(
+                sectionId = TvSearchCatalogSectionId,
+                itemId = tvSearchCatalogItemId("m99"),
+                sectionIndex = 0,
+                itemIndex = 40,
+            ),
+            sections = sections,
+        )
+
+        assertEquals(TvReturnResolution.Pending, resolved)
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/DevicePairingViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/DevicePairingViewModel.kt
@@ -68,6 +68,18 @@ class DevicePairingViewModel(
         }
     }
 
+    /**
+     * Bumped by every lookup, and by every decision.
+     *
+     * canDecide stays true while an EXISTING lookup refreshes — the previous
+     * result is deliberately left on screen rather than blanked — so a viewer
+     * can approve while a lookup is still in flight. If that lookup lands last
+     * it overwrites the outcome: a lookup error painted over a successful
+     * approval, or a decision's error quietly cleared. A decision is the more
+     * authoritative event, so starting one retires any lookup already running.
+     */
+    private var lookupGeneration = 0
+
     fun lookup() {
         val current = _uiState.value
         val token = current.token?.takeIf { it.isNotBlank() }
@@ -77,9 +89,18 @@ class DevicePairingViewModel(
             return
         }
 
+        val generation = ++lookupGeneration
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null, completedStatus = null) }
-            when (val result = repository.lookup(token = token, code = code)) {
+            val lookupResult = repository.lookup(token = token, code = code)
+            // Retired while in flight: a newer lookup or, more importantly, a
+            // decision has superseded this answer. Clearing isLoading is still
+            // this request's job, but nothing else it has to say is current.
+            if (generation != lookupGeneration) {
+                _uiState.update { it.copy(isLoading = false) }
+                return@launch
+            }
+            when (val result = lookupResult) {
                 is ApiResult.Success -> {
                     _uiState.update {
                         it.copy(isLoading = false, lookup = result.data, error = null)
@@ -120,6 +141,9 @@ class DevicePairingViewModel(
             return
         }
 
+        // Retires any lookup already running, before it can report back over
+        // the decision this is about to make.
+        lookupGeneration++
         viewModelScope.launch {
             _uiState.update { it.copy(isSubmitting = true, error = null, completedStatus = null) }
             val result = if (approve) {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/DevicePairingViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/DevicePairingViewModel.kt
@@ -58,6 +58,11 @@ class DevicePairingViewModel(
     }
 
     fun onCodeChanged(value: String) {
+        // Retires any lookup in flight. Without this a late answer for the
+        // previous code repopulates the details after the viewer has typed a
+        // different one — showing them a device that is not the one they are
+        // being asked about.
+        lookupGeneration++
         _uiState.update {
             it.copy(
                 code = value.trim().uppercase(),
@@ -79,6 +84,8 @@ class DevicePairingViewModel(
      * authoritative event, so starting one retires any lookup already running.
      */
     private var lookupGeneration = 0
+    /** Which lookup generation raised [DevicePairingUiState.isLoading]. */
+    private var loadingOwner = 0
 
     fun lookup() {
         val current = _uiState.value
@@ -90,6 +97,7 @@ class DevicePairingViewModel(
         }
 
         val generation = ++lookupGeneration
+        loadingOwner = generation
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null, completedStatus = null) }
             val lookupResult = repository.lookup(token = token, code = code)
@@ -97,7 +105,12 @@ class DevicePairingViewModel(
             // decision has superseded this answer. Clearing isLoading is still
             // this request's job, but nothing else it has to say is current.
             if (generation != lookupGeneration) {
-                _uiState.update { it.copy(isLoading = false) }
+                // Clear the loading flag only while this lookup still owns it.
+                // A newer lookup has raised it again for itself, and clearing
+                // it here would report that one as finished while it runs.
+                if (loadingOwner == generation) {
+                    _uiState.update { it.copy(isLoading = false) }
+                }
                 return@launch
             }
             when (val result = lookupResult) {
@@ -142,8 +155,11 @@ class DevicePairingViewModel(
         }
 
         // Retires any lookup already running, before it can report back over
-        // the decision this is about to make.
+        // the decision this is about to make. The retired lookup will not clear
+        // its own loading flag once it no longer owns the generation, so drop
+        // it here — otherwise the screen shows a spinner nothing will finish.
         lookupGeneration++
+        _uiState.update { it.copy(isLoading = false) }
         viewModelScope.launch {
             _uiState.update { it.copy(isSubmitting = true, error = null, completedStatus = null) }
             val result = if (approve) {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/DevicePairingViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/DevicePairingViewModel.kt
@@ -20,8 +20,21 @@ data class DevicePairingUiState(
     val completedStatus: String? = null,
     val error: String? = null,
 ) {
-    val canSubmit: Boolean
-        get() = !isSubmitting && (token?.isNotBlank() == true || code.isNotBlank())
+    /**
+     * Whether approving or denying is a real, informed decision right now.
+     *
+     * The identifier being present is not the test. A `silo://device?token=…`
+     * deep link arrives with a token already set and starts its lookup
+     * automatically, so "there is something to submit" is true from
+     * construction — before the server has said which device is asking, from
+     * where, or with which match code. Those details are the entire content of
+     * the decision, and they only exist once [lookup] resolves. Gating on the
+     * identifier let a viewer approve a sign-in they could not see, and kept
+     * approving available after a failed lookup had cleared [lookup] and
+     * reported the request invalid or expired.
+     */
+    val canDecide: Boolean
+        get() = lookup != null && !isSubmitting
 }
 
 class DevicePairingViewModel(

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
@@ -25,6 +25,18 @@ data class HomeUiState(
     val isLoading: Boolean = true,
     val isRefreshing: Boolean = false,
     val sections: List<ResolvedSection> = emptyList(),
+    /**
+     * Whether [sections] is the whole picture, or rows are still arriving.
+     *
+     * Surfaces that restore focus by identity need this: while hydration is
+     * still filling rows, a launch row can simply be absent, and "absent" has
+     * to mean "not here YET" rather than "gone" — otherwise focus is driven to
+     * the nearest survivor, which is a card the viewer never opened.
+     *
+     * Defaults true because a caller that does not know is describing a
+     * finished list; only a partial publish sets it false.
+     */
+    val sectionsFullyResolved: Boolean = true,
     val error: String? = null,
 )
 
@@ -154,8 +166,16 @@ class HomeViewModel(
                     // Only replace what's shown when the fetch fully resolved (or there
                     // was nothing yet) — a partial refresh must not clobber a good Home.
                     if (fullyResolved || !hadSections) {
-                        it.copy(isLoading = false, sections = overlaid, error = null)
+                        it.copy(
+                            isLoading = false,
+                            sections = overlaid,
+                            error = null,
+                            sectionsFullyResolved = fullyResolved,
+                        )
                     } else {
+                        // The partial result is discarded and the previous, good
+                        // sections stay on screen — so the flag keeps describing
+                        // THOSE, which were complete when they were published.
                         it.copy(isLoading = false, error = null)
                     }
                 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModels.kt
@@ -76,16 +76,15 @@ abstract class PersonalListViewModel(
     fun retry() = load(reset = true)
 
     fun refresh() {
+        // Claimed synchronously, for the same reason as load().
+        val generation = ++contentGeneration
+        _uiState.update { it.copy(isRefreshing = true, error = null) }
         viewModelScope.launch {
-            val generation = ++contentGeneration
-            _uiState.update { it.copy(isRefreshing = true, error = null) }
             val offset = 0
             val result = fetchPage(offset, pageSize)
-            // A newer replacement started while this refresh was in flight.
-            if (generation != contentGeneration) {
-                _uiState.update { it.copy(isRefreshing = false) }
-                return@launch
-            }
+            // A newer replacement started while this refresh was in flight and
+            // now owns isRefreshing, so this one clears nothing.
+            if (generation != contentGeneration) return@launch
             when (val r = result) {
                 is ApiResult.Success -> _uiState.update {
                     it.copy(
@@ -104,14 +103,21 @@ abstract class PersonalListViewModel(
     }
 
     private fun load(reset: Boolean) {
+        // Offset, generation and loading flag are all claimed SYNCHRONOUSLY,
+        // before the coroutine is launched. Doing it inside the launch left a
+        // window where loadMore() could see an idle list, queue itself, and
+        // have refresh() run first — the paging coroutine would then capture
+        // the refresh's generation, look current, and append its old-offset
+        // page anyway. Claiming here also makes the guard in loadMore() mean
+        // something: the flag is set by the time a second call can read it.
+        val state = _uiState.value
+        val offset = if (reset) 0 else state.items.size
+        val generation = if (reset) ++contentGeneration else contentGeneration
+        _uiState.update {
+            if (reset) it.copy(isLoading = true, error = null)
+            else it.copy(isLoadingMore = true)
+        }
         viewModelScope.launch {
-            val state = _uiState.value
-            val offset = if (reset) 0 else state.items.size
-            val generation = if (reset) ++contentGeneration else contentGeneration
-            _uiState.update {
-                if (reset) it.copy(isLoading = true, error = null)
-                else it.copy(isLoadingMore = true)
-            }
             val result = fetchPage(offset, pageSize)
             // Superseded WHILE IN FLIGHT: something replaced the list, so this
             // page's offset no longer describes anything. Checked here rather
@@ -121,7 +127,11 @@ abstract class PersonalListViewModel(
             // error on top would only undo that. The loading flag still has to
             // be released, because this request really has finished.
             if (generation != contentGeneration) {
-                _uiState.update { it.copy(isLoadingMore = false) }
+                // Only paging's own flag. isLoading and isRefreshing belong to
+                // whichever replacement superseded this one, and it will clear
+                // them when it lands — clearing them here would report that
+                // load as finished while it is still running.
+                if (!reset) _uiState.update { it.copy(isLoadingMore = false) }
                 return@launch
             }
             when (val r = result) {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModels.kt
@@ -55,17 +55,38 @@ abstract class PersonalListViewModel(
 
     fun loadMore() {
         val state = _uiState.value
-        if (state.isLoading || state.isLoadingMore || !state.hasMore) return
+        // isRefreshing too: refresh reloads from offset zero, so a page fetched
+        // alongside it uses an offset the replacement invalidates.
+        if (state.isLoading || state.isLoadingMore || state.isRefreshing || !state.hasMore) return
         load(reset = false)
     }
+
+    /**
+     * Bumped by every load that REPLACES the list — a reset or a refresh.
+     *
+     * Gating the triggers is not enough on its own. A page can already be in
+     * flight when a refresh starts, and refresh has no way to cancel it; when
+     * that page lands it appends items fetched at `offset = N` on top of a list
+     * that is now page one, leaving a hole where the middle used to be. Checking
+     * the generation on the way OUT is what makes a superseded page harmless,
+     * whichever order the two requests finish in.
+     */
+    private var contentGeneration = 0
 
     fun retry() = load(reset = true)
 
     fun refresh() {
         viewModelScope.launch {
+            val generation = ++contentGeneration
             _uiState.update { it.copy(isRefreshing = true, error = null) }
             val offset = 0
-            when (val r = fetchPage(offset, pageSize)) {
+            val result = fetchPage(offset, pageSize)
+            // A newer replacement started while this refresh was in flight.
+            if (generation != contentGeneration) {
+                _uiState.update { it.copy(isRefreshing = false) }
+                return@launch
+            }
+            when (val r = result) {
                 is ApiResult.Success -> _uiState.update {
                     it.copy(
                         items = r.data.items,
@@ -86,11 +107,24 @@ abstract class PersonalListViewModel(
         viewModelScope.launch {
             val state = _uiState.value
             val offset = if (reset) 0 else state.items.size
+            val generation = if (reset) ++contentGeneration else contentGeneration
             _uiState.update {
                 if (reset) it.copy(isLoading = true, error = null)
                 else it.copy(isLoadingMore = true)
             }
-            when (val r = fetchPage(offset, pageSize)) {
+            val result = fetchPage(offset, pageSize)
+            // Superseded WHILE IN FLIGHT: something replaced the list, so this
+            // page's offset no longer describes anything. Checked here rather
+            // than before the fetch — before it, there is nothing to be stale
+            // about. Dropping it silently is right: the replacement already
+            // published a coherent list, and applying this one's items or its
+            // error on top would only undo that. The loading flag still has to
+            // be released, because this request really has finished.
+            if (generation != contentGeneration) {
+                _uiState.update { it.copy(isLoadingMore = false) }
+                return@launch
+            }
+            when (val r = result) {
                 is ApiResult.Success -> {
                     hasLoadedOnce = true
                     _uiState.update {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModels.kt
@@ -113,7 +113,14 @@ abstract class PersonalListViewModel(
                 return@launch
             }
             when (val r = result) {
-                is ApiResult.Success -> _uiState.update {
+                is ApiResult.Success -> {
+                    // A refresh that publishes content has loaded once, whatever
+                    // the initial load did. Screens gate their resume re-fetch
+                    // on this flag, so leaving it false when a refresh overtakes
+                    // that load disables the resume refresh for the whole life
+                    // of the view model.
+                    hasLoadedOnce = true
+                    _uiState.update {
                     it.copy(
                         items = r.data.items,
                         hasMore = r.data.hasMore,
@@ -121,6 +128,7 @@ abstract class PersonalListViewModel(
                         isRefreshing = false,
                         error = null,
                     )
+                    }
                 }
                 is ApiResult.Error, is ApiResult.NetworkError -> {
                     _uiState.update { it.copy(isRefreshing = false) }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModels.kt
@@ -73,18 +73,45 @@ abstract class PersonalListViewModel(
      */
     private var contentGeneration = 0
 
+    /**
+     * Which request currently owns each loading flag.
+     *
+     * Generation alone cannot answer this. A reset owns isLoading and a refresh
+     * owns isRefreshing, so when one supersedes the other the newer request
+     * clears a DIFFERENT flag from the one the superseded request set — and the
+     * superseded one, told that "the newer replacement owns those flags",
+     * cleared nothing. A reset overtaken by a refresh therefore left isLoading
+     * true forever, and the surface spinning.
+     *
+     * Every request releases exactly the flag it claimed, and only while it is
+     * still the claimant.
+     */
+    private var requestSequence = 0
+    private var loadingOwner = 0
+    private var refreshingOwner = 0
+    private var loadingMoreOwner = 0
+
     fun retry() = load(reset = true)
 
     fun refresh() {
         // Claimed synchronously, for the same reason as load().
         val generation = ++contentGeneration
+        val requestId = ++requestSequence
+        refreshingOwner = requestId
         _uiState.update { it.copy(isRefreshing = true, error = null) }
         viewModelScope.launch {
             val offset = 0
             val result = fetchPage(offset, pageSize)
-            // A newer replacement started while this refresh was in flight and
-            // now owns isRefreshing, so this one clears nothing.
-            if (generation != contentGeneration) return@launch
+            // A newer replacement started while this refresh was in flight.
+            // Release isRefreshing unless a newer REFRESH has re-claimed it —
+            // a superseding reset owns isLoading instead and would not clear
+            // this one on its way past.
+            if (generation != contentGeneration) {
+                if (refreshingOwner == requestId) {
+                    _uiState.update { it.copy(isRefreshing = false) }
+                }
+                return@launch
+            }
             when (val r = result) {
                 is ApiResult.Success -> _uiState.update {
                     it.copy(
@@ -113,6 +140,8 @@ abstract class PersonalListViewModel(
         val state = _uiState.value
         val offset = if (reset) 0 else state.items.size
         val generation = if (reset) ++contentGeneration else contentGeneration
+        val requestId = ++requestSequence
+        if (reset) loadingOwner = requestId else loadingMoreOwner = requestId
         _uiState.update {
             if (reset) it.copy(isLoading = true, error = null)
             else it.copy(isLoadingMore = true)
@@ -127,11 +156,16 @@ abstract class PersonalListViewModel(
             // error on top would only undo that. The loading flag still has to
             // be released, because this request really has finished.
             if (generation != contentGeneration) {
-                // Only paging's own flag. isLoading and isRefreshing belong to
-                // whichever replacement superseded this one, and it will clear
-                // them when it lands — clearing them here would report that
-                // load as finished while it is still running.
-                if (!reset) _uiState.update { it.copy(isLoadingMore = false) }
+                // Release this request's own flag, and only while it still owns
+                // it. A later request of the same kind has already re-claimed
+                // it and will clear it itself.
+                _uiState.update {
+                    when {
+                        reset && loadingOwner == requestId -> it.copy(isLoading = false)
+                        !reset && loadingMoreOwner == requestId -> it.copy(isLoadingMore = false)
+                        else -> it
+                    }
+                }
                 return@launch
             }
             when (val r = result) {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/RequestsViewModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/RequestsViewModels.kt
@@ -148,7 +148,23 @@ class RequestSearchViewModel(
         _uiState.update { it.copy(mediaType = value, error = null) }
     }
 
-    fun search(page: Int = 1) {
+    /**
+     * Re-run the current search WITHOUT clearing what is on screen.
+     *
+     * [search] blanks results before refetching, which is right for a new query
+     * and wrong for a refresh: a viewer returning from a request detail would
+     * watch the row empty and refill, and anything relying on those cards
+     * staying put — a focus restoration, most obviously — loses its target for
+     * the duration. Returning is also exactly when the results ARE stale,
+     * because creating a request in the detail changes the status this row
+     * shows, so skipping the refresh is not an option either.
+     */
+    fun refreshInPlace() {
+        if (_uiState.value.submittedQuery.isBlank()) return
+        search(page = _uiState.value.page, preserveResults = true)
+    }
+
+    fun search(page: Int = 1, preserveResults: Boolean = false) {
         val submittedState = _uiState.value
         val query = submittedState.query.trim()
         val mediaType = submittedState.mediaType?.takeUnless { it == RequestMediaType.All }
@@ -174,10 +190,10 @@ class RequestSearchViewModel(
                 it.copy(
                     isLoading = true,
                     submittedQuery = query,
-                    results = emptyList(),
+                    results = if (preserveResults) it.results else emptyList(),
                     page = page,
-                    totalPages = 1,
-                    totalResults = 0,
+                    totalPages = if (preserveResults) it.totalPages else 1,
+                    totalResults = if (preserveResults) it.totalResults else 0,
                     error = null,
                 )
             }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/DevicePairingDecisionOrderingTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/DevicePairingDecisionOrderingTest.kt
@@ -1,0 +1,133 @@
+package org.siloserver.silo.viewmodel
+
+import org.siloserver.silo.model.auth.DeviceLoginDecisionResponse
+import org.siloserver.silo.model.auth.DeviceLoginLookupResponse
+import org.siloserver.silo.model.auth.DeviceLoginPollResponse
+import org.siloserver.silo.model.auth.DeviceLoginStartResponse
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.api.DeviceLoginApi
+import org.siloserver.silo.repository.DeviceLoginRepository
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * A decision is more authoritative than a lookup, and it can finish first.
+ *
+ * canDecide stays true while an existing lookup refreshes — the previous
+ * result is deliberately left on screen rather than blanked — so approving
+ * mid-lookup is an ordinary thing to do, not a contrived one. The lookup then
+ * lands last, and without a guard it overwrites the outcome of the decision
+ * the viewer actually made.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DevicePairingDecisionOrderingTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @AfterTest
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun lookupResponse() = DeviceLoginLookupResponse(
+        status = "pending",
+        userCode = "ABCD-1234",
+        matchCode = "42",
+        deviceName = "Living Room TV",
+        devicePlatform = "tvOS",
+        ipAddressHint = "192.0.2.10",
+    )
+
+    private class FakeApi : DeviceLoginApi {
+        val lookups = ArrayDeque<CompletableDeferred<ApiResult<DeviceLoginLookupResponse>>>()
+        val decisions = ArrayDeque<CompletableDeferred<ApiResult<DeviceLoginDecisionResponse>>>()
+
+        override suspend fun lookupDeviceLogin(token: String?, code: String?) =
+            CompletableDeferred<ApiResult<DeviceLoginLookupResponse>>()
+                .also { lookups.addLast(it) }
+                .await()
+
+        override suspend fun approveDeviceLogin(token: String?, code: String?) =
+            CompletableDeferred<ApiResult<DeviceLoginDecisionResponse>>()
+                .also { decisions.addLast(it) }
+                .await()
+
+        override suspend fun denyDeviceLogin(token: String?, code: String?) =
+            CompletableDeferred<ApiResult<DeviceLoginDecisionResponse>>()
+                .also { decisions.addLast(it) }
+                .await()
+
+        override suspend fun startDeviceLogin(
+            deviceName: String?,
+            devicePlatform: String?,
+        ): ApiResult<DeviceLoginStartResponse> = error("unused")
+
+        override suspend fun pollDeviceLogin(
+            deviceCode: String,
+        ): ApiResult<DeviceLoginPollResponse> = error("unused")
+    }
+
+    private fun viewModel(api: FakeApi) = DevicePairingViewModel(
+        repository = DeviceLoginRepository(api),
+        initialToken = "tok",
+        initialCode = null,
+    )
+
+    @Test
+    fun aLateLookupCannotOverwriteACompletedApproval() = runTest {
+        val api = FakeApi()
+        val vm = viewModel(api)
+
+        // The initial lookup resolves, so the decision is informed.
+        api.lookups.removeFirst().complete(ApiResult.Success(lookupResponse()))
+        assertEquals(true, vm.uiState.value.canDecide)
+
+        // Refreshing keeps the previous result on screen, so approving is still
+        // offered — and taken — while that refresh is in flight.
+        vm.lookup()
+        val staleLookup = api.lookups.removeFirst()
+        vm.approve()
+        api.decisions.removeFirst().complete(
+            ApiResult.Success(DeviceLoginDecisionResponse(status = "approved")),
+        )
+        assertEquals("approved", vm.uiState.value.completedStatus)
+
+        // The retired lookup lands last. It must not paint an error over an
+        // approval that already succeeded, nor blank the decision's outcome.
+        staleLookup.complete(ApiResult.Error(code = 404, error = "gone", message = "Expired"))
+        assertEquals("approved", vm.uiState.value.completedStatus)
+        assertNull(vm.uiState.value.error)
+        assertEquals(false, vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun aLateLookupCannotClearADecisionError() = runTest {
+        val api = FakeApi()
+        val vm = viewModel(api)
+        api.lookups.removeFirst().complete(ApiResult.Success(lookupResponse()))
+
+        vm.lookup()
+        val staleLookup = api.lookups.removeFirst()
+        vm.deny()
+        api.decisions.removeFirst().complete(
+            ApiResult.Error(code = 409, error = "conflict", message = "Already decided"),
+        )
+        val decisionError = vm.uiState.value.error
+
+        // A successful stale lookup would otherwise clear the error the
+        // decision reported, leaving the viewer believing the deny worked.
+        staleLookup.complete(ApiResult.Success(lookupResponse()))
+        assertEquals(decisionError, vm.uiState.value.error)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/DevicePairingUiStateTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/DevicePairingUiStateTest.kt
@@ -1,0 +1,84 @@
+package org.siloserver.silo.viewmodel
+
+import org.siloserver.silo.model.auth.DeviceLoginLookupResponse
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Approving a device login is an irreversible grant of access to someone else's
+ * session, so what makes it available is worth pinning down.
+ */
+class DevicePairingUiStateTest {
+
+    private fun lookup() = DeviceLoginLookupResponse(
+        status = "pending",
+        userCode = "ABCD-1234",
+        matchCode = "42",
+        deviceName = "Living Room TV",
+        devicePlatform = "tvOS",
+        ipAddressHint = "192.0.2.10",
+    )
+
+    @Test
+    fun `a deep link cannot be approved before its lookup resolves`() {
+        // The regression this pins: a silo://device?token=… link arrives with
+        // the token already set and starts its lookup automatically. Gating on
+        // "there is an identifier to submit" made Approve live from the first
+        // frame — before the device name, IP or match code existed to show, so
+        // the viewer would have been approving a request they could not see.
+        val state = DevicePairingUiState(token = "tok_abc")
+        assertFalse(state.canDecide)
+    }
+
+    @Test
+    fun `a typed code cannot be approved before its lookup resolves`() {
+        assertFalse(DevicePairingUiState(code = "ABCD-1234").canDecide)
+    }
+
+    @Test
+    fun `a resolved lookup can be approved`() {
+        assertTrue(DevicePairingUiState(token = "tok_abc", lookup = lookup()).canDecide)
+    }
+
+    @Test
+    fun `a failed lookup cannot be approved even though the token survives`() {
+        // The error path clears the lookup and keeps the identifier, which is
+        // exactly the state reached when the server calls the request invalid
+        // or expired. Approving it anyway was possible before.
+        val state = DevicePairingUiState(
+            token = "tok_abc",
+            lookup = null,
+            error = "That code has expired.",
+        )
+        assertFalse(state.canDecide)
+    }
+
+    @Test
+    fun `a decision already in flight cannot be submitted again`() {
+        val state = DevicePairingUiState(
+            token = "tok_abc",
+            lookup = lookup(),
+            isSubmitting = true,
+        )
+        assertFalse(state.canDecide)
+    }
+
+    @Test
+    fun `an initial lookup cannot be approved while it is still running`() {
+        assertFalse(DevicePairingUiState(token = "tok_abc", isLoading = true).canDecide)
+    }
+
+    @Test
+    fun `a refresh over an already-resolved lookup stays approvable`() {
+        // isLoading is not itself a gate. Pressing Check on a resolved request
+        // keeps the details on screen, so the decision the viewer can see is
+        // still the decision they would be making.
+        val state = DevicePairingUiState(
+            token = "tok_abc",
+            lookup = lookup(),
+            isLoading = true,
+        )
+        assertTrue(state.canDecide)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModelGenerationTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModelGenerationTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * A page fetched at `offset = N` describes a list that a refresh has since
@@ -141,6 +142,50 @@ class PersonalListViewModelGenerationTest {
         } finally {
             Dispatchers.setMain(dispatcher)
         }
+    }
+
+    /**
+     * A reset and a refresh claim DIFFERENT flags, so neither can be trusted to
+     * clear the other's on its way past. These two cover both orderings; before
+     * each request released the flag it actually owned, one of them left the
+     * surface spinning forever.
+     */
+    @Test
+    fun aResetSupersededByARefreshDoesNotStrandIsLoading() = runTest {
+        val vm = TestList()
+        vm.start()
+        vm.pending.removeFirst().complete(page("a", "b", hasMore = true))
+
+        vm.retry()
+        val staleReset = vm.pending.removeFirst()
+        assertTrue(vm.uiState.value.isLoading, "the reset should have claimed isLoading")
+
+        vm.refresh()
+        vm.pending.removeFirst().complete(page("x", "y"))
+        staleReset.complete(page("stale"))
+
+        assertFalse(vm.uiState.value.isLoading, "isLoading must not outlive the reset that claimed it")
+        assertFalse(vm.uiState.value.isRefreshing)
+        assertEquals(listOf("x", "y"), vm.uiState.value.items.map { it.contentId })
+    }
+
+    @Test
+    fun aRefreshSupersededByAResetDoesNotStrandIsRefreshing() = runTest {
+        val vm = TestList()
+        vm.start()
+        vm.pending.removeFirst().complete(page("a", "b", hasMore = true))
+
+        vm.refresh()
+        val staleRefresh = vm.pending.removeFirst()
+        assertTrue(vm.uiState.value.isRefreshing, "the refresh should have claimed isRefreshing")
+
+        vm.retry()
+        vm.pending.removeFirst().complete(page("x", "y"))
+        staleRefresh.complete(page("stale"))
+
+        assertFalse(vm.uiState.value.isRefreshing, "isRefreshing must not outlive the refresh that claimed it")
+        assertFalse(vm.uiState.value.isLoading)
+        assertEquals(listOf("x", "y"), vm.uiState.value.items.map { it.contentId })
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModelGenerationTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModelGenerationTest.kt
@@ -6,6 +6,8 @@ import org.siloserver.silo.network.ApiResult
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -102,6 +104,43 @@ class PersonalListViewModelGenerationTest {
         assertEquals(null, vm.uiState.value.error)
         assertEquals(listOf("x", "y"), vm.uiState.value.items.map { it.contentId })
         assertFalse(vm.uiState.value.isLoadingMore)
+    }
+
+    /**
+     * The trigger gate only works if the state it reads has already been
+     * claimed. Under a queuing dispatcher, a refresh that has not yet run its
+     * own body is invisible to loadMore() — so a page goes out, captures the
+     * refresh's generation once it finally runs, looks current, and appends at
+     * an offset belonging to the list the refresh replaced.
+     *
+     * An unconfined dispatcher cannot express this: it runs refresh eagerly to
+     * its first suspension, which claims the flag as a side effect and hides
+     * the very ordering under test.
+     */
+    @Test
+    fun aRefreshQueuedButNotYetRunStillBlocksPaging() = runTest {
+        val scheduler = TestCoroutineScheduler()
+        val queuing = StandardTestDispatcher(scheduler)
+        Dispatchers.setMain(queuing)
+        try {
+            val vm = TestList()
+            vm.start()
+            scheduler.advanceUntilIdle()
+            vm.pending.removeFirst().complete(page("a", "b", hasMore = true))
+            scheduler.advanceUntilIdle()
+
+            // Neither body has run yet; the gate has only the claimed state.
+            vm.refresh()
+            vm.loadMore()
+            scheduler.advanceUntilIdle()
+
+            assertEquals(listOf(0, 0), vm.offsets, "paging must not go out behind a queued refresh")
+            vm.pending.removeFirst().complete(page("x", "y"))
+            scheduler.advanceUntilIdle()
+            assertEquals(listOf("x", "y"), vm.uiState.value.items.map { it.contentId })
+        } finally {
+            Dispatchers.setMain(dispatcher)
+        }
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModelGenerationTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModelGenerationTest.kt
@@ -1,0 +1,119 @@
+package org.siloserver.silo.viewmodel
+
+import org.siloserver.silo.model.catalog.BrowseItem
+import org.siloserver.silo.model.catalog.CatalogResponse
+import org.siloserver.silo.network.ApiResult
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * A page fetched at `offset = N` describes a list that a refresh has since
+ * thrown away. Gating the TRIGGERS cannot prevent this on its own — the page is
+ * already in flight when the refresh starts, and nothing cancels it — so the
+ * check that matters happens when the page lands.
+ *
+ * These lists refresh on every resume, which is exactly when a viewer comes
+ * back from a detail page, so the interleaving is ordinary rather than exotic.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PersonalListViewModelGenerationTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun item(id: String) = BrowseItem(contentId = id, type = "movie", title = id)
+
+    private fun page(vararg ids: String, hasMore: Boolean = false) = ApiResult.Success(
+        CatalogResponse(items = ids.map(::item), hasMore = hasMore, total = ids.size),
+    )
+
+    private class TestList : PersonalListViewModel(pageSize = 2) {
+        val pending = ArrayDeque<CompletableDeferred<ApiResult<CatalogResponse>>>()
+        val offsets = mutableListOf<Int>()
+
+        override suspend fun fetchPage(offset: Int, limit: Int): ApiResult<CatalogResponse> {
+            offsets += offset
+            val deferred = CompletableDeferred<ApiResult<CatalogResponse>>()
+            pending.addLast(deferred)
+            return deferred.await()
+        }
+
+        fun start() = loadInitial()
+    }
+
+    @Test
+    fun refreshDiscardsAPageThatWasAlreadyInFlight() = runTest {
+        val vm = TestList()
+        vm.start()
+        vm.pending.removeFirst().complete(page("a", "b", hasMore = true))
+        assertEquals(listOf("a", "b"), vm.uiState.value.items.map { it.contentId })
+
+        // Page two goes out, then a resume refresh replaces the whole list.
+        vm.loadMore()
+        val pageTwo = vm.pending.removeFirst()
+        vm.refresh()
+        val refreshed = vm.pending.removeFirst()
+        assertEquals(listOf(0, 2, 0), vm.offsets)
+
+        // The refresh lands first and publishes a coherent page one.
+        refreshed.complete(page("x", "y", hasMore = true))
+        assertEquals(listOf("x", "y"), vm.uiState.value.items.map { it.contentId })
+
+        // The superseded page must not append: items fetched at offset 2 of the
+        // OLD list would land after "y" and leave a hole where the middle was.
+        pageTwo.complete(page("c", "d"))
+        assertEquals(listOf("x", "y"), vm.uiState.value.items.map { it.contentId })
+        assertFalse(vm.uiState.value.isLoadingMore)
+    }
+
+    @Test
+    fun aSupersededPageDoesNotPublishItsError() = runTest {
+        val vm = TestList()
+        vm.start()
+        vm.pending.removeFirst().complete(page("a", "b", hasMore = true))
+
+        vm.loadMore()
+        val pageTwo = vm.pending.removeFirst()
+        vm.refresh()
+        vm.pending.removeFirst().complete(page("x", "y", hasMore = true))
+
+        // A stale request's failure is not this list's failure. Showing it would
+        // put an error banner over content that loaded perfectly well.
+        pageTwo.complete(ApiResult.Error(code = 500, error = "stale", message = "stale page"))
+        assertEquals(null, vm.uiState.value.error)
+        assertEquals(listOf("x", "y"), vm.uiState.value.items.map { it.contentId })
+        assertFalse(vm.uiState.value.isLoadingMore)
+    }
+
+    @Test
+    fun anUncontestedPageStillAppends() = runTest {
+        val vm = TestList()
+        vm.start()
+        vm.pending.removeFirst().complete(page("a", "b", hasMore = true))
+
+        // The guard must not swallow ordinary pagination.
+        vm.loadMore()
+        vm.pending.removeFirst().complete(page("c", "d"))
+        assertEquals(listOf("a", "b", "c", "d"), vm.uiState.value.items.map { it.contentId })
+        assertFalse(vm.uiState.value.isLoadingMore)
+    }
+}


### PR DESCRIPTION
Bounded, observed TV focus acquisition; return focus by stable section and item identity rather than saved indices, which only describe the same card while the data is unchanged; modal and overlay focus ownership; centralised IME handling; and voice search from the remote.

Return restoration handles refreshes, pagination, scrolling, requester attachment and confirmed focus, across Calendar, Collections, Library, People, Personal, Requests and Search. Device pairing now requires resolved lookup data before it will offer a decision, and stale lookup and pagination results are ignored rather than allowed to land late.

## Review findings

All three CodeRabbit threads are addressed on the follow-up branch rather than here, to keep this PR at its reviewed size:

- **`HomeViewModel` fetch race** — overlapping `fetchSections()` publishers, where an older partial response could replace a newer complete one and mark sections not fully resolved. Closed by a `fetchGeneration` guard.
- **`TvSkylineSectionFeed` shared saveable slot** — `rememberSaveable` slots are positional, so two feeds composed at the same position in different surfaces shared one, and a return target armed on one could restore into the other. The feed now takes a required surface key.
- **`variant.enableUnitTest`** — deprecated in AGP 8.10.1 and removed in 9.0; replaced with the host-tests API, with the task list still offering only `testDebugUnitTest`.

> Note: this description was rewritten after the original was accidentally overwritten while folding in follow-up work. The scope and commits are unchanged; only the prose is new.
