### PR TITLE
fix(tv): let the playback selector menus reach every option

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
@@ -2,9 +2,11 @@ package org.siloserver.silo.tv.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,8 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.relocation.BringIntoViewRequester
-import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -25,13 +26,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -78,6 +88,63 @@ internal fun selectorExpansionAfterInteractivityChange(
 ): Boolean = expanded && interactive
 
 /**
+ * The next selectable row [from] the current one, or null at the list boundary.
+ *
+ * The menu drives its own d-pad walk rather than leaving it to Compose's focus
+ * search: the search would leave the popup once the next row was off-screen,
+ * stranding every option below the fold and — because each row only scrolls
+ * itself into view when it gains focus — never scrolling the list at all.
+ * Disabled rows (the "Unknown" audio fallback) are stepped over, not landed on.
+ */
+internal fun nextSelectorMenuIndex(
+    options: List<TvSelectorOption>,
+    from: Int,
+    forward: Boolean,
+): Int? {
+    val step = if (forward) 1 else -1
+    var candidate = from + step
+    while (candidate in options.indices) {
+        if (options[candidate].enabled) return candidate
+        candidate += step
+    }
+    return null
+}
+
+/**
+ * Where the menu must scroll to so the row at [rowTop]..[rowTop] + [rowHeight]
+ * is fully on screen, given the current [scroll] offset and [viewport] height.
+ *
+ * The menu scrolls itself rather than leaving it to `bringIntoView`: measured on
+ * a Google TV Streamer, focus moved onto the below-fold rows correctly while the
+ * requester scrolled nothing at all, so every row past the tenth stayed off
+ * screen even though it held focus. Returns [scroll] unchanged when the row is
+ * already visible, so an ordinary d-pad step does not jitter the list.
+ */
+internal fun selectorMenuScrollTarget(
+    scroll: Int,
+    rowTop: Int,
+    rowHeight: Int,
+    viewport: Int,
+    maxValue: Int,
+): Int {
+    if (viewport <= 0 || rowHeight <= 0) return scroll
+    val target = when {
+        rowTop < scroll -> rowTop
+        rowTop + rowHeight > scroll + viewport -> rowTop + rowHeight - viewport
+        else -> scroll
+    }
+    return target.coerceIn(0, maxOf(0, maxValue))
+}
+
+/** Index the menu should focus when it opens: the selected row, else the first
+ *  selectable one. */
+internal fun initialSelectorMenuIndex(options: List<TvSelectorOption>): Int {
+    val selected = options.indexOfFirst { it.selected && it.enabled }
+    if (selected >= 0) return selected
+    return options.indexOfFirst { it.enabled }.coerceAtLeast(0)
+}
+
+/**
  * A secondary `.compact` squared pill that opens an anchored dropdown of
  * [options]. Trigger layout mirrors tvOS `TVSelectorButton` at tvOS÷2 scale
  * (`[icon] LABEL  value  ⌄`).
@@ -110,6 +177,7 @@ fun TvAnchoredSelectorMenu(
     // Use the caller's requester when provided (Task 4 directs selector-row
     // focus to a specific trigger); otherwise a private one for focus-restore.
     val triggerFr = triggerFocusRequester ?: remember { FocusRequester() }
+    val menuScrollState = rememberScrollState()
 
     // Wrapping the trigger and the DropdownMenu in the same Box anchors the
     // popup at the trigger's layout position (the menu inherits the anchor's
@@ -187,68 +255,127 @@ fun TvAnchoredSelectorMenu(
                 // reloaded on selection) — requesting focus then throws.
                 runCatching { triggerFr.requestFocus() }
             },
+            scrollState = menuScrollState,
             containerColor = DarkSurfaceElevated,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,
         ) {
-            options.forEach { option ->
-                val interactionSource = remember(option.key) { MutableInteractionSource() }
-                val bringIntoViewRequester = remember(option.key) { BringIntoViewRequester() }
-                val focused by interactionSource.collectIsFocusedAsState()
-                LaunchedEffect(focused) {
-                    if (focused) bringIntoViewRequester.bringIntoView()
+            // Own both halves of the walk: which row takes focus, and where the
+            // list has to scroll for it to be visible. Compose's own focus
+            // search leaves the popup once the next row is off-screen, and
+            // BringIntoViewRequester was measured on a Google TV Streamer to
+            // scroll this menu not at all — so a row could hold focus while
+            // staying below the fold, which is what stranded every option past
+            // the tenth for two release candidates.
+            val rowTops = remember(options) { mutableStateMapOf<Int, Int>() }
+            val rowHeights = remember(options) { mutableStateMapOf<Int, Int>() }
+            val rowFocusRequesters = remember(options) { List(options.size) { FocusRequester() } }
+            var focusedIndex by remember(options) { mutableStateOf(initialSelectorMenuIndex(options)) }
+            LaunchedEffect(options) {
+                rowFocusRequesters.getOrNull(focusedIndex)?.let { requester ->
+                    runCatching { requester.requestFocus() }
                 }
-                val visual = tvSelectorRowVisualState(focused, option.selected, option.enabled)
-                val labelText = if (option.detail.isBlank()) {
-                    option.title
-                } else {
-                    "${option.title} — ${option.detail}"
-                }
-                DropdownMenuItem(
-                    interactionSource = interactionSource,
-                    modifier = Modifier
-                        .bringIntoViewRequester(bringIntoViewRequester)
-                        .padding(horizontal = 6.dp, vertical = 2.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(visual.container)
-                        .border(1.dp, visual.border, RoundedCornerShape(8.dp))
-                        .semantics { this.selected = option.selected },
-                    enabled = option.enabled,
-                    text = {
-                        androidx.compose.material3.Text(
-                            text = labelText,
-                            style = androidx.compose.material3.MaterialTheme.typography.bodyLarge.copy(
-                                fontSize = 14.sp,
-                                lineHeight = 18.sp,
-                                fontWeight = FontWeight.Medium,
-                            ),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    },
-                    leadingIcon = if (option.selected) {
-                        {
-                            androidx.compose.material3.Icon(
-                                imageVector = Icons.Filled.Check,
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp),
-                            )
+            }
+            Column(
+                // focusGroup is load-bearing, not decoration: key modifiers only
+                // see events on nodes that sit in the focus hierarchy, so without
+                // it the handler below is never called and the d-pad falls
+                // straight through to Compose's own focus search.
+                modifier = Modifier
+                    .focusGroup()
+                    .onPreviewKeyEvent { event ->
+                    if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                    val forward = when (event.key) {
+                        Key.DirectionDown -> true
+                        Key.DirectionUp -> false
+                        else -> return@onPreviewKeyEvent false
+                    }
+                    val next = nextSelectorMenuIndex(options, focusedIndex, forward)
+                    if (next != null) {
+                        rowFocusRequesters.getOrNull(next)?.let { requester ->
+                            runCatching { requester.requestFocus() }
                         }
+                    }
+                    // Consume at the boundary too: a d-pad press that runs off
+                    // the end must stay put rather than leak to the screen the
+                    // menu is covering.
+                    true
+                },
+            ) {
+                options.forEachIndexed { index, option ->
+                    val interactionSource = remember(option.key) { MutableInteractionSource() }
+                    val focused by interactionSource.collectIsFocusedAsState()
+                    LaunchedEffect(focused, rowTops[index], rowHeights[index]) {
+                        if (!focused) return@LaunchedEffect
+                        focusedIndex = index
+                        val target = selectorMenuScrollTarget(
+                            scroll = menuScrollState.value,
+                            rowTop = rowTops[index] ?: return@LaunchedEffect,
+                            rowHeight = rowHeights[index] ?: return@LaunchedEffect,
+                            viewport = menuScrollState.viewportSize,
+                            maxValue = menuScrollState.maxValue,
+                        )
+                        if (target != menuScrollState.value) menuScrollState.animateScrollTo(target)
+                    }
+                    val visual = tvSelectorRowVisualState(focused, option.selected, option.enabled)
+                    val labelText = if (option.detail.isBlank()) {
+                        option.title
                     } else {
-                        null
-                    },
-                    colors = MenuDefaults.itemColors(
-                        textColor = visual.content,
-                        leadingIconColor = visual.content,
-                        disabledTextColor = visual.content,
-                        disabledLeadingIconColor = visual.content,
-                    ),
-                    onClick = {
-                        option.onSelect()
-                        expansionRequested = false
-                        runCatching { triggerFr.requestFocus() }
-                    },
-                )
+                        "${option.title} — ${option.detail}"
+                    }
+                    DropdownMenuItem(
+                        interactionSource = interactionSource,
+                        modifier = Modifier
+                            .focusRequester(rowFocusRequesters[index])
+                            .onGloballyPositioned { coords ->
+                                // positionInParent is content-space: it does not
+                                // move when the menu scrolls, so it is a stable
+                                // scroll target.
+                                rowTops[index] = coords.positionInParent().y.toInt()
+                                rowHeights[index] = coords.size.height
+                            }
+                            .padding(horizontal = 6.dp, vertical = 2.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(visual.container)
+                            .border(1.dp, visual.border, RoundedCornerShape(8.dp))
+                            .semantics { this.selected = option.selected },
+                        enabled = option.enabled,
+                        text = {
+                            androidx.compose.material3.Text(
+                                text = labelText,
+                                style = androidx.compose.material3.MaterialTheme.typography.bodyLarge.copy(
+                                    fontSize = 14.sp,
+                                    lineHeight = 18.sp,
+                                    fontWeight = FontWeight.Medium,
+                                ),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        leadingIcon = if (option.selected) {
+                            {
+                                androidx.compose.material3.Icon(
+                                    imageVector = Icons.Filled.Check,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            }
+                        } else {
+                            null
+                        },
+                        colors = MenuDefaults.itemColors(
+                            textColor = visual.content,
+                            leadingIconColor = visual.content,
+                            disabledTextColor = visual.content,
+                            disabledLeadingIconColor = visual.content,
+                        ),
+                        onClick = {
+                            option.onSelect()
+                            expansionRequested = false
+                            runCatching { triggerFr.requestFocus() }
+                        },
+                    )
+                }
             }
         }
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
@@ -136,12 +136,18 @@ internal fun selectorMenuScrollTarget(
     return target.coerceIn(0, maxOf(0, maxValue))
 }
 
-/** Index the menu should focus when it opens: the selected row, else the first
- *  selectable one. */
+/**
+ * Index the menu should focus when it opens: the selected row, else the first
+ * selectable one, or -1 when there is nothing selectable at all.
+ *
+ * Returning 0 for a list with no enabled rows would aim focus at a disabled
+ * one, which cannot take it — the request fails silently and the menu opens
+ * with focus nowhere.
+ */
 internal fun initialSelectorMenuIndex(options: List<TvSelectorOption>): Int {
     val selected = options.indexOfFirst { it.selected && it.enabled }
     if (selected >= 0) return selected
-    return options.indexOfFirst { it.enabled }.coerceAtLeast(0)
+    return options.indexOfFirst { it.enabled }
 }
 
 /**
@@ -272,6 +278,7 @@ fun TvAnchoredSelectorMenu(
             val rowFocusRequesters = remember(options) { List(options.size) { FocusRequester() } }
             var focusedIndex by remember(options) { mutableStateOf(initialSelectorMenuIndex(options)) }
             LaunchedEffect(options) {
+                if (focusedIndex < 0) return@LaunchedEffect
                 rowFocusRequesters.getOrNull(focusedIndex)?.let { requester ->
                     runCatching { requester.requestFocus() }
                 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenuStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenuStateTest.kt
@@ -1,8 +1,23 @@
 package org.siloserver.silo.tv.ui.components
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+
+private fun option(
+    key: String,
+    selected: Boolean = false,
+    enabled: Boolean = true,
+) = TvSelectorOption(
+    key = key,
+    title = key,
+    detail = "",
+    selected = selected,
+    onSelect = {},
+    enabled = enabled,
+)
 
 class TvAnchoredSelectorMenuStateTest {
     @Test
@@ -26,5 +41,119 @@ class TvAnchoredSelectorMenuStateTest {
             interactive = true,
         )
         assertFalse(expanded)
+    }
+
+    // A subtitle list longer than the screen is the case that broke: the walk
+    // has to keep producing indices past the last on-screen row, because those
+    // are precisely the rows Compose's own focus search would not reach.
+    @Test
+    fun walkContinuesPastTheRowsThatFitOnScreen() {
+        val options = List(30) { option("sub$it") }
+
+        var index = initialSelectorMenuIndex(options)
+        val visited = mutableListOf(index)
+        while (true) {
+            val next = nextSelectorMenuIndex(options, index, forward = true) ?: break
+            index = next
+            visited += index
+        }
+
+        assertEquals(30, visited.size)
+        assertEquals(29, visited.last())
+    }
+
+    @Test
+    fun walkStopsAtBothEndsInsteadOfLeavingTheMenu() {
+        val options = listOf(option("a"), option("b"))
+
+        assertNull(nextSelectorMenuIndex(options, from = 1, forward = true))
+        assertNull(nextSelectorMenuIndex(options, from = 0, forward = false))
+    }
+
+    @Test
+    fun walkStepsOverDisabledRows() {
+        val options = listOf(
+            option("auto"),
+            option("unknown", enabled = false),
+            option("english"),
+        )
+
+        assertEquals(2, nextSelectorMenuIndex(options, from = 0, forward = true))
+        assertEquals(0, nextSelectorMenuIndex(options, from = 2, forward = false))
+    }
+
+    @Test
+    fun menuOpensOnTheSelectedRow() {
+        val options = listOf(option("auto"), option("off"), option("dutch", selected = true))
+
+        assertEquals(2, initialSelectorMenuIndex(options))
+    }
+
+    // 10 rows of 100 fit a 1000 viewport; row 10 begins exactly past the fold.
+    @Test
+    fun scrollFollowsFocusPastTheFold() {
+        val target = selectorMenuScrollTarget(
+            scroll = 0,
+            rowTop = 1000,
+            rowHeight = 100,
+            viewport = 1000,
+            maxValue = 700,
+        )
+
+        assertEquals(100, target)
+    }
+
+    @Test
+    fun scrollStaysPutForARowAlreadyOnScreen() {
+        val target = selectorMenuScrollTarget(
+            scroll = 300,
+            rowTop = 400,
+            rowHeight = 100,
+            viewport = 1000,
+            maxValue = 700,
+        )
+
+        assertEquals(300, target)
+    }
+
+    @Test
+    fun scrollFollowsFocusBackUpwards() {
+        val target = selectorMenuScrollTarget(
+            scroll = 500,
+            rowTop = 200,
+            rowHeight = 100,
+            viewport = 1000,
+            maxValue = 700,
+        )
+
+        assertEquals(200, target)
+    }
+
+    @Test
+    fun scrollNeverRunsPastTheEndOfTheList() {
+        val target = selectorMenuScrollTarget(
+            scroll = 0,
+            rowTop = 5000,
+            rowHeight = 100,
+            viewport = 1000,
+            maxValue = 700,
+        )
+
+        assertEquals(700, target)
+    }
+
+    // Before the first layout pass there is nothing measured to scroll against;
+    // holding position beats guessing and yanking the list.
+    @Test
+    fun scrollHoldsWhenNothingHasBeenMeasuredYet() {
+        assertEquals(250, selectorMenuScrollTarget(250, 900, 100, viewport = 0, maxValue = 700))
+        assertEquals(250, selectorMenuScrollTarget(250, 900, 0, viewport = 1000, maxValue = 700))
+    }
+
+    @Test
+    fun menuOpensOnTheFirstSelectableRowWhenNothingIsSelected() {
+        val options = listOf(option("unknown", enabled = false), option("english"))
+
+        assertEquals(1, initialSelectorMenuIndex(options))
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenuStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenuStateTest.kt
@@ -150,6 +150,24 @@ class TvAnchoredSelectorMenuStateTest {
         assertEquals(250, selectorMenuScrollTarget(250, 900, 0, viewport = 1000, maxValue = 700))
     }
 
+    // Aiming initial focus at a disabled row loses it silently: the row cannot
+    // take focus, so the menu opens with focus nowhere and the d-pad dead.
+    @Test
+    fun menuReportsNoInitialRowWhenNothingIsSelectable() {
+        val allDisabled = listOf(option("unknown", enabled = false), option("also-unknown", enabled = false))
+
+        assertEquals(-1, initialSelectorMenuIndex(allDisabled))
+        assertEquals(-1, initialSelectorMenuIndex(emptyList()))
+    }
+
+    // From that state a d-pad press must still reach the first selectable row.
+    @Test
+    fun walkFromNoInitialRowStillReachesTheFirstSelectableOne() {
+        val options = listOf(option("unknown", enabled = false), option("english"))
+
+        assertEquals(1, nextSelectorMenuIndex(options, from = -1, forward = true))
+    }
+
     @Test
     fun menuOpensOnTheFirstSelectableRowWhenNothingIsSelected() {
         val options = listOf(option("unknown", enabled = false), option("english"))


### PR DESCRIPTION
## Problem

On the TV detail screen, subtitle selection stopped working past the tenth row. D-pad Down walked to the last row that happened to be on screen, then focus left the popup for the detail screen behind it, and the list never scrolled. On a title with 17 subtitle tracks, everything from the seventh onwards was unreachable.

Reported against `v1.0.0-rc.3+6`. The previous fix for this (`46f60eef`, which *is* `v1.0.0-rc.2+5`) has been shipping in two release candidates without effect.

## Root cause

Measured on a Google TV Streamer. Two independent faults:

1. **Focus leaves the popup.** Compose's focus search abandons the `DropdownMenu` once the next row is off-screen — focus was observed landing on the detail screen's Resume button while the menu was still open. The rows that needed scrolling were never reached.
2. **`BringIntoViewRequester` does not scroll this menu.** An injected scroll moves the same list end to end, so the container is scrollable; the requester simply has no effect inside the popup.

The rc.2 fix addressed only the second, using the mechanism that does not work here. It could only ever scroll a row that focus reached, and focus could not reach the rows that needed scrolling.

## Approach

The menu now owns both halves of the walk:

- `nextSelectorMenuIndex` drives d-pad movement, stepping over disabled rows (the "Unknown" audio fallback) and consuming at the boundaries so focus cannot leak to the screen underneath.
- `selectorMenuScrollTarget` scrolls the menu's own `ScrollState` from measured row positions. `BringIntoViewRequester` is removed.

## Verification

On a Google TV Streamer against a 17-track title:

- focus walks the visible rows with the list static (nothing to scroll)
- from the last visible row, the list scrolls one row per press to the end
- Up scrolls back to the top
- both ends hold; focus never leaves the menu

9 unit tests cover the walk and the scroll arithmetic; the `androidTvApp` suite is green.

## Scope

`Version`, `Audio` and `Edition` share this component and get the same fix. No server, API or model changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TV menu navigation with reliable focus when opening.
  * Up and Down navigation now skips disabled options and stops at menu boundaries.
  * Automatically scrolls to keep the focused option visible.
  * Added fallback focus to the first selectable option when no selection exists.

* **Tests**
  * Added coverage for navigation, disabled options, focus behavior, scrolling, boundaries, and unmeasured layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->