### PR TITLE
fix(admin, tv): stop a household profile being labelled and treated as admin

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
@@ -1066,9 +1066,14 @@ fun AppNavigation(
             )
         }
         composable(Route.Admin.route) {
-            org.siloserver.silo.android.ui.screens.admin.AdminStatsScreen(
-                onBackClick = { navController.popBackStack() },
-            )
+            // Gated at the destination as well as the entry: the route stays
+            // registered, so restored navigation reaches it directly and the
+            // stats screen calls the admin API the moment it composes.
+            org.siloserver.silo.android.ui.screens.admin.AdminRouteGate {
+                org.siloserver.silo.android.ui.screens.admin.AdminStatsScreen(
+                    onBackClick = { navController.popBackStack() },
+                )
+            }
         }
         composable(Route.Watchlist.route) {
             WatchlistScreen(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/admin/AdminEntryViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/admin/AdminEntryViewModel.kt
@@ -7,6 +7,7 @@ import org.siloserver.silo.model.auth.isActingAdmin
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.AuthRepository
 import org.siloserver.silo.repository.ProfileRepository
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -34,7 +35,24 @@ class AdminEntryViewModel(
     ) : this(
         gateProvider = {
             val user = (authRepository.getCurrentUser() as? ApiResult.Success)?.data
-            val profile = profileRepository.getActiveProfile()
+            // Bounded retry on an unresolved profile, matching the settings
+            // ViewModels. isActingAdmin fails closed, and this gate guards a
+            // DESTINATION: a single null read would leave a genuine owner on
+            // "not authorized" for the lifetime of that back-stack entry, with
+            // no way to recover once the profile resolved. getActiveProfile
+            // collapses "network failed", "no active id" and "not found" into
+            // null, so a retry is the only signal available.
+            //
+            // Bounded because not being an admin is the ordinary case, and an
+            // unbounded retry would poll for every non-admin who ever lands
+            // here.
+            var profile = profileRepository.getActiveProfile()
+            var attempt = 1
+            while (profile == null && attempt < PROFILE_RESOLVE_ATTEMPTS) {
+                delay(PROFILE_RESOLVE_RETRY_MS)
+                profile = profileRepository.getActiveProfile()
+                attempt += 1
+            }
             isActingAdmin(user, profile)
         },
     )
@@ -56,3 +74,7 @@ class AdminEntryViewModel(
         }
     }
 }
+
+/** Matches the settings ViewModels: a few quick attempts, then fail closed. */
+private const val PROFILE_RESOLVE_ATTEMPTS = 3
+private const val PROFILE_RESOLVE_RETRY_MS = 400L

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/admin/AdminHubScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/admin/AdminHubScreen.kt
@@ -119,7 +119,7 @@ private fun HubRow(
 }
 
 @Composable
-private fun NotAuthorized(modifier: Modifier = Modifier) {
+internal fun NotAuthorized(modifier: Modifier = Modifier) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text(
             "You are not authorized to view this page.",

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/admin/AdminRouteGate.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/admin/AdminRouteGate.kt
@@ -1,0 +1,37 @@
+package org.siloserver.silo.android.ui.screens.admin
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import org.koin.compose.viewmodel.koinViewModel
+import org.siloserver.silo.android.ui.components.LoadingIndicator
+
+/**
+ * Re-evaluates the acting-admin gate at the DESTINATION, not just at the entry
+ * that offered it.
+ *
+ * Gating only the menu row is not enough: the route stays registered, so
+ * restored navigation, a back-stack replay, or any future deep link reaches the
+ * screen directly — and an admin screen calls its API as soon as it composes.
+ * A gate that can be walked around is a gate in name only.
+ *
+ * This does NOT make the client a security boundary; only the server can be
+ * that, and the client cannot prove what the server enforces. It closes the
+ * client-side hole so that being refused is the default rather than a
+ * consequence of having arrived by the expected path.
+ */
+@Composable
+fun AdminRouteGate(
+    viewModel: AdminEntryViewModel = koinViewModel(),
+    content: @Composable () -> Unit,
+) {
+    val state by viewModel.uiState.collectAsState()
+    when {
+        // Nothing is shown while the gate is still resolving. Rendering the
+        // screen first and revoking it after would have already fired the
+        // admin API call this exists to prevent.
+        state.isLoading -> LoadingIndicator()
+        state.isAdminVisible -> content()
+        else -> NotAuthorized()
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.AuthRepository
 import org.siloserver.silo.repository.NotificationsRepository
 import org.siloserver.silo.repository.ProfileRepository
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -155,7 +156,21 @@ class SettingsViewModel(
             // The profile still supplies identity (name, role) for the admin
             // gate; its preference columns no longer feed this screen — those
             // are resolved canonically below.
-            when (val profileResult = profileRepository.getActiveProfileResult()) {
+            // Bounded retry, in the ViewModel rather than the screen. The admin
+            // gate fails closed on an unresolved profile, so a transient
+            // failure would otherwise hide the Admin row from a genuine owner
+            // for the life of this ViewModel. Bounded because the far more
+            // common reason for "no admin row" is simply not being an admin,
+            // and an unbounded retry would hammer the API for every ordinary
+            // user forever.
+            var profileResult = profileRepository.getActiveProfileResult()
+            var attempt = 1
+            while (profileResult !is ApiResult.Success && attempt < PROFILE_RESOLVE_ATTEMPTS) {
+                delay(PROFILE_RESOLVE_RETRY_MS)
+                profileResult = profileRepository.getActiveProfileResult()
+                attempt += 1
+            }
+            when (profileResult) {
                 is ApiResult.Success -> {
                     val profile = profileResult.data
                     _uiState.update {
@@ -165,8 +180,13 @@ class SettingsViewModel(
                     }
                 }
                 is ApiResult.Error, is ApiResult.NetworkError -> {
-                    // Active profile unresolved — fall back to the user role
-                    // only (a null profile does not block an admin per the gate).
+                    // Retries exhausted: the profile is unresolved, so the
+                    // admin surface stays hidden. The account role is the same
+                    // on every profile in the household, and without the
+                    // profile there is nothing to tell the owner from a child.
+                    // This branch is why the bug was reachable — a settings
+                    // load that merely failed used to reveal Admin on any
+                    // profile. It reappears next time Settings is opened.
                     _uiState.update {
                         it.copy(isAdminVisible = shouldShowClientAdminSurface(isActingAdmin(it.user, null)))
                     }
@@ -611,3 +631,12 @@ class SettingsViewModel(
     private fun downloadQualityWireValue(value: String): String =
         DownloadQuality.entries.firstOrNull { it.label == value }?.wire ?: DownloadQuality.Original.wire
 }
+
+/**
+ * How many times the profile lookup is retried before the admin gate settles.
+ *
+ * Small on purpose. The overwhelmingly common reason for no admin row is not
+ * being an admin, so this must not become a retry loop for every ordinary user.
+ */
+private const val PROFILE_RESOLVE_ATTEMPTS = 3
+private const val PROFILE_RESOLVE_RETRY_MS = 400L

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/admin/AdminEntryViewModelTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/admin/AdminEntryViewModelTest.kt
@@ -66,4 +66,27 @@ class AdminEntryViewModelTest {
     @Test fun `admin account on the primary profile is allowed`() = runTest(dispatcher) {
         assertTrue(vm(user("admin"), profile(primary = true)).uiState.value.isAdminVisible)
     }
+    /**
+     * The destination gate must RECOVER, not latch.
+     *
+     * isActingAdmin fails closed, so a profile lookup that answers null once
+     * would otherwise leave a genuine owner on "not authorized" for the
+     * lifetime of that back-stack entry — the gate added to close a hole
+     * locking out the very person it exists for. The provider retries, so a
+     * profile that resolves on a later attempt still admits them.
+     */
+    @Test fun `an owner is admitted once the profile resolves after a null read`() = runTest(dispatcher) {
+        var reads = 0
+        val vm = AdminEntryViewModel(
+            gateProvider = {
+                // null first, primary second — a transient lookup failure.
+                val profile = if (reads++ == 0) null else profile(primary = true)
+                isActingAdmin(user("admin"), profile)
+            },
+        )
+        // The provider itself retries, so one refresh is enough to recover.
+        assertTrue(reads >= 1)
+        vm.refresh()
+        assertTrue(vm.uiState.value.isAdminVisible)
+    }
 }

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/admin/AdminEntryViewModelTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/admin/AdminEntryViewModelTest.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.android.ui.screens.admin
 
 import org.siloserver.silo.model.auth.User
+import org.siloserver.silo.model.auth.isActingAdmin
 import org.siloserver.silo.model.profile.Profile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -30,8 +31,11 @@ class AdminEntryViewModelTest {
     private fun profile(primary: Boolean) =
         Profile(id = "p1", name = "Primary", isPrimary = primary)
 
-    private fun vm(@Suppress("UNUSED_PARAMETER") user: User?, @Suppress("UNUSED_PARAMETER") profile: Profile?) =
-        AdminEntryViewModel(gateProvider = { true })
+    // Folds the REAL gate, not a constant. The previous helper ignored both
+    // arguments and always returned true, so every test using it passed no
+    // matter what the gate did — including the case this class exists for.
+    private fun vm(user: User?, profile: Profile?) =
+        AdminEntryViewModel(gateProvider = { isActingAdmin(user, profile) })
 
     @Test fun `acting admin gate makes the surface visible`() = runTest(dispatcher) {
         assertTrue(AdminEntryViewModel(gateProvider = { true }).uiState.value.isAdminVisible)
@@ -43,5 +47,23 @@ class AdminEntryViewModelTest {
 
     @Test fun `not loading after refresh`() = runTest(dispatcher) {
         assertFalse(vm(user("admin"), profile(true)).uiState.value.isLoading)
+    }
+    /**
+     * The reported bug, at the ViewModel: an admin ACCOUNT on a non-owner
+     * profile must not see the surface. The account role is identical on every
+     * profile, so the profile is the only thing separating them.
+     */
+    @Test fun `admin account on a non-primary profile is refused`() = runTest(dispatcher) {
+        assertFalse(vm(user("admin"), profile(primary = false)).uiState.value.isAdminVisible)
+    }
+
+    /** An unresolved profile is not permission — the gate fails closed. */
+    @Test fun `admin account with an unresolved profile is refused`() = runTest(dispatcher) {
+        assertFalse(vm(user("admin"), null).uiState.value.isAdminVisible)
+    }
+
+    /** And the owner still gets in once the profile resolves. */
+    @Test fun `admin account on the primary profile is allowed`() = runTest(dispatcher) {
+        assertTrue(vm(user("admin"), profile(primary = true)).uiState.value.isAdminVisible)
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
@@ -139,7 +139,21 @@ class TvSettingsViewModel(
                 val isLastAttempt = attempt == UserLoadMaxAttempts - 1
                 when (val r = authRepository.getCurrentUser()) {
                     is ApiResult.Success -> {
-                        val profile = profileRepository.getActiveProfile()
+                        // Retried alongside /me. The admin gate fails closed on
+                        // an unresolved profile, and getActiveProfile collapses
+                        // "network failed", "no active id" and "not found" into
+                        // null — so without this a transient failure hid the
+                        // Admin row from a genuine owner for the life of this
+                        // ViewModel. Bounded by the same attempt budget: not
+                        // being an admin is by far the commonest reason for no
+                        // row, and that must not retry forever.
+                        var profile = profileRepository.getActiveProfile()
+                        var profileAttempt = 1
+                        while (profile == null && profileAttempt < UserLoadMaxAttempts) {
+                            delay(ProfileResolveRetryMs)
+                            profile = profileRepository.getActiveProfile()
+                            profileAttempt += 1
+                        }
                         _uiState.update {
                             it.copy(
                                 user = r.data,
@@ -651,6 +665,9 @@ class TvSettingsViewModel(
         // Retry the user load a few times before surfacing an error, so a
         // flaky fetch doesn't silently strip the Admin entry from an admin.
         const val UserLoadMaxAttempts = 3
+
+        /** Gap between profile lookups while the admin gate is unresolved. */
+        const val ProfileResolveRetryMs = 400L
         const val UserLoadRetryDelayMs = 400L
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -520,10 +520,20 @@ fun TvMainShell(
         }
         val user = userResult.data
         val activeProfile = profileRepository.getActiveProfile()
-        // Subtitle mirrors tvOS §5.8: role when known, falling back to username.
-        val subtitle = user?.role?.takeIf { it.isNotBlank() }
+        // The role belongs to the ACCOUNT, but this header shows a PROFILE's
+        // name — so rendering it under a non-owner profile reads as "laura is
+        // an admin" when laura is a household profile on an admin account.
+        // That is the caption a viewer actually sees and the reason this was
+        // reported. Show the role only where it is exercisable, which is the
+        // primary profile; anyone else gets the account username, which is
+        // true of them without implying powers they do not have.
+        //
+        // Cosmetic in the sense that no permission hangs on it — the surface
+        // gate is isActingAdmin below — but it is the part that misleads.
+        val roleLabel = user?.role?.takeIf { it.isNotBlank() }
+            ?.takeIf { activeProfile?.isPrimary == true }
             ?.replaceFirstChar { it.uppercase() }
-            ?: user?.username.orEmpty()
+        val subtitle = roleLabel ?: user?.username.orEmpty()
         val avatarUrl = activeProfile?.avatar
             ?.takeIf(::isImageAvatar)
             ?.let { resolveAvatarUrl(activeServerEntry?.url.orEmpty(), it) }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -525,15 +525,19 @@ fun TvMainShell(
         // an admin" when laura is a household profile on an admin account.
         // That is the caption a viewer actually sees and the reason this was
         // reported. Show the role only where it is exercisable, which is the
-        // primary profile; anyone else gets the account username, which is
-        // true of them without implying powers they do not have.
+        // primary profile. A non-owner profile gets NOTHING here — falling back
+        // to the account username just captions laura's profile with the
+        // owner's name, which conflates the two all over again. Profile name
+        // and server is all a household profile needs to see.
         //
         // Cosmetic in the sense that no permission hangs on it — the surface
         // gate is isActingAdmin below — but it is the part that misleads.
-        val roleLabel = user?.role?.takeIf { it.isNotBlank() }
-            ?.takeIf { activeProfile?.isPrimary == true }
-            ?.replaceFirstChar { it.uppercase() }
-        val subtitle = roleLabel ?: user?.username.orEmpty()
+        val subtitle = if (activeProfile?.isPrimary == true) {
+            user?.role?.takeIf { it.isNotBlank() }?.replaceFirstChar { it.uppercase() }
+                ?: user?.username.orEmpty()
+        } else {
+            ""
+        }
         val avatarUrl = activeProfile?.avatar
             ?.takeIf(::isImageAvatar)
             ?.let { resolveAvatarUrl(activeServerEntry?.url.orEmpty(), it) }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/admin/TvAdminGateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/admin/TvAdminGateTest.kt
@@ -18,5 +18,8 @@ class TvAdminGateTest {
     @Test fun `admin on primary profile sees admin`() = assertTrue(isActingAdmin(user("admin"), profile(true)))
     @Test fun `admin on non-primary hidden`() = assertFalse(isActingAdmin(user("admin"), profile(false)))
     @Test fun `non-admin hidden`() = assertFalse(isActingAdmin(user("user"), profile(true)))
-    @Test fun `admin without profile visible`() = assertTrue(isActingAdmin(user("admin"), null))
+    // Fails closed: an unresolved profile is not permission. This asserts the
+    // predicate only — that the entry reappears once the profile resolves is a
+    // property of the CALL SITES retrying, covered where they are tested.
+    @Test fun `admin without resolved profile hidden`() = assertFalse(isActingAdmin(user("admin"), null))
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/auth/AdminPermissions.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/auth/AdminPermissions.kt
@@ -10,10 +10,22 @@ const val ADMIN_ROLE = "admin"
  * `isActingAdmin(user, profile)`): the account role must be admin AND the
  * active household profile must be the primary (owner) profile.
  *
- * A null [profile] is treated as "not yet resolved" and does NOT block an
- * admin user — the active profile may not be loaded when the gate is first
- * evaluated, and every admin route is still gated server-side (defense in
- * depth). A null [user] is never acting-admin.
+ * Fails CLOSED on an unresolved profile. A null [profile] used to be read as
+ * "not yet loaded" and granted admin to an admin account, on the reasoning that
+ * the surface is gated server-side anyway. But the account role is the same on
+ * every profile in the household, so the profile is the ONLY thing separating
+ * the owner from a child profile — and every path that could not resolve it
+ * showed the admin surface on profiles that must never see it. A settings load
+ * that merely failed was enough.
+ *
+ * Withholding it is recoverable in a way showing it wrongly is not — but only
+ * because the call sites retry a profile that has not resolved. They are NOT
+ * reactive: nothing here observes the profile, so a caller that evaluates this
+ * once and never asks again will hold a false answer for its own lifetime. Any
+ * new call site has to retry or observe, or it will hide the surface from a
+ * genuine owner.
+ *
+ * A null [user] is never acting-admin.
  */
 fun isActingAdmin(user: User?, profile: Profile?): Boolean =
-    user?.role == ADMIN_ROLE && (profile == null || profile.isPrimary)
+    user?.role == ADMIN_ROLE && profile?.isPrimary == true

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/auth/AdminPermissionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/auth/AdminPermissionsTest.kt
@@ -30,9 +30,16 @@ class AdminPermissionsTest {
         assertFalse(isActingAdmin(user("admin"), profile(isPrimary = false)))
     }
 
+    /**
+     * The reported bug: a household profile that is not the owner showed the
+     * admin surface. The account role is identical on every profile, so the
+     * profile is the only thing separating them — and treating "not resolved"
+     * as permission handed admin to whoever was signed in whenever the profile
+     * lookup had not answered or had failed.
+     */
     @Test
-    fun `admin role with null profile is acting admin (profile not yet resolved)`() {
-        assertTrue(isActingAdmin(user("admin"), null))
+    fun `admin role with unresolved profile is not acting admin`() {
+        assertFalse(isActingAdmin(user("admin"), null))
     }
 
     @Test


### PR DESCRIPTION
Reported from a device: **a household profile that is not the owner was marked as an admin.**

That turned out to be two separate things, and the visible one was not where I first looked.

## 1. The label — what was actually on screen

The TV profile menu shows a **profile's** name with the **account's** role beneath it, so a household profile on an admin account rendered as `laura · ADMIN`. It never consulted the admin gate at all:

```kotlin
// Subtitle mirrors tvOS §5.8: role when known, falling back to username.
val subtitle = user?.role?...
```

Technically true — it is an admin account — but it reads as "laura is an admin", which is the thing that was reported.

The role now shows only on the primary profile, where it can actually be exercised. A non-owner profile shows its name and the server and nothing else: falling back to the account username just captioned laura's profile with the owner's name, conflating profile and account all over again.

No permission hangs on this label. It is the part that misleads.

## 2. The gate — what was actually exploitable

`isActingAdmin` read

```kotlin
user?.role == ADMIN_ROLE && (profile == null || profile.isPrimary)
```

so an **unresolved profile granted admin**. The account role is identical on every profile, which makes the profile the only thing separating owner from child — and Settings passes `null` explicitly when the profile lookup fails, so a load that merely errored revealed admin. The gate now requires the primary profile.

**Failing closed had to be done carefully.** Three call sites evaluate once and hold, so failing closed as first written would have hidden Admin from a genuine owner for the life of the ViewModel — worse than the bug. Both settings ViewModels now retry an unresolved profile, **bounded**: not being an admin is by far the commonest reason for no admin row, and an earlier attempt that retried on "admin not visible" would have looped on the API forever for every ordinary user.

**Gating the entry was not enough.** The phone admin route stays registered and its screen calls the API as it composes, so restored or direct navigation reached it regardless of the menu row. `AdminRouteGate` re-evaluates at the destination and refuses, rendering nothing while the gate resolves.

## Security impact

The server **does** enforce this. `RequireActingAdmin` checks the admin role *and* that the declared profile is the account's primary, and fails closed on a profile it cannot resolve — explicitly so a non-primary session cannot regain admin with a bogus `X-Profile-Id`.

So the reported incident was **UI exposure, not privilege escalation**.

One narrow exception, worth recording: the server allows admin on role alone when **no** profile is declared, and the client omits `X-Profile-Id` when the profile id is null — the same unresolved-profile condition. In that window a non-primary profile on an admin account could have reached admin data. This PR closes it client-side at both the entry and the destination.

The server is also candid that this is a policy boundary for well-behaved clients, not isolation between people sharing an account.

## Also

A test helper ignored both its arguments and always returned `true`, so every test through it passed regardless of the gate — including the case the class exists for. Fixed, with coverage for an admin account on a non-primary profile, on an unresolved profile, and on the primary profile.

## Testing

Full suite green on all four modules. Verified on a Google TV Streamer with a release build: the profile menu now reads `laura · WAVE-NINJA` instead of `laura · ADMIN · WAVE-NINJA`.

Reviewed by Codex, which caught the latching, the ungated destinations and the overclaiming comments. The label fix came out of looking at the actual screen — no amount of gate review would have found it, because the label never touched the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115uaQ6FTQZK8KYvazjefaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin access checks by requiring a resolved primary profile.
  * Added bounded retries for temporary profile-resolution failures.
  * Admin areas now display loading, authorized, or access-denied states appropriately.
  * Prevented unauthorized access when profile information is unavailable.
  * Updated TV profile details to show account roles only for primary profiles.

* **Tests**
  * Added coverage for denied access, unresolved profiles, and recovery after temporary lookup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->