### PR TITLE
test(player): stop the load-ownership suite failing on a busy machine

### DIFF
--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModelLoadOwnershipIntegrationTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModelLoadOwnershipIntegrationTest.kt
@@ -825,15 +825,32 @@ private suspend fun PlayerViewModel.awaitState(
     awaitCondition { predicate(uiState.value) }
 }
 
+/**
+ * Polls [predicate] off the test scheduler, on a dispatcher that cannot be
+ * starved.
+ *
+ * The deadline is wall-clock, so it has to outlast the machine being busy. This
+ * used to poll on a single-parallelism slice of [Dispatchers.Default], which is
+ * sized to CPU count and fully subscribed when the Gradle suite runs its
+ * modules in parallel — the polling coroutine got almost no time while the
+ * timeout kept counting real seconds, and the test failed on a loaded machine
+ * while passing alone. [Dispatchers.IO] is elastic, so the poll keeps running
+ * under load.
+ *
+ * The timeout is a backstop against a genuine hang, not an assertion about
+ * latency, so it is generous. A real hang still fails, just later.
+ */
 private suspend fun awaitCondition(predicate: () -> Boolean) {
-    withContext(Dispatchers.Default.limitedParallelism(1)) {
-        withTimeout(5_000) {
+    withContext(Dispatchers.IO) {
+        withTimeout(AWAIT_CONDITION_TIMEOUT_MS) {
             while (!predicate()) {
                 delay(5)
             }
         }
     }
 }
+
+private const val AWAIT_CONDITION_TIMEOUT_MS = 30_000L
 
 private const val SERVER_ID = "server"
 private const val PROFILE_ID = "profile"


### PR DESCRIPTION
`PlayerViewModelLoadOwnershipIntegrationTest` fails intermittently under the full parallel suite and passes consistently when run alone. It fired on three separate branches today, each time costing a re-run just to establish it wasn't a real regression.

## Cause

`awaitCondition` polled on `Dispatchers.Default.limitedParallelism(1)` under a 5s **wall-clock** deadline. `Default` is sized to CPU count and fully subscribed when Gradle runs its modules in parallel, so the polling coroutine got almost no scheduler time while `withTimeout` kept counting real seconds. One failing run took 16s of wall clock against a 5s budget.

So the deadline wasn't measuring the thing it was meant to guard.

## Fix

Poll on `Dispatchers.IO`, which is elastic and keeps running while the CPU pool is saturated, and give the deadline enough headroom to survive a loaded machine. The timeout is a backstop against a genuine hang, not an assertion about latency — a real hang still fails, just later.

## Verification

Three consecutive full-suite runs across all four modules with `--rerun-tasks` — the configuration that reproduced the failure — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115uaQ6FTQZK8KYvazjefaW