### PR TITLE
fix(tv): return to the related item you opened, not the hero

### DIFF
--- a/androidTvApp/build.gradle.kts
+++ b/androidTvApp/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.android.build.api.variant.HasHostTestsBuilder
+import com.android.build.api.variant.HostTestBuilder
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.compose.multiplatform)
@@ -244,7 +247,11 @@ android {
 // task was ever reached.
 androidComponents {
     beforeVariants(selector().withBuildType("release")) { variant ->
-        variant.enableUnitTest = false
+        // Host-tests API rather than `variant.enableUnitTest`, which AGP 8.10.1
+        // deprecates and AGP 9.0 removes.
+        (variant as HasHostTestsBuilder)
+            .hostTests[HostTestBuilder.UNIT_TEST_TYPE]
+            ?.enable = false
     }
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -50,7 +50,8 @@ import org.siloserver.silo.model.section.ResolvedSection
 import org.siloserver.silo.tv.ui.focus.TvReturnResolution
 import org.siloserver.silo.tv.ui.focus.TvReturnTarget
 import org.siloserver.silo.tv.ui.focus.keyedTvReturnTargetSaver
-import org.siloserver.silo.tv.ui.focus.keyedValueSaver
+import org.siloserver.silo.tv.ui.focus.keyedBooleanSaver
+import org.siloserver.silo.tv.ui.focus.keyedIntSaver
 import org.siloserver.silo.tv.ui.focus.resolveTvReturnTarget
 import org.siloserver.silo.tv.ui.focus.toTvReturnSections
 import org.siloserver.silo.model.section.SectionItem
@@ -194,7 +195,7 @@ fun TvSkylineSectionFeed(
     // attachments (and the row restorer's enter-fallback redirect they imply).
     var detailReturnPending by rememberSaveable(
         surfaceKey,
-        stateSaver = keyedValueSaver(surfaceKey, false),
+        stateSaver = keyedBooleanSaver(surfaceKey, slot = "detailReturnPending"),
     ) { mutableStateOf(false) }
     // True while a ladder is actively driving focus back to the launch card.
     //
@@ -216,7 +217,7 @@ fun TvSkylineSectionFeed(
     // only just started.
     var returnGeneration by rememberSaveable(
         surfaceKey,
-        stateSaver = keyedValueSaver(surfaceKey, 0),
+        stateSaver = keyedIntSaver(surfaceKey, slot = "returnGeneration"),
     ) { mutableIntStateOf(0) }
     // Bumped when a ladder starts, so the row scrolls its own LazyRow to the
     // resolved card. Without it the card can sit outside the composed

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -49,7 +49,8 @@ import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.section.ResolvedSection
 import org.siloserver.silo.tv.ui.focus.TvReturnResolution
 import org.siloserver.silo.tv.ui.focus.TvReturnTarget
-import org.siloserver.silo.tv.ui.focus.TvReturnTargetSaver
+import org.siloserver.silo.tv.ui.focus.keyedTvReturnTargetSaver
+import org.siloserver.silo.tv.ui.focus.keyedValueSaver
 import org.siloserver.silo.tv.ui.focus.resolveTvReturnTarget
 import org.siloserver.silo.tv.ui.focus.toTvReturnSections
 import org.siloserver.silo.model.section.SectionItem
@@ -84,9 +85,12 @@ fun TvSkylineSectionFeed(
      * `rememberSaveable` slots are POSITIONAL. Two feeds composed at the same
      * position in different surfaces — Home and a library detail — otherwise
      * share one slot, so a return target armed on one could be restored into
-     * the other, sending focus to a card that surface never showed. The saved
-     * target itself carries no owner: it is only
-     * [sectionId, itemId, sectionIndex, itemIndex].
+     * the other, sending focus to a card that surface never showed.
+     *
+     * Keying the slot alone is not enough, because rememberSaveable does not
+     * validate a value RESTORED after process death against its inputs. This
+     * key is therefore written into the savers too, and a payload belonging to
+     * another surface is discarded on the way back.
      */
     surfaceKey: String,
     modifier: Modifier = Modifier,
@@ -176,12 +180,22 @@ fun TvSkylineSectionFeed(
     // somewhere else. Saveable so it survives both the outer round trip and
     // process death, which is exactly when the live focus state below is gone
     // and indices would be all that was left.
-    var returnTarget by rememberSaveable(surfaceKey, stateSaver = TvReturnTargetSaver) {
+    // Keyed SAVER, not just a keyed slot: rememberSaveable does not validate a
+    // value restored after process death against its inputs, so a process
+    // coming back on a different feed first would otherwise adopt this one's
+    // target. Same guard TvFlatReturnRestoration already applies.
+    var returnTarget by rememberSaveable(
+        surfaceKey,
+        stateSaver = keyedTvReturnTargetSaver(surfaceKey),
+    ) {
         mutableStateOf<TvReturnTarget?>(null)
     }
     // True while a restore target is armed. Gates the restore requester
     // attachments (and the row restorer's enter-fallback redirect they imply).
-    var detailReturnPending by rememberSaveable(surfaceKey) { mutableStateOf(false) }
+    var detailReturnPending by rememberSaveable(
+        surfaceKey,
+        stateSaver = keyedValueSaver(surfaceKey, false),
+    ) { mutableStateOf(false) }
     // True while a ladder is actively driving focus back to the launch card.
     //
     // Focus lands on the wrong card first often enough that these ladders exist
@@ -200,7 +214,10 @@ fun TvSkylineSectionFeed(
     // would pivot onto a newly clicked card, see it already focused, and clear
     // the NEW trip's pending state — losing restoration for the trip that had
     // only just started.
-    var returnGeneration by rememberSaveable(surfaceKey) { mutableIntStateOf(0) }
+    var returnGeneration by rememberSaveable(
+        surfaceKey,
+        stateSaver = keyedValueSaver(surfaceKey, 0),
+    ) { mutableIntStateOf(0) }
     // Bumped when a ladder starts, so the row scrolls its own LazyRow to the
     // resolved card. Without it the card can sit outside the composed
     // horizontal window after a reorder, the requester never attaches, and

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -78,6 +78,17 @@ import org.koin.compose.koinInject
 fun TvSkylineSectionFeed(
     sections: List<ResolvedSection>,
     onItemClick: (String) -> Unit,
+    /**
+     * Identifies the surface this feed instance belongs to.
+     *
+     * `rememberSaveable` slots are POSITIONAL. Two feeds composed at the same
+     * position in different surfaces — Home and a library detail — otherwise
+     * share one slot, so a return target armed on one could be restored into
+     * the other, sending focus to a card that surface never showed. The saved
+     * target itself carries no owner: it is only
+     * [sectionId, itemId, sectionIndex, itemIndex].
+     */
+    surfaceKey: String,
     modifier: Modifier = Modifier,
     /**
      * False while rows are still being hydrated.
@@ -165,12 +176,12 @@ fun TvSkylineSectionFeed(
     // somewhere else. Saveable so it survives both the outer round trip and
     // process death, which is exactly when the live focus state below is gone
     // and indices would be all that was left.
-    var returnTarget by rememberSaveable(stateSaver = TvReturnTargetSaver) {
+    var returnTarget by rememberSaveable(surfaceKey, stateSaver = TvReturnTargetSaver) {
         mutableStateOf<TvReturnTarget?>(null)
     }
     // True while a restore target is armed. Gates the restore requester
     // attachments (and the row restorer's enter-fallback redirect they imply).
-    var detailReturnPending by rememberSaveable { mutableStateOf(false) }
+    var detailReturnPending by rememberSaveable(surfaceKey) { mutableStateOf(false) }
     // True while a ladder is actively driving focus back to the launch card.
     //
     // Focus lands on the wrong card first often enough that these ladders exist
@@ -189,7 +200,7 @@ fun TvSkylineSectionFeed(
     // would pivot onto a newly clicked card, see it already focused, and clear
     // the NEW trip's pending state — losing restoration for the trip that had
     // only just started.
-    var returnGeneration by rememberSaveable { mutableIntStateOf(0) }
+    var returnGeneration by rememberSaveable(surfaceKey) { mutableIntStateOf(0) }
     // Bumped when a ladder starts, so the row scrolls its own LazyRow to the
     // resolved card. Without it the card can sit outside the composed
     // horizontal window after a reorder, the requester never attaches, and

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
@@ -538,6 +538,26 @@ private suspend fun awaitFlatPageSettled(
  * A target restored under a different key is discarded rather than adopted:
  * it describes somewhere the viewer was in another list entirely.
  */
+/**
+ * Saves [value] alongside the surface that owns it, and refuses a restored
+ * payload belonging to a different one.
+ *
+ * `rememberSaveable(key)` resets when a running composition observes a changed
+ * input, but it does NOT validate a value RESTORED after process death against
+ * that input — so a process coming back on a different surface first would
+ * adopt the previous surface's state as its own. Same reasoning as
+ * [keyedTvReturnTargetSaver]; this is the scalar case.
+ */
+internal fun <T : Any> keyedValueSaver(resetToken: String, default: T): Saver<T, Any> =
+    listSaver(
+        save = { value -> listOf(resetToken, value) },
+        restore = { saved ->
+            @Suppress("UNCHECKED_CAST")
+            val values = saved as List<Any>
+            if (values.size < 2 || values[0] != resetToken) default else values[1] as T
+        },
+    )
+
 internal fun keyedTvReturnTargetSaver(resetToken: String): Saver<TvReturnTarget?, Any> =
     listSaver(
         save = { target ->

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
@@ -533,12 +533,6 @@ private suspend fun awaitFlatPageSettled(
 }
 
 /**
- * [TvReturnTargetSaver], partitioned by the surface that saved it.
- *
- * A target restored under a different key is discarded rather than adopted:
- * it describes somewhere the viewer was in another list entirely.
- */
-/**
  * Saves [value] alongside the surface that owns it, and refuses a restored
  * payload belonging to a different one.
  *
@@ -581,9 +575,8 @@ internal fun keyedTvReturnTargetSaver(resetToken: String): Saver<TvReturnTarget?
             } ?: listOf(resetToken)
         },
         restore = { saved ->
-            @Suppress("UNCHECKED_CAST")
             val values = saved as? List<*>
-            if (values == null || values.size < 5 || values[0] != resetToken) {
+            if (values == null || values.size != 5 || values[0] != resetToken) {
                 null
             } else {
                 // Safe casts throughout: a right-owner, wrong-shape payload

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvFlatReturnRestoration.kt
@@ -548,13 +548,28 @@ private suspend fun awaitFlatPageSettled(
  * adopt the previous surface's state as its own. Same reasoning as
  * [keyedTvReturnTargetSaver]; this is the scalar case.
  */
-internal fun <T : Any> keyedValueSaver(resetToken: String, default: T): Saver<T, Any> =
+internal fun keyedBooleanSaver(resetToken: String, slot: String): Saver<Boolean, Any> =
     listSaver(
-        save = { value -> listOf(resetToken, value) },
+        save = { value -> listOf(resetToken, slot, value) },
         restore = { saved ->
-            @Suppress("UNCHECKED_CAST")
-            val values = saved as List<Any>
-            if (values.size < 2 || values[0] != resetToken) default else values[1] as T
+            val values = saved as? List<*> ?: return@listSaver false
+            val owned = values.size == 3 && values[0] == resetToken && values[1] == slot
+            // Typed, not cast. An erased `as T` validates against Any, so a
+            // payload with the right owner and the wrong type passes here and
+            // fails later where Compose reads it — a crash during restoration
+            // rather than a value we can reject. The slot name is carried too:
+            // the owner token alone cannot tell one scalar slot from another.
+            if (owned) values[2] as? Boolean ?: false else false
+        },
+    )
+
+internal fun keyedIntSaver(resetToken: String, slot: String): Saver<Int, Any> =
+    listSaver(
+        save = { value -> listOf(resetToken, slot, value) },
+        restore = { saved ->
+            val values = saved as? List<*> ?: return@listSaver 0
+            val owned = values.size == 3 && values[0] == resetToken && values[1] == slot
+            if (owned) values[2] as? Int ?: 0 else 0
         },
     )
 
@@ -567,16 +582,29 @@ internal fun keyedTvReturnTargetSaver(resetToken: String): Saver<TvReturnTarget?
         },
         restore = { saved ->
             @Suppress("UNCHECKED_CAST")
-            val values = saved as List<Any>
-            if (values.size < 5 || values[0] != resetToken) {
+            val values = saved as? List<*>
+            if (values == null || values.size < 5 || values[0] != resetToken) {
                 null
             } else {
-                TvReturnTarget(
-                    sectionId = values[1] as String,
-                    itemId = values[2] as String,
-                    sectionIndex = values[3] as Int,
-                    itemIndex = values[4] as Int,
-                )
+                // Safe casts throughout: a right-owner, wrong-shape payload
+                // should restore as "nothing to return to", not throw and take
+                // the screen down during restoration.
+                val sectionId = values[1] as? String
+                val itemId = values[2] as? String
+                val sectionIndex = values[3] as? Int
+                val itemIndex = values[4] as? Int
+                if (sectionId == null || itemId == null ||
+                    sectionIndex == null || itemIndex == null
+                ) {
+                    null
+                } else {
+                    TvReturnTarget(
+                        sectionId = sectionId,
+                        itemId = itemId,
+                        sectionIndex = sectionIndex,
+                        itemIndex = itemIndex,
+                    )
+                }
             }
         },
     )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -662,12 +662,13 @@ fun TvAppNavigation(
                     }
                 },
                 onItemDetail = { itemContentId ->
-                    // launchSingleTop suppresses the exact double-tap dupe; a
-                    // distinct related item (always a different contentId) still
-                    // pushes normally.
-                    navController.navigate(TvRoute.ItemDetail(itemContentId).route) {
-                        launchSingleTop = true
-                    }
+                    // Do not use launchSingleTop here. AndroidX matches the
+                    // ItemDetail destination node, not its contentId argument,
+                    // so A -> related B would reuse A's entry and leave no A
+                    // for Back to reveal. The broader exact-repeat helper lives
+                    // on #175; this branch only needs distinct related details
+                    // to push so its return restoration is actually reachable.
+                    navController.navigate(TvRoute.ItemDetail(itemContentId).route)
                 },
                 // Season switching replaces the current detail entry so paging
                 // through seasons never stacks pages — one Back returns to the

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -61,7 +61,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withTimeoutOrNull
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -350,73 +349,33 @@ private fun TvDetailContent(
         // Counting frames for that was measuring the wrong thing entirely: a
         // ~120-frame budget is one or two seconds depending on refresh rate,
         // and a load finishing just past it silently became a hero fallback.
-        val resolved = withTimeoutOrNull(RESTORE_DATA_TIMEOUT_MS) {
-            snapshotFlow { pendingSimilarIndexNow.value }.first { it >= 0 }
-        }
-
-        var restored = false
-        if (resolved != null && stillOwned()) {
-            // Now the target exists, so scroll the row to it — a card outside
-            // the composed window leaves the requester unattached.
-            similarRestoreRequest += 1
-            // Only NOW are frames the right clock: this waits for composition
-            // and focus attachment. As in the cast branch the return value is
-            // not evidence, since requestFocus() can report success and then
-            // roll back across the row's enter redirect.
-            // ~80 frames (40 attempts, two waits each) AND a wall-clock cap.
-            // Frames are the right clock for composition and attachment, but
-            // they are not a duration: if frame production pauses or starves,
-            // eighty of them is unbounded real time and the viewer would be
-            // fighting a restore that never gives up. The frame count decides
-            // how many attempts are reasonable; the deadline decides how long
-            // the viewer can be made to wait for them.
-            var revoked = false
-            withTimeoutOrNull(RESTORE_ATTACH_TIMEOUT_MS) {
-                for (attempt in 0 until 40) {
-                    if (similarRestoreFocused.value) {
-                        restored = true
-                        break
-                    }
-                    // Re-checked every attempt, not just at the end: ownership
-                    // can be revoked mid-loop — by a newer request, or by the
-                    // viewer pressing a direction key — and continuing to
-                    // request focus after that is fighting them for it.
-                    if (!stillOwned()) {
-                        revoked = true
-                        break
-                    }
-                    runCatching { similarReturnFocus.requestFocus() }
-                    withFrameNanos { }
-                    withFrameNanos { }
-                }
-            }
-            // Revocation must abandon the whole restore, including the Play
-            // fallback below: the viewer has taken focus somewhere themselves.
-            if (revoked) return@LaunchedEffect
-            // As above: count a success that landed on the final attempt.
-            if (!restored) restored = similarRestoreFocused.value
-        }
-
-        if (!stillOwned()) return@LaunchedEffect
-        if (restored) {
+        val result = restoreMoreLikeThisFocus(
+            awaitTarget = {
+                snapshotFlow { pendingSimilarIndexNow.value }.first { it >= 0 }
+            },
+            stillOwned = ::stillOwned,
+            // Once the target exists, ask the row to scroll it into its composed
+            // window before focus requests begin.
+            onTargetResolved = { similarRestoreRequest += 1 },
+            isTargetFocused = { similarRestoreFocused.value },
+            // The return value is not evidence: the row's enter redirect can
+            // roll an accepted request back. Only its focus callback counts.
+            requestTargetFocus = { runCatching { similarReturnFocus.requestFocus() } },
+            awaitFocusAttempt = {
+                withFrameNanos { }
+                withFrameNanos { }
+            },
+            // Never turned up, or focus kept rolling back — leave the viewer
+            // somewhere usable. The policy holds ownership across this
+            // suspension and re-checks it before requesting Play focus.
+            scrollToFallback = { listState.scrollToItem(0) },
+            requestFallbackFocus = { runCatching { playFocus.requestFocus() } },
+            dataTimeoutMillis = RESTORE_DATA_TIMEOUT_MS,
+            attachmentTimeoutMillis = RESTORE_ATTACH_TIMEOUT_MS,
+        )
+        if (result != TvSimilarFocusRestoreResult.Revoked && stillOwned()) {
             pendingSimilarContentId = null
-            return@LaunchedEffect
         }
-        // Never turned up, or focus kept rolling back — leave the user somewhere
-        // usable rather than with nothing focused. Hold the token ACROSS the
-        // scroll: it suspends, and releasing ownership first meant this could
-        // move focus on behalf of a request that had already been superseded.
-        listState.scrollToItem(0)
-        if (!stillOwned()) return@LaunchedEffect
-        // scrollToItem suspends, and the target can gain focus while it does.
-        // Checking only ownership here would let Play steal a restore that had
-        // just succeeded.
-        if (similarRestoreFocused.value) {
-            pendingSimilarContentId = null
-            return@LaunchedEffect
-        }
-        runCatching { playFocus.requestFocus() }
-        pendingSimilarContentId = null
     }
 
     val isEpisodicType = detail.type in setOf("series", "season", "episode")

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -251,6 +251,10 @@ private fun TvDetailContent(
     var pendingSimilarContentId by rememberSaveable(detail.contentId) {
         mutableStateOf<String?>(null)
     }
+    // Paired with the id because the id alone is an ABA token: a newer request
+    // for the SAME content passes every ownership check the old coroutine
+    // makes, letting it clear or override the new one.
+    var pendingSimilarGeneration by rememberSaveable(detail.contentId) { mutableStateOf(0) }
     val similarReturnFocus = remember { FocusRequester() }
     val similarRestoreFocused = remember { mutableStateOf(false) }
     // Bumped once the target resolves, so the row scrolls its own LazyRow to
@@ -334,6 +338,10 @@ private fun TvDetailContent(
         // coroutine — without the token it could keep requesting focus for the
         // rest of its window on behalf of a return nobody is waiting for.
         val ownedContentId = pendingSimilarContentId ?: return@LaunchedEffect
+        val ownedGeneration = pendingSimilarGeneration
+        fun stillOwned() =
+            pendingSimilarContentId == ownedContentId &&
+                pendingSimilarGeneration == ownedGeneration
 
         // Two different waits, on two different clocks.
         //
@@ -347,7 +355,7 @@ private fun TvDetailContent(
         }
 
         var restored = false
-        if (resolved != null && pendingSimilarContentId == ownedContentId) {
+        if (resolved != null && stillOwned()) {
             // Now the target exists, so scroll the row to it — a card outside
             // the composed window leaves the requester unattached.
             similarRestoreRequest += 1
@@ -361,10 +369,11 @@ private fun TvDetailContent(
                     restored = true
                     break
                 }
-                // Re-checked every attempt, not just at the end: the user can
-                // move during this window, and revoking mid-loop is the
-                // difference between giving up and fighting them for focus.
-                if (pendingSimilarContentId != ownedContentId) return@LaunchedEffect
+                // Re-checked every attempt, not just at the end: ownership can
+                // be revoked mid-loop — by a newer request, or by the viewer
+                // pressing a direction key — and continuing to request focus
+                // after that is fighting them for it.
+                if (!stillOwned()) return@LaunchedEffect
                 runCatching { similarReturnFocus.requestFocus() }
                 withFrameNanos { }
                 withFrameNanos { }
@@ -373,7 +382,7 @@ private fun TvDetailContent(
             if (!restored) restored = similarRestoreFocused.value
         }
 
-        if (pendingSimilarContentId != ownedContentId) return@LaunchedEffect
+        if (!stillOwned()) return@LaunchedEffect
         if (restored) {
             pendingSimilarContentId = null
             return@LaunchedEffect
@@ -383,7 +392,14 @@ private fun TvDetailContent(
         // scroll: it suspends, and releasing ownership first meant this could
         // move focus on behalf of a request that had already been superseded.
         listState.scrollToItem(0)
-        if (pendingSimilarContentId != ownedContentId) return@LaunchedEffect
+        if (!stillOwned()) return@LaunchedEffect
+        // scrollToItem suspends, and the target can gain focus while it does.
+        // Checking only ownership here would let Play steal a restore that had
+        // just succeeded.
+        if (similarRestoreFocused.value) {
+            pendingSimilarContentId = null
+            return@LaunchedEffect
+        }
         runCatching { playFocus.requestFocus() }
         pendingSimilarContentId = null
     }
@@ -522,6 +538,21 @@ private fun TvDetailContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            // A pending restore is a convenience, and the moment the viewer
+            // steers for themselves it stops being one. This is the only signal
+            // that a move was genuinely user-initiated — a focus-gain callback
+            // is not, because the rail's own enter redirect produces one.
+            // Returns false throughout: this observes, it never consumes.
+            .onPreviewKeyEvent { event ->
+                if (
+                    pendingSimilarContentId != null &&
+                    event.type == KeyEventType.KeyDown &&
+                    event.key in tvDirectionalKeys
+                ) {
+                    pendingSimilarContentId = null
+                }
+                false
+            }
             .background(MaterialTheme.colorScheme.background),
     ) {
         CompositionLocalProvider(LocalBringIntoViewSpec provides detailBringIntoViewSpec) {
@@ -786,6 +817,7 @@ private fun TvDetailContent(
                                     items = state.moreLikeThis,
                                     onItemClick = { clickedContentId ->
                                         pendingCastFocusIndex = -1
+                                        pendingSimilarGeneration += 1
                                         pendingSimilarContentId = clickedContentId
                                         similarRestoreFocused.value = false
                                         onItemDetail(clickedContentId)
@@ -805,12 +837,11 @@ private fun TvDetailContent(
                                             // when some other card gains focus
                                             // was self-defeating: the row's own
                                             // enter redirect lands on card 0
-                                            // first, so our restore cancelled
+                                            // first, so the restore cancelled
                                             // itself on the way to card N.
                                             // onFocusChanged carries no evidence
-                                            // that a move was user-initiated;
-                                            // the short data window below is
-                                            // what bounds surprising the user.
+                                            // that a move was user-initiated —
+                                            // the key handler on the root does.
                                             if (focusedIndex == pendingSimilarIndex) {
                                                 similarRestoreFocused.value = true
                                             }
@@ -1948,3 +1979,11 @@ private suspend fun LazyListState.animateScrollToItemPaced(index: Int) {
  * further ~80 frames, so the whole restore can outlast this value.
  */
 private const val RESTORE_DATA_TIMEOUT_MS = 1_500L
+
+/** Direction keys that count as the viewer steering for themselves. */
+private val tvDirectionalKeys = setOf(
+    Key.DirectionUp,
+    Key.DirectionDown,
+    Key.DirectionLeft,
+    Key.DirectionRight,
+)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -59,6 +59,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -234,6 +238,31 @@ private fun TvDetailContent(
     // restore loop exits on it instead of re-requesting for a fixed window,
     // which held focus hostage on that card for ~a second after returning.
     val castRestoreFocused = remember { mutableStateOf(false) }
+    // Same treatment for More Like This. Returning from a related item only
+    // became reachable once item-detail navigation stopped reusing this entry;
+    // before that you never came back to this page, so the generic
+    // snap-to-hero below was the only outcome that existed.
+    //
+    // Stores the CONTENT ID, not the list index. After process death the saved
+    // index could outlive the list it indexed: the rail reloads over the
+    // network, so the index can arrive before the list does, and the reloaded
+    // list can come back in a different order — restoring focus to whichever
+    // title now happens to sit at that position.
+    var pendingSimilarContentId by rememberSaveable(detail.contentId) {
+        mutableStateOf<String?>(null)
+    }
+    val similarReturnFocus = remember { FocusRequester() }
+    val similarRestoreFocused = remember { mutableStateOf(false) }
+    // Bumped once the target resolves, so the row scrolls its own LazyRow to
+    // that card: a card outside the composed window leaves the requester
+    // unattached and every retry doomed.
+    var similarRestoreRequest by remember { mutableStateOf(0) }
+    // Resolved against the CURRENT list, so it simply stays -1 until the rail
+    // has loaded and becomes correct if the order changed.
+    val pendingSimilarIndex = pendingSimilarContentId?.let { pendingId ->
+        state.moreLikeThis.indexOfFirst { it.contentId == pendingId }
+    } ?: -1
+    val pendingSimilarIndexNow = rememberUpdatedState(pendingSimilarIndex)
     val firstSimilarFocus = remember { FocusRequester() }
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
@@ -257,21 +286,106 @@ private fun TvDetailContent(
             // value alone: keep the pending window open (the rail's enter
             // targets the launch card while it is) across the pop transition,
             // re-requesting every couple of frames.
+            // Success comes ONLY from the rail's focus callback. Accumulating
+            // requestFocus()'s return value defeated the very rollback this
+            // loop exists to survive: one transient true skipped the Play
+            // fallback even though focus had bounced back off the redirect.
             var restored = false
             for (attempt in 0 until 40) {
                 if (castRestoreFocused.value) {
                     restored = true
                     break
                 }
-                restored = runCatching { castReturnFocus.requestFocus() }.getOrDefault(false) || restored
+                runCatching { castReturnFocus.requestFocus() }
                 withFrameNanos { }
                 withFrameNanos { }
             }
+            // The last attempt's request can land after the loop's final check,
+            // so re-read before giving up — otherwise Play immediately steals
+            // focus from a restore that actually succeeded.
+            if (!restored) restored = castRestoreFocused.value
             pendingCastFocusIndex = -1
-            if (restored) return@LaunchedEffect
+            if (restored) {
+                // Don't leave the other rail's requester armed.
+                pendingSimilarContentId = null
+                return@LaunchedEffect
+            }
         }
+        // A pending More Like This restore is owned by the effect below, which
+        // can outlive this one while it waits for the rail to load. It performs
+        // the hero fallback itself if the target never turns up.
+        if (pendingSimilarContentId != null) return@LaunchedEffect
         listState.scrollToItem(0)
         runCatching { playFocus.requestFocus() }
+    }
+
+    // Returning from a related item: land back on the card that opened it
+    // rather than snapping to the hero.
+    //
+    // Keyed on the CONTENT ID alone, deliberately. Keying it on the pending id
+    // as well fired this on the way OUT — the moment the click recorded it —
+    // so it spun its whole window against a page being navigated away from,
+    // cleared the pending id, and left nothing to restore on the way back.
+    // Content id only means it runs once per entry to this page, which is
+    // exactly when a restore is due.
+    LaunchedEffect(detail.contentId) {
+        // The exact request this coroutine owns. Every step below re-checks it,
+        // because clearing or replacing the pending id does NOT cancel this
+        // coroutine — without the token it could keep requesting focus for the
+        // rest of its window on behalf of a return nobody is waiting for.
+        val ownedContentId = pendingSimilarContentId ?: return@LaunchedEffect
+
+        // Two different waits, on two different clocks.
+        //
+        // First the DATA. After process death the rail reloads over the network
+        // — debounced, then several requests — so the target may not exist yet.
+        // Counting frames for that was measuring the wrong thing entirely: a
+        // ~120-frame budget is one or two seconds depending on refresh rate,
+        // and a load finishing just past it silently became a hero fallback.
+        val resolved = withTimeoutOrNull(RESTORE_DATA_TIMEOUT_MS) {
+            snapshotFlow { pendingSimilarIndexNow.value }.first { it >= 0 }
+        }
+
+        var restored = false
+        if (resolved != null && pendingSimilarContentId == ownedContentId) {
+            // Now the target exists, so scroll the row to it — a card outside
+            // the composed window leaves the requester unattached.
+            similarRestoreRequest += 1
+            // Only NOW are frames the right clock: this waits for composition
+            // and focus attachment. As in the cast branch the return value is
+            // not evidence, since requestFocus() can report success and then
+            // roll back across the row's enter redirect.
+            // ~80 frames (40 attempts, two waits each).
+            for (attempt in 0 until 40) {
+                if (similarRestoreFocused.value) {
+                    restored = true
+                    break
+                }
+                // Re-checked every attempt, not just at the end: the user can
+                // move during this window, and revoking mid-loop is the
+                // difference between giving up and fighting them for focus.
+                if (pendingSimilarContentId != ownedContentId) return@LaunchedEffect
+                runCatching { similarReturnFocus.requestFocus() }
+                withFrameNanos { }
+                withFrameNanos { }
+            }
+            // As above: count a success that landed on the final attempt.
+            if (!restored) restored = similarRestoreFocused.value
+        }
+
+        if (pendingSimilarContentId != ownedContentId) return@LaunchedEffect
+        if (restored) {
+            pendingSimilarContentId = null
+            return@LaunchedEffect
+        }
+        // Never turned up, or focus kept rolling back — leave the user somewhere
+        // usable rather than with nothing focused. Hold the token ACROSS the
+        // scroll: it suspends, and releasing ownership first meant this could
+        // move focus on behalf of a request that had already been superseded.
+        listState.scrollToItem(0)
+        if (pendingSimilarContentId != ownedContentId) return@LaunchedEffect
+        runCatching { playFocus.requestFocus() }
+        pendingSimilarContentId = null
     }
 
     val isEpisodicType = detail.type in setOf("series", "season", "episode")
@@ -641,6 +755,7 @@ private fun TvDetailContent(
                                     // actually fires — openPerson can no-op when
                                     // the person can't be resolved.
                                     viewModel.openPerson(member) { personId ->
+                                        pendingSimilarContentId = null
                                         pendingCastFocusIndex = index
                                         castRestoreFocused.value = false
                                         onOpenPerson(personId)
@@ -669,7 +784,40 @@ private fun TvDetailContent(
                                     title = "More Like This",
                                     showHeader = false,
                                     items = state.moreLikeThis,
-                                    onItemClick = onItemDetail,
+                                    onItemClick = { clickedContentId ->
+                                        pendingCastFocusIndex = -1
+                                        pendingSimilarContentId = clickedContentId
+                                        similarRestoreFocused.value = false
+                                        onItemDetail(clickedContentId)
+                                    },
+                                    restoreFocusIndex = pendingSimilarIndex,
+                                    // Only while a return is pending, so ordinary
+                                    // re-entry stops being forced at the return
+                                    // target and goes back to the row restorer's
+                                    // own remembered card.
+                                    restoreFocusRequester = similarReturnFocus
+                                        .takeIf { pendingSimilarIndex >= 0 },
+                                    restoreFocusRequest = similarRestoreRequest
+                                        .takeIf { pendingSimilarIndex >= 0 } ?: 0,
+                                    onItemFocusedAtIndex = if (pendingSimilarIndex >= 0) {
+                                        { _, focusedIndex ->
+                                            // ONLY the target counts. Revoking
+                                            // when some other card gains focus
+                                            // was self-defeating: the row's own
+                                            // enter redirect lands on card 0
+                                            // first, so our restore cancelled
+                                            // itself on the way to card N.
+                                            // onFocusChanged carries no evidence
+                                            // that a move was user-initiated;
+                                            // the short data window below is
+                                            // what bounds surprising the user.
+                                            if (focusedIndex == pendingSimilarIndex) {
+                                                similarRestoreFocused.value = true
+                                            }
+                                        }
+                                    } else {
+                                        null
+                                    },
                                     style = TvRowStyle.Poster,
                                     horizontalPadding = Spacing.safeArea,
                                     rowTopPadding = 0.dp,
@@ -1787,3 +1935,16 @@ private suspend fun LazyListState.animateScrollToItemPaced(index: Int) {
         animateScrollToItem(index)
     }
 }
+
+/**
+ * Wall-clock budget for the More Like This rail to load a restore target.
+ *
+ * Deliberately short. Landing back on the card you came from is a nicety, and
+ * one that stops being welcome the moment the user has started doing something
+ * else — a restore that fires seconds later reads as the app yanking focus, not
+ * as helpfulness. Past this the ordinary hero fallback runs instead.
+ *
+ * Bounds the DATA wait only. Once the target resolves, focus attachment gets a
+ * further ~80 frames, so the whole restore can outlast this value.
+ */
+private const val RESTORE_DATA_TIMEOUT_MS = 1_500L

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -363,21 +363,36 @@ private fun TvDetailContent(
             // and focus attachment. As in the cast branch the return value is
             // not evidence, since requestFocus() can report success and then
             // roll back across the row's enter redirect.
-            // ~80 frames (40 attempts, two waits each).
-            for (attempt in 0 until 40) {
-                if (similarRestoreFocused.value) {
-                    restored = true
-                    break
+            // ~80 frames (40 attempts, two waits each) AND a wall-clock cap.
+            // Frames are the right clock for composition and attachment, but
+            // they are not a duration: if frame production pauses or starves,
+            // eighty of them is unbounded real time and the viewer would be
+            // fighting a restore that never gives up. The frame count decides
+            // how many attempts are reasonable; the deadline decides how long
+            // the viewer can be made to wait for them.
+            var revoked = false
+            withTimeoutOrNull(RESTORE_ATTACH_TIMEOUT_MS) {
+                for (attempt in 0 until 40) {
+                    if (similarRestoreFocused.value) {
+                        restored = true
+                        break
+                    }
+                    // Re-checked every attempt, not just at the end: ownership
+                    // can be revoked mid-loop — by a newer request, or by the
+                    // viewer pressing a direction key — and continuing to
+                    // request focus after that is fighting them for it.
+                    if (!stillOwned()) {
+                        revoked = true
+                        break
+                    }
+                    runCatching { similarReturnFocus.requestFocus() }
+                    withFrameNanos { }
+                    withFrameNanos { }
                 }
-                // Re-checked every attempt, not just at the end: ownership can
-                // be revoked mid-loop — by a newer request, or by the viewer
-                // pressing a direction key — and continuing to request focus
-                // after that is fighting them for it.
-                if (!stillOwned()) return@LaunchedEffect
-                runCatching { similarReturnFocus.requestFocus() }
-                withFrameNanos { }
-                withFrameNanos { }
             }
+            // Revocation must abandon the whole restore, including the Play
+            // fallback below: the viewer has taken focus somewhere themselves.
+            if (revoked) return@LaunchedEffect
             // As above: count a success that landed on the final attempt.
             if (!restored) restored = similarRestoreFocused.value
         }
@@ -1979,6 +1994,16 @@ private suspend fun LazyListState.animateScrollToItemPaced(index: Int) {
  * further ~80 frames, so the whole restore can outlast this value.
  */
 private const val RESTORE_DATA_TIMEOUT_MS = 1_500L
+
+/**
+ * Wall-clock ceiling on the focus-attachment retries.
+ *
+ * The retry budget is a frame count because attachment is a composition
+ * concern, but a frame count is not a duration — at 24Hz eighty frames is over
+ * three seconds, and with frame production paused it is unbounded. This caps
+ * how long the viewer can be fighting a restore for.
+ */
+private const val RESTORE_ATTACH_TIMEOUT_MS = 2_000L
 
 /** Direction keys that count as the viewer steering for themselves. */
 private val tvDirectionalKeys = setOf(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSimilarFocusRestoration.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSimilarFocusRestoration.kt
@@ -1,0 +1,74 @@
+package org.siloserver.silo.tv.ui.screens.detail
+
+import kotlinx.coroutines.withTimeoutOrNull
+
+internal enum class TvSimilarFocusRestoreResult {
+    Restored,
+    Fallback,
+    Revoked,
+}
+
+/**
+ * Drives a pending More Like This return without tying its policy to Compose.
+ *
+ * Data and attachment use separate deadlines because they wait for different
+ * things. Once the card exists, [maxFocusAttempts] bounds how often focus can
+ * be requested while [attachmentTimeoutMillis] bounds the real time spent if
+ * frame production stalls. Ownership is checked between attempts and after
+ * every suspension so an obsolete restore neither keeps requesting focus nor
+ * moves focus to the fallback on the viewer's behalf.
+ */
+internal suspend fun restoreMoreLikeThisFocus(
+    awaitTarget: suspend () -> Unit,
+    stillOwned: () -> Boolean,
+    onTargetResolved: () -> Unit,
+    isTargetFocused: () -> Boolean,
+    requestTargetFocus: () -> Unit,
+    awaitFocusAttempt: suspend () -> Unit,
+    scrollToFallback: suspend () -> Unit,
+    requestFallbackFocus: () -> Unit,
+    dataTimeoutMillis: Long,
+    attachmentTimeoutMillis: Long,
+    maxFocusAttempts: Int = 40,
+): TvSimilarFocusRestoreResult {
+    val resolved = withTimeoutOrNull(dataTimeoutMillis) {
+        awaitTarget()
+        true
+    } ?: false
+
+    var restored = false
+    if (resolved && stillOwned()) {
+        onTargetResolved()
+        var revoked = false
+        withTimeoutOrNull(attachmentTimeoutMillis) {
+            repeat(maxFocusAttempts) {
+                if (isTargetFocused()) {
+                    restored = true
+                    return@withTimeoutOrNull
+                }
+                if (!stillOwned()) {
+                    revoked = true
+                    return@withTimeoutOrNull
+                }
+                requestTargetFocus()
+                awaitFocusAttempt()
+            }
+        }
+        if (revoked || !stillOwned()) return TvSimilarFocusRestoreResult.Revoked
+        // A request made by the final attempt can be observed just after that
+        // attempt completes, so check the callback-owned state once more.
+        if (!restored) restored = isTargetFocused()
+    }
+
+    if (!stillOwned()) return TvSimilarFocusRestoreResult.Revoked
+    if (restored) return TvSimilarFocusRestoreResult.Restored
+
+    scrollToFallback()
+    if (!stillOwned()) return TvSimilarFocusRestoreResult.Revoked
+    // Scrolling suspends and can compose the target card; do not let fallback
+    // focus steal a restore that completed while the scroll was in flight.
+    if (isTargetFocused()) return TvSimilarFocusRestoreResult.Restored
+
+    requestFallbackFocus()
+    return TvSimilarFocusRestoreResult.Fallback
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeScreen.kt
@@ -179,6 +179,7 @@ private fun TvHomeContent(
     sectionsFullyResolved: Boolean = true,
 ) {
     TvSkylineSectionFeed(
+        surfaceKey = "home",
         sections = sections,
         sectionsComplete = sectionsFullyResolved,
         onItemClick = onItemClick,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
@@ -124,6 +124,7 @@ fun TvLibraryDetailScreen(
     ) {
         when (state.selectedTab) {
             TvLibraryTab.Recommended -> RecommendedTab(
+                surfaceKey = "library-$libraryId",
                 state = state,
                 onItemClick = onItemClick,
                 onRetry = viewModel::retryRecommended,
@@ -239,6 +240,8 @@ fun TvLibraryDetailScreen(
 
 @Composable
 private fun RecommendedTab(
+    /** Distinguishes this feed's saveable slots from other surfaces'. */
+    surfaceKey: String,
     state: TvLibraryDetailViewModel.UiState,
     onItemClick: (String) -> Unit,
     onRetry: () -> Unit,
@@ -275,6 +278,7 @@ private fun RecommendedTab(
         }
         else -> {
             TvSkylineSectionFeed(
+                surfaceKey = surfaceKey,
                 sections = rows,
                 onItemClick = onItemClick,
                 focusRequest = focusRequest,

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnTargetTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/focus/TvReturnTargetTest.kt
@@ -671,4 +671,56 @@ class TvReturnTargetTest {
         val saved = with(saver) { scope.save(null) }
         assertEquals(null, saved?.let { saver.restore(it) })
     }
+
+    @Test
+    fun `a right-owner target with malformed fields restores as empty`() {
+        assertEquals(
+            null,
+            keyedTvReturnTargetSaver("browse")
+                .restore(listOf("browse", TvFlatSectionId, "q", "zero", 3)),
+        )
+        assertEquals(
+            null,
+            keyedTvReturnTargetSaver("browse")
+                .restore(listOf("browse", TvFlatSectionId, "q", 0, 3, "extra")),
+        )
+    }
+
+    @Test
+    fun `a saved boolean is discarded for a different owner or slot`() {
+        val saver = keyedBooleanSaver("home", slot = "pending")
+        val saved = with(saver) { SaverScope { true }.save(true) }
+
+        assertEquals(false, keyedBooleanSaver("library", slot = "pending").restore(saved!!))
+        assertEquals(false, keyedBooleanSaver("home", slot = "generation").restore(saved))
+        assertEquals(true, keyedBooleanSaver("home", slot = "pending").restore(saved))
+    }
+
+    @Test
+    fun `a right-owner boolean payload with the wrong type restores its default`() {
+        assertEquals(
+            false,
+            keyedBooleanSaver("home", slot = "pending")
+                .restore(listOf("home", "pending", 1)),
+        )
+    }
+
+    @Test
+    fun `a saved int is discarded for a different owner or slot`() {
+        val saver = keyedIntSaver("home", slot = "generation")
+        val saved = with(saver) { SaverScope { true }.save(7) }
+
+        assertEquals(0, keyedIntSaver("library", slot = "generation").restore(saved!!))
+        assertEquals(0, keyedIntSaver("home", slot = "pending").restore(saved))
+        assertEquals(7, keyedIntSaver("home", slot = "generation").restore(saved))
+    }
+
+    @Test
+    fun `a right-owner int payload with the wrong type restores its default`() {
+        assertEquals(
+            0,
+            keyedIntSaver("home", slot = "generation")
+                .restore(listOf("home", "generation", true)),
+        )
+    }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSimilarFocusRestorationTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSimilarFocusRestorationTest.kt
@@ -1,0 +1,59 @@
+package org.siloserver.silo.tv.ui.screens.detail
+
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvSimilarFocusRestorationTest {
+    @Test
+    fun attachmentTimeoutFallsBackToTheHero() = runTest {
+        var fallbackScrolled = false
+        var fallbackRequests = 0
+
+        val result = restoreMoreLikeThisFocus(
+            awaitTarget = { },
+            stillOwned = { true },
+            onTargetResolved = { },
+            isTargetFocused = { false },
+            requestTargetFocus = { },
+            awaitFocusAttempt = { awaitCancellation() },
+            scrollToFallback = { fallbackScrolled = true },
+            requestFallbackFocus = { fallbackRequests += 1 },
+            dataTimeoutMillis = 100,
+            attachmentTimeoutMillis = 100,
+        )
+
+        assertEquals(TvSimilarFocusRestoreResult.Fallback, result)
+        assertTrue(fallbackScrolled)
+        assertEquals(1, fallbackRequests)
+    }
+
+    @Test
+    fun ownershipRevokedMidLoopStopsRequestsWithoutFallback() = runTest {
+        var owned = true
+        var targetRequests = 0
+        var fallbackScrolled = false
+        var fallbackRequested = false
+
+        val result = restoreMoreLikeThisFocus(
+            awaitTarget = { },
+            stillOwned = { owned },
+            onTargetResolved = { },
+            isTargetFocused = { false },
+            requestTargetFocus = { targetRequests += 1 },
+            awaitFocusAttempt = { owned = false },
+            scrollToFallback = { fallbackScrolled = true },
+            requestFallbackFocus = { fallbackRequested = true },
+            dataTimeoutMillis = 100,
+            attachmentTimeoutMillis = 100,
+        )
+
+        assertEquals(TvSimilarFocusRestoreResult.Revoked, result)
+        assertEquals(1, targetRequests)
+        assertFalse(fallbackScrolled)
+        assertFalse(fallbackRequested)
+    }
+}


### PR DESCRIPTION
Opening something from **More Like This** and pressing Back dropped focus on the hero, so the viewer lost their place in the rail and had to travel back down to it. Three fixes, each one found because the previous attempt was wrong in an instructive way.

## Restore by identity, not by index

The first version remembered the row index. Recommendations can reorder or regenerate between visits, so a saved index could name a different title on return. It now remembers the **content id** and resolves the index when the data lands, with a generation token so an older restore cannot claim a newer one's target.

## Two waits on two different clocks

Restoration needs the rail's data *and* a composed focus target, and those are not the same wait. A frame-count loop is a poor network clock — the rail deliberately delays before fetching. It now waits for the data on a snapshot flow with a wall-clock timeout, then uses a short frame-based window purely for focus attachment.

## The viewer's own input wins

The restore could pull focus back after the viewer had deliberately moved away. Directional key-down on the root now cancels a pending restore.

The obvious version of this was self-defeating: revoking on any non-target focus gain cancelled the restore *on its own way to the target*, because a row's enter handling transiently focuses card 0 first. Revocation is keyed to actual directional input instead.

## Success is the row's callback, not `requestFocus()`'s return

An early version accumulated `requestFocus()`'s return value and treated any transient `true` as done — so focus could roll back and the fallback would be skipped, which is precisely the failure the code was meant to prevent. Success is now determined solely by the row's focus callback.

## Return-trip state is not shared

The return target was stored in a saveable slot shared across surfaces, so one feed's return trip could consume another's. Each surface now keys its own state.

## Testing

`:androidTvApp` and `:androidApp` suites green. Reviewed with Codex over several passes — the self-defeating revocation, the index-vs-identity problem, and the `requestFocus()` overclaim were each caught that way rather than by me.

Not device-verified: this is D-pad focus behaviour, so it wants a look on real hardware before it is trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115uaQ6FTQZK8KYvazjefaW