### PR TITLE
fix(auth): use native branding for server names

### DIFF
--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/NetworkModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/NetworkModule.kt
@@ -27,6 +27,7 @@ val networkModule = module {
     single<org.siloserver.silo.network.HomeRealtimeClient> { org.siloserver.silo.network.DefaultHomeRealtimeClient(get(), get()) }
     single<CalendarApi> { DefaultCalendarApi(get()) }
     single { HealthApi(get()) }
+    single { BrandingApi(get()) }
     single { SettingsApi(get()) }
     single { LibraryPlaybackPrefsApi(get()) }
     single { DownloadsApi(get()) }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
@@ -44,11 +44,19 @@ import kotlinx.coroutines.SupervisorJob
  * and TokenManager, so sharing instances is safe and efficient.
  */
 val repositoryModule = module {
-    // Repositories — `getOrNull()` for ServerRegistry / HealthApi keeps these
+    // Repositories — optional multi-server identity dependencies keep these
     // working when the multi-server platform binding isn't installed
     // (commonMain tests, hypothetical iOS reuse). Both repos no-op the
     // multi-server side effects when the registry is null.
-    single { AuthRepository(get(), get(), getOrNull(), getOrNull()) }
+    single {
+        AuthRepository(
+            authApi = get(),
+            tokenManager = get(),
+            serverRegistry = getOrNull(),
+            healthApi = getOrNull(),
+            brandingApi = getOrNull(),
+        )
+    }
     single { OnboardingRepository(get()) }
     single { DeviceLoginRepository(get()) }
     single {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/server/ServerEntry.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/server/ServerEntry.kt
@@ -10,7 +10,8 @@ import kotlinx.serialization.Serializable
  * the same value share an id, so re-adding the same server upserts rather
  * than duplicates.
  *
- * Names: [fetchedName] is what the server reports via `/api/v1/health`;
+ * Names: [fetchedName] is the server's native branding identity, with the
+ * legacy health name used only when branding is unavailable;
  * [userOverrideName] is whatever the user types in the rename dialog and
  * always wins when both are present.
  */

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/BrandingApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/BrandingApi.kt
@@ -1,0 +1,30 @@
+package org.siloserver.silo.network.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.get
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.siloserver.silo.network.ApiResult
+
+@Serializable
+data class BrandingStatus(
+    @SerialName("server_name")
+    val serverName: String? = null,
+)
+
+open class BrandingApi(private val client: HttpClient) {
+    open suspend fun getBranding(): ApiResult<BrandingStatus> = safeApiCall {
+        client.get("/api/v1/theme/branding") {
+            timeout {
+                connectTimeoutMillis = BRANDING_TIMEOUT_MS
+                requestTimeoutMillis = BRANDING_TIMEOUT_MS
+                socketTimeoutMillis = BRANDING_TIMEOUT_MS
+            }
+        }
+    }
+
+    private companion object {
+        const val BRANDING_TIMEOUT_MS = 6_000L
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.repository
 
 import org.siloserver.silo.model.auth.AuthSession
+import org.siloserver.silo.model.auth.InvitationLookupResponse
 import org.siloserver.silo.model.auth.LoginResponse
 import org.siloserver.silo.model.auth.LoginRequest
 import org.siloserver.silo.model.auth.SetupStatusResponse
@@ -11,7 +12,7 @@ import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.network.api.AuthApi
-import org.siloserver.silo.model.auth.InvitationLookupResponse
+import org.siloserver.silo.network.api.BrandingApi
 import org.siloserver.silo.network.api.HealthApi
 import org.siloserver.silo.network.map
 
@@ -20,6 +21,7 @@ class AuthRepository(
     private val tokenManager: TokenManager,
     private val serverRegistry: ServerRegistry? = null,
     private val healthApi: HealthApi? = null,
+    private val brandingApi: BrandingApi? = null,
 ) {
     /**
      * Persists a successful auth response's tokens into the active server's
@@ -200,20 +202,26 @@ class AuthRepository(
     }
 
     /**
-     * Best-effort: hit `/api/v1/health` and update the active registry entry's
-     * fetched name. Quietly no-ops if there's no registry, no active server,
-     * or the call fails — this is purely for nicer UX in the server list.
+     * Best-effort: read the native branding identity and update the active
+     * registry entry's fetched name. Health is a fallback for older servers
+     * without the branding endpoint. Quietly no-ops if no usable name can be
+     * resolved — this is purely for nicer UX in the server list.
      */
     suspend fun refreshActiveServerName() {
         val registry = serverRegistry ?: return
-        val api = healthApi ?: return
         val activeId = registry.activeServerId.value ?: return
-        val result = api.checkHealth()
-        if (result is ApiResult.Success && registry.activeServerId.value == activeId) {
-            result.data.serverName
-                ?.trim()
-                ?.takeIf { it.isNotBlank() }
-                ?.let { registry.setFetchedName(activeId, it) }
+        val brandingName = (brandingApi?.getBranding() as? ApiResult.Success)
+            ?.data
+            ?.serverName
+            .usableServerName()
+        val resolvedName = brandingName ?: (healthApi?.checkHealth() as? ApiResult.Success)
+            ?.data
+            ?.serverName
+            .usableServerName()
+        if (resolvedName != null && registry.activeServerId.value == activeId) {
+            registry.setFetchedName(activeId, resolvedName)
         }
     }
+
+    private fun String?.usableServerName(): String? = this?.trim()?.takeIf { it.isNotBlank() }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/BrandingApiTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/BrandingApiTest.kt
@@ -1,0 +1,39 @@
+package org.siloserver.silo.network.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.SiloJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class BrandingApiTest {
+    @Test
+    fun `getBranding decodes native server name`() = runTest {
+        val api = BrandingApi(
+            HttpClient(
+                MockEngine {
+                    respond(
+                        content = """{"server_name":"Home Silo","login_subtitle":"Welcome"}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                },
+            ) {
+                install(ContentNegotiation) { json(SiloJson) }
+            },
+        )
+
+        val result = assertIs<ApiResult.Success<BrandingStatus>>(api.getBranding())
+
+        assertEquals("Home Silo", result.data.serverName)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryServerNameTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryServerNameTest.kt
@@ -1,0 +1,167 @@
+package org.siloserver.silo.repository
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import org.siloserver.silo.model.server.ServerEntry
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.ServerRegistry
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.api.AuthApi
+import org.siloserver.silo.network.api.BrandingApi
+import org.siloserver.silo.network.api.BrandingStatus
+import org.siloserver.silo.network.api.HealthApi
+import org.siloserver.silo.network.api.HealthStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AuthRepositoryServerNameTest {
+    @Test
+    fun `refresh prefers native branding over compat-backed health name`() = runTest {
+        val registry = RecordingServerRegistry()
+        val health = FakeHealthApi(ApiResult.Success(HealthStatus("ok", "StreamApp")))
+        val repository = repository(
+            registry = registry,
+            branding = FakeBrandingApi(ApiResult.Success(BrandingStatus("  Home Silo  "))),
+            health = health,
+        )
+
+        repository.refreshActiveServerName()
+
+        assertEquals("Home Silo", registry.fetchedName)
+        assertEquals(0, health.calls)
+    }
+
+    @Test
+    fun `refresh falls back to health when branding is unavailable`() = runTest {
+        val registry = RecordingServerRegistry()
+        val repository = repository(
+            registry = registry,
+            branding = FakeBrandingApi(ApiResult.Error(404, "not_found", "missing")),
+            health = FakeHealthApi(ApiResult.Success(HealthStatus("ok", "Legacy Home"))),
+        )
+
+        repository.refreshActiveServerName()
+
+        assertEquals("Legacy Home", registry.fetchedName)
+    }
+
+    @Test
+    fun `refresh falls back to health when branding name is blank`() = runTest {
+        val registry = RecordingServerRegistry()
+        val repository = repository(
+            registry = registry,
+            branding = FakeBrandingApi(ApiResult.Success(BrandingStatus("  "))),
+            health = FakeHealthApi(ApiResult.Success(HealthStatus("ok", "Fallback"))),
+        )
+
+        repository.refreshActiveServerName()
+
+        assertEquals("Fallback", registry.fetchedName)
+    }
+
+    @Test
+    fun `refresh ignores response after active server changes`() = runTest {
+        val registry = RecordingServerRegistry()
+        val repository = repository(
+            registry = registry,
+            branding = FakeBrandingApi(ApiResult.Success(BrandingStatus("Wrong Server"))) {
+                registry.activate("other")
+            },
+            health = FakeHealthApi(ApiResult.Success(HealthStatus("ok", "Fallback"))),
+        )
+
+        repository.refreshActiveServerName()
+
+        assertNull(registry.fetchedName)
+    }
+
+    private fun repository(
+        registry: RecordingServerRegistry,
+        branding: BrandingApi,
+        health: HealthApi,
+    ) = AuthRepository(
+        authApi = AuthApi(unusedClient()),
+        tokenManager = FakeTokenManager,
+        serverRegistry = registry,
+        healthApi = health,
+        brandingApi = branding,
+    )
+}
+
+private class FakeBrandingApi(
+    private val result: ApiResult<BrandingStatus>,
+    private val beforeReturn: suspend () -> Unit = {},
+) : BrandingApi(unusedClient()) {
+    override suspend fun getBranding(): ApiResult<BrandingStatus> {
+        beforeReturn()
+        return result
+    }
+}
+
+private class FakeHealthApi(
+    private val result: ApiResult<HealthStatus>,
+) : HealthApi(unusedClient()) {
+    var calls = 0
+        private set
+
+    override suspend fun checkHealth(): ApiResult<HealthStatus> {
+        calls += 1
+        return result
+    }
+}
+
+private class RecordingServerRegistry : ServerRegistry {
+    private val activeId = MutableStateFlow<String?>("active")
+    private val savedEntries = MutableStateFlow(
+        listOf(ServerEntry(id = "active", url = "https://silo.example")),
+    )
+
+    var fetchedName: String? = null
+        private set
+
+    override val entries: StateFlow<List<ServerEntry>> = savedEntries
+    override val activeServerId: StateFlow<String?> = activeId
+    override val activeEntry: StateFlow<ServerEntry?> = MutableStateFlow(savedEntries.value.single())
+
+    fun activate(serverId: String) {
+        activeId.value = serverId
+    }
+
+    override suspend fun addOrUpdate(url: String, fetchedName: String?): String = "active"
+    override suspend fun rename(serverId: String, userOverrideName: String?) = Unit
+    override suspend fun setFetchedName(serverId: String, fetchedName: String?) {
+        this.fetchedName = fetchedName
+    }
+    override suspend fun setProfileId(serverId: String, profileId: String?) = Unit
+    override suspend fun remove(serverId: String) = Unit
+    override suspend fun signOut(serverId: String) = Unit
+    override suspend fun switchTo(serverId: String) {
+        activeId.value = serverId
+    }
+    override suspend fun touchActive() = Unit
+}
+
+private object FakeTokenManager : TokenManager {
+    override val sessionExpired = MutableSharedFlow<Unit>()
+    override suspend fun getAccessToken(): String? = null
+    override suspend fun getRefreshToken(): String? = null
+    override suspend fun saveTokens(accessToken: String, refreshToken: String, expiresIn: Long) = Unit
+    override suspend fun clearTokens() = Unit
+    override suspend fun invalidateSession() = Unit
+    override suspend fun getProfileId(): String? = null
+    override suspend fun setProfileId(profileId: String?) = Unit
+    override suspend fun getProfileToken(): String? = null
+    override suspend fun setProfileToken(token: String?) = Unit
+    override suspend fun getServerUrl(): String = "https://silo.example"
+    override suspend fun setServerUrl(url: String) = Unit
+    override suspend fun getCurrentServerId(): String? = "active"
+    override suspend fun switchActiveServer(serverId: String?) = Unit
+    override suspend fun signOutCurrentServer() = Unit
+}
+
+private fun unusedClient(): HttpClient = HttpClient(MockEngine { error("Unexpected request") })


### PR DESCRIPTION
## Problem

The Android phone and TV clients refresh saved server names from `GET /api/v1/health.server_name`. That field is currently backed by the Jellyfin compatibility setting, so native clients can show “StreamApp” even when Jellyfin compatibility is disabled.

Fixes #191.
Related to Silo-Server/silo-server#553.

## Approach

- Add a shared client for the public `GET /api/v1/theme/branding` endpoint.
- Prefer `branding.server_name`, with `GET /api/v1/health` as an older-server fallback.
- Trim and reject blank names.
- Keep user rename overrides and URL fallback behavior unchanged.
- Guard the registry update so a delayed response cannot rename a newly activated server.

## Validation

- Focused shared tests for branding decoding and name resolution passed.
- `:shared:testDebugUnitTest` passed.
- `:androidApp:testDebugUnitTest` passed.
- `:androidTvApp:testDebugUnitTest` passed.
- `:androidApp:assembleDebug` passed.
- `:androidTvApp:assembleDebug` passed.
- `:shared:lintDebug` and `:androidTvApp:lintDebug` passed.
- `:androidApp:lintDebug` remains blocked by 9 pre-existing findings; the first is `MissingPermission` in `PushNotificationPresenter.kt:119`. No finding references a changed file.

## Risk

Low. The new lookup is best-effort and uses a public endpoint. Servers without that endpoint continue through the existing health request, while failures preserve the current saved or URL-derived display behavior.

## AI use

Implemented and validated with Codex on behalf of the repository maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying a server’s native branding name.
  * Server names now prioritize branding information, with health-based and existing fallback behavior preserved.
  * Added safeguards to prevent outdated server responses from overwriting current information.

* **Bug Fixes**
  * Blank branding names now correctly fall back to other available names.
  * Improved server-name updates when switching between servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->