### PR TITLE
fix(tv): stop auto-advance cutting off the end of an episode

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -2625,8 +2625,10 @@ private fun TvRoomIndicator(
  * next-episode panel on the right: an "Up Next" / "Playing Next" eyebrow,
  * series-context-free episode metadata ("S·E · title" + overview), a Play Now
  * primary button, a Keep Watching dismiss button, a Back button, an auto-play
- * countdown ring (counts to zero then plays the next episode), and finished /
- * loading states when no next episode is available.
+ * countdown ring (a card raised at the end counts a wall clock to zero and then
+ * plays the next episode; one raised at the credits marker mirrors the
+ * remaining playback time and waits for the stream to actually end), and
+ * finished / loading states when no next episode is available.
  *
  * Replaces the old "Still watching?" dialog as the sole end-of-playback
  * surface; the pass-out gate now manifests as the overlay appearing WITHOUT a

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -89,6 +89,7 @@ import org.siloserver.silo.repository.SubtitlesRepository
 import org.siloserver.silo.repository.port.PlaybackWriteScope
 import org.siloserver.silo.repository.port.TrackSelectionFingerprintUpdate
 import org.siloserver.silo.tv.ui.screens.detail.TvDetailTrackSelectionSession
+import kotlin.math.ceil
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -929,9 +930,13 @@ class TvPlayerViewModel(
         // mini-player pane beside the next-episode panel — in place of the idle
         // controls. `nextUpVideoEnded` distinguishes "almost finished" (credits
         // reached, still playing) from "end of playback" (stream ended).
-        // `nextUpCountdownSeconds` drives the auto-play CountdownRing: non-null
-        // counts down to 0 and then plays the next episode; null means no
-        // countdown (auto-play off, pass-out gate hit, or no next episode).
+        // `nextUpCountdownSeconds` drives the auto-play CountdownRing; null
+        // means no countdown (auto-play off, pass-out gate hit, or no next
+        // episode). A card raised at end-of-playback counts a wall clock down
+        // to 0 and then plays the next episode. A card raised at the credits
+        // marker instead mirrors the remaining playback time, so reaching 0
+        // means "the stream should be over" — it waits for the player to say
+        // so rather than cutting the tail off.
         val showNextUp: Boolean = false,
         val nextUpVideoEnded: Boolean = false,
         val nextUpCountdownSeconds: Int? = null,
@@ -1782,6 +1787,7 @@ class TvPlayerViewModel(
                                 showNextUp = false,
                                 nextUpVideoEnded = false,
                                 nextUpCountdownSeconds = null,
+                                nextUpCountdownTotalSeconds = NEXT_UP_COUNTDOWN_SECONDS,
                                 // T11: clear the subtitle-refresh nonce on every
                                 // fresh mount. It is bumped once per post-download
                                 // refresh; without this reset a later backend
@@ -3011,12 +3017,25 @@ class TvPlayerViewModel(
         val threshold = passOutThreshold.value
         val passOutGated = threshold > 0 && autoAdvanceCount >= threshold
         val autoCountdown = autoPlayNextEnabled.value && !passOutGated
+        val current = _uiState.value
+        // Pre-end commits anchor the countdown to the remaining playback time
+        // (see startNextUpCountdown); only an at-end commit uses the wall clock.
+        val initialCountdown = when {
+            !autoCountdown -> null
+            videoEnded -> NEXT_UP_COUNTDOWN_SECONDS
+            else -> ceil((current.duration - current.position).coerceAtLeast(0.0)).toInt()
+        }
 
         _uiState.update {
             it.copy(
                 showNextUp = true,
                 nextUpVideoEnded = videoEnded,
-                nextUpCountdownSeconds = if (autoCountdown) NEXT_UP_COUNTDOWN_SECONDS else null,
+                nextUpCountdownSeconds = initialCountdown,
+                // The ring draws remaining/total, so a pre-end countdown longer
+                // than the wall-clock default has to carry its own total or the
+                // ring renders past full.
+                nextUpCountdownTotalSeconds = initialCountdown?.coerceAtLeast(1)
+                    ?: NEXT_UP_COUNTDOWN_SECONDS,
             )
         }
         if (autoCountdown) startNextUpCountdown()
@@ -3025,20 +3044,52 @@ class TvPlayerViewModel(
     private fun startNextUpCountdown() {
         nextUpCountdownJob?.cancel()
         nextUpCountdownJob = viewModelScope.launch {
-            var remaining = NEXT_UP_COUNTDOWN_SECONDS
-            while (remaining > 0) {
+            // Two anchors, matching phone and tvOS:
+            //  - Card committed BEFORE the end (credits crossing): the countdown
+            //    mirrors the remaining playback time, so it freezes on pause,
+            //    grows on a backward seek, and the advance fires only once the
+            //    player reports the stream ended. A fixed wall clock here cut off
+            //    the final scene of anything whose credits marker sits more than
+            //    ten seconds from the actual end.
+            //  - Card committed AT the end (stream ended with no earlier
+            //    crossing): there is no playback left to anchor to, so a short
+            //    wall-clock countdown gives the viewer a window to cancel.
+            val startedAtEnd = _uiState.value.nextUpVideoEnded
+            var wallRemaining = NEXT_UP_COUNTDOWN_SECONDS
+            while (true) {
                 delay(1_000)
-                remaining -= 1
+                // Bail if something dismissed the overlay underneath us.
+                if (!_uiState.value.showNextUp) return@launch
+                val remaining = if (startedAtEnd) {
+                    wallRemaining -= 1
+                    wallRemaining.coerceAtLeast(0)
+                } else {
+                    val state = _uiState.value
+                    ceil((state.duration - state.position).coerceAtLeast(0.0)).toInt()
+                }
                 _uiState.update {
-                    // Bail if something dismissed the overlay underneath us.
-                    if (!it.showNextUp) it else it.copy(nextUpCountdownSeconds = remaining)
+                    if (!it.showNextUp) {
+                        it
+                    } else {
+                        it.copy(
+                            nextUpCountdownSeconds = remaining,
+                            // A backward seek can push the remaining time past
+                            // where the ring started; grow the total with it.
+                            nextUpCountdownTotalSeconds =
+                                maxOf(it.nextUpCountdownTotalSeconds, remaining, 1),
+                        )
+                    }
                 }
                 if (!_uiState.value.showNextUp) return@launch
+                val playbackEnded =
+                    if (startedAtEnd) wallRemaining <= 0 else _uiState.value.nextUpVideoEnded
+                if (!playbackEnded) continue
+                // Automatic countdown-expiry advance: increment the pass-out streak
+                // so a long unattended binge eventually trips the "still watching?"
+                // gate. An explicit Play Now (below) resets the streak instead.
+                advanceToNextEpisode(nextAutoAdvanceCount = autoAdvanceCount + 1)
+                return@launch
             }
-            // Automatic countdown-expiry advance: increment the pass-out streak
-            // so a long unattended binge eventually trips the "still watching?"
-            // gate. An explicit Play Now (below) resets the streak instead.
-            advanceToNextEpisode(nextAutoAdvanceCount = autoAdvanceCount + 1)
         }
     }
 


### PR DESCRIPTION
TV started a fixed ten-second wall clock the moment playback crossed the credits marker, and advanced when it expired — whether or not the stream had ended. Anything whose credits marker sits more than ten seconds from the actual end therefore lost its final scene, its post-credits material, or a long credits tail. The earlier position could also be persisted as the final one.

## What changed

Adopts the two-anchor model phone and tvOS already use:

- **Card raised at the credits crossing** anchors its countdown to the remaining playback time. It freezes on pause, grows on a backward seek, and advances only once the player reports the stream ended.
- **Card raised at end-of-media** keeps the wall clock, which is what suits that case — there is no playback left to anchor to, and a short window to cancel is the whole point.

The countdown ring needed its own total, since a pre-end countdown can be far longer than the ten-second default and would otherwise render past full. It grows with the countdown when a backward seek pushes remaining time past where the ring started.

## Device testing

Installed on a Google TV Streamer and watched two episodes auto-advance end to end. Both exercised the **at-end** branch and behaved correctly — card appeared, counted down, rolled into the next episode — which is the regression check that matters, since this commit touches that path.

The **pre-end** branch did not fire in testing, because neither test title carried a credits marker (one had none at all; the other's scrub-bar ticks turned out to be chapter markers). Reading the code, that branch needs: solo playback, a non-null `credits.start`, a natural crossing with no seek active, a resolved next episode, and autoplay on with the pass-out gate untripped. Resuming or seeking directly into credits will never trigger it — by design, so that resuming inside the credits doesn't instantly skip.

So: the path this commit preserves is device-verified; the path it fixes is verified by reading, and wants a title with a real credits marker to confirm on hardware.

## Testing

`:androidTvApp` compiles and its unit tests pass on this branch in isolation. Reviewed with Codex, which confirmed the countdown loop, the ring total growing on a backward seek, and that dismiss/advance/fresh-mount leave no stale state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115uaQ6FTQZK8KYvazjefaW