### PR TITLE
fix(playback): bind control-socket sends to the session that owns them

### DIFF
--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/PlaybackRealtimeClient.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/PlaybackRealtimeClient.kt
@@ -6,9 +6,14 @@ import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.http.encodeURLParameter
 import io.ktor.websocket.Frame
 import io.ktor.websocket.readText
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -72,7 +77,29 @@ class DefaultPlaybackRealtimeClient(
     private val json: Json = SiloJson,
 ) : PlaybackRealtimeClient {
 
-    private var session: DefaultClientWebSocketSession? = null
+    /**
+     * The socket paired with the playback session it belongs to.
+     *
+     * Holding the id alongside the socket is what makes a send answerable to a
+     * caller. With a bare socket field, a reconnect overwrites it while the
+     * outgoing connection's `finally` clears it unconditionally — so a late
+     * close from session A disables session B's remote control, and an ack for
+     * A goes out over B's socket and vanishes. Both are indistinguishable from
+     * a flaky network at the call site.
+     */
+    private data class RealtimeConnection(
+        val sessionId: String,
+        val socket: DefaultClientWebSocketSession,
+    )
+
+    /**
+     * Guards [connection]. A volatile read-then-write is not a compare-and-set:
+     * a newer connection can install itself between the two, and the older one
+     * then clears it. Every access is a suspend call site, so a mutex is enough
+     * and needs no atomics dependency.
+     */
+    private val connectionLock = Mutex()
+    private var connection: RealtimeConnection? = null
 
     override fun connect(sessionId: String): Flow<PlaybackRealtimeEvent> = callbackFlow {
         val token = tokenManager.getAccessToken()
@@ -98,9 +125,27 @@ class DefaultPlaybackRealtimeClient(
                 append("&profile_token=").append(profileToken.encodeURLParameter())
             }
         }
+        var owned: RealtimeConnection? = null
+        // Clear on identity under the lock, never a blind null: this connection
+        // may already have been superseded by a newer one, and clearing that
+        // would leave the live socket unreachable to every send.
+        // NonCancellable: every caller below runs on a teardown path, and two of
+        // the three run while this coroutine is already cancelled. A cancellable
+        // acquisition simply throws there, leaving a dead socket installed as the
+        // target of every subsequent send until some later connection happens to
+        // overwrite it.
+        suspend fun releaseIfStillOwned() {
+            withContext(NonCancellable) {
+                connectionLock.withLock {
+                    if (connection === owned) connection = null
+                }
+            }
+        }
         try {
             client.webSocket(urlString = url) {
-                session = this
+                val current = RealtimeConnection(sessionId, this)
+                owned = current
+                connectionLock.withLock { connection = current }
                 // R2: signal open AFTER the session is assigned, so the
                 // controller's hello can't race ahead of a live socket.
                 trySend(PlaybackRealtimeEvent.Opened)
@@ -110,12 +155,17 @@ class DefaultPlaybackRealtimeClient(
                         decodePlaybackFrame(json, frame.readText())?.let { trySend(it) }
                     }
                 } finally {
-                    session = null
+                    releaseIfStillOwned()
                 }
             }
             trySend(PlaybackRealtimeEvent.Closed())
+        } catch (cancellation: CancellationException) {
+            // Not a socket failure. Reporting Closed here tells the controller to
+            // reconnect the very session that is being torn down.
+            releaseIfStillOwned()
+            throw cancellation
         } catch (e: Throwable) {
-            session = null
+            releaseIfStillOwned()
             trySend(PlaybackRealtimeEvent.Closed(e.message))
         } finally {
             close()
@@ -123,9 +173,23 @@ class DefaultPlaybackRealtimeClient(
         awaitClose { }
     }
 
-    private suspend fun sendText(text: String) { session?.send(Frame.Text(text)) }
+    /**
+     * Writes only on the connection that belongs to [sessionId]. Every envelope
+     * already names its session, so a send that cannot be matched to the open
+     * socket is for a connection that has moved on — dropping it is correct, and
+     * strictly better than writing it down somebody else's socket.
+     */
+    private suspend fun sendText(sessionId: String, text: String) {
+        // Resolve under the lock, then send outside it — the send is network I/O
+        // and must not block a teardown trying to release the field.
+        val current = connectionLock.withLock {
+            connection?.takeIf { it.sessionId == sessionId }
+        } ?: return
+        current.socket.send(Frame.Text(text))
+    }
 
     override suspend fun sendHello(sessionId: String) = sendText(
+        sessionId,
         json.encodeToString(
             PlaybackHelloEnvelope.serializer(),
             PlaybackHelloEnvelope(
@@ -137,6 +201,7 @@ class DefaultPlaybackRealtimeClient(
     )
 
     override suspend fun sendAck(sessionId: String, commandId: String) = sendText(
+        sessionId,
         json.encodeToString(
             PlaybackAckEnvelope.serializer(),
             PlaybackAckEnvelope(commandId = commandId, sessionId = sessionId),
@@ -144,6 +209,7 @@ class DefaultPlaybackRealtimeClient(
     )
 
     override suspend fun sendResult(sessionId: String, commandId: String, status: String, error: String?) = sendText(
+        sessionId,
         json.encodeToString(
             PlaybackResultEnvelope.serializer(),
             PlaybackResultEnvelope(commandId = commandId, sessionId = sessionId, status = status, error = error),


### PR DESCRIPTION
`DefaultPlaybackRealtimeClient` held one mutable socket field. A reconnect overwrote it while the outgoing connection's `finally` cleared it unconditionally, so:

- a late close from session A disabled session B's remote-control socket, and
- an ack for A could go out over B's connection and vanish.

Both are indistinguishable from a flaky network at the call site, which is why this is easy to miss in the field.

## What changed

The socket is now paired with the session id that owns it. Sends resolve against that pairing — every envelope already names its session, so a send that cannot be matched belongs to a connection that has moved on, and dropping it is strictly better than writing it down someone else's socket.

Clearing compares identity under a mutex rather than blind-nulling a volatile. A volatile read-then-write is not a compare-and-set: a newer connection can install itself between the read and the write, and the older one then clears it.

Cleanup is non-cancellable, because two of its three callers run while the coroutine is already cancelled — a cancellable acquisition simply threw there, leaving a dead socket installed as the target of every subsequent send.

Cancellation is rethrown rather than reported as a socket failure, which had told the controller to reconnect the very session being torn down.

## Reachability

Koin hands out this client per injection, but the same instance survives `LaunchedEffect(sessionId)` changes — the old effect is cancelled and the next session connects through that same client. So the cross-session case is reachable, not theoretical.

## Testing

`:shared` compiles and its unit tests pass on this branch in isolation. Reviewed with Codex across several passes; the identity-qualified clearing and session-qualified sends were confirmed sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115uaQ6FTQZK8KYvazjefaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback connection stability when sessions overlap or reconnect.
  * Prevented stale connections from interrupting newer active connections.
  * Ensured cancellation and connection failures clean up reliably.
  * Prevented messages from being sent through the wrong playback session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->