### PR TITLE
fix(playback): stop a route change during teardown killing playback

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
@@ -421,6 +421,13 @@ class SiloPlayerFactory(
                 preferredTextLanguage = preferredTextLanguage,
             )
         }
+        // Assigning identical parameters still costs a full reselection, and a
+        // reselection is what crashes when it lands mid-teardown. The callers
+        // re-run on every capability report and on recomposition, so most of
+        // these assignments change nothing — the guard above cannot help those,
+        // because it samples the player from this thread while the reselection
+        // happens later on ExoPlayer's own.
+        if (next == base) return
         player.trackSelectionParameters = next
     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -474,6 +474,12 @@ fun PlayerScreen(
         hdrEnabled,
     ) {
         val backend = videoBackend ?: return@LaunchedEffect
+        // Not while the screen is leaving — see the TV screen's copy of this
+        // guard. A route change during teardown (here: a headphone unplug or
+        // Bluetooth drop rather than HDMI) re-reports capabilities as the
+        // session is torn down, and the reselection it triggers dereferences a
+        // null media period inside ExoPlayer.
+        if (exitRequested || uiState.sessionId == null) return@LaunchedEffect
         backend.applyTrackSelection(
             audioCaps = audioCaps,
             displayHdr = if (hdrEnabled) displayHdr else org.siloserver.silo.model.playback.HdrCapabilities(),

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1159,6 +1159,13 @@ fun TvPlayerScreen(
         dolbyVisionEnabled,
     ) {
         val backend = videoBackend ?: return@LaunchedEffect
+        // Not while the screen is leaving. A route change is exactly what fires
+        // this during teardown — pulling HDMI (a KVM switched to another input)
+        // re-reports capabilities as the session is being torn down — and the
+        // reselection it triggers then dereferences a null media period inside
+        // ExoPlayer. The player-side guard cannot see this: it samples state
+        // from the caller's thread, and the teardown completes on ExoPlayer's.
+        if (exitRequested || state.sessionId == null) return@LaunchedEffect
         // With Dolby Vision off, drop DV profiles (except 5 — no watchable
         // base layer) so the DV MIME preference is not added and multi-track
         // content selects the HEVC/HDR10 variant. DolbyVisionPolicy is the


### PR DESCRIPTION
## Problem

The NPE that #182 was merged to fix **still reproduces on a build containing that fix**. Caught nine times on a Google TV Streamer, both on teardown and mid-playback:

```
NullPointerException: MediaPeriodHolder.info
  at ExoPlayerImplInternal.seekToCurrentPosition(...:1225)
  at ExoPlayerImplInternal.reselectTracksInternalAndSeek(...:2303)
  at ExoPlayerImplInternal.handleMessage(...:812)
```

## Why #182 could not work

```kotlin
if (shouldSkipTrackReselection(player.playbackState, player.currentTimeline.isEmpty)) return
player.trackSelectionParameters = next
```

It samples `playbackState` and the timeline **on the calling thread**, then hands the parameters to ExoPlayer, which performs the reselection later **on its own playback thread**. The window it targets sits between those two moments. Both sampled conditions can look healthy while the media period is gone by the time the reselection runs, so the guard narrows the race and cannot close it.

Its unit test passed throughout, because it only ever asserted that the two sampled conditions map to skip/don't-skip — not that the crash stopped.

## Trigger

Reported by the user and consistent with all nine captures: a **KVM switched to another input pulls HDMI**, the audio sink changes, `AudioCapabilityManager` reports new capabilities, and the `LaunchedEffect` keyed on those capabilities re-applies presets to a session that is already going away.

That also matches the original report — "an audio-route change killing playback" — so #182 had the right trigger and the wrong mechanism.

## Approach

Neither change relies on observing the player from the wrong thread.

1. **Skip when nothing changed.** Assigning identical parameters still costs a full reselection. Callers re-run on every capability report and on recomposition, so most assignments change nothing while carrying the whole risk.
2. **Skip once the screen is leaving.** `exitRequested || sessionId == null` is state the app owns, rather than state it has to sample from the player.

The phone screen carries the same unguarded effect — reached by a headphone unplug or Bluetooth drop rather than HDMI — and gets the same guard.

## Verification

Unit suites green (`android-shared`, `androidTvApp`, `androidApp`); both apps compile.

**Not yet verified on device.** Reproducing it needs the display route pulled at teardown, and the test Streamer is asleep behind the KVM. Given this is the second attempt at this crash, that verification should happen before it merges — the first attempt shipped green through two release candidates without fixing anything.