### PR TITLE
fix(tv): register DownloadStorage so the orphaned-server purge can run

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -193,10 +193,17 @@ val androidTvModule = module {
     // graph has no downloads (streaming-only), so register the resolver inline:
     // it just always finds no local media and the VM falls back to the server
     // stream. The stores are local-only JSON under filesDir.
+    // Registered rather than constructed inline because the orphaned-server
+    // purge resolves it from the graph at startup. It is streaming-only here,
+    // so there are no download bytes to delete — but the purge also clears the
+    // Room rows of removed servers (resume positions, cached home and catalog
+    // rows, pending outbox ops), and without this definition the whole purge
+    // fails at startup and none of that is ever reclaimed.
+    single { org.siloserver.silo.common.downloads.DownloadStorage(androidContext()) }
     single {
         org.siloserver.silo.common.downloads.OfflineMediaResolver(
             org.siloserver.silo.common.downloads.DownloadMetadataStore(get()),
-            org.siloserver.silo.common.downloads.DownloadStorage(androidContext()),
+            get(),
             get(),
         )
     }


### PR DESCRIPTION
## The bug

`installOrphanedServerDataPurge` resolves `DownloadStorage` from Koin, but only
`AndroidModule` (phone) defines it — `AndroidTvModule` never did. On Android TV
the resolution throws on **every** startup:

```
SiloTvApplication: Orphaned server purge init failed
  No definition found for type '…DownloadStorage'. Check your Modules configuration…
  at org.siloserver.silo.tv.SiloTvApplication.onCreate
```

Because the call sits inside `runCatching { … }.onFailure { Log.w(…) }`, the
failure degrades to a warning nobody reads, so the purge has simply never run
on TV.

## Why it matters on a streaming-only client

The TV graph has no downloads, so there are no bytes to reclaim — but the purge
is not only about files. Per `OrphanedServerDataPurger`'s own docs, removing a
server otherwise leaves behind its Room rows, so re-adding it "resurrected its
Downloads list, resume positions, cached home and catalog rows, and any pending
outbox ops". On TV those have been accumulating for every server a user has
ever removed.

## The fix

Register `DownloadStorage` in `AndroidTvModule` and let `OfflineMediaResolver`
take it from the graph, so the resolver and the purge share one instance rather
than each constructing their own.

## Evidence

Found in a device logcat from an NVIDIA Shield: the failure appears on three
consecutive app startups. After this change, a build installed on the same
device logs it zero times and starts clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android TV startup handling for orphaned downloaded-server data.
  * Preserved streaming-only media resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->