### PR TITLE
fix(player): keep playback alive on bad input, and stop sessions outliving their screen

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionLifecycle.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionLifecycle.kt
@@ -616,7 +616,14 @@ class PlaybackSessionLifecycle(
                 )
             }
 
+            // The adopted id, not the published state's. Reconnecting and
+            // Failed carry no session id, so reading it from Active alone meant
+            // leaving during an outage — or after the outage timeout gave up —
+            // never told the server to stop. The transcode then ran on until it
+            // timed out, holding a stream slot the viewer had already walked
+            // away from.
             val sessionId = (_state.value as? SessionState.Active)?.session?.sessionId
+                ?: lastAdoptedSessionId
             // Fire the final snapshot regardless — even during Reconnecting we
             // want to durably record where the user was so a fresh login resumes
             // there.
@@ -745,6 +752,18 @@ class PlaybackSessionLifecycle(
                     position = pos,
                     isPaused = lastIsPaused,
                 )
+                // Re-check ownership AFTER the call. Cancelling this job is not
+                // enough to stop what follows: the network wrapper catches
+                // cancellation and hands back a NetworkError, so a reporter
+                // belonging to the previous episode carries on and acts on a
+                // reply about a session nobody is watching any more.
+                //
+                // Everything below reacts to that reply by rewriting shared
+                // state — publishing Reconnecting, restoring Active, or
+                // starting a replacement session from the CURRENT start
+                // params. Left unguarded, a late answer about episode A does
+                // all of that to episode B.
+                if (!ownsProgressReply(sess.sessionId)) continue
                 when {
                     isPlaybackSessionMissing(result) -> handleSessionMissing(sess.sessionId)
                     result is ApiResult.NetworkError -> {
@@ -762,6 +781,17 @@ class PlaybackSessionLifecycle(
             }
         }
     }
+
+    /**
+     * Whether a progress reply still concerns the session on screen.
+     *
+     * Compared against the adopted id rather than the published state, because
+     * the states this guards against — Reconnecting and Failed — carry no
+     * session id of their own, and a reply arriving during one of them is
+     * exactly the case that must not act.
+     */
+    private fun ownsProgressReply(sessionId: String): Boolean =
+        lastAdoptedSessionId == sessionId
 
     // ---- Internal: 404 session-missing recovery -----------------------------
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionLifecycle.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionLifecycle.kt
@@ -675,7 +675,19 @@ class PlaybackSessionLifecycle(
                     context = NonCancellable + Dispatchers.IO,
                     start = CoroutineStart.LAZY,
                 ) {
-                    stop(expectedSessionId)
+                    // This scope has a SupervisorJob but no
+                    // CoroutineExceptionHandler, and nothing joins this job for
+                    // its result, so an unexpected throw from stop() would
+                    // escape as an uncaught coroutine exception and take the
+                    // process down. Teardown failing is not worth a crash: the
+                    // server session expires on its own timeout.
+                    try {
+                        stop(expectedSessionId)
+                    } catch (cancellation: CancellationException) {
+                        throw cancellation
+                    } catch (t: Throwable) {
+                        Log.w(TAG, "async stop failed for $expectedSessionId", t)
+                    }
                 }.also {
                     pendingStopJob = it
                     pendingStopSessionId = expectedSessionId

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionManager.kt
@@ -1025,6 +1025,42 @@ open class PlaybackSessionManager(
         return disowned
     }
 
+    /**
+     * Fire-and-forget abandonment on the manager's own scope.
+     *
+     * Callers reach this exactly when their own scope is being torn down, which
+     * rules out doing the work inline. `viewModelScope.launch(NonCancellable)`
+     * looks like the answer and does run, but it severs the parent link to
+     * produce an untracked coroutine nothing can await or observe failures
+     * from. This scope already outlives any screen and is what the
+     * committed-session cleanup uses, so a release belongs here rather than in
+     * a ViewModel on its way out.
+     *
+     * Only stops the session while the manager still owns it. The unconditional
+     * variant stops even when it failed to disown, and [stopSession]'s
+     * predecessor branch then clears a newer pending publication and stops its
+     * replacement — a real hazard once the release is dispatched rather than
+     * inline, because the window widens. When ownership has moved on, the id is
+     * recorded as an orphan and the next drain stops it with a plain repository
+     * call that cannot disturb whoever owns playback now.
+     */
+    fun abandonActiveVideoSessionAsync(sessionId: String) {
+        sessionCleanupScope.launch {
+            runCatching {
+                val disowned = videoAttemptMutex.withLock {
+                    val active = activeVideoAttempt.get()
+                    if (active?.sessionId != sessionId) {
+                        orphanedSessionIds += sessionId
+                        false
+                    } else {
+                        activeVideoAttempt.compareAndSet(active, null)
+                    }
+                }
+                if (disowned) stopSession(sessionId)
+            }
+        }
+    }
+
     suspend fun rollbackUnpublishedVideoSession(sessionId: String): Boolean {
         val rollback = videoAttemptMutex.withLock {
             rollbackPendingPublicationLocked(sessionId)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackTeardownGate.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackTeardownGate.kt
@@ -1,0 +1,74 @@
+package org.siloserver.silo.common.player
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Serialises one player screen's teardown of the process-scoped
+ * [PlaybackSessionLifecycle] so it happens exactly once.
+ *
+ * A screen has several exit routes — an ordered stop awaited before navigation,
+ * an async Back/remote-stop, and a `ViewModel.onCleared()` fallback — and more
+ * than one can fire for the same exit. That is not merely redundant: every
+ * [PlaybackSessionLifecycle.stop] bumps `stopEpoch`, and a stop issued *after*
+ * the next screen has captured its ownership epoch causes that screen's
+ * adoption to be rejected ("Playback start was superseded"). On Android TV the
+ * deferred `onCleared()` stop landed exactly there and broke auto-advance on
+ * every episode transition.
+ *
+ * The gate is deliberately one-shot per screen. Once any route has taken
+ * ownership of teardown, the others must not touch the singleton lifecycle.
+ *
+ * Residual, accepted: if the underlying stop *and* its one handoff both fail
+ * unexpectedly, the claim stays taken and teardown is incomplete, leaving the
+ * server session to expire on its own timeout. That is the pre-existing
+ * behaviour for a failed stop and is not an adoption hazard — every route here
+ * names the session it is ending, and once the next session has been adopted a
+ * late stop for the old id returns at the ownership guard *before* touching
+ * `stopEpoch`, so it cannot supersede anyone.
+ */
+class PlaybackTeardownGate(private val lifecycle: PlaybackSessionLifecycle) {
+
+    private val claimed = AtomicBoolean(false)
+
+    /** True once some route has taken ownership of this screen's teardown. */
+    val isClaimed: Boolean get() = claimed.get()
+
+    /**
+     * Ordered teardown, awaited before navigating to the next item.
+     *
+     * If the stop fails or is cancelled the claim is *not* released: releasing
+     * it would leave teardown unowned whenever [stopDetached] has already run
+     * and skipped, because a flag reset neither notifies nor reschedules it.
+     * Ownership is handed to the lifecycle-owned tracked job instead, which
+     * outlives the screen and which a later start awaits through
+     * [PlaybackSessionLifecycle.acquireOwnershipEpoch].
+     */
+    suspend fun stopOrdered(expectedSessionId: String?) {
+        if (!claimed.compareAndSet(false, true)) return
+        try {
+            lifecycle.stop(expectedSessionId = expectedSessionId)
+        } catch (t: Throwable) {
+            lifecycle.stopAsync(expectedSessionId = expectedSessionId)
+            throw t
+        }
+    }
+
+    /**
+     * Detached teardown: the Back/remote-stop route, and the `onCleared()`
+     * fallback for a screen that went away without any exit route running.
+     * Does nothing once teardown is already owned.
+     *
+     * Both go through [PlaybackSessionLifecycle.stopAsync] rather than a direct
+     * suspend stop. Nothing awaits either caller — `onCleared`'s settlement
+     * callback even wraps its body in `runCatching` — so a direct stop that
+     * threw would be swallowed with the claim already consumed and no owner
+     * left to retry. The tracked job cannot be abandoned that way, and it has
+     * the side benefit that a later start awaits it through
+     * [PlaybackSessionLifecycle.acquireOwnershipEpoch].
+     */
+    fun stopDetached(expectedSessionId: String?) {
+        if (claimed.compareAndSet(false, true)) {
+            lifecycle.stopAsync(expectedSessionId = expectedSessionId)
+        }
+    }
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/audio/DelayAudioProcessor.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/audio/DelayAudioProcessor.kt
@@ -73,7 +73,10 @@ class DelayAudioProcessor : BaseAudioProcessor() {
 
     fun getActiveDelayMs(): Int = activeDelayMs
 
+    private var bytesPerFrame: Int = 0
+
     override fun onConfigure(inputAudioFormat: AudioFormat): AudioFormat {
+        bytesPerFrame = inputAudioFormat.bytesPerFrame
         // Output format == input; we don't resample or rechannel.
         // bytesPerFrame already accounts for channelCount * sampleSize, so
         // bytesPerSecond is simply sampleRate * bytesPerFrame.
@@ -93,18 +96,34 @@ class DelayAudioProcessor : BaseAudioProcessor() {
     override fun queueInput(inputBuffer: ByteBuffer) {
         when {
             remainingHeadBytes > 0 -> {
-                // Positive delay: emit silence equal to remaining head bytes,
-                // then pass input through.
+                // Positive delay: emit ONLY silence until the head is paid off,
+                // leaving the input unconsumed so it is offered again.
+                //
+                // Emitting silence AND the input on the same pass was the bug:
+                // any delay longer than one decoder buffer produced
+                // silence, audio, silence, audio... — chopped, half-rate sound
+                // for the length of the offset, rather than a clean head delay.
+                // The old unit test used a single input buffer larger than the
+                // entire delay, so the streaming case it was meant to cover
+                // could not fail.
                 val inputLen = inputBuffer.remaining()
-                val silenceLen = minOf(remainingHeadBytes, inputLen)
-                val outBuffer = replaceOutputBuffer(silenceLen + inputLen)
+                if (inputLen == 0) return
+                // Frame-aligned: a partial frame of silence would shift every
+                // channel by a fraction of a sample.
+                val alignedRemaining = if (bytesPerFrame > 0) {
+                    remainingHeadBytes - (remainingHeadBytes % bytesPerFrame)
+                } else {
+                    remainingHeadBytes
+                }
+                val silenceLen = minOf(alignedRemaining.coerceAtLeast(0), inputLen)
+                if (silenceLen <= 0) {
+                    // Sub-frame remainder: drop it and start passing audio.
+                    remainingHeadBytes = 0
+                    return
+                }
+                val outBuffer = replaceOutputBuffer(silenceLen)
                 outBuffer.order(ByteOrder.nativeOrder())
-                // Emit silence.
-                val silenceBytes = ByteArray(silenceLen)  // zero-initialized
-                outBuffer.put(silenceBytes)
-                // Then emit input — via scratch to handle the self-aliased
-                // buffer case (see [scratch]).
-                copyThroughScratch(inputBuffer, outBuffer, inputLen)
+                outBuffer.put(ByteArray(silenceLen)) // zero-initialised
                 outBuffer.flip()
                 remainingHeadBytes -= silenceLen
             }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/subtitle/PgsSupExtractor.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/subtitle/PgsSupExtractor.kt
@@ -149,6 +149,21 @@ class PgsSupExtractor(
             return Extractor.RESULT_CONTINUE
         }
 
+        // Reject a hostile bitmap BEFORE Media3 sizes an allocation from it.
+        // The parser trusts the declared width and height, allocating
+        // IntArray(width * height) plus an ARGB bitmap, so a few bytes can ask
+        // for hundreds of megabytes. Catching the failure afterwards is too
+        // late — the memory pressure has already happened, and on a small box
+        // the process simply goes.
+        if (segmentType == SEGMENT_TYPE_OBJECT && !isPgsObjectWithinBudget(payload)) {
+            malformedSets++
+            org.siloserver.silo.common.player.SubDiag.log(
+                "SUP object rejected: declared bitmap outside budget",
+            )
+            discardPendingDisplaySet()
+            return Extractor.RESULT_CONTINUE
+        }
+
         // First segment of a set carries the time the whole set is shown at.
         if (displaySet.isEmpty()) {
             displaySetTimeUs = pts90kHz * C.MICROS_PER_SECOND / PTS_CLOCK_HZ
@@ -214,23 +229,46 @@ class PgsSupExtractor(
         // process caused by being unhealthy; it is one specific allocation
         // sized by untrusted input, and refusing to catch it on principle means
         // a bad caption kills playback.
-        try {
-            parseDisplaySet(activeParser, output, bytes, timeUs)
+        val decoded = try {
+            decodeDisplaySet(activeParser, bytes, timeUs)
         } catch (e: Exception) {
             malformedSets++
-            org.siloserver.silo.common.player.SubDiag.log("SUP set $emittedSets rejected: ${e::class.simpleName}: ${e.message}")
+            org.siloserver.silo.common.player.SubDiag.log(
+                "SUP set $emittedSets rejected: ${e::class.simpleName}: ${e.message}",
+            )
+            null
         } catch (e: OutOfMemoryError) {
+            // Narrow by construction: this block now contains only parsing and
+            // cue encoding, both sized by the display set's own declared
+            // dimensions. It is not a general OOM handler — the sample queue is
+            // no longer inside it.
             malformedSets++
-            org.siloserver.silo.common.player.SubDiag.log("SUP set $emittedSets exhausted memory and was dropped")
+            org.siloserver.silo.common.player.SubDiag.log(
+                "SUP set $emittedSets exhausted memory and was dropped",
+            )
+            null
         }
+        decoded?.let { publishDisplaySet(output, it, timeUs) }
     }
 
-    private fun parseDisplaySet(
+    /**
+     * Decode a display set WITHOUT touching the sample queue.
+     *
+     * Parsing and publication are separated on purpose. Writing samples from
+     * inside the parse callback means a failure partway through — after
+     * sampleData and before sampleMetadata — leaves uncommitted bytes in the
+     * queue, and the next sample then lands on a boundary the queue disagrees
+     * about. A dropped caption is recoverable; a corrupt queue is not.
+     *
+     * So everything untrusted happens here and produces plain byte arrays, and
+     * the caller publishes only if this returned normally.
+     */
+    private fun decodeDisplaySet(
         activeParser: SubtitleParser,
-        output: TrackOutput,
         bytes: ByteArray,
         timeUs: Long,
-    ) {
+    ): List<ByteArray> {
+        val encodedSamples = mutableListOf<ByteArray>()
         activeParser.parse(
             bytes,
             0,
@@ -246,9 +284,15 @@ class PgsSupExtractor(
             // Duration stays unset: PGS ends a caption with the next display
             // set, and the parser's REPLACE behaviour already means a new
             // sample supersedes the last one.
-            val encoded = cueEncoder.encode(cues.cues, C.TIME_UNSET)
-            val data = ParsableByteArray(encoded)
-            output.sampleData(data, encoded.size)
+            encodedSamples += cueEncoder.encode(cues.cues, C.TIME_UNSET)
+        }
+        return encodedSamples
+    }
+
+    /** Publish decoded samples. Nothing here can throw on untrusted input. */
+    private fun publishDisplaySet(output: TrackOutput, samples: List<ByteArray>, timeUs: Long) {
+        samples.forEach { encoded ->
+            output.sampleData(ParsableByteArray(encoded), encoded.size)
             output.sampleMetadata(
                 (timeUs + offsetUsProvider()).coerceAtLeast(0L),
                 C.BUFFER_FLAG_KEY_FRAME,
@@ -309,6 +353,8 @@ class PgsSupExtractor(
         /** `PG` magic, 4-byte PTS, 4-byte DTS, type, 2-byte length. */
         const val SEGMENT_HEADER_SIZE = 13
         const val SEGMENT_TYPE_END = 0x80
+        /** ODS — the only segment that declares bitmap dimensions. */
+        const val SEGMENT_TYPE_OBJECT = 0x15
         private const val CONTAINER_SEGMENT_HEADER_SIZE = 3
         private const val MAX_DISPLAY_SET_BYTES = 16 * 1024 * 1024
         private const val MAX_DISPLAY_SET_SEGMENTS = 512
@@ -319,3 +365,47 @@ class PgsSupExtractor(
         private const val MAGIC_G = MAGIC_G_INT.toByte()
     }
 }
+
+/**
+ * Whether an ODS payload declares a bitmap this device should attempt.
+ *
+ * Reads only the object header, which is not a second PGS parser: two 16-bit
+ * fields at a fixed offset. RLE correctness stays Media3's problem; this exists
+ * solely so the allocation it performs is one we chose to allow.
+ *
+ * Layout, first-sequence object:
+ *   0..1  object id
+ *   2     version
+ *   3     sequence descriptor  (bit 7 set = first/base sequence)
+ *   4..6  object data length, 24-bit  (present only on a first sequence)
+ *   7..8  width, 16-bit
+ *   9..10 height, 16-bit
+ *
+ * Continuation segments carry no dimensions and are passed through: the base
+ * sequence they belong to was already judged.
+ */
+private fun isPgsObjectWithinBudget(payload: ByteArray): Boolean {
+    if (payload.size < 4) return false
+    val isFirstSequence = (payload[3].toInt() and 0x80) != 0
+    if (!isFirstSequence) return true
+    if (payload.size < 11) return false
+
+    fun u8(i: Int) = payload[i].toInt() and 0xFF
+    val objectDataLength = (u8(4) shl 16) or (u8(5) shl 8) or u8(6)
+    val width = (u8(7) shl 8) or u8(8)
+    val height = (u8(9) shl 8) or u8(10)
+
+    // object_data_length counts the four width/height bytes, so anything below
+    // them is malformed rather than merely small.
+    if (objectDataLength < 4) return false
+    if (width <= 0 || height <= 0) return false
+    if (width > MAX_PGS_DIMENSION || height > MAX_PGS_DIMENSION) return false
+    if (width.toLong() * height.toLong() > MAX_PGS_BITMAP_PIXELS) return false
+    if (objectDataLength.toLong() - 4L > MAX_PGS_OBJECT_DATA_BYTES) return false
+    return true
+}
+
+/** A full-frame 1080p caption is allowed; a 4K one is not, on TV memory. */
+private const val MAX_PGS_BITMAP_PIXELS = 1920L * 1080L
+private const val MAX_PGS_OBJECT_DATA_BYTES = 8L * 1024L * 1024L
+private const val MAX_PGS_DIMENSION = 4096

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/subtitle/PgsSupExtractor.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/subtitle/PgsSupExtractor.kt
@@ -65,6 +65,8 @@ class PgsSupExtractor(
     private var displaySetSegmentCount = 0
     private var failedClosed = false
     private var emittedSets = 0
+    /** Display sets dropped because the parser could not survive them. */
+    private var malformedSets = 0
     private var emittedCues = 0
 
     override fun sniff(input: ExtractorInput): Boolean {
@@ -188,6 +190,7 @@ class PgsSupExtractor(
         displaySetTimeUs = C.TIME_UNSET
         displaySetSegmentCount = 0
         val activeParser = parser ?: return
+        val output = trackOutput ?: return
         if (timeUs == C.TIME_UNSET) return
 
         emittedSets++
@@ -196,6 +199,38 @@ class PgsSupExtractor(
                 "SUP set=$emittedSets t=${timeUs / 1000}ms bytes=${bytes.size}",
             )
         }
+        // The bundled Media3 PGS parser trusts the display set's own 16-bit
+        // width/height: it allocates IntArray(width * height) and applies RLE
+        // runs with no pixel bound of its own. A corrupt or hostile set can
+        // therefore throw NegativeArraySizeException, an oversized-run
+        // IllegalArgumentException, or ask for an allocation large enough to
+        // take the process down on a low-memory box.
+        //
+        // Bounding the byte length upstream does not help — a handful of bytes
+        // can declare an enormous bitmap. So the parse is contained here, and a
+        // damaged caption costs one missing subtitle rather than the film.
+        //
+        // OutOfMemoryError is caught deliberately. It is not an error this
+        // process caused by being unhealthy; it is one specific allocation
+        // sized by untrusted input, and refusing to catch it on principle means
+        // a bad caption kills playback.
+        try {
+            parseDisplaySet(activeParser, output, bytes, timeUs)
+        } catch (e: Exception) {
+            malformedSets++
+            org.siloserver.silo.common.player.SubDiag.log("SUP set $emittedSets rejected: ${e::class.simpleName}: ${e.message}")
+        } catch (e: OutOfMemoryError) {
+            malformedSets++
+            org.siloserver.silo.common.player.SubDiag.log("SUP set $emittedSets exhausted memory and was dropped")
+        }
+    }
+
+    private fun parseDisplaySet(
+        activeParser: SubtitleParser,
+        output: TrackOutput,
+        bytes: ByteArray,
+        timeUs: Long,
+    ) {
         activeParser.parse(
             bytes,
             0,

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/subtitle/SubripPayloadNormalizer.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/subtitle/SubripPayloadNormalizer.kt
@@ -11,7 +11,17 @@ internal fun normalizeSubripPayloadIfNeeded(
     offset: Int,
     length: Int,
 ): ByteArray? {
-    val text = data.decodeToString(offset, offset + length)
+    // Decoded STRICTLY, not leniently. decodeToString substitutes U+FFFD for
+    // anything that is not valid UTF-8 — and since a rewrite re-encodes what it
+    // decoded, those substitutions become permanent: a Windows-1252 subtitle
+    // comes back with "José" rendered as "Jos�" for the rest of its life.
+    //
+    // Legacy SRT files are commonly Windows-1252 or another single-byte
+    // regional encoding, so a failed UTF-8 decode is ordinary rather than
+    // exceptional. Falling back to Windows-1252 recovers the accents; if even
+    // that cannot be decoded, the payload is left exactly as it arrived, on
+    // the grounds that not normalising is better than corrupting.
+    val text = decodeSubtitleText(data, offset, length) ?: return null
     val normalized = normalizeSubripTextIfNeeded(text)
     return if (normalized == text) null else normalized.encodeToByteArray()
 }
@@ -127,3 +137,28 @@ private fun nextNonBlankIndex(lines: List<String>, startIndex: Int): Int? {
     }
     return null
 }
+
+private fun decodeSubtitleText(data: ByteArray, offset: Int, length: Int): String? =
+    decodeStrictly(data, offset, length, Charsets.UTF_8)
+        ?: decodeStrictly(data, offset, length, WINDOWS_1252)
+
+private fun decodeStrictly(
+    data: ByteArray,
+    offset: Int,
+    length: Int,
+    charset: java.nio.charset.Charset,
+): String? = try {
+    charset.newDecoder()
+        .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+        .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+        .decode(java.nio.ByteBuffer.wrap(data, offset, length))
+        .toString()
+} catch (_: java.nio.charset.CharacterCodingException) {
+    null
+} catch (_: IllegalArgumentException) {
+    null
+}
+
+private val WINDOWS_1252: java.nio.charset.Charset =
+    runCatching { java.nio.charset.Charset.forName("windows-1252") }
+        .getOrElse { Charsets.ISO_8859_1 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/EpisodeSelectionHandoff.kt
@@ -20,6 +20,123 @@ import org.siloserver.silo.playback.canonicalSubtitleLanguage
 data class EpisodeSelectionHandoff(
     val source: EpisodeSourceIntent? = null,
     val subtitle: EpisodeSubtitleIntent = EpisodeSubtitleIntent.auto(),
+    /**
+     * The audio the viewer chose, carried the same way subtitles are.
+     *
+     * Nothing carried audio before, so a household watching a dub or a
+     * commentary track was returned to the server default at every automatic
+     * episode change — a choice they had to make again all evening.
+     *
+     * Described by metadata rather than index for the same reason subtitles
+     * are: the next episode's track list is a different list, and position
+     * three in one file has nothing to do with position three in the next.
+     */
+    val audio: EpisodeAudioIntent = EpisodeAudioIntent.auto(),
+)
+
+@Serializable
+enum class EpisodeAudioMode { AUTO, TRACK }
+
+@Serializable
+data class EpisodeAudioIntent(
+    val mode: EpisodeAudioMode,
+    val language: String? = null,
+    val codecFamily: String? = null,
+    val channelCount: Int? = null,
+    val title: String? = null,
+) {
+    companion object {
+        fun auto() = EpisodeAudioIntent(EpisodeAudioMode.AUTO)
+    }
+}
+
+/**
+ * Pick the track in [candidates] that best answers [intent].
+ *
+ * Language is canonicalised first, because "eng" and "en" are the same choice
+ * spelled two ways and the catalog and the player disagree about which to use.
+ * Codec is reduced to a family for the same reason: the player reports MIME
+ * types like `audio/eac3` where the catalog says `eac3`.
+ *
+ * Title carries real weight rather than being decoration. A commentary track
+ * routinely shares language, codec AND channel count with the main mix, so
+ * those three cannot tell them apart — the name is the only thing that can.
+ *
+ * An unresolved tie returns null. Guessing between two tracks that both match
+ * everything known about the choice is how a viewer ends up in a director's
+ * commentary they never asked for, and the server default is a better answer
+ * than a coin toss.
+ */
+fun resolveEpisodeAudioIntent(
+    intent: EpisodeAudioIntent,
+    candidates: List<EpisodeAudioCandidate>,
+): Int? {
+    if (intent.mode != EpisodeAudioMode.TRACK) return null
+    if (candidates.isEmpty()) return null
+
+    val language = canonicalEpisodeLanguage(intent.language)
+    // A track with no language at all is still a choice a viewer made, so an
+    // intent without one narrows on the other fields rather than giving up.
+    var pool = if (language == null) {
+        candidates
+    } else {
+        candidates.filter { canonicalEpisodeLanguage(it.language) == language }
+    }
+    if (pool.isEmpty()) return null
+    if (pool.size == 1) return pool.single().index
+
+    val title = normalizedEpisodeToken(intent.title)
+    if (title != null) {
+        val byTitle = pool.filter { normalizedEpisodeToken(it.title) == title }
+        if (byTitle.size == 1) return byTitle.single().index
+        if (byTitle.isNotEmpty()) pool = byTitle
+    }
+
+    val codec = episodeAudioCodecFamily(intent.codecFamily)
+    if (codec != null) {
+        val byCodec = pool.filter { episodeAudioCodecFamily(it.codecFamily) == codec }
+        if (byCodec.size == 1) return byCodec.single().index
+        if (byCodec.isNotEmpty()) pool = byCodec
+    }
+
+    val channels = intent.channelCount
+    if (channels != null) {
+        val byChannels = pool.filter { it.channelCount == channels }
+        if (byChannels.size == 1) return byChannels.single().index
+        if (byChannels.isNotEmpty()) pool = byChannels
+    }
+
+    // Still ambiguous: say so rather than pick.
+    return pool.singleOrNull()?.index
+}
+
+/**
+ * The one canonicaliser, shared with subtitles.
+ *
+ * An earlier version here rolled its own and was wrong three ways: it ran the
+ * token through a normaliser that strips '-', so `en-US` became `enus` before
+ * any locale lookup; it passed three-letter codes straight through, so `fre`
+ * and `fra` never met; and `Locale.isO3Language` throws on unrecognised input,
+ * turning odd metadata into a failed playback start.
+ *
+ * canonicalSubtitleLanguage already handles all of that and treats `und` as
+ * absent. Audio and subtitles have no reason to disagree about what a language
+ * is.
+ */
+private fun canonicalEpisodeLanguage(raw: String?): String? =
+    canonicalSubtitleLanguage(raw)
+
+/** `audio/eac3` from the player and `eac3` from the catalog are one codec. */
+private fun episodeAudioCodecFamily(raw: String?): String? =
+    normalizedEpisodeToken(raw?.substringAfterLast('/'))
+
+data class EpisodeAudioCandidate(
+    val index: Int,
+    val language: String?,
+    val codecFamily: String?,
+    val channelCount: Int?,
+    /** Often the only thing separating a commentary track from the main mix. */
+    val title: String? = null,
 )
 
 @Serializable
@@ -60,6 +177,8 @@ data class ResolvedEpisodeSelection(
     val fileId: Int?,
     val subtitleTrackIndex: Int?,
     val subtitleIntentSpecified: Boolean,
+    /** Null keeps the server default, which is what AUTO means. */
+    val audioTrackIndex: Int? = null,
 )
 
 fun captureEpisodeSourceIntent(version: FileVersion?): EpisodeSourceIntent? {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
@@ -44,6 +44,10 @@ class PlaybackStartupStallDetector(
         this.started = false
         this.signaled = false
         this.firstFrameRendered = false
+        // Re-baselined on arm. The counters are cumulative on the player, so
+        // "greater than zero" would be satisfied instantly by the previous
+        // attempt's frames when a player is reused.
+        this.renderedBaseline = null
         this.decoderStartupAtMs = null
         this.paused = false
         this.lastProgressPositionMs = this.startPositionMs
@@ -52,17 +56,20 @@ class PlaybackStartupStallDetector(
     }
 
     /**
-     * Attempt-qualified. An unqualified callback let a first frame queued by the
-     * PREVIOUS item arrive after a replan or episode change and disarm the new
-     * attempt's watchdog before it had rendered anything — leaving a black
-     * picture with no fallback, and diagnostics recording a first frame that
-     * never happened for this stream.
+     * Deliberately absent: there is no onFirstFrameRendered here.
+     *
+     * Media3's callback carries no identity, so a frame rendered by the
+     * OUTGOING stream could arrive after a replan and vouch for the incoming
+     * one — disarming its watchdog before it had rendered anything. Qualifying
+     * the callback with a key rebuilt from live state does not help, because
+     * that key describes the state at DELIVERY, not the item that rendered.
+     *
+     * The counters below answer the same question with evidence that belongs to
+     * this attempt by construction: a baseline is taken when the attempt is
+     * armed, and only growth beyond it counts. Nothing has to be trusted about
+     * where a callback came from, because no callback is consulted.
      */
-    fun onFirstFrameRendered(sessionKey: String) {
-        if (sessionKey != this.sessionKey) return
-        firstFrameRendered = true
-        decoderStartupAtMs = null
-    }
+    private var renderedBaseline: Int? = null
 
     fun sample(
         sessionKey: String,
@@ -81,7 +88,10 @@ class PlaybackStartupStallDetector(
 
         val decoderOutputCount = decoderRenderedOutputBufferCount +
             decoderSkippedOutputBufferCount + decoderDroppedBufferCount
-        if (!firstFrameRendered && decoderRenderedOutputBufferCount > 0) {
+        val baseline = renderedBaseline ?: decoderRenderedOutputBufferCount.also {
+            renderedBaseline = it
+        }
+        if (!firstFrameRendered && decoderRenderedOutputBufferCount > baseline) {
             firstFrameRendered = true
             decoderStartupAtMs = null
         }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
@@ -37,18 +37,6 @@ class PlaybackStartupStallDetector(
         playMethod: PlayMethod,
         startPositionMs: Long,
         nowMs: Long,
-        /**
-         * The decoder's rendered count AT MOUNT.
-         *
-         * Taken here rather than on the first sample, because sampling runs
-         * every 500ms and only while the screen is STARTED: a stream that
-         * renders before its first sample would otherwise have its own frames
-         * become the baseline, the detector would never recognise a first
-         * frame, and a perfectly healthy stream would run into the decoder
-         * deadline. Null when the player cannot be read, which leaves the
-         * lazy capture as the fallback it always was.
-         */
-        renderedOutputBufferCount: Int? = null,
     ) {
         if (this.sessionKey == sessionKey) return
         this.sessionKey = sessionKey
@@ -59,7 +47,6 @@ class PlaybackStartupStallDetector(
         // Re-baselined on arm. The counters are cumulative on the player, so
         // "greater than zero" would be satisfied instantly by the previous
         // attempt's frames when a player is reused.
-        this.renderedBaseline = renderedOutputBufferCount
         this.decoderStartupAtMs = null
         this.paused = false
         this.lastProgressPositionMs = this.startPositionMs
@@ -68,20 +55,29 @@ class PlaybackStartupStallDetector(
     }
 
     /**
-     * Deliberately absent: there is no onFirstFrameRendered here.
+     * A frame rendered. Which stream rendered it is NOT known.
      *
-     * Media3's callback carries no identity, so a frame rendered by the
-     * OUTGOING stream could arrive after a replan and vouch for the incoming
-     * one — disarming its watchdog before it had rendered anything. Qualifying
-     * the callback with a key rebuilt from live state does not help, because
-     * that key describes the state at DELIVERY, not the item that rendered.
+     * Media3's callback carries no identity, so one from an outgoing stream can
+     * vouch for its replacement. That is a real defect and it is deliberately
+     * left in place: the two cheaper alternatives are both worse.
      *
-     * The counters below answer the same question with evidence that belongs to
-     * this attempt by construction: a baseline is taken when the attempt is
-     * armed, and only growth beyond it counts. Nothing has to be trusted about
-     * where a callback came from, because no callback is consulted.
+     * Qualifying the callback with a key rebuilt from live state fails, because
+     * that key describes when the event was DELIVERED, not what rendered it.
+     * Comparing decoder counters against a mount baseline fails too, because
+     * Media3 creates fresh DecoderCounters when a renderer is enabled — so an
+     * outgoing count compared against a restarted counter would make a healthy
+     * stream look frozen until it had rendered as many frames again, which
+     * trades a rare missed freeze for a common false one.
+     *
+     * The correct fix is AnalyticsListener.onRenderedFirstFrame(EventTime),
+     * whose EventTime identifies the media period, carried through a mount key
+     * on the MediaItem tag. That is Media3 integration work whose failure modes
+     * are device-specific, and it is not being written blind.
      */
-    private var renderedBaseline: Int? = null
+    fun onFirstFrameRendered() {
+        firstFrameRendered = true
+        decoderStartupAtMs = null
+    }
 
     fun sample(
         sessionKey: String,
@@ -100,10 +96,7 @@ class PlaybackStartupStallDetector(
 
         val decoderOutputCount = decoderRenderedOutputBufferCount +
             decoderSkippedOutputBufferCount + decoderDroppedBufferCount
-        val baseline = renderedBaseline ?: decoderRenderedOutputBufferCount.also {
-            renderedBaseline = it
-        }
-        if (!firstFrameRendered && decoderRenderedOutputBufferCount > baseline) {
+        if (!firstFrameRendered && decoderRenderedOutputBufferCount > 0) {
             firstFrameRendered = true
             decoderStartupAtMs = null
         }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
@@ -51,7 +51,15 @@ class PlaybackStartupStallDetector(
         this.lastProgressAtMs = nowMs
     }
 
-    fun onFirstFrameRendered() {
+    /**
+     * Attempt-qualified. An unqualified callback let a first frame queued by the
+     * PREVIOUS item arrive after a replan or episode change and disarm the new
+     * attempt's watchdog before it had rendered anything — leaving a black
+     * picture with no fallback, and diagnostics recording a first frame that
+     * never happened for this stream.
+     */
+    fun onFirstFrameRendered(sessionKey: String) {
+        if (sessionKey != this.sessionKey) return
         firstFrameRendered = true
         decoderStartupAtMs = null
     }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
@@ -37,6 +37,18 @@ class PlaybackStartupStallDetector(
         playMethod: PlayMethod,
         startPositionMs: Long,
         nowMs: Long,
+        /**
+         * The decoder's rendered count AT MOUNT.
+         *
+         * Taken here rather than on the first sample, because sampling runs
+         * every 500ms and only while the screen is STARTED: a stream that
+         * renders before its first sample would otherwise have its own frames
+         * become the baseline, the detector would never recognise a first
+         * frame, and a perfectly healthy stream would run into the decoder
+         * deadline. Null when the player cannot be read, which leaves the
+         * lazy capture as the fallback it always was.
+         */
+        renderedOutputBufferCount: Int? = null,
     ) {
         if (this.sessionKey == sessionKey) return
         this.sessionKey = sessionKey
@@ -47,7 +59,7 @@ class PlaybackStartupStallDetector(
         // Re-baselined on arm. The counters are cumulative on the player, so
         // "greater than zero" would be satisfied instantly by the previous
         // attempt's frames when a player is reused.
-        this.renderedBaseline = null
+        this.renderedBaseline = renderedOutputBufferCount
         this.decoderStartupAtMs = null
         this.paused = false
         this.lastProgressPositionMs = this.startPositionMs

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
@@ -44,9 +44,17 @@ class PlaybackStartupStallDetector(
         this.started = false
         this.signaled = false
         this.firstFrameRendered = false
-        // Re-baselined on arm. The counters are cumulative on the player, so
-        // "greater than zero" would be satisfied instantly by the previous
-        // attempt's frames when a player is reused.
+        // Only the startup deadline is cleared here — this is NOT a counter
+        // baseline, despite the shape of the check in sample(). Taking one was
+        // tried and reverted: Media3 creates fresh DecoderCounters when a
+        // renderer is enabled, so a baseline captured at mount can be compared
+        // against a counter that restarted at zero, and a healthy stream then
+        // looks frozen until it has rendered as many frames again. That trades
+        // a rare missed freeze for a common invented one. The residual — a
+        // reused player whose cumulative count makes the first sample look like
+        // this attempt already rendered — is accepted, and the real fix is
+        // AnalyticsListener.onRenderedFirstFrame(EventTime) carried through a
+        // mount key, which needs hardware to validate.
         this.decoderStartupAtMs = null
         this.paused = false
         this.lastProgressPositionMs = this.startPositionMs

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetector.kt
@@ -22,6 +22,7 @@ class PostResumeVideoStallDetector(
 
     private var sessionKey: String? = null
     private var firstFrameRendered = false
+    private var renderedBaseline: Int? = null
     private var pausedAfterFirstFrame = false
     private var pausedDuringRecovery = false
     private var stage = Stage.IDLE
@@ -33,6 +34,7 @@ class PostResumeVideoStallDetector(
         if (this.sessionKey == sessionKey) return
         this.sessionKey = sessionKey
         firstFrameRendered = false
+        renderedBaseline = null
         pausedAfterFirstFrame = false
         pausedDuringRecovery = false
         stage = Stage.IDLE
@@ -42,12 +44,20 @@ class PostResumeVideoStallDetector(
     }
 
     /**
-     * Attempt-qualified, for the same reason as the startup detector: a first
-     * frame belonging to the outgoing item must not mark this one as healthy.
+     * Whether THIS attempt has rendered anything, from its own counters.
+     *
+     * Media3's onRenderedFirstFrame carries no identity, so it cannot say which
+     * stream rendered — a frame from the outgoing one would otherwise mark this
+     * attempt live before it had shown anything, disarming the very watchdog
+     * that exists to catch that. Counters are attributable by construction: a
+     * baseline is taken the first time this attempt is measured, and only
+     * growth beyond it counts.
      */
-    fun onFirstFrameRendered(sessionKey: String) {
-        if (sessionKey != this.sessionKey) return
-        firstFrameRendered = true
+    private fun noteRenderedFrames(renderedOutputBufferCount: Int) {
+        val baseline = renderedBaseline ?: renderedOutputBufferCount.also {
+            renderedBaseline = it
+        }
+        if (renderedOutputBufferCount > baseline) firstFrameRendered = true
     }
 
     fun onIsPlayingChanged(
@@ -57,7 +67,11 @@ class PostResumeVideoStallDetector(
         currentPositionMs: Long,
         renderedOutputBufferCount: Int?,
     ) {
-        if (sessionKey != this.sessionKey || !firstFrameRendered || stage == Stage.EXHAUSTED) return
+        if (sessionKey != this.sessionKey) return
+        // Counted before the firstFrameRendered gate: this callback is one of
+        // the two places a count arrives, and the gate below depends on it.
+        renderedOutputBufferCount?.let(::noteRenderedFrames)
+        if (!firstFrameRendered || stage == Stage.EXHAUSTED) return
         if (!isPlaying) {
             if (stage == Stage.IDLE) {
                 pausedAfterFirstFrame = true
@@ -85,7 +99,9 @@ class PostResumeVideoStallDetector(
         durationMs: Long,
         renderedOutputBufferCount: Int?,
     ): Signal? {
-        if (sessionKey != this.sessionKey || renderedOutputBufferCount == null || stage == Stage.IDLE ||
+        if (sessionKey != this.sessionKey) return null
+        renderedOutputBufferCount?.let(::noteRenderedFrames)
+        if (renderedOutputBufferCount == null || stage == Stage.IDLE ||
             stage == Stage.EXHAUSTED
         ) return null
         if (!playWhenReady || !isPlaying || !isReady) return null

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetector.kt
@@ -30,11 +30,11 @@ class PostResumeVideoStallDetector(
     private var baselinePositionMs = 0L
     private var baselineRenderedCount = 0
 
-    fun onMounted(sessionKey: String) {
+    fun onMounted(sessionKey: String, renderedOutputBufferCount: Int? = null) {
         if (this.sessionKey == sessionKey) return
         this.sessionKey = sessionKey
         firstFrameRendered = false
-        renderedBaseline = null
+        renderedBaseline = renderedOutputBufferCount
         pausedAfterFirstFrame = false
         pausedDuringRecovery = false
         stage = Stage.IDLE

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetector.kt
@@ -22,7 +22,6 @@ class PostResumeVideoStallDetector(
 
     private var sessionKey: String? = null
     private var firstFrameRendered = false
-    private var renderedBaseline: Int? = null
     private var pausedAfterFirstFrame = false
     private var pausedDuringRecovery = false
     private var stage = Stage.IDLE
@@ -30,11 +29,10 @@ class PostResumeVideoStallDetector(
     private var baselinePositionMs = 0L
     private var baselineRenderedCount = 0
 
-    fun onMounted(sessionKey: String, renderedOutputBufferCount: Int? = null) {
+    fun onMounted(sessionKey: String) {
         if (this.sessionKey == sessionKey) return
         this.sessionKey = sessionKey
         firstFrameRendered = false
-        renderedBaseline = renderedOutputBufferCount
         pausedAfterFirstFrame = false
         pausedDuringRecovery = false
         stage = Stage.IDLE
@@ -44,20 +42,12 @@ class PostResumeVideoStallDetector(
     }
 
     /**
-     * Whether THIS attempt has rendered anything, from its own counters.
-     *
-     * Media3's onRenderedFirstFrame carries no identity, so it cannot say which
-     * stream rendered — a frame from the outgoing one would otherwise mark this
-     * attempt live before it had shown anything, disarming the very watchdog
-     * that exists to catch that. Counters are attributable by construction: a
-     * baseline is taken the first time this attempt is measured, and only
-     * growth beyond it counts.
+     * A frame rendered. Provenance unknown — see PlaybackStartupStallDetector
+     * for why neither a rebuilt key nor a counter baseline can supply it, and
+     * what the real fix is.
      */
-    private fun noteRenderedFrames(renderedOutputBufferCount: Int) {
-        val baseline = renderedBaseline ?: renderedOutputBufferCount.also {
-            renderedBaseline = it
-        }
-        if (renderedOutputBufferCount > baseline) firstFrameRendered = true
+    fun onFirstFrameRendered() {
+        firstFrameRendered = true
     }
 
     fun onIsPlayingChanged(
@@ -67,11 +57,7 @@ class PostResumeVideoStallDetector(
         currentPositionMs: Long,
         renderedOutputBufferCount: Int?,
     ) {
-        if (sessionKey != this.sessionKey) return
-        // Counted before the firstFrameRendered gate: this callback is one of
-        // the two places a count arrives, and the gate below depends on it.
-        renderedOutputBufferCount?.let(::noteRenderedFrames)
-        if (!firstFrameRendered || stage == Stage.EXHAUSTED) return
+        if (sessionKey != this.sessionKey || !firstFrameRendered || stage == Stage.EXHAUSTED) return
         if (!isPlaying) {
             if (stage == Stage.IDLE) {
                 pausedAfterFirstFrame = true
@@ -99,9 +85,7 @@ class PostResumeVideoStallDetector(
         durationMs: Long,
         renderedOutputBufferCount: Int?,
     ): Signal? {
-        if (sessionKey != this.sessionKey) return null
-        renderedOutputBufferCount?.let(::noteRenderedFrames)
-        if (renderedOutputBufferCount == null || stage == Stage.IDLE ||
+        if (sessionKey != this.sessionKey || renderedOutputBufferCount == null || stage == Stage.IDLE ||
             stage == Stage.EXHAUSTED
         ) return null
         if (!playWhenReady || !isPlaying || !isReady) return null

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetector.kt
@@ -41,7 +41,12 @@ class PostResumeVideoStallDetector(
         baselineRenderedCount = 0
     }
 
-    fun onFirstFrameRendered() {
+    /**
+     * Attempt-qualified, for the same reason as the startup detector: a first
+     * frame belonging to the outgoing item must not mark this one as healthy.
+     */
+    fun onFirstFrameRendered(sessionKey: String) {
+        if (sessionKey != this.sessionKey) return
         firstFrameRendered = true
     }
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionLifecycleTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionLifecycleTest.kt
@@ -858,6 +858,151 @@ class PlaybackSessionLifecycleTest {
     }
 
     // ------------------------------------------------------------------------
+    // Exactly-once teardown (auto-advance)
+    // ------------------------------------------------------------------------
+
+    /**
+     * The auto-advance regression: the outgoing screen's deferred onCleared stop
+     * used to land after the incoming episode had captured its ownership epoch,
+     * bumping stopEpoch and getting the incoming adoption rejected. On device
+     * that surfaced as "Playback start was superseded." on every episode change.
+     */
+    @Test
+    fun `gated duplicate teardown does not supersede the next item`() = runTest {
+        val sessionMgr = FakeSessionManager()
+        val lifecycle = newLifecycle(sessionMgr, scope = backgroundScope)
+        val gate = PlaybackTeardownGate(lifecycle)
+
+        val epochA = lifecycle.acquireOwnershipEpoch()
+        assertTrue(
+            lifecycle.adoptActiveSessionIfCurrent(
+                params = defaultStartParams(),
+                session = makeSession("sess-a"),
+                expectedOwnershipEpoch = epochA,
+            ),
+        )
+        // Ordered pre-navigation stop of the outgoing episode.
+        gate.stopOrdered(expectedSessionId = "sess-a")
+
+        // The incoming episode captures its epoch, and only THEN does the old
+        // screen's deferred onCleared fallback fire.
+        val epochB = lifecycle.acquireOwnershipEpoch()
+        gate.stopDetached(expectedSessionId = "sess-a")
+
+        val adopted = lifecycle.adoptActiveSessionIfCurrent(
+            params = defaultStartParams(),
+            session = makeSession("sess-b"),
+            expectedOwnershipEpoch = epochB,
+        )
+
+        assertTrue(adopted, "next episode must adopt despite the late duplicate teardown")
+        assertEquals("sess-b", (lifecycle.state.value as SessionState.Active).session.sessionId)
+        assertEquals(1, sessionMgr.stopCallCount, "outgoing session stopped exactly once")
+    }
+
+    /** Control: without the gate the same interleaving really does break. */
+    @Test
+    fun `ungated duplicate teardown supersedes the next item`() = runTest {
+        val sessionMgr = FakeSessionManager()
+        val lifecycle = newLifecycle(sessionMgr, scope = backgroundScope)
+
+        val epochA = lifecycle.acquireOwnershipEpoch()
+        lifecycle.adoptActiveSessionIfCurrent(
+            params = defaultStartParams(),
+            session = makeSession("sess-a"),
+            expectedOwnershipEpoch = epochA,
+        )
+        lifecycle.stop(expectedSessionId = "sess-a")
+
+        val epochB = lifecycle.acquireOwnershipEpoch()
+        lifecycle.stop(expectedSessionId = "sess-a")
+
+        assertFalse(
+            lifecycle.adoptActiveSessionIfCurrent(
+                params = defaultStartParams(),
+                session = makeSession("sess-b"),
+                expectedOwnershipEpoch = epochB,
+            ),
+            "this is the bug the gate exists to prevent",
+        )
+    }
+
+    /**
+     * The claim must never be consumed without leaving an owner. Here the
+     * fallback lands while the ordered stop is still in flight — so it correctly
+     * skips — and the ordered stop then fails. Teardown has to survive that.
+     */
+    @Test
+    fun `fallback during a suspended ordered stop cannot abandon teardown`() = runTest {
+        val firstStopReached = CompletableDeferred<Unit>()
+        val releaseFirstStop = CompletableDeferred<Unit>()
+        val sessionMgr = object : FakeSessionManager() {
+            var attempts = 0
+            override suspend fun stopSession(sessionId: String): ApiResult<Unit> {
+                attempts++
+                if (attempts == 1) {
+                    firstStopReached.complete(Unit)
+                    releaseFirstStop.await()
+                    throw IllegalStateException("stop failed")
+                }
+                return super.stopSession(sessionId)
+            }
+        }
+        val lifecycle = newLifecycle(sessionMgr, scope = backgroundScope)
+        val gate = PlaybackTeardownGate(lifecycle)
+
+        val epochA = lifecycle.acquireOwnershipEpoch()
+        lifecycle.adoptActiveSessionIfCurrent(
+            params = defaultStartParams(),
+            session = makeSession("sess-a"),
+            expectedOwnershipEpoch = epochA,
+        )
+
+        // runCatching so the failure stays inside this coroutine.
+        val ordered = backgroundScope.async {
+            runCatching { gate.stopOrdered(expectedSessionId = "sess-a") }
+        }
+        firstStopReached.await()
+
+        // The dying screen's onCleared fires mid-flight and finds it claimed.
+        gate.stopDetached(expectedSessionId = "sess-a")
+
+        releaseFirstStop.complete(Unit)
+        assertTrue(ordered.await().isFailure, "the ordered stop really did fail")
+        // The handoff job runs on Dispatchers.IO, so the test scheduler cannot
+        // see it. Join it through the same API a real next start uses.
+        lifecycle.acquireOwnershipEpoch()
+        assertEquals(2, sessionMgr.attempts, "the tracked job must retry the abandoned teardown")
+        assertEquals(SessionState.Idle, lifecycle.state.value)
+    }
+
+    /**
+     * The detached routes only schedule the stop, so nothing is positioned to
+     * catch it. The lifecycle scope has a SupervisorJob but no
+     * CoroutineExceptionHandler, so an escaping throw would be an uncaught
+     * coroutine exception — process death rather than a lingering session.
+     */
+    @Test
+    fun `a failing async stop does not escape as an uncaught exception`() = runTest {
+        val sessionMgr = object : FakeSessionManager() {
+            override suspend fun stopSession(sessionId: String): ApiResult<Unit> =
+                throw IllegalStateException("stop failed")
+        }
+        val lifecycle = newLifecycle(sessionMgr, scope = backgroundScope)
+
+        val epoch = lifecycle.acquireOwnershipEpoch()
+        lifecycle.adoptActiveSessionIfCurrent(
+            params = defaultStartParams(),
+            session = makeSession("sess-a"),
+            expectedOwnershipEpoch = epoch,
+        )
+
+        lifecycle.stopAsync(expectedSessionId = "sess-a")
+        // Joins the tracked job. If the failure escaped, runTest reports it.
+        lifecycle.acquireOwnershipEpoch()
+    }
+
+    // ------------------------------------------------------------------------
     // Test infrastructure
     // ------------------------------------------------------------------------
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/audio/DelayAudioProcessorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/audio/DelayAudioProcessorTest.kt
@@ -59,14 +59,58 @@ class DelayAudioProcessorTest {
         p.configure(makeStereo16Pcm44k())
         p.flush(StreamMetadata.DEFAULT)
         val input = inputBytes(4_000)
+
+        // The head is paid off first, on its own. The input is deliberately
+        // NOT consumed on this pass, so it is offered again.
         p.queueInput(input)
-        val out = p.output
-        // Expect 1764 silence bytes + 4000 input bytes
-        assertEquals(5_764, out.remaining())
-        // First 1764 bytes should be zero
-        repeat(1_764) {
-            assertEquals(0.toByte(), out.get())
+        val silence = p.output
+        assertEquals(1_764, silence.remaining())
+        repeat(1_764) { assertEquals(0.toByte(), silence.get()) }
+        assertEquals(4_000, input.remaining())
+
+        // Then the audio, unbroken.
+        p.queueInput(input)
+        assertEquals(4_000, p.output.remaining())
+    }
+
+    /**
+     * The real streaming shape, which the single-large-buffer test above cannot
+     * express: a delay spanning MANY decoder buffers.
+     *
+     * The processor used to emit silence and audio on every pass until the head
+     * was consumed, so a delay longer than one buffer came out as
+     * silence, audio, silence, audio... — audible as chopped, half-rate sound
+     * for the length of the offset. Silence must come out in one unbroken run.
+     */
+    @Test
+    fun `a delay longer than one buffer does not interleave audio`() {
+        val p = DelayAudioProcessor()
+        p.setDelayMs(100) // 17_640 bytes — far more than one buffer
+        p.configure(makeStereo16Pcm44k())
+        p.flush(StreamMetadata.DEFAULT)
+
+        var silenceEmitted = 0
+        var passes = 0
+        while (silenceEmitted < 17_640 && passes < 200) {
+            passes++
+            val chunk = inputBytes(512)
+            p.queueInput(chunk)
+            val out = p.output
+            val len = out.remaining()
+            if (len == 0) continue
+            // Every byte before the head is paid off must be silence. A single
+            // non-zero byte here is the interleaving bug.
+            repeat(len) { assertEquals(0.toByte(), out.get()) }
+            silenceEmitted += len
+            // Audio is held back while the head is outstanding.
+            assertEquals(512, chunk.remaining())
         }
+        assertEquals(17_640, silenceEmitted)
+
+        // Head paid: audio now flows.
+        val audio = inputBytes(512)
+        p.queueInput(audio)
+        assertEquals(512, p.output.remaining())
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/subtitle/PgsSupExtractorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/subtitle/PgsSupExtractorTest.kt
@@ -176,6 +176,64 @@ class PgsSupExtractorTest {
         }
     }
 
+    /**
+     * A caption declaring an enormous bitmap must never reach the parser.
+     *
+     * Media3 trusts these two 16-bit fields: it allocates IntArray(w * h) and
+     * an ARGB bitmap from them. 40000x40000 asks for 1.6 billion pixels — over
+     * 6 GB — from eleven bytes of input. Catching the failure afterwards is too
+     * late on a TV box, where the process simply disappears.
+     */
+    @Test
+    fun anObjectDeclaringAnUnreasonableBitmapIsRejected() {
+        val out = ByteArrayOutputStream()
+        out.writeSegment(pts90kHz = 90_000, type = SEGMENT_TYPE_PCS, payload = byteArrayOf(0xAA.toByte()))
+        out.writeSegment(
+            pts90kHz = 90_000,
+            type = PgsSupExtractor.SEGMENT_TYPE_OBJECT,
+            payload = objectSegment(width = 40_000, height = 40_000),
+        )
+        out.writeSegment(pts90kHz = 90_000, type = PgsSupExtractor.SEGMENT_TYPE_END, payload = ByteArray(0))
+
+        val factory = RecordingParserFactory()
+        val extractor = PgsSupExtractor(factory, { 0L }, pgsFormat())
+        extractor.init(FakeExtractorOutput())
+        drain(extractor, FakeExtractorInput.Builder().setData(out.toByteArray()).build())
+
+        assertEquals(0, factory.parsed.size)
+    }
+
+    /** A full-frame 1080p caption is legitimate and must still play. */
+    @Test
+    fun aFullFrameObjectIsAccepted() {
+        val out = ByteArrayOutputStream()
+        out.writeSegment(pts90kHz = 90_000, type = SEGMENT_TYPE_PCS, payload = byteArrayOf(0xAA.toByte()))
+        out.writeSegment(
+            pts90kHz = 90_000,
+            type = PgsSupExtractor.SEGMENT_TYPE_OBJECT,
+            payload = objectSegment(width = 1920, height = 1080),
+        )
+        out.writeSegment(pts90kHz = 90_000, type = PgsSupExtractor.SEGMENT_TYPE_END, payload = ByteArray(0))
+
+        val factory = RecordingParserFactory()
+        val extractor = PgsSupExtractor(factory, { 0L }, pgsFormat())
+        extractor.init(FakeExtractorOutput())
+        drain(extractor, FakeExtractorInput.Builder().setData(out.toByteArray()).build())
+
+        assertEquals(1, factory.parsed.size)
+    }
+
+    /** First-sequence ODS payload: id, version, descriptor, length, w, h. */
+    private fun objectSegment(width: Int, height: Int): ByteArray = byteArrayOf(
+        0x00, 0x01, // object id
+        0x00, // version
+        0x80.toByte(), // first sequence
+        0x00, 0x00, 0x10, // object data length (>= 4)
+        (width shr 8 and 0xFF).toByte(), (width and 0xFF).toByte(),
+        (height shr 8 and 0xFF).toByte(), (height and 0xFF).toByte(),
+        0x00, 0x00, // token RLE bytes
+    )
+
     /** Two display sets: PTS 1s and 3s, each one PCS segment then END. */
     private fun supStream(): ByteArray {
         val out = ByteArrayOutputStream()

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/subtitle/SubripPayloadNormalizerTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/subtitle/SubripPayloadNormalizerTest.kt
@@ -3,6 +3,8 @@ package org.siloserver.silo.common.player.subtitle
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.assertNotNull
 
 class SubripPayloadNormalizerTest {
     @Test
@@ -110,5 +112,26 @@ class SubripPayloadNormalizerTest {
             "subtitle normalization runs per payload during playback and must not flood normal logcat",
         )
         assertFalse(source.contains("SubRip payload len="))
+    }
+
+    /**
+     * A Windows-1252 subtitle that needs rewriting must keep its accents.
+     *
+     * Lenient UTF-8 decoding turned every high byte into U+FFFD, and because a
+     * rewrite re-encodes what it decoded, the damage was permanent — "José"
+     * became "Jos\uFFFD" in the cues the viewer actually read.
+     */
+    @Test
+    fun `a windows-1252 payload keeps its accents through a rewrite`() {
+        // Timecode-first, so normalisation must rewrite it and therefore decode.
+        val text = "00:00:01,000 --> 00:00:02,000\nJosé\n"
+        val bytes = text.toByteArray(java.nio.charset.Charset.forName("windows-1252"))
+
+        val out = normalizeSubripPayloadIfNeeded(bytes, 0, bytes.size)
+
+        assertNotNull(out)
+        val decoded = out!!.decodeToString()
+        assertTrue(decoded.contains("José"), "accents were lost: $decoded")
+        assertFalse(decoded.contains('\uFFFD'), "replacement characters present: $decoded")
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
@@ -185,10 +185,49 @@ class PlaybackStartupStallDetectorTest {
             bufferedPositionMs = 5_000,
             decoderInputBufferCount = 1,
         )
-        detector.onFirstFrameRendered()
+        detector.onFirstFrameRendered("rendered")
         assertNull(
             detector.sample(
                 sessionKey = "rendered",
+                nowMs = 2_000,
+                playWhenReady = true,
+                isPlaying = true,
+                isBuffering = false,
+                currentPositionMs = 2_000,
+                bufferedPositionMs = 5_000,
+                decoderInputBufferCount = 10,
+            ),
+        )
+    }
+
+    /**
+     * A first frame belonging to a DIFFERENT attempt must not disarm this one.
+     *
+     * Media3 delivers the callback asynchronously, so one queued by the
+     * outgoing stream can land after a replan or episode change. Crediting it
+     * here marked the replacement healthy before it had rendered anything —
+     * a black picture with its watchdog switched off, and diagnostics recording
+     * a first frame that never happened for this stream.
+     */
+    @Test
+    fun aFirstFrameFromAnotherAttemptDoesNotDisarmTheDeadline() {
+        val detector = PlaybackStartupStallDetector(startupGraceMs = 1_000)
+        detector.onMounted("attempt-b", PlayMethod.DIRECT, 0, 0)
+        detector.sample(
+            sessionKey = "attempt-b",
+            nowMs = 100,
+            playWhenReady = true,
+            isPlaying = true,
+            isBuffering = false,
+            currentPositionMs = 100,
+            bufferedPositionMs = 5_000,
+            decoderInputBufferCount = 1,
+        )
+        detector.onFirstFrameRendered("attempt-a")
+        // Still armed, because nothing has rendered for attempt-b.
+        assertNotNull(
+            detector.sample(
+                sessionKey = "attempt-b",
                 nowMs = 2_000,
                 playWhenReady = true,
                 isPlaying = true,
@@ -353,7 +392,7 @@ class PlaybackStartupStallDetectorTest {
         )
         detector.onMounted("session", PlayMethod.DIRECT, 0, 0)
         detector.sample("session", 100, true, true, false, 1_000, 5_000)
-        detector.onFirstFrameRendered()
+        detector.onFirstFrameRendered("session")
 
         assertNull(detector.sample("session", 900, true, false, true, 1_000, 6_000))
         assertNotNull(detector.sample("session", 1_101, true, false, true, 1_000, 7_000))

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
@@ -185,60 +185,10 @@ class PlaybackStartupStallDetectorTest {
             bufferedPositionMs = 5_000,
             decoderInputBufferCount = 1,
         )
-        // A rendered frame for THIS attempt is what disarms the deadline.
-        detector.sample(
-            sessionKey = "rendered",
-            nowMs = 150,
-            playWhenReady = true,
-            isPlaying = true,
-            isBuffering = false,
-            currentPositionMs = 100,
-            bufferedPositionMs = 5_000,
-            decoderInputBufferCount = 1,
-            decoderRenderedOutputBufferCount = 1,
-        )
+        detector.onFirstFrameRendered()
         assertNull(
             detector.sample(
                 sessionKey = "rendered",
-                nowMs = 2_000,
-                playWhenReady = true,
-                isPlaying = true,
-                isBuffering = false,
-                currentPositionMs = 2_000,
-                bufferedPositionMs = 5_000,
-                decoderInputBufferCount = 10,
-                decoderRenderedOutputBufferCount = 1,
-            ),
-        )
-    }
-
-    /**
-     * A first frame belonging to a DIFFERENT attempt must not disarm this one.
-     *
-     * Media3 delivers the callback asynchronously, so one queued by the
-     * outgoing stream can land after a replan or episode change. Crediting it
-     * here marked the replacement healthy before it had rendered anything —
-     * a black picture with its watchdog switched off, and diagnostics recording
-     * a first frame that never happened for this stream.
-     */
-    @Test
-    fun aFirstFrameFromAnotherAttemptDoesNotDisarmTheDeadline() {
-        val detector = PlaybackStartupStallDetector(startupGraceMs = 1_000)
-        detector.onMounted("attempt-b", PlayMethod.DIRECT, 0, 0)
-        detector.sample(
-            sessionKey = "attempt-b",
-            nowMs = 100,
-            playWhenReady = true,
-            isPlaying = true,
-            isBuffering = false,
-            currentPositionMs = 100,
-            bufferedPositionMs = 5_000,
-            decoderInputBufferCount = 1,
-        )
-        // Still armed, because nothing has rendered for attempt-b.
-        assertNotNull(
-            detector.sample(
-                sessionKey = "attempt-b",
                 nowMs = 2_000,
                 playWhenReady = true,
                 isPlaying = true,
@@ -403,27 +353,10 @@ class PlaybackStartupStallDetectorTest {
         )
         detector.onMounted("session", PlayMethod.DIRECT, 0, 0)
         detector.sample("session", 100, true, true, false, 1_000, 5_000)
-        // First frame is now evidenced by rendered-count growth rather than an
-        // unattributable callback.
-        detector.sample(
-            "session", 100, true, true, false, 1_000, 5_000,
-            decoderRenderedOutputBufferCount = 1,
-        )
+        detector.onFirstFrameRendered()
 
-        // Rendered count held steady: it must not appear to go backwards, which
-        // would read as a fresh attempt rather than a frozen one.
-        assertNull(
-            detector.sample(
-                "session", 900, true, false, true, 1_000, 6_000,
-                decoderRenderedOutputBufferCount = 1,
-            ),
-        )
-        assertNotNull(
-            detector.sample(
-                "session", 1_101, true, false, true, 1_000, 7_000,
-                decoderRenderedOutputBufferCount = 1,
-            ),
-        )
+        assertNull(detector.sample("session", 900, true, false, true, 1_000, 6_000))
+        assertNotNull(detector.sample("session", 1_101, true, false, true, 1_000, 7_000))
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
@@ -185,7 +185,18 @@ class PlaybackStartupStallDetectorTest {
             bufferedPositionMs = 5_000,
             decoderInputBufferCount = 1,
         )
-        detector.onFirstFrameRendered("rendered")
+        // A rendered frame for THIS attempt is what disarms the deadline.
+        detector.sample(
+            sessionKey = "rendered",
+            nowMs = 150,
+            playWhenReady = true,
+            isPlaying = true,
+            isBuffering = false,
+            currentPositionMs = 100,
+            bufferedPositionMs = 5_000,
+            decoderInputBufferCount = 1,
+            decoderRenderedOutputBufferCount = 1,
+        )
         assertNull(
             detector.sample(
                 sessionKey = "rendered",
@@ -196,6 +207,7 @@ class PlaybackStartupStallDetectorTest {
                 currentPositionMs = 2_000,
                 bufferedPositionMs = 5_000,
                 decoderInputBufferCount = 10,
+                decoderRenderedOutputBufferCount = 1,
             ),
         )
     }
@@ -223,7 +235,6 @@ class PlaybackStartupStallDetectorTest {
             bufferedPositionMs = 5_000,
             decoderInputBufferCount = 1,
         )
-        detector.onFirstFrameRendered("attempt-a")
         // Still armed, because nothing has rendered for attempt-b.
         assertNotNull(
             detector.sample(
@@ -392,10 +403,27 @@ class PlaybackStartupStallDetectorTest {
         )
         detector.onMounted("session", PlayMethod.DIRECT, 0, 0)
         detector.sample("session", 100, true, true, false, 1_000, 5_000)
-        detector.onFirstFrameRendered("session")
+        // First frame is now evidenced by rendered-count growth rather than an
+        // unattributable callback.
+        detector.sample(
+            "session", 100, true, true, false, 1_000, 5_000,
+            decoderRenderedOutputBufferCount = 1,
+        )
 
-        assertNull(detector.sample("session", 900, true, false, true, 1_000, 6_000))
-        assertNotNull(detector.sample("session", 1_101, true, false, true, 1_000, 7_000))
+        // Rendered count held steady: it must not appear to go backwards, which
+        // would read as a fresh attempt rather than a frozen one.
+        assertNull(
+            detector.sample(
+                "session", 900, true, false, true, 1_000, 6_000,
+                decoderRenderedOutputBufferCount = 1,
+            ),
+        )
+        assertNotNull(
+            detector.sample(
+                "session", 1_101, true, false, true, 1_000, 7_000,
+                decoderRenderedOutputBufferCount = 1,
+            ),
+        )
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetectorTest.kt
@@ -9,7 +9,7 @@ class PostResumeVideoStallDetectorTest {
     fun performsBoundedSeekThenReprepareWhenClockAdvancesWithoutFrames() {
         val detector = PostResumeVideoStallDetector(1_000, 1_000, 500, 2_000)
         detector.onMounted("session")
-        detector.onFirstFrameRendered()
+        detector.onFirstFrameRendered("session")
         detector.onIsPlayingChanged("session", false, 0, 10_000, 20)
         detector.onIsPlayingChanged("session", true, 100, 10_000, 20)
 
@@ -33,7 +33,7 @@ class PostResumeVideoStallDetectorTest {
     fun frameProgressCancelsRecovery() {
         val detector = PostResumeVideoStallDetector(1_000, 1_000, 500, 2_000)
         detector.onMounted("session")
-        detector.onFirstFrameRendered()
+        detector.onFirstFrameRendered("session")
         detector.onIsPlayingChanged("session", false, 0, 10_000, 20)
         detector.onIsPlayingChanged("session", true, 100, 10_000, 20)
 
@@ -49,7 +49,7 @@ class PostResumeVideoStallDetectorTest {
         detector.onIsPlayingChanged("session", true, 100, 0, 0)
         assertNull(detector.sample("session", 2_000, true, true, true, 1_500, 60_000, 0))
 
-        detector.onFirstFrameRendered()
+        detector.onFirstFrameRendered("session")
         detector.onIsPlayingChanged("session", false, 2_100, 58_000, 20)
         detector.onIsPlayingChanged("session", true, 2_200, 58_000, 20)
         assertNull(detector.sample("session", 4_000, true, true, true, 59_000, 60_000, 20))
@@ -59,7 +59,7 @@ class PostResumeVideoStallDetectorTest {
     fun pauseDuringRecoveryDoesNotCountTowardTheStageDeadline() {
         val detector = PostResumeVideoStallDetector(1_000, 1_000, 500, 2_000)
         detector.onMounted("session")
-        detector.onFirstFrameRendered()
+        detector.onFirstFrameRendered("session")
         detector.onIsPlayingChanged("session", false, 0, 10_000, 20)
         detector.onIsPlayingChanged("session", true, 100, 10_000, 20)
         detector.onIsPlayingChanged("session", false, 500, 10_400, 20)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetectorTest.kt
@@ -9,8 +9,8 @@ class PostResumeVideoStallDetectorTest {
     fun performsBoundedSeekThenReprepareWhenClockAdvancesWithoutFrames() {
         val detector = PostResumeVideoStallDetector(1_000, 1_000, 500, 2_000)
         detector.onMounted("session")
-        detector.onFirstFrameRendered("session")
         detector.onIsPlayingChanged("session", false, 0, 10_000, 20)
+        detector.onIsPlayingChanged("session", false, 0, 10_000, 21)
         detector.onIsPlayingChanged("session", true, 100, 10_000, 20)
 
         assertNull(detector.sample("session", 500, true, true, true, 10_600, 60_000, 20))
@@ -33,8 +33,8 @@ class PostResumeVideoStallDetectorTest {
     fun frameProgressCancelsRecovery() {
         val detector = PostResumeVideoStallDetector(1_000, 1_000, 500, 2_000)
         detector.onMounted("session")
-        detector.onFirstFrameRendered("session")
         detector.onIsPlayingChanged("session", false, 0, 10_000, 20)
+        detector.onIsPlayingChanged("session", false, 0, 10_000, 21)
         detector.onIsPlayingChanged("session", true, 100, 10_000, 20)
 
         assertNull(detector.sample("session", 1_100, true, true, true, 11_000, 60_000, 21))
@@ -49,7 +49,6 @@ class PostResumeVideoStallDetectorTest {
         detector.onIsPlayingChanged("session", true, 100, 0, 0)
         assertNull(detector.sample("session", 2_000, true, true, true, 1_500, 60_000, 0))
 
-        detector.onFirstFrameRendered("session")
         detector.onIsPlayingChanged("session", false, 2_100, 58_000, 20)
         detector.onIsPlayingChanged("session", true, 2_200, 58_000, 20)
         assertNull(detector.sample("session", 4_000, true, true, true, 59_000, 60_000, 20))
@@ -59,8 +58,8 @@ class PostResumeVideoStallDetectorTest {
     fun pauseDuringRecoveryDoesNotCountTowardTheStageDeadline() {
         val detector = PostResumeVideoStallDetector(1_000, 1_000, 500, 2_000)
         detector.onMounted("session")
-        detector.onFirstFrameRendered("session")
         detector.onIsPlayingChanged("session", false, 0, 10_000, 20)
+        detector.onIsPlayingChanged("session", false, 0, 10_000, 21)
         detector.onIsPlayingChanged("session", true, 100, 10_000, 20)
         detector.onIsPlayingChanged("session", false, 500, 10_400, 20)
         detector.onIsPlayingChanged("session", true, 10_000, 10_400, 20)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PostResumeVideoStallDetectorTest.kt
@@ -9,8 +9,8 @@ class PostResumeVideoStallDetectorTest {
     fun performsBoundedSeekThenReprepareWhenClockAdvancesWithoutFrames() {
         val detector = PostResumeVideoStallDetector(1_000, 1_000, 500, 2_000)
         detector.onMounted("session")
+        detector.onFirstFrameRendered()
         detector.onIsPlayingChanged("session", false, 0, 10_000, 20)
-        detector.onIsPlayingChanged("session", false, 0, 10_000, 21)
         detector.onIsPlayingChanged("session", true, 100, 10_000, 20)
 
         assertNull(detector.sample("session", 500, true, true, true, 10_600, 60_000, 20))
@@ -33,8 +33,8 @@ class PostResumeVideoStallDetectorTest {
     fun frameProgressCancelsRecovery() {
         val detector = PostResumeVideoStallDetector(1_000, 1_000, 500, 2_000)
         detector.onMounted("session")
+        detector.onFirstFrameRendered()
         detector.onIsPlayingChanged("session", false, 0, 10_000, 20)
-        detector.onIsPlayingChanged("session", false, 0, 10_000, 21)
         detector.onIsPlayingChanged("session", true, 100, 10_000, 20)
 
         assertNull(detector.sample("session", 1_100, true, true, true, 11_000, 60_000, 21))
@@ -58,8 +58,8 @@ class PostResumeVideoStallDetectorTest {
     fun pauseDuringRecoveryDoesNotCountTowardTheStageDeadline() {
         val detector = PostResumeVideoStallDetector(1_000, 1_000, 500, 2_000)
         detector.onMounted("session")
+        detector.onFirstFrameRendered()
         detector.onIsPlayingChanged("session", false, 0, 10_000, 20)
-        detector.onIsPlayingChanged("session", false, 0, 10_000, 21)
         detector.onIsPlayingChanged("session", true, 100, 10_000, 20)
         detector.onIsPlayingChanged("session", false, 500, 10_400, 20)
         detector.onIsPlayingChanged("session", true, 10_000, 10_400, 20)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlaybackStatsSheet.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlaybackStatsSheet.kt
@@ -150,7 +150,10 @@ internal fun PlayerStatsSnapshot.mobileStatsRows(): List<Pair<String, String>> =
     videoDecoderName?.let { add("Video decoder" to it) }
     audioCodec?.let { add("Audio codec" to it) }
     audioDecoderName?.let { add("Audio decoder" to it) }
-    bitrateBps?.let { add("Bitrate" to formatStatsBitrate(it)) }
+    // Media3's onBandwidthEstimate value — measured network throughput, not the
+    // media bitrate. Labelling it "Bitrate" reads as a ~19 Mbps stream claiming
+    // 151 Mbps on a fast LAN.
+    bitrateBps?.let { add("Estimated bandwidth" to formatStatsBitrate(it)) }
     if (droppedFrames > 0) add("Dropped frames" to droppedFrames.toString())
     if (audioUnderruns > 0) add("Audio underruns" to audioUnderruns.toString())
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -631,16 +631,23 @@ fun PlayerScreen(
         if (!isLocalMedia && uiState.sessionId != null) {
             PlaybackRuntimeCorrectionMetrics.reset()
             dvSanitizerReported = false
+            // See TvPlayerScreen: the baseline has to be taken at mount, not on
+            // the first sample, or a stream that renders quickly makes its own
+            // frames the baseline and never registers a first frame.
+            val renderedAtMount = (activePlayerHolder.player.value as? androidx.media3.exoplayer.ExoPlayer)
+                ?.videoDecoderCounters?.renderedOutputBufferCount
             startupStallDetector.onMounted(
                 sessionKey = "${uiState.sessionId}:$effectiveStreamUrl:${plan?.planId.orEmpty()}:" +
                     "${plan?.decisionTrace?.size ?: 0}:${uiState.mediaMountGeneration}",
                 playMethod = playMethod,
                 startPositionMs = mediaSpec.startPositionMs,
                 nowMs = SystemClock.elapsedRealtime(),
+                renderedOutputBufferCount = renderedAtMount,
             )
             postResumeStallDetector.onMounted(
                 "${uiState.sessionId}:$effectiveStreamUrl:${plan?.planId.orEmpty()}:" +
                     "${plan?.decisionTrace?.size ?: 0}:${uiState.mediaMountGeneration}",
+                renderedOutputBufferCount = renderedAtMount,
             )
         }
         backend.mount(mediaSpec, playWhenReady = !viewModel.uiState.value.isPaused)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -775,8 +775,15 @@ fun PlayerScreen(
                 }
 
                 override fun onRenderedFirstFrame() {
-                    startupStallDetector.onFirstFrameRendered()
-                    postResumeStallDetector.onFirstFrameRendered()
+                    val live = viewModel.uiState.value
+                    val key = live.sessionId?.let { sessionId ->
+                        "$sessionId:${live.streamUrl}:${live.playbackPlan?.planId.orEmpty()}:" +
+                            "${live.playbackPlan?.decisionTrace?.size ?: 0}:${live.mediaMountGeneration}"
+                    }
+                    if (key != null) {
+                        startupStallDetector.onFirstFrameRendered(key)
+                        postResumeStallDetector.onFirstFrameRendered(key)
+                    }
                     viewModel.onFirstVideoFrameRendered()
                 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -775,15 +775,11 @@ fun PlayerScreen(
                 }
 
                 override fun onRenderedFirstFrame() {
-                    val live = viewModel.uiState.value
-                    val key = live.sessionId?.let { sessionId ->
-                        "$sessionId:${live.streamUrl}:${live.playbackPlan?.planId.orEmpty()}:" +
-                            "${live.playbackPlan?.decisionTrace?.size ?: 0}:${live.mediaMountGeneration}"
-                    }
-                    if (key != null) {
-                        startupStallDetector.onFirstFrameRendered(key)
-                        postResumeStallDetector.onFirstFrameRendered(key)
-                    }
+                    // The detectors are NOT told a frame arrived. This callback
+                    // carries no identity, so one rendered by the outgoing
+                    // stream is indistinguishable from this one's — and keying
+                    // it off live state describes when it was delivered, not
+                    // what rendered it. They read their own counters instead.
                     viewModel.onFirstVideoFrameRendered()
                 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -631,23 +631,16 @@ fun PlayerScreen(
         if (!isLocalMedia && uiState.sessionId != null) {
             PlaybackRuntimeCorrectionMetrics.reset()
             dvSanitizerReported = false
-            // See TvPlayerScreen: the baseline has to be taken at mount, not on
-            // the first sample, or a stream that renders quickly makes its own
-            // frames the baseline and never registers a first frame.
-            val renderedAtMount = (activePlayerHolder.player.value as? androidx.media3.exoplayer.ExoPlayer)
-                ?.videoDecoderCounters?.renderedOutputBufferCount
             startupStallDetector.onMounted(
                 sessionKey = "${uiState.sessionId}:$effectiveStreamUrl:${plan?.planId.orEmpty()}:" +
                     "${plan?.decisionTrace?.size ?: 0}:${uiState.mediaMountGeneration}",
                 playMethod = playMethod,
                 startPositionMs = mediaSpec.startPositionMs,
                 nowMs = SystemClock.elapsedRealtime(),
-                renderedOutputBufferCount = renderedAtMount,
             )
             postResumeStallDetector.onMounted(
                 "${uiState.sessionId}:$effectiveStreamUrl:${plan?.planId.orEmpty()}:" +
                     "${plan?.decisionTrace?.size ?: 0}:${uiState.mediaMountGeneration}",
-                renderedOutputBufferCount = renderedAtMount,
             )
         }
         backend.mount(mediaSpec, playWhenReady = !viewModel.uiState.value.isPaused)
@@ -782,11 +775,8 @@ fun PlayerScreen(
                 }
 
                 override fun onRenderedFirstFrame() {
-                    // The detectors are NOT told a frame arrived. This callback
-                    // carries no identity, so one rendered by the outgoing
-                    // stream is indistinguishable from this one's — and keying
-                    // it off live state describes when it was delivered, not
-                    // what rendered it. They read their own counters instead.
+                    startupStallDetector.onFirstFrameRendered()
+                    postResumeStallDetector.onFirstFrameRendered()
                     viewModel.onFirstVideoFrameRendered()
                 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -1191,7 +1191,8 @@ class PlayerViewModel(
                 title = watchDetail?.title ?: playbackState.title,
                 subtitle = watchDetail?.let { detail -> buildSubtitle(detail) } ?: playbackState.subtitle.orEmpty(),
                 artworkUrl = playbackState.artworkUrl,
-                sessionId = playbackState.sessionId,
+                sessionId = playbackState.sessionId
+                    ?.also { retainedOwnedSessionId = it },
                 playMethod = playbackState.playMethod,
                 playbackPlan = playbackState.playbackPlan,
                 requestHeaders = playbackState.requestHeaders,
@@ -2510,7 +2511,8 @@ class PlayerViewModel(
             current.copy(
                 error = null,
                 isBuffering = false,
-                sessionId = decision.session.sessionId,
+                sessionId = decision.session.sessionId
+                    .also { retainedOwnedSessionId = it },
                 playMethod = decision.session.playMethod,
                 playbackPlan = decision.session.playbackPlan,
                 delivery = decision.plan.delivery,
@@ -2722,7 +2724,8 @@ class PlayerViewModel(
         _uiState.update { current ->
             current.copy(
                 error = null,
-                sessionId = playback.sessionId,
+                sessionId = playback.sessionId
+                    ?.also { retainedOwnedSessionId = it },
                 playMethod = ready.session.playMethod,
                 playbackPlan = ready.session.playbackPlan,
                 delivery = ready.plan.delivery,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -684,6 +684,16 @@ class PlayerViewModel(
     private var lifecycleObserverJob: Job? = null
     private var resolveNextEpisodeJob: Job? = null
     private val exitPrepared = AtomicBoolean(false)
+
+    /**
+     * The session this view model owns, kept past the point UI state is cleared.
+     *
+     * Teardown happens in two stages — onExit() then onCleared() — and the first
+     * clears sessionId. Reading ownership from UI state in the second therefore
+     * yields null, and null means "stop whatever is playing", which after a
+     * player-to-player navigation is somebody else's session.
+     */
+    private var retainedOwnedSessionId: String? = null
     private var finalPositionScope: PlaybackWriteScope? = null
     private val initialPlayerLoadGate = InitialPlayerLoadGate()
 
@@ -1609,7 +1619,8 @@ class PlayerViewModel(
                                 } + downloaded
                             current.copy(
                                 error = null,
-                                sessionId = decision.session.sessionId,
+                                sessionId = decision.session.sessionId
+                                    .also { retainedOwnedSessionId = it },
                                 playMethod = decision.session.playMethod,
                                 playbackPlan = decision.session.playbackPlan,
                                 delivery = decision.plan.delivery,
@@ -3536,10 +3547,15 @@ class PlayerViewModel(
         // one finishes tearing down, and an unqualified stop then kills the
         // playback the viewer is currently watching. TV already qualifies both
         // of its exits; phone did not.
-        val ownedSessionId = _uiState.value.sessionId
+        val ownedSessionId = _uiState.value.sessionId ?: retainedOwnedSessionId
+        retainedOwnedSessionId = ownedSessionId
         viewModelScope.launch {
             mobileSubtitleTransactions.persistCommittedSelectionAndFlush()
-            sessionLifecycle.stop(expectedSessionId = ownedSessionId)
+            // Never unqualified. A null expectedSessionId disables the ownership
+            // guard entirely, which is the opposite of what a missing token
+            // should mean — if we cannot say which session was ours, we have no
+            // business stopping anyone's.
+            ownedSessionId?.let { sessionLifecycle.stop(expectedSessionId = it) }
         }
         val state = _uiState.value
         val cid = state.contentId.takeIf { it.isNotBlank() }
@@ -3737,9 +3753,13 @@ class PlayerViewModel(
     }
 
     override fun onCleared() {
-        // Snapshot before anything below can clear UI state — onExit() runs
-        // first and this must still know which session was ours.
-        val clearedSessionId = _uiState.value.sessionId
+        // The RETAINED token, not the live state. An explicit back/remote exit
+        // calls onExit() before navigation, which clears sessionId — so by the
+        // time onCleared runs, a "snapshot" of UI state is already null, and a
+        // null token disables the ownership guard and stops whatever session is
+        // current. That is precisely the session a replacement screen may have
+        // just adopted.
+        val clearedSessionId = _uiState.value.sessionId ?: retainedOwnedSessionId
         org.siloserver.silo.common.player.debug.PlaybackDebugState.screenError = null
         org.siloserver.silo.common.player.ActivePlaybackFile.clear(_uiState.value.mediaFileId)
         loadOwners.invalidate()
@@ -3752,7 +3772,7 @@ class PlayerViewModel(
         // stopAsync() is app-scoped and de-duplicates against an in-flight stop.
         // Qualified for the same reason as the ordered stop above: by the time
         // onCleared runs, a replacement screen may already own playback.
-        sessionLifecycle.stopAsync(expectedSessionId = clearedSessionId)
+        clearedSessionId?.let { sessionLifecycle.stopAsync(expectedSessionId = it) }
         controlsHideJob?.cancel()
         introObserverJob?.cancel()
         lifecycleObserverJob?.cancel()

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -3530,9 +3530,16 @@ class PlayerViewModel(
         loadJob = null
         mobileSubtitleTransactions.invalidate()
         mobileSubtitleTransactions.requestDurableFinalPersistence()
+        // Qualified by the session this view model actually owns. The lifecycle
+        // is process-scoped, and phone navigation REPLACES the player back-stack
+        // entry — so a new view model can adopt its session before the outgoing
+        // one finishes tearing down, and an unqualified stop then kills the
+        // playback the viewer is currently watching. TV already qualifies both
+        // of its exits; phone did not.
+        val ownedSessionId = _uiState.value.sessionId
         viewModelScope.launch {
             mobileSubtitleTransactions.persistCommittedSelectionAndFlush()
-            sessionLifecycle.stop()
+            sessionLifecycle.stop(expectedSessionId = ownedSessionId)
         }
         val state = _uiState.value
         val cid = state.contentId.takeIf { it.isNotBlank() }
@@ -3730,6 +3737,9 @@ class PlayerViewModel(
     }
 
     override fun onCleared() {
+        // Snapshot before anything below can clear UI state — onExit() runs
+        // first and this must still know which session was ours.
+        val clearedSessionId = _uiState.value.sessionId
         org.siloserver.silo.common.player.debug.PlaybackDebugState.screenError = null
         org.siloserver.silo.common.player.ActivePlaybackFile.clear(_uiState.value.mediaFileId)
         loadOwners.invalidate()
@@ -3740,7 +3750,9 @@ class PlayerViewModel(
         onExit()
         // viewModelScope is cancelling here, so onExit's ordered stop may not run.
         // stopAsync() is app-scoped and de-duplicates against an in-flight stop.
-        sessionLifecycle.stopAsync()
+        // Qualified for the same reason as the ordered stop above: by the time
+        // onCleared runs, a replacement screen may already own playback.
+        sessionLifecycle.stopAsync(expectedSessionId = clearedSessionId)
         controlsHideJob?.cancel()
         introObserverJob?.cancel()
         lifecycleObserverJob?.cancel()

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -950,6 +950,14 @@ class PlayerViewModel(
                 )) {
                     is VideoPlayerUiState.Ready -> {
                         unpublishedReadySessionId = playbackState.sessionId
+                        // Retained BEFORE the suspending UI application below.
+                        // The starter has already installed the lifecycle owner
+                        // and started its reporter by this point, so an exit
+                        // during that suspension would otherwise find neither a
+                        // published session nor a retained one — and skipping
+                        // teardown there strands the lifecycle and its reporter
+                        // running for a screen nobody is on.
+                        playbackState.sessionId?.let { retainedOwnedSessionId = it }
                         if (!ownsLoad(loadOwner)) {
                             stopStaleReadySession(playbackState.sessionId)
                             unpublishedReadySessionId = null

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/performance/MobilePlayerLifecyclePerformanceSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/performance/MobilePlayerLifecyclePerformanceSourceTest.kt
@@ -26,7 +26,11 @@ class MobilePlayerLifecyclePerformanceSourceTest {
         assertTrue(viewModel.contains("val scope = finalPositionScope"))
         assertTrue(viewModel.contains("scope = scope,"))
         assertTrue(viewModel.contains("finalPlaybackPositionWriter.submit("))
-        assertTrue(viewModel.contains("sessionLifecycle.stopAsync()"))
+        // Still the non-blocking teardown this test exists to protect, now
+        // qualified by the session this view model owned — phone navigation
+        // replaces the player entry, so an unqualified stop could kill the
+        // session a newer screen had already adopted.
+        assertTrue(viewModel.contains("sessionLifecycle.stopAsync(expectedSessionId ="))
         assertTrue(!viewModel.contains("runBlocking("))
         assertTrue(!screen.contains("onDispose { viewModel.onExit() }"))
         assertTrue(screen.contains("viewModel.claimInitialRouteLoad()"))

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
@@ -192,7 +192,17 @@ class MobileSubtitleTransactionAdapterTest {
         assertEquals(downloaded, harness.adapter.snapshot.committedIdentity)
         assertEquals(7, harness.adapter.snapshot.transition.committed.audioTrackIndex)
         assertEquals(
-            listOf(CommittedSubtitle(downloaded, audioTrackIndex = 7, qualityPreference = "auto")),
+            listOf(
+                CommittedSubtitle(
+                    downloaded,
+                    audioTrackIndex = 7,
+                    qualityPreference = "auto",
+                    // This scenario changes AUDIO explicitly, which is now
+                    // recorded so a subtitle-only commit cannot be mistaken for
+                    // the viewer choosing the audio it happened to carry.
+                    audioPreferenceSpecified = true,
+                ),
+            ),
             harness.persistence.persisted,
         )
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormatting.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormatting.kt
@@ -96,6 +96,54 @@ object TvPlaybackFormatting {
         return if (tokens.isEmpty()) "Auto" else tokens.joinToString(" · ")
     }
 
+    /**
+     * Picker labels for a whole version list, disambiguated against each other.
+     *
+     * [versionShortLabel] is built from resolution + HDR/DV alone, so a title
+     * holding two 4K Dolby Vision files renders two identical "4K · DV" rows
+     * and the user cannot tell them apart. Selection still works (the option id
+     * is the unique fileId) — the list is just unreadable.
+     *
+     * Only colliding labels get a suffix, so the common single-version-per-tier
+     * case is untouched. Attributes are accumulated until the group's labels
+     * are actually distinct: no single attribute need be unique on its own, so
+     * e.g. {20GB HEVC, 20GB AV1, 40GB HEVC, 40GB AV1} separates on codec+size.
+     * Codec leads because it is a real playback/compatibility difference; size
+     * usually does the work when a remux and an encode share a codec.
+     */
+    fun versionPickerLabels(versions: List<FileVersion>): List<String> {
+        val base = versions.map { versionShortLabel(it) }
+        val colliding = base.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+        if (colliding.isEmpty()) return base
+
+        val suffixes = MutableList(versions.size) { "" }
+        for (label in colliding) {
+            val indexes = base.indices.filter { base[it] == label }
+            // Widen the attribute tuple until this group is separated, or until
+            // we run out of attributes and accept an honest duplicate.
+            for (depth in 1..VERSION_DISCRIMINATORS.size) {
+                val attempt = indexes.associateWith { index ->
+                    VERSION_DISCRIMINATORS.take(depth)
+                        .mapNotNull { it(versions[index]) }
+                        .joinToString(" · ")
+                }
+                indexes.forEach { suffixes[it] = attempt.getValue(it) }
+                if (attempt.values.toSet().size == indexes.size) break
+            }
+        }
+        return base.mapIndexed { index, label ->
+            val suffix = suffixes[index]
+            if (suffix.isBlank()) label else "$label · $suffix"
+        }
+    }
+
+    /** Attributes tried, in order, when version labels collide. */
+    private val VERSION_DISCRIMINATORS: List<(FileVersion) -> String?> = listOf(
+        { v -> v.codecVideo?.takeIf { it.isNotBlank() }?.uppercase(Locale.ROOT) },
+        { v -> formatFileSize(v.fileSize) },
+        { v -> v.container?.takeIf { it.isNotBlank() }?.uppercase(Locale.ROOT) },
+    )
+
     fun isDolbyVision(version: FileVersion): Boolean =
         DolbyVisionDetection.isDolbyVision(videoCodec = version.codecVideo) ||
             version.videoTracks.orEmpty().any { track ->

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormatting.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormatting.kt
@@ -127,8 +127,13 @@ object TvPlaybackFormatting {
                         .mapNotNull { it(versions[index]) }
                         .joinToString(" · ")
                 }
-                indexes.forEach { suffixes[it] = attempt.getValue(it) }
-                if (attempt.values.toSet().size == indexes.size) break
+                val distinct = attempt.values.toSet().size
+                // Only keep a tuple that actually separates something. Now that
+                // the codec can be resolved from the video track, two identical
+                // versions would otherwise both gain the same suffix — a
+                // fabricated difference that distinguishes nothing.
+                if (distinct > 1) indexes.forEach { suffixes[it] = attempt.getValue(it) }
+                if (distinct == indexes.size) break
             }
         }
         return base.mapIndexed { index, label ->
@@ -139,7 +144,11 @@ object TvPlaybackFormatting {
 
     /** Attributes tried, in order, when version labels collide. */
     private val VERSION_DISCRIMINATORS: List<(FileVersion) -> String?> = listOf(
-        { v -> v.codecVideo?.takeIf { it.isNotBlank() }?.uppercase(Locale.ROOT) },
+        // Through resolvedVideoCodec, so a version whose codec lives only on its
+        // video track can still discriminate. Consulting codecVideo alone left
+        // two colliding versions sharing a label when the metadata to tell them
+        // apart was right there.
+        { v -> resolvedVideoCodec(v)?.uppercase(Locale.ROOT) },
         { v -> formatFileSize(v.fileSize) },
         { v -> v.container?.takeIf { it.isNotBlank() }?.uppercase(Locale.ROOT) },
     )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
@@ -70,6 +71,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -712,6 +714,9 @@ private fun PaneColumn(
 @Composable
 private fun LabelValueRow(label: String, value: String) {
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        // Fixed gap, weighted value — same reasoning as HudFocusedSettingRow: a
+        // lone weighted spacer collapses to 0dp once the two texts fill the row,
+        // which is how "SubtitlesArabic — SRT · Exter…" rendered.
         Text(
             text = label,
             color = MaterialTheme.colorScheme.onSurface,
@@ -720,8 +725,10 @@ private fun LabelValueRow(label: String, value: String) {
                 lineHeight = HudBodyLineHeight,
                 fontWeight = FontWeight.Medium,
             ),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
-        Box(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.width(12.dp))
         Text(
             text = value,
             color = Color.White.copy(alpha = 0.7f),
@@ -731,6 +738,8 @@ private fun LabelValueRow(label: String, value: String) {
             ),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(1f),
         )
     }
 }
@@ -895,13 +904,16 @@ private fun HudVideoPane(
                             onPresentPicker(
                                 HudPickerPresentation(
                                     title = "Version",
-                                    options = fileVersions.map { version ->
-                                        HudPickerOption(
-                                            id = version.fileId.toString(),
-                                            label = org.siloserver.silo.tv.ui.screens.detail
-                                                .TvPlaybackFormatting.versionShortLabel(version),
-                                        )
-                                    },
+                                    // Disambiguated as a set: two 4K DV files
+                                    // otherwise render as two identical rows.
+                                    options = org.siloserver.silo.tv.ui.screens.detail
+                                        .TvPlaybackFormatting.versionPickerLabels(fileVersions)
+                                        .mapIndexed { index, label ->
+                                            HudPickerOption(
+                                                id = fileVersions[index].fileId.toString(),
+                                                label = label,
+                                            )
+                                        },
                                     selectedId = (currentVersion?.fileId ?: -1).toString(),
                                     onSelect = { id ->
                                         id.toIntOrNull()?.let(onSelectFileVersion)
@@ -1454,22 +1466,14 @@ private fun HudSubtitlesPane(
         ) {
             HudSubtitlePreview(appearance = appearance)
 
-            HudFocusedSettingRow(
-                label = "No background",
-                value = if (appearance.backgroundStyle == SubtitleBackgroundStylePreset.None) "On" else "Off",
-                enabled = enabled,
-                leftFocusRequester = subtitleTrackFocus,
-                onActivate = {
-                    // Toggle: turning it back off restores the default Box
-                    // background (Apple parity) rather than staying stuck on None.
-                    val target = if (appearance.backgroundStyle == SubtitleBackgroundStylePreset.None) {
-                        SubtitleBackgroundStylePreset.Box
-                    } else {
-                        SubtitleBackgroundStylePreset.None
-                    }
-                    onAppearanceChanged(appearance.copy(backgroundStyle = target))
-                },
-            )
+            // There is deliberately no "No background" toggle here. It was a
+            // second control over backgroundStyle, which the Background picker
+            // in the left column already exposes as "No background" — and
+            // toggling it off could not know what the style had been, so it
+            // hard-coded Box and silently destroyed the user's choice
+            // (Drop Shadow -> On -> Off left you on Box, persisted immediately).
+            // tvOS has no such toggle either: TVPlayerInfoHUD offers a single
+            // Style picker plus a Background color row.
 
             // Color swatches stay inline — tvOS draws color swatches directly,
             // and a row→dialog of colors would lose the at-a-glance palette.
@@ -1792,7 +1796,11 @@ private fun PlayerStatsSnapshot.hudRows(): List<Pair<String, String>> = buildLis
     videoDecoderName?.let { add("Video decoder" to it) }
     audioCodec?.let { add("Audio codec" to it) }
     audioDecoderName?.let { add("Audio decoder" to it) }
-    bitrateBps?.let { add("Bitrate" to formatBitrate(it)) }
+    // NOT the media bitrate: this is Media3's onBandwidthEstimate value, i.e.
+    // measured network throughput. Labelling it "Bitrate" read as a ~19 Mbps
+    // stream reporting 151.3 Mbps on a fast LAN, which is actively misleading
+    // in a panel whose whole job is diagnosing playback.
+    bitrateBps?.let { add("Estimated bandwidth" to formatBitrate(it)) }
     if (droppedFrames > 0) add("Dropped frames" to droppedFrames.toString())
     if (audioUnderruns > 0) add("Audio underruns" to audioUnderruns.toString())
 }
@@ -2007,6 +2015,14 @@ internal fun HudFocusedSettingRow(
             .padding(horizontal = 10.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        // A single weighted spacer used to be the only thing between label and
+        // value. Compose measures unweighted children first, so once the two
+        // texts filled the row that spacer resolved to 0dp and they abutted
+        // ("BackgroundNo background", "SubtitlesDanish — SRT · E…").
+        //
+        // Now the gap is fixed and unconditional, and the value region carries
+        // the weight: it still right-aligns, but it is the side that gives way
+        // and ellipsizes when the row is cramped.
         Text(
             text = label,
             color = labelColor,
@@ -2018,10 +2034,11 @@ internal fun HudFocusedSettingRow(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
-        Box(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.width(12.dp))
         Row(
+            modifier = Modifier.weight(1f),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(5.dp),
+            horizontalArrangement = Arrangement.spacedBy(5.dp, Alignment.End),
         ) {
             if (colorHex != null) {
                 Box(
@@ -2032,6 +2049,10 @@ internal fun HudFocusedSettingRow(
                         .border(0.5.dp, Color.White.copy(alpha = 0.45f), CircleShape),
                 )
             }
+            // Weighted so the swatch and chevron are measured first and the
+            // value is what gives way. Unweighted, a long value consumes the
+            // width and squeezes the trailing chevron toward zero.
+            // fill = false keeps short values grouped against the right edge.
             Text(
                 text = value,
                 color = valueColor,
@@ -2042,6 +2063,7 @@ internal fun HudFocusedSettingRow(
                 ),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
             )
             Icon(
                 imageVector = Icons.Filled.ChevronRight,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1315,11 +1315,8 @@ fun TvPlayerScreen(
                     }
                 }
                 override fun onRenderedFirstFrame() {
-                    // The detectors are NOT told a frame arrived. This callback
-                    // carries no identity, so one rendered by the outgoing
-                    // stream is indistinguishable from this one's — and keying
-                    // it off live state describes when it was delivered, not
-                    // what rendered it. They read their own counters instead.
+                    startupStallDetector.onFirstFrameRendered()
+                    postResumeStallDetector.onFirstFrameRendered()
                     viewModel.onFirstVideoFrameRendered()
                 }
                 override fun onPlaybackStateChanged(playbackState: Int) {
@@ -1543,24 +1540,16 @@ fun TvPlayerScreen(
         state.sessionId?.let { sessionId ->
             PlaybackRuntimeCorrectionMetrics.reset()
             dvSanitizerReported = false
-            // Read once, at mount. Counters are cumulative on the player and
-            // reset when a renderer is enabled rather than per app-level mount,
-            // so this value is what separates this attempt's frames from the
-            // previous one's.
-            val renderedAtMount = (activePlayerHolder.player.value as? androidx.media3.exoplayer.ExoPlayer)
-                ?.videoDecoderCounters?.renderedOutputBufferCount
             startupStallDetector.onMounted(
                 sessionKey = "$sessionId:$url:${plan?.planId.orEmpty()}:" +
                     "${plan?.decisionTrace?.size ?: 0}:${state.transportMountNonce}",
                 playMethod = method,
                 startPositionMs = mediaSpec.startPositionMs,
                 nowMs = SystemClock.elapsedRealtime(),
-                renderedOutputBufferCount = renderedAtMount,
             )
             postResumeStallDetector.onMounted(
                 "$sessionId:$url:${plan?.planId.orEmpty()}:" +
                     "${plan?.decisionTrace?.size ?: 0}:${state.transportMountNonce}",
-                renderedOutputBufferCount = renderedAtMount,
             )
         }
         backend.mount(mediaSpec, playWhenReady = !viewModel.uiState.value.isPaused)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1117,6 +1117,18 @@ fun TvPlayerScreen(
         }
     }
 
+    // A subtitle or audio change that failed has to say so. Stage, validation,
+    // commit, rollback and mount failures all populated subtitleFailureMessage
+    // and nothing ever read it: "Applying…" simply vanished and the tick
+    // returned to the previous track, which is indistinguishable from the
+    // viewer having imagined pressing it. Audio replans share this adapter, so
+    // they were equally silent.
+    LaunchedEffect(state.subtitleFailureId) {
+        val message = state.subtitleFailureMessage ?: return@LaunchedEffect
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        viewModel.onSubtitleFailureShown(state.subtitleFailureId)
+    }
+
     // Surface transient Watch Together server rejections (e.g. a guest seek the
     // server refuses) as a brief Toast. These flow on the repo errors stream and
     // do NOT eject the user. Only collected while bound to a room.
@@ -1303,15 +1315,11 @@ fun TvPlayerScreen(
                     }
                 }
                 override fun onRenderedFirstFrame() {
-                    val live = viewModel.uiState.value
-                    val key = live.sessionId?.let { sessionId ->
-                        "$sessionId:${live.streamUrl}:${live.playbackPlan?.planId.orEmpty()}:" +
-                            "${live.playbackPlan?.decisionTrace?.size ?: 0}:${live.transportMountNonce}"
-                    }
-                    if (key != null) {
-                        startupStallDetector.onFirstFrameRendered(key)
-                        postResumeStallDetector.onFirstFrameRendered(key)
-                    }
+                    // The detectors are NOT told a frame arrived. This callback
+                    // carries no identity, so one rendered by the outgoing
+                    // stream is indistinguishable from this one's — and keying
+                    // it off live state describes when it was delivered, not
+                    // what rendered it. They read their own counters instead.
                     viewModel.onFirstVideoFrameRendered()
                 }
                 override fun onPlaybackStateChanged(playbackState: Int) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1543,16 +1543,24 @@ fun TvPlayerScreen(
         state.sessionId?.let { sessionId ->
             PlaybackRuntimeCorrectionMetrics.reset()
             dvSanitizerReported = false
+            // Read once, at mount. Counters are cumulative on the player and
+            // reset when a renderer is enabled rather than per app-level mount,
+            // so this value is what separates this attempt's frames from the
+            // previous one's.
+            val renderedAtMount = (activePlayerHolder.player.value as? androidx.media3.exoplayer.ExoPlayer)
+                ?.videoDecoderCounters?.renderedOutputBufferCount
             startupStallDetector.onMounted(
                 sessionKey = "$sessionId:$url:${plan?.planId.orEmpty()}:" +
                     "${plan?.decisionTrace?.size ?: 0}:${state.transportMountNonce}",
                 playMethod = method,
                 startPositionMs = mediaSpec.startPositionMs,
                 nowMs = SystemClock.elapsedRealtime(),
+                renderedOutputBufferCount = renderedAtMount,
             )
             postResumeStallDetector.onMounted(
                 "$sessionId:$url:${plan?.planId.orEmpty()}:" +
                     "${plan?.decisionTrace?.size ?: 0}:${state.transportMountNonce}",
+                renderedOutputBufferCount = renderedAtMount,
             )
         }
         backend.mount(mediaSpec, playWhenReady = !viewModel.uiState.value.isPaused)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1724,13 +1724,18 @@ fun TvPlayerScreen(
         state.showSubtitleMenu,
         state.showSubtitleStyleDialog,
         state.isScrubbing,
+        state.showNextUp,
     ) {
         // Never auto-hide mid-scrub: hiding the scrubber would tear down the
         // in-flight preview under the user. The timer re-arms once the scrub
         // commits or cancels (isScrubbing flips back to false).
+        //
+        // Up Next counts down for longer than this timer, and it is a
+        // focus-owning surface: letting the timer fire under it hides the
+        // controls and pulls focus to the root, off the primary action.
         if (state.showControls && !state.isPaused && !state.hudOpen &&
             !state.showSubtitleMenu && !state.showSubtitleStyleDialog &&
-            !state.isScrubbing
+            !state.isScrubbing && !state.showNextUp
         ) {
             delay(CONTROLS_AUTO_HIDE_MS)
             viewModel.setControlsVisible(false)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1303,8 +1303,15 @@ fun TvPlayerScreen(
                     }
                 }
                 override fun onRenderedFirstFrame() {
-                    startupStallDetector.onFirstFrameRendered()
-                    postResumeStallDetector.onFirstFrameRendered()
+                    val live = viewModel.uiState.value
+                    val key = live.sessionId?.let { sessionId ->
+                        "$sessionId:${live.streamUrl}:${live.playbackPlan?.planId.orEmpty()}:" +
+                            "${live.playbackPlan?.decisionTrace?.size ?: 0}:${live.transportMountNonce}"
+                    }
+                    if (key != null) {
+                        startupStallDetector.onFirstFrameRendered(key)
+                        postResumeStallDetector.onFirstFrameRendered(key)
+                    }
                     viewModel.onFirstVideoFrameRendered()
                 }
                 override fun onPlaybackStateChanged(playbackState: Int) {
@@ -1465,11 +1472,18 @@ fun TvPlayerScreen(
                         recovery.correctionId,
                         "rendered_frame_progress",
                     )
-                    is PostResumeVideoStallDetector.Signal.Failed -> viewModel.onRuntimeCorrection(
-                        "runtime_correction_failed",
-                        recovery.correctionId,
-                        "bounded_recovery_exhausted",
-                    )
+                    is PostResumeVideoStallDetector.Signal.Failed -> {
+                        viewModel.onRuntimeCorrection(
+                            "runtime_correction_failed",
+                            recovery.correctionId,
+                            "bounded_recovery_exhausted",
+                        )
+                        // Tell the viewer too. This signal fires once and never
+                        // again, so a frozen picture with running audio would
+                        // otherwise sit there indefinitely, recorded in
+                        // telemetry and invisible on screen.
+                        viewModel.onPlaybackRecoveryExhausted()
+                    }
                     null -> Unit
                 }
                 delay(1_000)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -783,6 +783,11 @@ class TvPlayerViewModel(
      */
     private var manualAudioSelectionApplied = false
 
+    /** Monotonic across the screen's life, so no id is ever reused. */
+    private var subtitleFailureIdSeed = 0L
+
+    private fun nextSubtitleFailureId(): Long = ++subtitleFailureIdSeed
+
     /** Guards [startServerRecoveryFallback] against concurrent fallbacks racing the same session. */
     private var recoveryJob: Job? = null
 
@@ -1079,11 +1084,14 @@ class TvPlayerViewModel(
                     subtitleApplying = snapshot.subtitleApplying,
                     subtitleFailureMessage = snapshot.failureMessage,
                     subtitleFailureId = when {
-                        snapshot.failureMessage == null -> 0L
-                        // A new failure only when this is not the same one
-                        // already on screen, so a recomposition does not
-                        // re-announce it.
-                        state.subtitleFailureMessage == null -> state.subtitleFailureId + 1
+                        snapshot.failureMessage == null -> state.subtitleFailureId
+                        // Any failure that is not the one already on screen is a
+                        // new event. Requiring the previous slot to be empty
+                        // meant a second, different failure inherited the first
+                        // one's id and was therefore never shown — the effect
+                        // keys on the id alone.
+                        snapshot.failureMessage != state.subtitleFailureMessage ->
+                            nextSubtitleFailureId()
                         else -> state.subtitleFailureId
                     },
                     subtitleUrls = authoritativeTvSubtitleRows(
@@ -1615,10 +1623,17 @@ class TvPlayerViewModel(
         transportMountGate.beginLoad()
         introAutoSkipController.reset()
         manualSubtitleSelectionApplied = false
-        // A carried TRACK intent stays manual, otherwise the choice survives
-        // exactly one transition and reverts to AUTO on the next.
-        manualAudioSelectionApplied =
-            launchArgs.episodeSelectionHandoff?.audio?.mode == EpisodeAudioMode.TRACK
+        // Cleared here and raised only if the carried choice actually RESOLVES
+        // against this episode's tracks.
+        //
+        // Seeding it from the intent alone was wrong: resolveEpisodeAudioIntent
+        // deliberately returns null when nothing matches or the match is
+        // ambiguous, and that null means the server default plays. Marking it
+        // manual anyway made the next auto-advance capture that default as a
+        // deliberate choice — so one unresolvable episode turned a server
+        // default into a preference that then propagated for the rest of the
+        // series.
+        manualAudioSelectionApplied = false
         _uiState.update { it.copy(isBuffering = false) }
 
         _uiState.update {
@@ -1688,8 +1703,18 @@ class TvPlayerViewModel(
                             existingPendingInitialSubtitleIndex = pendingInitialSubtitleIndex,
                         )
                         pendingInitialSubtitleIndex = subtitleSelection.pendingInitialSubtitleIndex
-                        if (episodeSelectionHandoff != null && result.resolvedEpisodeSelection != null) {
+                        val resolvedSelection = result.resolvedEpisodeSelection
+                        if (episodeSelectionHandoff != null && resolvedSelection != null) {
                             pendingInitialSubtitleAttempts = 0
+                            // The carried audio choice counts as the viewer's
+                            // only once it RESOLVED to a real track here. A
+                            // TRACK intent that matched nothing leaves the
+                            // server default playing, and calling that manual
+                            // would hand it on to the next episode as though it
+                            // had been chosen.
+                            if (resolvedSelection.audioTrackIndex != null) {
+                                manualAudioSelectionApplied = true
+                            }
                         }
                         val localTrackSelection = result.fileId
                             ?.let { fileId -> userItemStatePort.localTrackSelection(contentId, fileId) }
@@ -2455,11 +2480,10 @@ class TvPlayerViewModel(
             // comparing strings would let an old acknowledgement clear a new
             // failure that merely said the same thing. Text is what the viewer
             // reads; it was never an identity.
-            if (it.subtitleFailureId == shownId) {
-                it.copy(subtitleFailureMessage = null, subtitleFailureId = 0L)
-            } else {
-                it
-            }
+            // The message clears; the id does NOT reset. Resetting the counter
+            // let a later re-emission of an old failure manufacture id 1 again
+            // and replay something already dismissed.
+            if (it.subtitleFailureId == shownId) it.copy(subtitleFailureMessage = null) else it
         }
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -41,6 +41,8 @@ import org.siloserver.silo.common.player.seek.sourcePositionForPlayer
 import org.siloserver.silo.common.network.ServerReachabilityMonitor
 import org.siloserver.silo.common.player.video.VideoPlaybackSessionCoordinator
 import org.siloserver.silo.common.player.video.VideoPlaybackStartRequest
+import org.siloserver.silo.common.player.video.EpisodeAudioIntent
+import org.siloserver.silo.common.player.video.EpisodeAudioMode
 import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
 import org.siloserver.silo.common.player.video.EpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.EpisodeSubtitleMode
@@ -135,6 +137,28 @@ data class PlayerTrackEntry(
     val trackId: String? = null,
 )
 
+/**
+ * The server catalog index for the audio currently in force.
+ *
+ * UNRESOLVED — review says the plan index should win here and that preferring
+ * the Media3 ordinal is why audio reverts to the first language after a replan
+ * (a remuxed stream carrying only the chosen track reports ordinal zero). But
+ * PlayerTrackEntriesTest.replanSelectionMapsMedia3OrdinalToStableServerAudioIndex
+ * asserts the current order deliberately, and flipping it may break the case
+ * where Media3 auto-selects a track the plan does not know about, leaving the
+ * plan stale and the ordinal correct. Not changed until that is settled.
+ *
+ * The argument for the plan winning: A Media3 group ordinal is not an index into the server
+ * catalog, and after a remux or transcode the two stop agreeing entirely: a
+ * replacement stream carrying only the chosen track reports ordinal zero, so
+ * preferring the ordinal made the next replan ask for catalog track zero and
+ * the audio silently reverted to the first language. Opening subtitles or
+ * power-cycling a receiver was enough to trigger it.
+ *
+ * The ordinal is still the answer when there is no plan index — which is
+ * exactly what an explicit selection passes, since the viewer is choosing a
+ * track the plan does not yet know about.
+ */
 internal fun selectedServerAudioTrackIndex(
     selectedPlayerOrdinal: Int?,
     catalogAudioTracks: List<AudioTrack>?,
@@ -173,8 +197,26 @@ internal fun captureTvEpisodeSelectionHandoff(
     committedSubtitleIdentity: SubtitleIdentity,
     catalogSubtitles: List<PlayerSubtitleInfo>,
     hasExplicitSubtitleSelection: Boolean,
+    selectedAudioTrack: PlayerTrackEntry? = null,
+    hasExplicitAudioSelection: Boolean = false,
 ): EpisodeSelectionHandoff = EpisodeSelectionHandoff(
     source = captureEpisodeSourceIntent(activeVersion),
+    // Only an explicit choice travels. Carrying whatever the server happened to
+    // default to would pin that default onto every later episode, which looks
+    // identical to a preference the viewer never expressed.
+    audio = if (!hasExplicitAudioSelection || selectedAudioTrack == null) {
+        EpisodeAudioIntent.auto()
+    } else {
+        EpisodeAudioIntent(
+            mode = EpisodeAudioMode.TRACK,
+            language = selectedAudioTrack.language,
+            codecFamily = selectedAudioTrack.codecOrMime,
+            channelCount = selectedAudioTrack.channelCount.takeIf { it > 0 },
+            // The label is what tells a commentary track from the main mix when
+            // language, codec and channel count are identical.
+            title = selectedAudioTrack.label,
+        )
+    },
     subtitle = if (!hasExplicitSubtitleSelection) {
         org.siloserver.silo.common.player.video.EpisodeSubtitleIntent.auto()
     } else {
@@ -733,6 +775,13 @@ class TvPlayerViewModel(
     private var pendingPersistedSubtitleFingerprint: String? = null
     private var autoTextSubtitleSelectionAttempted = false
     private var manualSubtitleSelectionApplied = false
+    /**
+     * Whether the viewer picked the current audio track themselves.
+     *
+     * Only an explicit choice is carried into the next episode; a server
+     * default must not be pinned onto every later one.
+     */
+    private var manualAudioSelectionApplied = false
 
     /** Guards [startServerRecoveryFallback] against concurrent fallbacks racing the same session. */
     private var recoveryJob: Job? = null
@@ -890,6 +939,8 @@ class TvPlayerViewModel(
         val pendingSubtitleIdentity: SubtitleIdentity? = null,
         val subtitleApplying: Boolean = false,
         val subtitleFailureMessage: String? = null,
+        /** Distinguishes two failures that happen to read the same. */
+        val subtitleFailureId: Long = 0L,
         // Dialog visibility — owned here so HUD rows can request them and
         // the screen renders the Popups above the open HUD.
         val showSubtitleSearchDialog: Boolean = false,
@@ -982,6 +1033,11 @@ class TvPlayerViewModel(
                 committed: org.siloserver.silo.model.playback.CommittedSubtitle,
                 context: TvSubtitlePlaybackContext,
             ): Boolean {
+                // Only when AUDIO was what changed. Every commit carries the
+                // current audio index — a subtitle-only change included — so
+                // testing the index for non-null marked the server default as
+                // the viewer's choice after any successful subtitle change.
+                if (committed.audioPreferenceSpecified) onAudioSelectionCommitted()
                 val writeScope = context.writeScope ?: return false
                 return userItemStatePort.recordTrackSelection(
                     scope = writeScope,
@@ -1022,6 +1078,14 @@ class TvPlayerViewModel(
                     pendingSubtitleIdentity = snapshot.pendingIdentity,
                     subtitleApplying = snapshot.subtitleApplying,
                     subtitleFailureMessage = snapshot.failureMessage,
+                    subtitleFailureId = when {
+                        snapshot.failureMessage == null -> 0L
+                        // A new failure only when this is not the same one
+                        // already on screen, so a recomposition does not
+                        // re-announce it.
+                        state.subtitleFailureMessage == null -> state.subtitleFailureId + 1
+                        else -> state.subtitleFailureId
+                    },
                     subtitleUrls = authoritativeTvSubtitleRows(
                         snapshotRows = snapshot.subtitleTracks,
                         previousRows = state.subtitleUrls,
@@ -1551,6 +1615,10 @@ class TvPlayerViewModel(
         transportMountGate.beginLoad()
         introAutoSkipController.reset()
         manualSubtitleSelectionApplied = false
+        // A carried TRACK intent stays manual, otherwise the choice survives
+        // exactly one transition and reverts to AUTO on the next.
+        manualAudioSelectionApplied =
+            launchArgs.episodeSelectionHandoff?.audio?.mode == EpisodeAudioMode.TRACK
         _uiState.update { it.copy(isBuffering = false) }
 
         _uiState.update {
@@ -2361,6 +2429,40 @@ class TvPlayerViewModel(
      * frozen frame, no message, and no reason to think pressing anything would
      * help. Telemetry recorded this; nobody told the person watching.
      */
+    /**
+     * The screen has shown [TvPlayerViewModel.UiState.subtitleFailureMessage].
+     *
+     * Cleared on acknowledgement rather than on a timer so the same failure
+     * cannot be reported twice, and so a later failure with identical text
+     * still surfaces.
+     */
+    /**
+     * An audio change has committed, so it is now the viewer's choice.
+     *
+     * Set here rather than when the change was requested: staging, validation,
+     * adoption, mount and rollback can all fail, and a flag raised on intent
+     * would carry whatever track survived the failure into the next episode as
+     * though it had been chosen.
+     */
+    fun onAudioSelectionCommitted() {
+        manualAudioSelectionApplied = true
+    }
+
+    fun onSubtitleFailureShown(shownId: Long) {
+        _uiState.update {
+            // Acknowledged by ID, not by text. Two failures can carry the same
+            // words — a mount deadline reported twice reads identically — and
+            // comparing strings would let an old acknowledgement clear a new
+            // failure that merely said the same thing. Text is what the viewer
+            // reads; it was never an identity.
+            if (it.subtitleFailureId == shownId) {
+                it.copy(subtitleFailureMessage = null, subtitleFailureId = 0L)
+            } else {
+                it
+            }
+        }
+    }
+
     fun onPlaybackRecoveryExhausted() {
         _uiState.update {
             if (it.error != null) it else it.copy(
@@ -3107,6 +3209,8 @@ class TvPlayerViewModel(
             activeVersion = activeVersion,
             committedSubtitleIdentity = state.committedSubtitleIdentity,
             catalogSubtitles = state.subtitleUrls,
+            selectedAudioTrack = state.audioTracks.firstOrNull { it.isSelected },
+            hasExplicitAudioSelection = manualAudioSelectionApplied,
             hasExplicitSubtitleSelection = manualSubtitleSelectionApplied,
         )
         _playNextRequests.tryEmit(PlayNextRequest(next.contentId, nextAutoAdvanceCount, handoff))

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -2136,18 +2136,10 @@ class TvPlayerViewModel(
                 ?.session
                 ?.sessionId
             if (!isActive || recoveryContentGeneration != contentLoadGeneration) {
-                abandonedSessionId?.let { sessionId ->
-                    // Detached from this cancelled scope on purpose: the whole
-                    // point is to run after the reason for abandoning.
-                    // NonCancellable: this runs precisely because the
-                    // surrounding work was cancelled, so it must not inherit
-                    // that cancellation and skip the release.
-                    viewModelScope.launch(NonCancellable) {
-                        runCatching {
-                            playbackSessionManager.abandonActiveVideoSession(sessionId)
-                        }
-                    }
-                }
+                // Released on the manager's own scope, which outlives this
+                // screen: the whole point is to run after the reason for
+                // abandoning, and this ViewModel's scope may already be gone.
+                abandonedSessionId?.let(playbackSessionManager::abandonActiveVideoSessionAsync)
             }
             coroutineContext.ensureActive()
             if (recoveryContentGeneration != contentLoadGeneration) return@launch
@@ -2448,21 +2440,6 @@ class TvPlayerViewModel(
     }
 
     /**
-     * Bounded recovery has given up and the picture is not coming back.
-     *
-     * The detector reports Failed exactly once and then goes quiet forever, so
-     * without surfacing it the viewer is left with advancing audio over a
-     * frozen frame, no message, and no reason to think pressing anything would
-     * help. Telemetry recorded this; nobody told the person watching.
-     */
-    /**
-     * The screen has shown [TvPlayerViewModel.UiState.subtitleFailureMessage].
-     *
-     * Cleared on acknowledgement rather than on a timer so the same failure
-     * cannot be reported twice, and so a later failure with identical text
-     * still surfaces.
-     */
-    /**
      * An audio change has committed, so it is now the viewer's choice.
      *
      * Set here rather than when the change was requested: staging, validation,
@@ -2474,6 +2451,13 @@ class TvPlayerViewModel(
         manualAudioSelectionApplied = true
     }
 
+    /**
+     * The screen has shown [TvPlayerViewModel.UiState.subtitleFailureMessage].
+     *
+     * Cleared on acknowledgement rather than on a timer so the same failure
+     * cannot be reported twice, and so a later failure with identical text
+     * still surfaces.
+     */
     fun onSubtitleFailureShown(shownId: Long) {
         _uiState.update {
             // Acknowledged by ID, not by text. Two failures can carry the same
@@ -2488,6 +2472,14 @@ class TvPlayerViewModel(
         }
     }
 
+    /**
+     * Bounded recovery has given up and the picture is not coming back.
+     *
+     * The detector reports Failed exactly once and then goes quiet forever, so
+     * without surfacing it the viewer is left with advancing audio over a
+     * frozen frame, no message, and no reason to think pressing anything would
+     * help. Telemetry recorded this; nobody told the person watching.
+     */
     fun onPlaybackRecoveryExhausted() {
         _uiState.update {
             if (it.error != null) it else it.copy(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -15,6 +15,7 @@ import org.siloserver.silo.common.player.PlaybackAnalyticsListener
 import org.siloserver.silo.common.player.PlaybackCapabilityDetector
 import org.siloserver.silo.common.player.PlaybackSessionLifecycle
 import org.siloserver.silo.common.player.PlaybackSessionManager
+import org.siloserver.silo.common.player.PlaybackTeardownGate
 import org.siloserver.silo.common.player.FinalPlaybackPosition
 import org.siloserver.silo.common.player.FinalPlaybackPositionWriter
 import org.siloserver.silo.common.player.VideoSessionStartV3
@@ -3128,6 +3129,10 @@ class TvPlayerViewModel(
                 _uiState.update {
                     it.copy(
                         showNextUp = true,
+                        // Up Next owns the screen: the HUD is rendered purely on
+                        // hudOpen, so leaving it set draws the tab row and panes
+                        // underneath the overlay.
+                        hudOpen = false,
                         nextUpVideoEnded = true,
                         nextUpCountdownSeconds = null,
                     )
@@ -3168,7 +3173,7 @@ class TvPlayerViewModel(
         nextUpCountdownJob?.cancel()
         nextUpCountdownJob = null
         _uiState.update {
-            it.copy(showNextUp = true, nextUpCountdownSeconds = null)
+            it.copy(showNextUp = true, hudOpen = false, nextUpCountdownSeconds = null)
         }
     }
 
@@ -3183,6 +3188,7 @@ class TvPlayerViewModel(
         _uiState.update {
             it.copy(
                 showNextUp = true,
+                hudOpen = false,
                 nextUpVideoEnded = videoEnded,
                 nextUpCountdownSeconds = if (autoCountdown) NEXT_UP_COUNTDOWN_SECONDS else null,
             )
@@ -4063,6 +4069,15 @@ class TvPlayerViewModel(
     private val exitSessionId: String?
         get() = _uiState.value.sessionId ?: lastAdoptedSessionId
 
+    /**
+     * Keeps this screen's lifecycle teardown to exactly one stop. Without it,
+     * [onCleared]'s deferred stop lands after the *next* episode's start has
+     * captured its ownership epoch, bumps stopEpoch, and gets that start
+     * rejected as "Playback start was superseded" — auto-advance dying on every
+     * episode transition.
+     */
+    private val lifecycleTeardown = PlaybackTeardownGate(sessionLifecycle)
+
     private fun prepareSessionExit() {
         contentLoadGeneration++
         episodeSelectionHandoffSlot.invalidate()
@@ -4109,7 +4124,7 @@ class TvPlayerViewModel(
         playbackMutationFence.invalidateAll()
         prepareSessionExit()
         subtitleTransactions.persistCommittedSelectionAndFlush()
-        sessionLifecycle.stop(expectedSessionId = exitSessionId)
+        lifecycleTeardown.stopOrdered(expectedSessionId = exitSessionId)
     }
 
     /** Ordinary Back/remote-stop path: snapshot locally and return to detail immediately. */
@@ -4151,7 +4166,7 @@ class TvPlayerViewModel(
         subtitlePersistenceReservation?.let(
             subtitleTransactions::requestDurableFinalPersistence,
         )
-        sessionLifecycle.stopAsync(expectedSessionId = exitSessionId)
+        lifecycleTeardown.stopDetached(expectedSessionId = exitSessionId)
     }
 
     fun onExit() {
@@ -4387,7 +4402,7 @@ class TvPlayerViewModel(
                 subtitleTransactions::requestDurableFinalPersistence,
             )
             playbackMutationFence.invalidateAll()
-            sessionLifecycle.stop(expectedSessionId = teardownSessionId)
+            lifecycleTeardown.stopDetached(expectedSessionId = teardownSessionId)
         }
         subtitleSnapshotSettlement.reset()
         org.siloserver.silo.common.player.debug.PlaybackDebugState.screenError = null

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -3785,12 +3785,21 @@ class TvPlayerViewModel(
             )
             when (val r = subtitlesRepository.download(request)) {
                 is ApiResult.Success -> {
-                    refreshSubtitles(
+                    val merged = refreshSubtitles(
                         autoSelectSubtitleId = r.data.subtitle.id,
                         source = TvSubtitleRefreshSource.Download,
                     )
                     _subtitleSearch.update {
-                        it.copy(downloadingResultId = null, completedNonce = it.completedNonce + 1)
+                        if (merged) {
+                            it.copy(downloadingResultId = null, completedNonce = it.completedNonce + 1)
+                        } else {
+                            // Downloaded on the server, but we could not list it
+                            // back — say so rather than closing as a success.
+                            it.copy(
+                                downloadingResultId = null,
+                                error = "Downloaded, but the subtitle list could not be refreshed.",
+                            )
+                        }
                     }
                 }
                 is ApiResult.Error, is ApiResult.NetworkError -> _subtitleSearch.update {
@@ -3812,13 +3821,22 @@ class TvPlayerViewModel(
      * label so the rebuild preserves the user's choice (Media3 track-group
      * overrides don't survive a re-prepare — groups are new instances).
      */
+    /**
+     * Re-list subtitles after a download or AI job, returning whether it worked.
+     *
+     * It used to return Unit, so callers bumped completedNonce regardless — and
+     * both dialogs read that nonce as "the track merged and was selected" and
+     * dismissed themselves. A server-side job that succeeded followed by a
+     * failed list request therefore closed as a success with no new subtitle
+     * anywhere, which is indistinguishable from the feature not working.
+     */
     internal suspend fun refreshSubtitles(
         autoSelectSubtitleId: Int?,
         source: TvSubtitleRefreshSource = TvSubtitleRefreshSource.Realtime,
-    ) {
+    ): Boolean {
         val state = _uiState.value
-        val mediaFileId = state.mediaFileId ?: return
-        val sessionId = state.sessionId ?: return
+        val mediaFileId = state.mediaFileId ?: return false
+        val sessionId = state.sessionId ?: return false
         subtitleTransactions.updatePlaybackContext(subtitlePlaybackContext(state))
         val owner = subtitleTransactions.beginRefresh(source)
         val downloaded = try {
@@ -3827,7 +3845,7 @@ class TvPlayerViewModel(
             is ApiResult.Error -> {
                 Log.w(TAG, "refreshSubtitles failed: ${r.code} ${r.message}")
                 subtitleTransactions.completeRefreshFailure(owner, r.message)
-                return
+                return false
             }
             is ApiResult.NetworkError -> {
                 Log.w(TAG, "refreshSubtitles network error", r.exception)
@@ -3835,7 +3853,7 @@ class TvPlayerViewModel(
                     owner,
                     r.exception.message ?: "Subtitle refresh failed.",
                 )
-                return
+                return false
             }
             }
         } catch (cancellation: CancellationException) {
@@ -3848,7 +3866,12 @@ class TvPlayerViewModel(
             sessionId = sessionId,
             serverUrl = state.serverUrl,
         )
-        subtitleTransactions.applyRefresh(
+        // The adapter's answer, not an assumption. applyRefresh returns false
+        // when the refresh lost ownership before it could be applied — so a
+        // list request that SUCCEEDED but went stale in flight would otherwise
+        // still be reported as merged, and the dialog would close on a track
+        // that was never installed.
+        return subtitleTransactions.applyRefresh(
             owner = owner,
             subtitleTracks = downloadedRows,
             autoSelectDownloadId = autoSelectSubtitleId,
@@ -3930,12 +3953,20 @@ class TvPlayerViewModel(
             activeAiJobId = null
             when (outcome) {
                 is SubtitlesRepository.SubtitleJobOutcome.Completed -> {
-                    refreshSubtitles(
+                    val merged = refreshSubtitles(
                         autoSelectSubtitleId = outcome.resultSubtitleId,
                         source = TvSubtitleRefreshSource.AiCompletion,
                     )
                     _aiTranslate.update {
-                        it.copy(phase = AiJobPhase.Idle, completedNonce = it.completedNonce + 1)
+                        if (merged) {
+                            it.copy(phase = AiJobPhase.Idle, completedNonce = it.completedNonce + 1)
+                        } else {
+                            it.copy(
+                                phase = AiJobPhase.Failed(
+                                    "Translated, but the subtitle list could not be refreshed.",
+                                ),
+                            )
+                        }
                     }
                 }
                 is SubtitlesRepository.SubtitleJobOutcome.Failed -> _aiTranslate.update {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -2029,6 +2029,32 @@ class TvPlayerViewModel(
             )
             // PlaybackRepository's safe-call layer may translate cancellation to an ApiResult.
             // Re-check both coroutine and content generations before any response can adopt.
+            //
+            // Bailing out here is not enough on its own. By the time this
+            // returns, the manager has already committed and taken ownership of
+            // the replacement session — so abandoning the result quietly leaves
+            // a transcode running on the server that nothing will ever stop.
+            // The viewer sees playback exit; the server keeps the stream slot
+            // until it times out. Release it explicitly on every abandon path.
+            val abandonedSessionId = (result as? ApiResult.Success)
+                ?.data
+                ?.let { it as? VideoSessionStartV3.Ready }
+                ?.session
+                ?.sessionId
+            if (!isActive || recoveryContentGeneration != contentLoadGeneration) {
+                abandonedSessionId?.let { sessionId ->
+                    // Detached from this cancelled scope on purpose: the whole
+                    // point is to run after the reason for abandoning.
+                    // NonCancellable: this runs precisely because the
+                    // surrounding work was cancelled, so it must not inherit
+                    // that cancellation and skip the release.
+                    viewModelScope.launch(NonCancellable) {
+                        runCatching {
+                            playbackSessionManager.abandonActiveVideoSession(sessionId)
+                        }
+                    }
+                }
+            }
             coroutineContext.ensureActive()
             if (recoveryContentGeneration != contentLoadGeneration) return@launch
             when (result) {
@@ -2325,6 +2351,22 @@ class TvPlayerViewModel(
     fun onFirstVideoFrameRendered() {
         hasRenderedFirstFrame = true
         playbackSessionManager.reportFirstVideoFrame(_uiState.value.stats)
+    }
+
+    /**
+     * Bounded recovery has given up and the picture is not coming back.
+     *
+     * The detector reports Failed exactly once and then goes quiet forever, so
+     * without surfacing it the viewer is left with advancing audio over a
+     * frozen frame, no message, and no reason to think pressing anything would
+     * help. Telemetry recorded this; nobody told the person watching.
+     */
+    fun onPlaybackRecoveryExhausted() {
+        _uiState.update {
+            if (it.error != null) it else it.copy(
+                error = "Playback stopped responding. Press Back and try again.",
+            )
+        }
     }
 
     fun onRuntimeCorrection(event: String, correctionId: String, stage: String, details: Map<String, String> = emptyMap()) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -15,6 +15,9 @@ import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
 import org.siloserver.silo.common.player.video.EpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.ResolvedEpisodeSelection
 import org.siloserver.silo.common.player.video.resolveEpisodeSourceIntent
+import org.siloserver.silo.common.player.video.EpisodeAudioCandidate
+import org.siloserver.silo.common.player.video.EpisodeAudioIntent
+import org.siloserver.silo.common.player.video.resolveEpisodeAudioIntent
 import org.siloserver.silo.common.player.video.resolveEpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.resolvedPlaybackDelivery
 import org.siloserver.silo.common.player.video.shouldReachServerForPlayback
@@ -146,7 +149,13 @@ class TvVideoPlaybackStarter(
                     profileId = profileId,
                     capabilities = capabilities,
                     clientPlaybackContext = playbackContext,
-                    audioTrackIndex = request.audioTrackIndex,
+                    // An explicit request wins; otherwise the audio the viewer
+                    // chose in the previous episode travels here. Without this
+                    // the carry-over resolved a track and then threw it away,
+                    // and a dubbed household was returned to the server default
+                    // at every automatic transition.
+                    audioTrackIndex = request.audioTrackIndex
+                        ?: resolvedEpisodeSelection.audioTrackIndex,
                     subtitleTrackIndex = serverSubtitleTrackIndex,
                     qualityPreference = playbackQualityIntent,
                     startPosition = startRequestPosition,
@@ -365,10 +374,29 @@ fun resolveTvPlaybackStartSelection(
             plannedTracks = emptyList(),
         ),
     )
+    // Audio travels the same way subtitles do — by what the track IS, not where
+    // it sat. The next episode's list is a different list, so a remembered
+    // position would land on whatever happens to occupy it.
+    val resolvedAudioIndex = resolveEpisodeAudioIntent(
+        intent = episodeSelectionHandoff?.audio ?: EpisodeAudioIntent.auto(),
+        // track.index, not the list position. The server addresses audio by its
+        // own catalog index and the two are not the same number — the ordinal
+        // is only meaningful to whoever built the list.
+        candidates = selectedVersion.audioTracks.orEmpty().map { track ->
+            EpisodeAudioCandidate(
+                index = track.index,
+                language = track.language,
+                codecFamily = track.codec,
+                channelCount = track.channels?.takeIf { it > 0 },
+                title = track.title,
+            )
+        },
+    )
     return ResolvedEpisodeSelection(
         fileId = selectedVersion.fileId,
         subtitleTrackIndex = resolvedSubtitle.trackIndex,
         subtitleIntentSpecified = resolvedSubtitle.intentSpecified,
+        audioTrackIndex = resolvedAudioIndex,
     )
 }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormattingTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormattingTest.kt
@@ -47,6 +47,79 @@ class TvPlaybackFormattingTest {
         assertEquals("Auto - English", automaticTrackLabel("English"))
     }
 
+    // --- versionPickerLabels ---
+
+    @Test fun versionPickerLabels_leaveDistinctLabelsAlone() {
+        val versions = listOf(
+            fileVersion(fileId = 1, resolution = "1080p"),
+            fileVersion(fileId = 2, resolution = "2160p", hdr = true),
+        )
+        assertEquals(listOf("1080P", "4K · HDR"), TvPlaybackFormatting.versionPickerLabels(versions))
+    }
+
+    @Test fun versionPickerLabels_disambiguateCollidingLabelsBySize() {
+        // The device case: one title, two 4K DV files, two identical rows.
+        val dv = listOf(VideoTrack(codec = "hevc", dolbyVision = "Profile 7"))
+        val versions = listOf(
+            fileVersion(fileId = 1, resolution = "1080p"),
+            fileVersion(fileId = 2, resolution = "2160p", hdr = true, video = dv, fileSize = 62_000_000_000),
+            fileVersion(fileId = 3, resolution = "2160p", hdr = true, video = dv, fileSize = 18_000_000_000),
+        )
+
+        val labels = TvPlaybackFormatting.versionPickerLabels(versions)
+
+        assertEquals("1080P", labels[0])
+        assertEquals(labels.distinct().size, labels.size, "colliding rows must be distinguishable")
+        assertTrue(labels[1].startsWith("4K · DV · "), "got ${labels[1]}")
+        assertTrue(labels[2].startsWith("4K · DV · "), "got ${labels[2]}")
+    }
+
+    @Test fun versionPickerLabels_fallBackToCodecWhenSizesMatch() {
+        val dv = listOf(VideoTrack(codec = "hevc", dolbyVision = "Profile 7"))
+        val versions = listOf(
+            fileVersion(fileId = 1, resolution = "2160p", hdr = true, video = dv, codecVideo = "hevc", fileSize = 42),
+            fileVersion(fileId = 2, resolution = "2160p", hdr = true, video = dv, codecVideo = "av1", fileSize = 42),
+        )
+
+        val labels = TvPlaybackFormatting.versionPickerLabels(versions)
+
+        assertEquals(labels.distinct().size, labels.size)
+        assertTrue(labels.any { it.endsWith("AV1") }, "got $labels")
+    }
+
+    /**
+     * No single attribute is unique here — every codec and every size is
+     * shared — but codec+size identifies each file, so the labels must widen
+     * rather than give up after one attribute.
+     */
+    @Test fun versionPickerLabels_widenUntilTheGroupIsActuallySeparated() {
+        val dv = listOf(VideoTrack(codec = "hevc", dolbyVision = "Profile 7"))
+        fun v(id: Int, codec: String, size: Long) =
+            fileVersion(fileId = id, resolution = "2160p", hdr = true, video = dv, codecVideo = codec, fileSize = size)
+        val versions = listOf(
+            v(1, "hevc", 20_000_000_000),
+            v(2, "av1", 20_000_000_000),
+            v(3, "hevc", 40_000_000_000),
+            v(4, "av1", 40_000_000_000),
+        )
+
+        val labels = TvPlaybackFormatting.versionPickerLabels(versions)
+
+        assertEquals(4, labels.distinct().size, "every version must be distinguishable; got $labels")
+        assertTrue(labels.all { it.startsWith("4K · DV · ") }, "got $labels")
+    }
+
+    @Test fun versionPickerLabels_indistinguishableVersionsStayEqual() {
+        // Nothing to say them apart with: better a duplicate label than a
+        // fabricated difference. Selection still works on fileId.
+        val dv = listOf(VideoTrack(codec = "hevc", dolbyVision = "Profile 7"))
+        val versions = listOf(
+            fileVersion(fileId = 1, resolution = "2160p", hdr = true, video = dv),
+            fileVersion(fileId = 2, resolution = "2160p", hdr = true, video = dv),
+        )
+        assertEquals(listOf("4K · DV", "4K · DV"), TvPlaybackFormatting.versionPickerLabels(versions))
+    }
+
     // --- versionShortLabel ---
 
     @Test fun versionShortLabel_4kHdr() {

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleSettlementOwnershipTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleSettlementOwnershipTest.kt
@@ -804,7 +804,7 @@ class TvSubtitleSettlementOwnershipTest {
         assertBefore(
             exitBody,
             "subtitleTransactions.invalidateAndAwaitSettlement()",
-            "sessionLifecycle.stop(",
+            "lifecycleTeardown.stopOrdered(",
         )
         // Every exit path runs prepareSessionExit, which blanks uiState.sessionId.
         // If the id is not latched BEFORE that write, each of the three stops
@@ -818,7 +818,7 @@ class TvSubtitleSettlementOwnershipTest {
             "lastAdoptedSessionId = it",
             "sessionId = null",
         )
-        assertTrue(exitBody.contains("sessionLifecycle.stop(expectedSessionId = exitSessionId)"))
+        assertTrue(exitBody.contains("lifecycleTeardown.stopOrdered(expectedSessionId = exitSessionId)"))
         assertBefore(
             clearBody,
             "subtitleTransactions.reserveDurableFinalPersistence()",
@@ -837,13 +837,15 @@ class TvSubtitleSettlementOwnershipTest {
         assertBefore(
             clearBody,
             "subtitleTransactions::requestDurableFinalPersistence",
-            "sessionLifecycle.stop(",
+            "lifecycleTeardown.stopDetached(",
         )
-        // stop(expectedSessionId = …) is still stop(): teardown is deferred
-        // behind settlement work, so it must name the session it is ending or it
-        // lands on whatever the next screen has since adopted.
-        assertTrue(clearBody.contains("sessionLifecycle.stop(expectedSessionId"))
-        assertFalse(clearBody.contains("sessionLifecycle.stopAsync()"))
+        // Teardown is deferred behind settlement work, so it must name the
+        // session it is ending or it lands on whatever the next screen has since
+        // adopted. It also has to go through the gate: an unguarded stop here
+        // bumps stopEpoch after the next episode captured its ownership epoch
+        // and supersedes it, which is how auto-advance broke.
+        assertTrue(clearBody.contains("lifecycleTeardown.stopDetached(expectedSessionId"))
+        assertFalse(clearBody.contains("sessionLifecycle.stop"))
         val adoptionBody = source
             .substringAfter("private suspend fun adoptSubtitlePlayback(")
             .substringBefore("private suspend fun confirmSubtitlePlaybackPublication(")

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapterTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapterTest.kt
@@ -333,7 +333,17 @@ class TvSubtitleTransactionAdapterTest {
         assertEquals(downloaded, harness.adapter.snapshot.committedIdentity)
         assertEquals(7, harness.adapter.snapshot.transition.committed.audioTrackIndex)
         assertEquals(
-            listOf(CommittedSubtitle(downloaded, audioTrackIndex = 7, qualityPreference = "auto")),
+            listOf(
+                CommittedSubtitle(
+                    downloaded,
+                    audioTrackIndex = 7,
+                    qualityPreference = "auto",
+                    // This scenario changes AUDIO explicitly, which is now
+                    // recorded so a subtitle-only commit cannot be mistaken for
+                    // the viewer choosing the audio it happened to carry.
+                    audioPreferenceSpecified = true,
+                ),
+            ),
             harness.persistence.persisted,
         )
     }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/SubtitleTransition.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/SubtitleTransition.kt
@@ -39,6 +39,15 @@ data class CommittedSubtitle(
     val identity: SubtitleIdentity,
     val audioTrackIndex: Int? = null,
     val qualityPreference: String? = null,
+    /**
+     * Whether the AUDIO was what this commit changed.
+     *
+     * Every commit carries the current audio index, including one that only
+     * changed subtitles — so the index alone cannot say whether the viewer
+     * chose that audio or merely happens to be listening to it. Callers that
+     * persist an audio preference need the difference.
+     */
+    val audioPreferenceSpecified: Boolean = false,
 )
 
 data class PendingSubtitle(
@@ -171,7 +180,12 @@ private fun SubtitleTransitionState.select(identity: SubtitleIdentity): Subtitle
         )
     }
     if (identity.requiresClientMount()) {
-        val updated = CommittedSubtitle(identity, audioTrackIndex, qualityPreference)
+        val updated = CommittedSubtitle(
+            identity = identity,
+            audioTrackIndex = audioTrackIndex,
+            qualityPreference = qualityPreference,
+            audioPreferenceSpecified = pending?.audioPreferenceSpecified == true,
+        )
         return SubtitleTransitionResult(
             state = copy(
                 committed = updated,
@@ -244,6 +258,7 @@ private fun SubtitleTransitionState.validate(
         identity = latest.identity,
         audioTrackIndex = latest.audioTrackIndex,
         qualityPreference = latest.qualityPreference,
+        audioPreferenceSpecified = latest.audioPreferenceSpecified,
     )
     return SubtitleTransitionResult(
         state = copy(committed = updated, pending = null),

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
@@ -174,11 +174,20 @@ class HomeViewModel(
                 // local optimistic overlay applied.
                 if (
                     fullyResolved &&
+                    // A superseded fetch must not write its sections to the
+                    // cache either: the next cold start would serve them.
+                    generation == fetchGeneration &&
                     requestIdentityGeneration == identityTransitions.generation.value
                 ) {
                     homeCache.cacheHome(resolved, cacheWriteLease)
                 }
                 val overlaid = overlayLocalState(resolved)
+                // Checked AGAIN, after the cache write and the overlay. Both
+                // suspend, and a newer fetch can complete and publish during
+                // either — so a check taken before them proves only that this
+                // reply was current when it arrived, not that it still is when
+                // it finally writes.
+                if (generation != fetchGeneration) return
                 _uiState.update {
                     // Only replace what's shown when the fetch fully resolved (or there
                     // was nothing yet) — a partial refresh must not clobber a good Home.

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
@@ -109,7 +109,15 @@ class HomeViewModel(
         viewModelScope.launch {
             // Stale-while-revalidate: serve the cached home instantly (offline-
             // capable), then refresh from the network below.
+            // Captured BEFORE the cached read, which suspends: a refresh can
+            // start and publish fresh sections while we are in there, and
+            // overlaying the cache on top would put stale rows back on screen.
+            val bootstrapGeneration = fetchGeneration
             val cached = homeCache.getCachedHome()
+            if (fetchGeneration != bootstrapGeneration) {
+                fetchSections()
+                return@launch
+            }
             if (cached != null && cached.sections.isNotEmpty()) {
                 val overlaid = overlayLocalState(cached.sections)
                 _uiState.update { it.copy(isLoading = false, sections = overlaid, error = null) }
@@ -123,8 +131,14 @@ class HomeViewModel(
     fun refresh() {
         viewModelScope.launch {
             _uiState.update { it.copy(isRefreshing = true, error = null) }
-            fetchSections()
-            _uiState.update { it.copy(isRefreshing = false) }
+            val generation = fetchSections()
+            // Only the newest fetch may clear the flag. A superseded refresh
+            // clearing it hides the spinner while a newer fetch is still
+            // running, and re-opens refreshFromRealtime's single-flight gate so
+            // it fires a redundant request.
+            if (generation == fetchGeneration) {
+                _uiState.update { it.copy(isRefreshing = false) }
+            }
         }
     }
 
@@ -143,7 +157,11 @@ class HomeViewModel(
         )
     }
 
-    private suspend fun fetchSections() {
+    /**
+     * Runs one home fetch and returns the generation it ran as, so callers can
+     * tell whether their own work is still the newest before acting on it.
+     */
+    private suspend fun fetchSections(): Int {
         val requestIdentityGeneration = identityTransitions.generation.value
         val cacheWriteLease = HomeCacheWriteLease(requestIdentityGeneration)
         // Whether we already have something to show (cached or prior fetch) — if a
@@ -165,7 +183,7 @@ class HomeViewModel(
                 }
                 // Superseded while in flight: a newer fetch has already
                 // answered, so this reply describes a home nobody is looking at.
-                if (generation != fetchGeneration) return
+                if (generation != fetchGeneration) return generation
                 val resolved = hydration.sections
                 // Don't persist a partially-resolved home over a good cached one.
                 val fullyResolved = hydration.fullyResolved
@@ -187,7 +205,7 @@ class HomeViewModel(
                 // either — so a check taken before them proves only that this
                 // reply was current when it arrived, not that it still is when
                 // it finally writes.
-                if (generation != fetchGeneration) return
+                if (generation != fetchGeneration) return generation
                 _uiState.update {
                     // Only replace what's shown when the fetch fully resolved (or there
                     // was nothing yet) — a partial refresh must not clobber a good Home.
@@ -208,7 +226,7 @@ class HomeViewModel(
             }
             is ApiResult.Error -> {
                 // A superseded fetch's failure is not this home's failure.
-                if (generation != fetchGeneration) return
+                if (generation != fetchGeneration) return generation
                 _uiState.update {
                     it.copy(
                         isLoading = false,
@@ -219,7 +237,7 @@ class HomeViewModel(
                 }
             }
             is ApiResult.NetworkError -> {
-                if (generation != fetchGeneration) return
+                if (generation != fetchGeneration) return generation
                 _uiState.update {
                     it.copy(
                         isLoading = false,
@@ -228,6 +246,7 @@ class HomeViewModel(
                 }
             }
         }
+        return generation
     }
 
     // -- Card context-menu actions --

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
@@ -76,6 +76,19 @@ class HomeViewModel(
     private var realtimeRefreshInFlight = false
 
     /**
+     * Bumped by every fetch, checked before any of them publishes.
+     *
+     * loadSections(), refresh() and refreshFromRealtime() can all be in flight
+     * at once — a resume observer fires while an initial load is still
+     * running — and each captures hadSections BEFORE its network call. Without
+     * ordering, an older partial response lands after a newer complete one,
+     * replaces good sections and marks them not fully resolved, which now also
+     * tells the TV's focus restoration to keep waiting for rows that already
+     * arrived.
+     */
+    private var fetchGeneration = 0
+
+    /**
      * Debounced realtime refetch: quiet (no spinner) and single-flight —
      * an in-flight realtime or manual refresh already delivers the fresh
      * sections, so overlapping signals are dropped rather than raced.
@@ -135,6 +148,7 @@ class HomeViewModel(
         val cacheWriteLease = HomeCacheWriteLease(requestIdentityGeneration)
         // Whether we already have something to show (cached or prior fetch) — if a
         // refresh fails we keep it rather than replacing it with a blocking error.
+        val generation = ++fetchGeneration
         val hadSections = _uiState.value.sections.isNotEmpty()
         when (val result = sectionRepository.getHomeSections()) {
             is ApiResult.Success -> {
@@ -149,6 +163,9 @@ class HomeViewModel(
                 val hydration = hydrateHomeSections(sections) { sectionId ->
                     sectionRepository.getHomeSectionItems(sectionId)
                 }
+                // Superseded while in flight: a newer fetch has already
+                // answered, so this reply describes a home nobody is looking at.
+                if (generation != fetchGeneration) return
                 val resolved = hydration.sections
                 // Don't persist a partially-resolved home over a good cached one.
                 val fullyResolved = hydration.fullyResolved
@@ -181,6 +198,8 @@ class HomeViewModel(
                 }
             }
             is ApiResult.Error -> {
+                // A superseded fetch's failure is not this home's failure.
+                if (generation != fetchGeneration) return
                 _uiState.update {
                     it.copy(
                         isLoading = false,
@@ -191,6 +210,7 @@ class HomeViewModel(
                 }
             }
             is ApiResult.NetworkError -> {
+                if (generation != fetchGeneration) return
                 _uiState.update {
                     it.copy(
                         isLoading = false,


### PR DESCRIPTION
First of three follow-ups to #168, split by theme so each stays reviewable. Player robustness; the audio-selection and profiles/navigation work follows in its own PR.

## Playback survives bad input

A malformed caption could kill playback outright. Subtitle bitmaps arriving from the wire are now rejected rather than trusted, and track identity is no longer misread — both cases previously took the whole session down rather than dropping the track.

## Sessions stop when their screen does

Server sessions could outlive the screen that started them: cancelled mid-start, superseded by a replan, or abandoned on an error path that returned before teardown. Ownership is now retained at Ready, and every session the screen adopts is owned — so it is stopped exactly once, by whoever owns it.

A frame-baseline attempt at the same problem is included here as its own commit **and its revert**. It compared decoder counters against a mount baseline, which fails because Media3 creates fresh `DecoderCounters` when a renderer is enabled — an outgoing count against a restarted counter makes a healthy stream look frozen until it has rendered as many frames again. That trades a rare missed freeze for a common false one. It is left in the history rather than squashed away because the reasoning is worth keeping.

## Overlapping refreshes

`fetchSections()` publishers could overlap — a resume observer firing while an initial load is still running — and each captured `hadSections` before its network call. An older partial response could then land after a newer complete one, replace good sections, and mark them not fully resolved, which also told TV focus restoration to keep waiting for rows that had already arrived. A `fetchGeneration` guard now serialises them: every fetch is stamped, and a result is dropped if a newer one has started.

This closes the `HomeViewModel` finding CodeRabbit raised on #168, which merged before the fix.

## Also

Audio delay, subtitle encodings and refresh reporting were unbroken; auto-play next episode was unbroken; the TV HUD's row layout, version labels and stats naming were repaired.

## Verification

All four module suites pass and both APKs assemble. Fixes carry regression tests where the boundary is testable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio selections can carry between TV episodes when a matching track is available.
  * TV version choices now show clearer labels when versions share the same name.
* **Bug Fixes**
  * Improved playback teardown prevents duplicate or outdated sessions from stopping active playback.
  * Audio delay, subtitle decoding, and malformed subtitle graphics are handled more reliably.
  * Prevented stale home-screen refreshes from replacing newer content.
  * TV playback now surfaces subtitle, audio, and recovery failures.
  * Improved TV player layout, controls, and overlay behavior.
  * Renamed “Bitrate” to “Estimated bandwidth” for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->