### PR TITLE
fix(tv): release the screen while playback is paused

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1186,16 +1186,23 @@ fun TvPlayerScreen(
         onDispose { hdrDisplayController.restore() }
     }
 
-    DisposableEffect(context) {
+    // Hold the screen awake only while playback is actually advancing. The
+    // flag used to be held for the life of the screen, which on a TV meant a
+    // paused player suppressed the system screensaver indefinitely — a static
+    // image parked on the panel for hours is exactly what burn-in protection
+    // exists to prevent. Mirrors the phone player's gate (same user-visible
+    // rule: pause long enough and the screensaver takes over, resume and the
+    // screen is held again). Buffering counts as playing so a rebuffer at a
+    // scene boundary cannot blank the screen mid-watch.
+    val keepScreenAwake = !state.isPaused && (state.isPlaying || state.isBuffering)
+    DisposableEffect(context, keepScreenAwake) {
         val window = (context as? Activity)?.window
-        if (window != null) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        if (keepScreenAwake) {
+            window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
-        onDispose {
-            if (window != null) {
-                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-            }
-        }
+        onDispose { window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) }
     }
 
     val latestLifecycleRoomSnapshot by rememberUpdatedState(roomSnapshot)

--- a/androidTvApp/src/androidMain/res/layout/tv_player_view.xml
+++ b/androidTvApp/src/androidMain/res/layout/tv_player_view.xml
@@ -3,6 +3,5 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:keepScreenOn="true"
     app:surface_type="surface_view"
     app:use_controller="false" />


### PR DESCRIPTION
## Problem

A paused player held the display awake indefinitely — the system screensaver never fired, leaving a static frame parked on the panel for as long as the viewer was away. Reported against a Shield; on an OLED this is exactly what burn-in protection exists to prevent.

## Root cause — two unconditional holders

1. **`TvPlayerScreen`** added `FLAG_KEEP_SCREEN_ON` in a `DisposableEffect(context)` — set at mount, cleared at dispose, blind to playback state.
2. **`tv_player_view.xml`** hardcoded `android:keepScreenOn="true"` on the `PlayerView`. A view-level `keepScreenOn` propagates to the same window flag and never releases — which is why gating the effect alone changed nothing when verified on device.

## Fix

The window flag is now gated on `!isPaused && (isPlaying || isBuffering)` — the same rule the phone player already adopted for its own version of this report (Pixel 8 Pro / S25 Ultra), so both form factors now behave identically: pause long enough and the screensaver takes over; resume and the screen is held again. Buffering counts as playing so a rebuffer at a scene boundary cannot blank the screen mid-watch.

The XML attribute is removed; the gated effect is the flag's single owner.

## Verification

On a Google TV Streamer, reading the window flags from `dumpsys window` at each transition:

```
PLAYING : isPlaying=True   keepScreenOn=1
PAUSED  : isPlaying=False  keepScreenOn=0
RESUMED : isPlaying=True   keepScreenOn=1
PAUSED-2: isPlaying=False  keepScreenOn=0
```

`androidTvApp` unit suite green.

## Scope

TV only — the phone already has this gate. The TV audiobook player never held the flag, so audio-only playback is unaffected (the screensaver firing over a paused audiobook cover is already the intended behaviour).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The TV display now stays awake during playback and buffering.
  * The display automatically turns off its keep-awake behavior when playback is paused or inactive.
  * Screen-awake behavior now updates reliably whenever playback status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->