### PR TITLE
fix(tv): stop a duplicate feed entry crashing the app

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
@@ -116,6 +116,10 @@ fun TvCatalogGrid(
     emptyState: (@Composable () -> Unit)? = null,
 ) {
     val resolvedGridState = gridState ?: rememberLazyGridState()
+    // Keyed lazy lists throw on a repeated key, which is fatal. Paging can
+    // hand the same item back across pages, so the grid guarantees uniqueness
+    // itself rather than trusting every caller to.
+    val uniqueItems = remember(items) { items.distinctBy { it.contentId } }
 
     // Backoff gate against an endless load-more retry storm. When a load-more
     // completes without growing the list while the server still reports more
@@ -130,19 +134,19 @@ fun TvCatalogGrid(
     // Trigger pagination when the user is within 6 items of the end. The
     // `loadMoreRequestedSize` guard is read inside the derived state so a failed
     // page (size unchanged) stays gated until a retry or a successful growth.
-    val shouldLoadMore by remember(items.size, hasMore, isLoading) {
+    val shouldLoadMore by remember(uniqueItems.size, hasMore, isLoading) {
         derivedStateOf {
-            if (!hasMore || isLoading || items.isEmpty()) return@derivedStateOf false
-            if (items.size == loadMoreRequestedSize) return@derivedStateOf false
+            if (!hasMore || isLoading || uniqueItems.isEmpty()) return@derivedStateOf false
+            if (uniqueItems.size == loadMoreRequestedSize) return@derivedStateOf false
             val lastVisible = resolvedGridState.layoutInfo.visibleItemsInfo
                 .lastOrNull()?.index ?: return@derivedStateOf false
-            lastVisible >= items.size - loadMoreThreshold
+            lastVisible >= uniqueItems.size - loadMoreThreshold
         }
     }
 
     LaunchedEffect(shouldLoadMore) {
         if (shouldLoadMore) {
-            loadMoreRequestedSize = items.size
+            loadMoreRequestedSize = uniqueItems.size
             onLoadMore()
         }
     }
@@ -153,7 +157,7 @@ fun TvCatalogGrid(
     // list back to page size while keeping the same first item) — so a fresh
     // list is never mistaken for a stalled page. A failed load-more changes
     // neither key, so the gate correctly holds until the retry footer is used.
-    LaunchedEffect(items.firstOrNull()?.contentId, items.size) {
+    LaunchedEffect(uniqueItems.firstOrNull()?.contentId, uniqueItems.size) {
         loadMoreRequestedSize = -1
     }
 
@@ -179,8 +183,8 @@ fun TvCatalogGrid(
 
     val loadMoreStalled = hasMore &&
         !isLoading &&
-        items.isNotEmpty() &&
-        loadMoreRequestedSize == items.size
+        uniqueItems.isNotEmpty() &&
+        loadMoreRequestedSize == uniqueItems.size
 
     CompositionLocalProvider(LocalBringIntoViewSpec provides TvSmoothBringIntoViewSpec) {
     LazyVerticalGrid(
@@ -215,7 +219,7 @@ fun TvCatalogGrid(
             }
         }
 
-        if (items.isEmpty() && !isLoading && emptyState != null) {
+        if (uniqueItems.isEmpty() && !isLoading && emptyState != null) {
             item(span = { GridItemSpan(maxLineSpan) }) {
                 Box(
                     modifier = Modifier
@@ -228,7 +232,9 @@ fun TvCatalogGrid(
             }
         } else {
             itemsIndexed(
-                items = items,
+                // See TvMediaRow: a repeated contentId is fatal to a keyed
+                // lazy list, and paging can hand the same item back twice.
+                items = uniqueItems,
                 key = { _, item -> item.contentId },
                 contentType = { _, item -> item.type },
             ) { index, item ->

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
@@ -120,6 +120,24 @@ fun TvCatalogGrid(
     // hand the same item back across pages, so the grid guarantees uniqueness
     // itself rather than trusting every caller to.
     val uniqueItems = remember(items) { items.distinctBy { it.contentId } }
+    // The caller speaks positions in the list it handed us; we render the
+    // deduplicated one. Translate on both edges — the incoming restore index
+    // through contentId into our list, and outgoing focus reports back into
+    // the caller's list — so a duplicate earlier in the feed cannot shift
+    // either side's arithmetic. distinctBy keeps first occurrences, so the
+    // first raw index of a rendered item is the item itself.
+    val resolvedRestoreItemIndex = remember(items, uniqueItems, restoreItemIndex) {
+        items.getOrNull(restoreItemIndex)?.contentId
+            ?.let { id -> uniqueItems.indexOfFirst { it.contentId == id } }
+            ?: -1
+    }
+    val rawIndexByContentId = remember(items) {
+        buildMap {
+            items.forEachIndexed { rawIndex, item ->
+                putIfAbsent(item.contentId, rawIndex)
+            }
+        }
+    }
 
     // Backoff gate against an endless load-more retry storm. When a load-more
     // completes without growing the list while the server still reports more
@@ -240,7 +258,7 @@ fun TvCatalogGrid(
             ) { index, item ->
                 val (actions, userState) = rememberTvBrowseItemCardActions(item)
                 val isRestoreTarget =
-                    restoreItemFocusRequester != null && index == restoreItemIndex
+                    restoreItemFocusRequester != null && index == resolvedRestoreItemIndex
                 if (isRestoreTarget) {
                     // Keyed on the callback as well as the item: an owner
                     // change while the same card survives has to re-announce
@@ -290,7 +308,13 @@ fun TvCatalogGrid(
                         // card's outer Column while the Material Card inside it
                         // owns focus, so isFocused is never true here and the
                         // helper would never see a card take focus at all.
-                        .onFocusChanged { onItemFocusedAtIndex(item, index, it.hasFocus) },
+                        .onFocusChanged {
+                            onItemFocusedAtIndex(
+                                item,
+                                rawIndexByContentId[item.contentId] ?: index,
+                                it.hasFocus,
+                            )
+                        },
                     overlay = OverlayDataExtractor.fromBrowseItem(item),
                     actions = actions,
                 )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvHomeHeroCarousel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvHomeHeroCarousel.kt
@@ -92,19 +92,23 @@ fun TvHomeHeroCarousel(
     onFocusEntered: () -> Unit = {},
     onActiveItemChanged: (SectionItem) -> Unit = {},
 ) {
-    if (items.isEmpty()) return
+    // See TvCatalogGrid: a repeated key is fatal to a keyed lazy list. Every
+    // index below addresses this list, not the caller's, so the card the
+    // carousel reports as active is the card it actually drew.
+    val uniqueItems = remember(items) { items.distinctBy { it.contentId } }
+    if (uniqueItems.isEmpty()) return
 
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val internalInitialFocusRequester = remember { FocusRequester() }
     val targetInitialFocusRequester = initialFocusRequester ?: internalInitialFocusRequester
-    var activeIndex by remember(items.map { it.contentId }) { mutableIntStateOf(0) }
+    var activeIndex by remember(uniqueItems.map { it.contentId }) { mutableIntStateOf(0) }
     var heroHasFocus by remember { androidx.compose.runtime.mutableStateOf(false) }
 
-    LaunchedEffect(items.map { it.contentId }) {
-        activeIndex = activeIndex.coerceIn(0, items.lastIndex)
+    LaunchedEffect(uniqueItems.map { it.contentId }) {
+        activeIndex = activeIndex.coerceIn(0, uniqueItems.lastIndex)
         listState.scrollToItem(activeIndex)
-        onActiveItemChanged(items[activeIndex])
+        onActiveItemChanged(uniqueItems[activeIndex])
     }
 
     LaunchedEffect(autoFocus) {
@@ -122,14 +126,14 @@ fun TvHomeHeroCarousel(
     }
 
     LaunchedEffect(activeIndex) {
-        onActiveItemChanged(items[activeIndex])
+        onActiveItemChanged(uniqueItems[activeIndex])
         scope.launch { listState.animateScrollToItem(activeIndex) }
     }
 
-    LaunchedEffect(activeIndex, heroHasFocus, items.size) {
-        if (heroHasFocus || items.size <= 1) return@LaunchedEffect
+    LaunchedEffect(activeIndex, heroHasFocus, uniqueItems.size) {
+        if (heroHasFocus || uniqueItems.size <= 1) return@LaunchedEffect
         delay(HOME_HERO_AUTO_ADVANCE_MS)
-        activeIndex = (activeIndex + 1) % items.size
+        activeIndex = (activeIndex + 1) % uniqueItems.size
     }
 
     BoxWithConstraints(
@@ -160,7 +164,9 @@ fun TvHomeHeroCarousel(
                 .height(heroHeight),
         ) {
             itemsIndexed(
-                items,
+                // See TvMediaRow: a repeated contentId is fatal to a keyed
+                // lazy list.
+                uniqueItems,
                 key = { _, item -> item.contentId },
                 contentType = { _, _ -> "hero-card" },
             ) { index, item ->
@@ -187,7 +193,7 @@ fun TvHomeHeroCarousel(
         }
 
         HeroPageIndicator(
-            total = items.size,
+            total = uniqueItems.size,
             activeIndex = activeIndex,
             modifier = Modifier
                 .align(Alignment.BottomCenter)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -142,6 +142,15 @@ fun TvMediaRow(
     // deduplicated one, which can be shorter. Translate through contentId so a
     // duplicate earlier in the row cannot shift the restored card.
     val restoreFocusContentId = items.getOrNull(restoreFocusIndex)?.contentId
+    // Outbound focus reports also speak the caller's list. distinctBy keeps
+    // first occurrences, so a rendered item's first raw index is itself.
+    val rawIndexByContentId = remember(items) {
+        buildMap {
+            items.forEachIndexed { rawIndex, item ->
+                putIfAbsent(item.contentId, rawIndex)
+            }
+        }
+    }
     val resolvedRestoreFocusIndex = remember(rowItems, restoreFocusContentId) {
         restoreFocusContentId
             ?.let { contentId -> rowItems.indexOfFirst { it.item.contentId == contentId } }
@@ -246,8 +255,10 @@ fun TvMediaRow(
                     },
                 ).then(
                     if (isRestoreFocusTarget && onRestoreFocusTargetPlaced != null) {
+                        // Caller's coordinates, matching Disposed below: the
+                        // consumer compares this against the index it passed in.
                         Modifier.onGloballyPositioned {
-                            onRestoreFocusTargetPlaced(restoreFocusRequest, index)
+                            onRestoreFocusTargetPlaced(restoreFocusRequest, restoreFocusIndex)
                         }
                     } else {
                         Modifier
@@ -275,7 +286,10 @@ fun TvMediaRow(
                         Modifier.onFocusChanged { st ->
                             if (st.isFocused) {
                                 onItemFocused?.invoke(item)
-                                onItemFocusedAtIndex?.invoke(item, index)
+                                onItemFocusedAtIndex?.invoke(
+                                    item,
+                                    rawIndexByContentId[item.contentId] ?: index,
+                                )
                             }
                         }
                     } else {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -119,7 +119,12 @@ fun TvMediaRow(
     if (items.isEmpty()) return
     val rowState = rememberLazyListState()
     val rowItems = remember(items, showProgress, style, cardLayout) {
-        items.map { item ->
+        // Deduplicate before keying. A repeated contentId inside one row makes
+        // the lazy list throw ("Key ... was already used"), which is fatal —
+        // and a row has no reason to show the same title twice anyway. Feeds
+        // can legitimately overlap, so this is a property of the row, not a
+        // bug to fix upstream of it.
+        items.distinctBy { it.contentId }.map { item ->
             TvMediaRowItemModel(
                 item = item,
                 progress = if (showProgress) item.progressFraction() else null,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -138,12 +138,20 @@ fun TvMediaRow(
             )
         }
     }
-    val restoreFocusContentId = rowItems.getOrNull(restoreFocusIndex)?.item?.contentId
+    // The caller counts positions in the list it handed us; we render a
+    // deduplicated one, which can be shorter. Translate through contentId so a
+    // duplicate earlier in the row cannot shift the restored card.
+    val restoreFocusContentId = items.getOrNull(restoreFocusIndex)?.contentId
+    val resolvedRestoreFocusIndex = remember(rowItems, restoreFocusContentId) {
+        restoreFocusContentId
+            ?.let { contentId -> rowItems.indexOfFirst { it.item.contentId == contentId } }
+            ?: -1
+    }
 
-    LaunchedEffect(restoreFocusRequest, restoreFocusIndex, restoreFocusContentId) {
+    LaunchedEffect(restoreFocusRequest, resolvedRestoreFocusIndex, restoreFocusContentId) {
         prepareTvMediaRowFocusRestore(
             requestId = restoreFocusRequest,
-            restoreFocusIndex = restoreFocusIndex,
+            restoreFocusIndex = resolvedRestoreFocusIndex,
             itemCount = rowItems.size,
             scrollToItem = rowState::scrollToItem,
         )
@@ -213,11 +221,14 @@ fun TvMediaRow(
             ) { index, rowItem ->
                 val item = rowItem.item
                 val isRestoreFocusTarget =
-                    restoreFocusRequest > 0 && index == restoreFocusIndex
+                    restoreFocusRequest > 0 && index == resolvedRestoreFocusIndex
                 if (isRestoreFocusTarget && onRestoreFocusTargetDisposed != null) {
-                    DisposableEffect(restoreFocusRequest, index) {
+                    // Report the position the caller asked about, not ours. It
+                    // compares this against the index it passed in, and after
+                    // deduplication the two coordinate spaces can differ.
+                    DisposableEffect(restoreFocusRequest, restoreFocusIndex) {
                         onDispose {
-                            onRestoreFocusTargetDisposed(restoreFocusRequest, index)
+                            onRestoreFocusTargetDisposed(restoreFocusRequest, restoreFocusIndex)
                         }
                     }
                 }
@@ -228,7 +239,7 @@ fun TvMediaRow(
                 val appliedCardModifier = itemCardModifier.then(
                     if (index == 0) firstItemCardModifier else Modifier,
                 ).then(
-                    if (restoreFocusRequester != null && index == restoreFocusIndex) {
+                    if (restoreFocusRequester != null && index == resolvedRestoreFocusIndex) {
                         Modifier.focusRequester(restoreFocusRequester)
                     } else {
                         Modifier

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -806,7 +806,7 @@ private fun TvDetailContent(
                                     restoreFocusRequest = similarRestoreRequest
                                         .takeIf { pendingSimilarIndex >= 0 } ?: 0,
                                     onItemFocusedAtIndex = if (pendingSimilarIndex >= 0) {
-                                        { _, focusedIndex ->
+                                        { focusedItem, _ ->
                                             // ONLY the target counts. Revoking
                                             // when some other card gains focus
                                             // was self-defeating: the row's own
@@ -816,7 +816,11 @@ private fun TvDetailContent(
                                             // onFocusChanged carries no evidence
                                             // that a move was user-initiated —
                                             // the key handler on the root does.
-                                            if (focusedIndex == pendingSimilarIndex) {
+                                            // Identity, not position: index
+                                            // arithmetic is what broke when the
+                                            // row learned to deduplicate, and
+                                            // the item is right here anyway.
+                                            if (focusedItem.contentId == pendingSimilarContentId) {
                                                 similarRestoreFocused.value = true
                                             }
                                         }


### PR DESCRIPTION
## Problem

Reported from a release build — a **fatal** crash, the app dies:

```
IllegalArgumentException: Key "series-tvdb-280619" was already used.
If you are using LazyColumn/Row please make sure you provide a unique key for each item.
```

Compose requires lazy-list keys to be unique and throws on the draw pass when they are not. A feed that returns the same series twice in one row therefore takes the whole app down. No feed response should be able to do that.

## Approach

Three shared TV surfaces key their cards on `contentId` — `TvMediaRow`, `TvCatalogGrid` and `TvHomeHeroCarousel` — and all three now deduplicate before keying.

This is correct on its own terms, not just as a crash guard: a row has no reason to draw the same title twice. Feeds legitimately overlap — a title can sit in Continue Watching *and* in a genre row — so uniqueness is a property each list should hold for itself rather than something every caller must guarantee.

The deduplicated list is then used for **everything that indexes into it**, not only for rendering:

- the hero carousel reports its active item as `items[activeIndex]` and auto-advances modulo the list size
- the grid compares the last visible index against the list size to trigger load-more

Leaving those pointed at the caller's list would have traded a crash for a carousel that reports a different card than the one it drew.

## Verification

`androidTvApp` unit suite green; TV app compiles.

**Not reproduced locally** — the report is from someone else's device and the stack is obfuscated, so I can't say which of the three surfaces threw. All three share the shape, so all three are fixed.

## Follow-ups (not in this PR)

- **Why is there a duplicate at all?** A row showing one series twice is wrong even without the crash. Diagnosing it needs the feed that produced it.
- **The phone app keys 8 lists on `contentId`** the same way and has the same exposure. Each needs the same index-desync check performed here, and the reported crash is on TV, so they are left alone rather than changed blind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate titles from TV catalog grids, home carousels, and media rows.
  * Improved pagination, scrolling, auto-advance, and page indicators when duplicate content is received.
  * Prevented repeated loading attempts and display errors caused by duplicate items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->