### PR TITLE
fix(playback): let the audio route settle before reselecting tracks

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
@@ -375,6 +375,11 @@ class SiloPlayerFactory(
      * Apply capability-aware track selection presets to [player]. Call at
      * player construction and again whenever [AudioPassthroughCapabilities]
      * changes (HDMI hot-plug, BT pair, user-toggled "force Atmos" setting).
+     *
+     * Returns whether parameters were actually assigned. A skip — teardown
+     * guard or no-op parameters — must be visible to callers that track
+     * "presets have been applied once", or a skipped first run silently
+     * reclassifies the real first application as a later change.
      */
     fun applyTrackSelectionPresets(
         player: Player,
@@ -383,7 +388,7 @@ class SiloPlayerFactory(
         preferredAudioLanguage: String? = null,
         preferredTextLanguage: String? = null,
         hdrEnabled: Boolean = true,
-    ) {
+    ): Boolean {
         // ExoPlayer resolves a track reselection by seeking the current media
         // period. With no media period — idle, empty timeline, or torn down
         // while this was in flight — that path dereferences a null holder and
@@ -398,7 +403,7 @@ class SiloPlayerFactory(
         // player is already past the point of having anything to reselect.
         // Presets are re-applied on the next construction anyway, so skipping
         // costs nothing.
-        if (shouldSkipTrackReselection(player.playbackState, player.currentTimeline.isEmpty)) return
+        if (shouldSkipTrackReselection(player.playbackState, player.currentTimeline.isEmpty)) return false
 
         val base = player.trackSelectionParameters
         val next = if (isTv) {
@@ -422,6 +427,7 @@ class SiloPlayerFactory(
             )
         }
         player.trackSelectionParameters = next
+        return true
     }
 
     /**

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/backend/Media3VideoPlaybackBackend.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/backend/Media3VideoPlaybackBackend.kt
@@ -88,7 +88,7 @@ class Media3VideoPlaybackBackend(
         preferredAudioLanguage: String?,
         preferredTextLanguage: String?,
         hdrEnabled: Boolean,
-    ) {
+    ): Boolean =
         playerFactory.applyTrackSelectionPresets(
             player = player,
             audioCaps = audioCaps,
@@ -97,7 +97,6 @@ class Media3VideoPlaybackBackend(
             preferredTextLanguage = preferredTextLanguage,
             hdrEnabled = hdrEnabled,
         )
-    }
 
     override fun release() {
         playerFactory.releasePlayer(player)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackend.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackend.kt
@@ -38,13 +38,14 @@ interface VideoPlaybackBackend {
 
     fun selectAudioTrack(track: VideoPlayerTrackEntry)
 
+    /** Returns whether presets were actually assigned; false = skipped. */
     fun applyTrackSelection(
         audioCaps: AudioPassthroughCapabilities,
         displayHdr: HdrCapabilities = HdrCapabilities(),
         preferredAudioLanguage: String? = null,
         preferredTextLanguage: String? = null,
         hdrEnabled: Boolean = true,
-    )
+    ): Boolean
 
     fun release()
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -103,6 +103,10 @@ import androidx.compose.ui.unit.sp
 
 private const val TAG = "PlayerScreen"
 
+/** See the TV screen's copy: a capability change waits this long before track
+ *  presets are re-applied, so a sink being rebuilt is not asked to reselect. */
+private const val TrackSelectionSettleMs = 1_500L
+
 internal fun shouldClearPlaybackOnControllerDispose(isChangingConfigurations: Boolean): Boolean =
     !isChangingConfigurations
 
@@ -346,6 +350,9 @@ fun PlayerScreen(
             )
         }
     }
+    // False until presets have been applied once for the current backend, so
+    // only later capability changes wait for the route to settle.
+    var trackPresetsApplied by remember(videoBackend) { mutableStateOf(false) }
 
     // Applies a local audio switch. The ViewModel does not commit on this call:
     // AudioTrackManager returns Unit and does nothing silently when the group is
@@ -474,6 +481,11 @@ fun PlayerScreen(
         hdrEnabled,
     ) {
         val backend = videoBackend ?: return@LaunchedEffect
+        // Let the audio route settle first — see the TV screen's copy of this.
+        // Here the route change is a headphone unplug or a Bluetooth drop
+        // rather than an HDMI switch, but the failure is the same: a
+        // reselection during a sink rebuild has no media period to seek.
+        if (trackPresetsApplied) delay(TrackSelectionSettleMs)
         backend.applyTrackSelection(
             audioCaps = audioCaps,
             displayHdr = if (hdrEnabled) displayHdr else org.siloserver.silo.model.playback.HdrCapabilities(),
@@ -481,6 +493,7 @@ fun PlayerScreen(
             preferredTextLanguage = uiState.preferredTextLanguage,
             hdrEnabled = hdrEnabled,
         )
+        trackPresetsApplied = true
     }
 
     // Mirror the user's preferred playback speed onto the live MediaController,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -486,14 +486,17 @@ fun PlayerScreen(
         // rather than an HDMI switch, but the failure is the same: a
         // reselection during a sink rebuild has no media period to seek.
         if (trackPresetsApplied) delay(TrackSelectionSettleMs)
-        backend.applyTrackSelection(
-            audioCaps = audioCaps,
-            displayHdr = if (hdrEnabled) displayHdr else org.siloserver.silo.model.playback.HdrCapabilities(),
-            preferredAudioLanguage = uiState.preferredAudioLanguage,
-            preferredTextLanguage = uiState.preferredTextLanguage,
-            hdrEnabled = hdrEnabled,
-        )
-        trackPresetsApplied = true
+        // Only a REAL application counts — see the TV screen's copy.
+        if (backend.applyTrackSelection(
+                audioCaps = audioCaps,
+                displayHdr = if (hdrEnabled) displayHdr else org.siloserver.silo.model.playback.HdrCapabilities(),
+                preferredAudioLanguage = uiState.preferredAudioLanguage,
+                preferredTextLanguage = uiState.preferredTextLanguage,
+                hdrEnabled = hdrEnabled,
+            )
+        ) {
+            trackPresetsApplied = true
+        }
     }
 
     // Mirror the user's preferred playback speed onto the live MediaController,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -428,6 +428,9 @@ fun TvPlayerScreen(
             )
         }
     }
+    // False until presets have been applied once for the current backend, so
+    // only later capability changes wait for the route to settle.
+    var trackPresetsApplied by remember(videoBackend) { mutableStateOf(false) }
     LaunchedEffect(videoBackend) {
         videoBackend?.let { backend ->
             viewModel.onBackendCapabilities(backend.capabilities)
@@ -1159,6 +1162,23 @@ fun TvPlayerScreen(
         dolbyVisionEnabled,
     ) {
         val backend = videoBackend ?: return@LaunchedEffect
+        // Let the audio route settle before asking media3 to reselect.
+        //
+        // A reselection is resolved by seeking the current media period, and
+        // while an audio sink is being torn down and rebuilt there is no such
+        // period — the seek then dereferences a null holder and kills playback
+        // outright (MediaPeriodHolder.info in seekToCurrentPosition). A KVM
+        // switching inputs produces exactly that: HDMI drops or returns, the
+        // sink is rebuilt, and capabilities are re-reported mid-rebuild.
+        //
+        // Guarding by state cannot see this window — the player looks healthy
+        // from here throughout, which is why two previous attempts (#182, #186)
+        // did not help. Waiting does: this effect restarts on every capability
+        // report, so route churn coalesces into a single application once the
+        // reports stop. Only capability *changes* wait; the first application
+        // for a backend still runs immediately, because startup track selection
+        // must not be deferred.
+        if (trackPresetsApplied) delay(TrackSelectionSettleMs)
         // With Dolby Vision off, drop DV profiles (except 5 — no watchable
         // base layer) so the DV MIME preference is not added and multi-track
         // content selects the HEVC/HDR10 variant. DolbyVisionPolicy is the
@@ -1176,6 +1196,7 @@ fun TvPlayerScreen(
             preferredTextLanguage = state.preferredTextLanguage,
             hdrEnabled = hdrEnabled,
         )
+        trackPresetsApplied = true
     }
 
     // HDR display-mode switching: attach the controller to the activity window
@@ -2984,6 +3005,15 @@ private fun PlaybackExecutionPlan?.validatedPassthroughCodecs(): List<String> {
 }
 
 private const val TAG = "TvPlayerScreen"
+
+/**
+ * How long a capability change waits before track-selection presets are
+ * re-applied, so an audio sink that is being rebuilt is not asked to reselect
+ * mid-rebuild. Long enough to cover a KVM input switch settling; short enough
+ * that a genuine capability change (AVR powered on, headphones paired) still
+ * takes effect while the viewer is watching.
+ */
+private const val TrackSelectionSettleMs = 1_500L
 
 /**
  * Flatten an ExoPlayer [Tracks] object into TV-facing entries. Audio/video

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1189,14 +1189,20 @@ fun TvPlayerScreen(
                 org.siloserver.silo.player.DolbyVisionPolicy.Snapshot(dolbyVisionEnabled = dolbyVisionEnabled),
             ),
         )
-        backend.applyTrackSelection(
-            audioCaps = audioCaps,
-            displayHdr = effectiveDisplayHdr,
-            preferredAudioLanguage = state.preferredAudioLanguage,
-            preferredTextLanguage = state.preferredTextLanguage,
-            hdrEnabled = hdrEnabled,
-        )
-        trackPresetsApplied = true
+        // Only a REAL application counts. The factory skips silently while the
+        // player is idle or unmounted; letting that skip flip the flag would
+        // reclassify the true first application as a "later capability change"
+        // and defer startup track selection by the settle delay.
+        if (backend.applyTrackSelection(
+                audioCaps = audioCaps,
+                displayHdr = effectiveDisplayHdr,
+                preferredAudioLanguage = state.preferredAudioLanguage,
+                preferredTextLanguage = state.preferredTextLanguage,
+                hdrEnabled = hdrEnabled,
+            )
+        ) {
+            trackPresetsApplied = true
+        }
     }
 
     // HDR display-mode switching: attach the controller to the activity window


### PR DESCRIPTION
## Problem

A KVM switching inputs killed playback outright:

```
NullPointerException: MediaPeriodHolder.info
  at ExoPlayerImplInternal.seekToCurrentPosition(...:1225)
  at ExoPlayerImplInternal.reselectTracksInternalAndSeek(...:2303)
```

A reselection is resolved by seeking the current media period. While an audio sink is being torn down and rebuilt there is no such period, so the seek dereferences a null holder. Pulling HDMI produces exactly that: the sink is rebuilt and capabilities are re-reported mid-rebuild, and the `LaunchedEffect` keyed on those capabilities re-applies presets straight into the gap.

## Why the previous attempts could not work

Both guarded the call site by sampling the player:

- **#182** — `playbackState` and `currentTimeline.isEmpty`
- **#186** — those, plus session state and a no-op parameter check

Neither can see the window. The player looks healthy from the caller's thread throughout, because the teardown completes on ExoPlayer's own. #182 shipped through two release candidates without effect; #186 reproduced the crash on the very build that contained it, with all its guards passing legitimately:

| guard | value at crash |
| --- | --- |
| `exitRequested` | false — playback live |
| `sessionId == null` | false — session healthy |
| `next == base` | false — capabilities genuinely changed |

## Approach

Stop trying to observe the window; stay out of it.

A capability change now waits before presets are re-applied. Because the effect restarts on every capability report, route churn coalesces into a single application once the reports stop. The first application for a session still runs immediately, so startup track selection is not deferred.

## Verification

On a Google TV Streamer, across a KVM switching away and back repeatedly:

| | |
| --- | --- |
| HDMI route changes | **8** (add/remove/add) |
| including rapid churn | remove → add → remove within ~2s — the pattern that reproduced the crash |
| `seekToCurrentPosition` NPEs | **0** |
| player errors | **0** |
| session | survived |

The previous crash coincided exactly with an `addProviderRoutes … ROUTE_ID_HDMI`; that transition occurred three times here without incident.

Unit suites green across `android-shared`, `androidTvApp`, `androidApp`.

**Limits of this result:** one session, and playback was paused by the end, so not every switch is confirmed mid-play. The mechanism is play-state independent — the effect fires on capability change either way — but a second run playing throughout would make it airtight.

## Scope

The phone screen carries the same effect, reached by a headphone unplug or Bluetooth drop rather than an HDMI switch, and gets the same treatment. Supersedes #186 (closed).