### PR TITLE
chore: gate API-level mistakes with lint in CI

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -63,3 +63,48 @@ jobs:
           path: |
             **/build/reports/tests/**
           if-no-files-found: ignore
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+
+      - name: Run lint
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # NewApi and InlinedApi are fatal here. Two startup crashes reached
+          # users because nothing checked API levels: a Spatializer call gated
+          # at 31 for a class introduced at 32, and an unguarded API 28 call.
+          # Existing findings are held in per-module lint-baseline.xml, so only
+          # NEW violations fail. If this job fails, fix the call — do not
+          # regenerate the baseline to make it pass.
+          ./gradlew \
+            -Dorg.gradle.jvmargs="-Xmx4g -Dfile.encoding=UTF-8" \
+            :android-shared:lintDebug :androidApp:lintDebug :androidTvApp:lintDebug \
+            --max-workers=2
+
+      - name: Upload lint reports
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: lint-reports
+          path: |
+            **/build/reports/lint-results-*.html
+            **/build/reports/lint-results-*.xml
+          if-no-files-found: ignore

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -94,9 +94,16 @@ jobs:
           # Existing findings are held in per-module lint-baseline.xml, so only
           # NEW violations fail. If this job fails, fix the call — do not
           # regenerate the baseline to make it pass.
+          #
+          # lintVitalRelease runs here too. checkReleaseBuilds makes it part of
+          # assembleRelease, which only ever runs from release.yml on a v* tag —
+          # so without this the release variant is gated by a check that no pull
+          # request exercises, and the first run would be mid-release. It also
+          # covers the release-only source sets that lintDebug never sees.
           ./gradlew \
             -Dorg.gradle.jvmargs="-Xmx4g -Dfile.encoding=UTF-8" \
             :android-shared:lintDebug :androidApp:lintDebug :androidTvApp:lintDebug \
+            :androidApp:lintVitalRelease :androidTvApp:lintVitalRelease \
             --max-workers=2
 
       - name: Upload lint reports

--- a/android-shared/build.gradle.kts
+++ b/android-shared/build.gradle.kts
@@ -160,6 +160,23 @@ android {
             isReturnDefaultValues = true
         }
     }
+
+    // Lint had never run on this project. The two crashes it would have caught
+    // — a Spatializer call gated at API 31 when the class arrives at 32, and a
+    // getAddress() call with no guard at all — both shipped from this module,
+    // which app-level lint does not analyse unless asked. Hence the gate here
+    // and checkDependencies in the apps.
+    //
+    // The baseline holds today's known findings (overwhelmingly desugared
+    // java.* calls and deliberate media3 @UnstableApi usage) so that only NEW
+    // violations fail. Delete it and regenerate deliberately; do not add to it
+    // to make a build pass.
+    lint {
+        baseline = file("lint-baseline.xml")
+        abortOnError = true
+        fatal += setOf("NewApi", "InlinedApi")
+        checkReleaseBuilds = true
+    }
 }
 
 // Room schema export — the generated JSON schemas are committed under

--- a/android-shared/lint-baseline.xml
+++ b/android-shared/lint-baseline.xml
@@ -1,0 +1,3294 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.10.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.1)" variant="all" version="8.10.1">
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.registerDefaultNetworkCallback: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="            cm.registerDefaultNetworkCallback("
+        errorLine2="            ^">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/data/sync/OutboxSyncStarter.kt"
+            line="75"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getActiveNetwork: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="    @Volatile private var defaultNetwork: Network? = connectivity.activeNetwork"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackNetworkMonitor.kt"
+            line="53"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getActiveNetwork: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="            if (network == defaultNetwork) refresh(connectivity.activeNetwork)"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackNetworkMonitor.kt"
+            line="63"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.registerDefaultNetworkCallback: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="        connectivity.registerDefaultNetworkCallback(callback)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackNetworkMonitor.kt"
+            line="70"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 28 (current min is 24): `android.media.AudioFormat#ENCODING_E_AC3_JOC`"
+        errorLine1="            EncodingSupport(&quot;eac3_joc&quot;, AudioFormat.ENCODING_E_AC3_JOC),"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt"
+            line="345"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 25 (current min is 24): `android.media.AudioFormat#ENCODING_DOLBY_TRUEHD`"
+        errorLine1="            EncodingSupport(&quot;truehd&quot;, AudioFormat.ENCODING_DOLBY_TRUEHD, Build.VERSION_CODES.N_MR1),"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt"
+            line="348"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 28 (current min is 24): `android.media.AudioFormat#ENCODING_AC4`"
+        errorLine1="            EncodingSupport(&quot;ac4&quot;, AudioFormat.ENCODING_AC4, Build.VERSION_CODES.P),"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt"
+            line="349"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 25): `android.view.Display.HdrCapabilities#HDR_TYPE_HDR10_PLUS`"
+        errorLine1="            Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS in types"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt"
+            line="76"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.provider.MediaStore#VOLUME_EXTERNAL_PRIMARY`"
+        errorLine1="        Video -> MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1004"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.provider.MediaStore#VOLUME_EXTERNAL_PRIMARY`"
+        errorLine1="        Audio -> MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1005"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.provider.MediaStore#VOLUME_EXTERNAL_PRIMARY`"
+        errorLine1="        Downloads -> MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1006"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.media.MediaCodecInfo.CodecProfileLevel#AVCLevel6`"
+        errorLine1="        CodecProfileLevel.AVCLevel6 to 60,"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="497"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.media.MediaCodecInfo.CodecProfileLevel#AVCLevel61`"
+        errorLine1="        CodecProfileLevel.AVCLevel61 to 61,"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="498"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.media.MediaCodecInfo.CodecProfileLevel#AVCLevel62`"
+        errorLine1="        CodecProfileLevel.AVCLevel62 to 62,"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="499"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.channels.FileChannel#open`"
+        errorLine1="                FileChannel.open("
+        errorLine2="                            ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="380"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    file.toPath(),"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="381"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#WRITE`"
+        errorLine1="                    StandardOpenOption.WRITE,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="382"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#APPEND`"
+        errorLine1="                    StandardOpenOption.APPEND,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="383"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="                    LinkOption.NOFOLLOW_LINKS,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="384"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="        val path = target.toPath()"
+        errorLine2="                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="484"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#exists`"
+        errorLine1="        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) return false"
+        errorLine2="                   ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="485"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) return false"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="485"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#walkFileTree`"
+        errorLine1="        Files.walkFileTree(path, object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="              ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="489"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor()`"
+        errorLine1="        Files.walkFileTree(path, object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="489"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor`"
+        errorLine1="        Files.walkFileTree(path, object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="489"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                deleted = Files.deleteIfExists(file) || deleted"
+        errorLine2="                                ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="491"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                return FileVisitResult.CONTINUE"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="492"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                deleted = Files.deleteIfExists(directory) || deleted"
+        errorLine2="                                ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="497"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                return FileVisitResult.CONTINUE"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="498"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(directory.toPath())"
+        errorLine2="                                                                     ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="529"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#newDirectoryStream`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(directory.toPath())"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="529"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                if (directoryStream is SecureDirectoryStream&lt;*>) {"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="530"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                    val secure = directoryStream as SecureDirectoryStream&lt;Path>"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="532"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    val relative = directory.toPath().fileSystem.getPath(tempFile.name)"
+        errorLine2="                                             ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="533"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    val relative = directory.toPath().fileSystem.getPath(tempFile.name)"
+        errorLine2="                                                                 ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="533"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    val relative = directory.toPath().fileSystem.getPath(tempFile.name)"
+        errorLine2="                                                      ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="533"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#newByteChannel`"
+        errorLine1="                    val channel = secure.newByteChannel(relative, CREATE_NEW_NOFOLLOW)"
+        errorLine2="                                         ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="534"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    FileChannel.open(tempFile.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="552"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.channels.FileChannel#open`"
+        errorLine1="                    FileChannel.open(tempFile.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="552"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.FileAlreadyExistsException`"
+        errorLine1="            } catch (_: java.nio.file.FileAlreadyExistsException) {"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="556"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="582"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#isRegularFile`"
+        errorLine1="            Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                  ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="582"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="582"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move("
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="603"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                source.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="604"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                target.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="605"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#ATOMIC_MOVE`"
+        errorLine1="                StandardCopyOption.ATOMIC_MOVE,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="606"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="                StandardCopyOption.REPLACE_EXISTING,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="607"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.AtomicMoveNotSupportedException`"
+        errorLine1="        } catch (_: AtomicMoveNotSupportedException) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="609"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(finalFile.name))"
+        errorLine2="                                                                  ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="649"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(finalFile.name))"
+        errorLine2="                                                       ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="649"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#move`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(finalFile.name))"
+        errorLine2="                           ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="649"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            return runCatching { Files.deleteIfExists(tempFile.toPath()) }.getOrDefault(false)"
+        errorLine2="                                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="660"
+            column="64"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="            return runCatching { Files.deleteIfExists(tempFile.toPath()) }.getOrDefault(false)"
+        errorLine2="                                       ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="660"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#CREATE_NEW`"
+        errorLine1="            StandardOpenOption.CREATE_NEW,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="668"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#WRITE`"
+        errorLine1="            StandardOpenOption.WRITE,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="669"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            LinkOption.NOFOLLOW_LINKS,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="670"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.provider.MediaStore.Downloads#getContentUri`"
+        errorLine1="        Downloads -> MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                          ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1006"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getReason`"
+        errorLine1="        override val reason: Int get() = record.reason"
+        errorLine2="                                                ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="70"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getTimestamp`"
+        errorLine1="        override val timestampMs: Long get() = record.timestamp"
+        errorLine2="                                                      ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="71"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getPid`"
+        errorLine1="        override val pid: Int get() = record.pid"
+        errorLine2="                                             ~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="72"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getProcessName`"
+        errorLine1="        override val processName: String get() = record.processName.orEmpty()"
+        errorLine2="                                                        ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="73"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getStatus`"
+        errorLine1="        override val status: Int get() = record.status"
+        errorLine2="                                                ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="74"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getProcessStateSummary`"
+        errorLine1="        override val processStateSummary: ByteArray? get() = record.processStateSummary?.copyOf()"
+        errorLine2="                                                                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="75"
+            column="69"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint#covers`"
+        errorLine1="                        point.covers("
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="251"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint()`"
+        errorLine1="                            android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint("
+        errorLine2="                                                                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="252"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint()`"
+        errorLine1="                val requested = android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint("
+        errorLine2="                                                                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="267"
+            column="80"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint#covers`"
+        errorLine1="                points.any { point -> point.covers(requested) }"
+        errorLine2="                                            ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="272"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            canonicalRoot.toPath().relativize(target.canonicalFile.toPath()).first().toString()"
+        errorLine2="                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="76"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            canonicalRoot.toPath().relativize(target.canonicalFile.toPath()).first().toString()"
+        errorLine2="                                                                   ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="76"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#relativize`"
+        errorLine1="            canonicalRoot.toPath().relativize(target.canonicalFile.toPath()).first().toString()"
+        errorLine2="                                   ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="76"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.deleteIfExists(tmp.toPath())"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="117"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="            Files.deleteIfExists(tmp.toPath())"
+        errorLine2="                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="117"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            ?.let { legacy -> Files.deleteIfExists(legacy.toPath()) }"
+        errorLine2="                                                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="122"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="            ?.let { legacy -> Files.deleteIfExists(legacy.toPath()) }"
+        errorLine2="                                    ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="122"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(parent.toPath())"
+        errorLine2="                                                                  ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="151"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#newDirectoryStream`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(parent.toPath())"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="151"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                if (directoryStream is SecureDirectoryStream&lt;*>) {"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="152"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                    val secure = directoryStream as SecureDirectoryStream&lt;Path>"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="154"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    val relative = parent.toPath().fileSystem.getPath(candidate.name)"
+        errorLine2="                                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="155"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    val relative = parent.toPath().fileSystem.getPath(candidate.name)"
+        errorLine2="                                                              ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="155"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    val relative = parent.toPath().fileSystem.getPath(candidate.name)"
+        errorLine2="                                                   ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="155"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#newByteChannel`"
+        errorLine1="                    val channel = secure.newByteChannel(relative, CREATE_NEW_NOFOLLOW)"
+        errorLine2="                                         ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="156"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    FileChannel.open(candidate.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="163"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.channels.FileChannel#open`"
+        errorLine1="                    FileChannel.open(candidate.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="163"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.FileAlreadyExistsException`"
+        errorLine1="            } catch (_: java.nio.file.FileAlreadyExistsException) {"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="167"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(target.name))"
+        errorLine2="                                                                  ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="189"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(target.name))"
+        errorLine2="                                                       ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="189"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#move`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(target.name))"
+        errorLine2="                           ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="189"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move("
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="207"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                source.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="208"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                target.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="209"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#ATOMIC_MOVE`"
+        errorLine1="                StandardCopyOption.ATOMIC_MOVE,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="210"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="                StandardCopyOption.REPLACE_EXISTING,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="211"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.AtomicMoveNotSupportedException`"
+        errorLine1="        } catch (_: AtomicMoveNotSupportedException) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="213"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#CREATE_NEW`"
+        errorLine1="            StandardOpenOption.CREATE_NEW,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="223"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#WRITE`"
+        errorLine1="            StandardOpenOption.WRITE,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="224"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            LinkOption.NOFOLLOW_LINKS,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="225"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                        val relative = root.toPath().relativize(legacy.toPath())"
+        errorLine2="                                            ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="70"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                        val relative = root.toPath().relativize(legacy.toPath())"
+        errorLine2="                                                                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="70"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#relativize`"
+        errorLine1="                        val relative = root.toPath().relativize(legacy.toPath())"
+        errorLine2="                                                     ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="70"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Implicit cast from `Path` to `Iterable` requires API level 26 (current min is 24)"
+        errorLine1="                        relative.firstOrNull()?.toString()?.let(::add)"
+        errorLine2="                        ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="71"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="        val path = root.toPath()"
+        errorLine2="                        ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="86"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#isSymbolicLink`"
+        errorLine1="        if (Files.isSymbolicLink(path)) return@runCatching null"
+        errorLine2="                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="87"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#exists`"
+        errorLine1="        if (Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS) &amp;&amp;"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="88"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="        if (Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS) &amp;&amp;"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="88"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#isDirectory`"
+        errorLine1="            !Files.isDirectory(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                   ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="89"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            !Files.isDirectory(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="89"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="        val path = candidate.toPath()"
+        errorLine2="                             ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="100"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#exists`"
+        errorLine1="        if (!Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)) return"
+        errorLine2="                   ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="101"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="        if (!Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)) return"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="101"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#walkFileTree`"
+        errorLine1="        Files.walkFileTree("
+        errorLine2="              ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="102"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor()`"
+        errorLine1="            object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="104"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor`"
+        errorLine1="            object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="104"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                    Files.deleteIfExists(file)"
+        errorLine2="                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="106"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                    return FileVisitResult.CONTINUE"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="107"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                    Files.deleteIfExists(file)"
+        errorLine2="                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="113"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                    return FileVisitResult.CONTINUE"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="114"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                    Files.deleteIfExists(dir)"
+        errorLine2="                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="119"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                    return FileVisitResult.CONTINUE"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="120"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.Activity#setPictureInPictureParams`"
+        errorLine1="            activity.setPictureInPictureParams(buildParams(activity, surface, state))"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="97"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder()`"
+        errorLine1="        val builder = PictureInPictureParams.Builder()"
+        errorLine2="                                             ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="148"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#setAspectRatio`"
+        errorLine1="            .setAspectRatio(aspectRatioFor(state))"
+        errorLine2="             ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="149"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#setActions`"
+        errorLine1="            .setActions(remoteActions(context, state.isPlaying))"
+        errorLine2="             ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="150"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#setSourceRectHint`"
+        errorLine1="            builder.setSourceRectHint(rect)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="153"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#build`"
+        errorLine1="        return builder.build()"
+        errorLine2="                       ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="172"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SpecifyForegroundServiceType"
+        message="Missing dataSync foregroundServiceType in the AndroidManifest.xml"
+        errorLine1="            ForegroundInfo(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadWorker.kt"
+            line="451"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of Gradle than 8.12 is available: 8.14.5"
+        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/wrapper/gradle-wrapper.properties"
+            line="3"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.application than 8.10.1 is available: 9.3.1"
+        errorLine1="agp = &quot;8.10.1&quot;"
+        errorLine2="      ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="3"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.library than 8.10.1 is available: 9.3.1"
+        errorLine1="agp = &quot;8.10.1&quot;"
+        errorLine2="      ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="3"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.test than 8.10.1 is available: 9.3.1"
+        errorLine1="agp = &quot;8.10.1&quot;"
+        errorLine2="      ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="3"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-common than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-common-ktx than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-container than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-datasource-okhttp than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-exoplayer than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-exoplayer-hls than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-extractor than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-session than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-test-utils than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-test-utils-robolectric than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-ui than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-ui-compose than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.tvprovider:tvprovider than 1.0.0 is available: 1.1.0"
+        errorLine1="tvprovider = &quot;1.0.0&quot;"
+        errorLine2="             ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="15"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-process than 2.10.0 is available: 2.11.0"
+        errorLine1="lifecycle = &quot;2.10.0&quot;"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-compose than 2.10.0 is available: 2.11.0"
+        errorLine1="lifecycle = &quot;2.10.0&quot;"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-compose than 2.10.0 is available: 2.11.0"
+        errorLine1="lifecycle = &quot;2.10.0&quot;"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.activity:activity-compose than 1.12.4 is available: 1.13.0"
+        errorLine1="activity-compose = &quot;1.12.4&quot;"
+        errorLine2="                   ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="22"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.tv:tv-material than 1.0.1 is available: 1.1.0"
+        errorLine1="tv-compose = &quot;1.0.1&quot;"
+        errorLine2="             ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="23"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose.ui:ui-test-junit4 than 1.9.2 is available: 1.11.4"
+        errorLine1="compose-ui-test = &quot;1.9.2&quot;"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="29"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose.ui:ui-test-manifest than 1.9.2 is available: 1.11.4"
+        errorLine1="compose-ui-test = &quot;1.9.2&quot;"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="29"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test:core-ktx than 1.6.1 is available: 1.7.0"
+        errorLine1="androidx-test-core = &quot;1.6.1&quot;"
+        errorLine2="                     ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="32"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.baselineprofile than 1.3.4 is available: 1.4.1"
+        errorLine1="benchmark = &quot;1.3.4&quot;"
+        errorLine2="            ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.benchmark:benchmark-macro-junit4 than 1.3.4 is available: 1.4.1"
+        errorLine1="benchmark = &quot;1.3.4&quot;"
+        errorLine2="            ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.ext:junit than 1.2.1 is available: 1.3.0"
+        errorLine1="androidx-test-ext-junit = &quot;1.2.1&quot;"
+        errorLine2="                          ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="37"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.uiautomator:uiautomator than 2.3.0 is available: 2.4.0"
+        errorLine1="uiautomator = &quot;2.3.0&quot;"
+        errorLine2="              ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="38"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.firebase:firebase-messaging than 25.1.0 is available: 25.1.1"
+        errorLine1="firebase-messaging = &quot;25.1.0&quot;"
+        errorLine2="                     ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="39"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.android.gms:play-services-cast-framework than 21.5.0 is available: 22.3.1"
+        errorLine1="play-services-cast-framework = &quot;21.5.0&quot;"
+        errorLine2="                               ~~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="45"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.mediarouter:mediarouter than 1.7.0 is available: 1.8.1"
+        errorLine1="androidx-mediarouter = &quot;1.7.0&quot;"
+        errorLine2="                       ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="46"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.window:window than 1.4.0 is available: 1.5.1"
+        errorLine1="androidx-window = &quot;1.4.0&quot;"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="$HOME/projects/silo/silo-android/.worktrees/lint-gate/gradle/libs.versions.toml"
+            line="47"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    presentation: AndroidSubtitlePresentation,"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="13"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AndroidSubtitlePresentation.Phone -> AndroidSubtitleTextSize.Fractional("
+        errorLine2="                                ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="16"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AndroidSubtitlePresentation.Television -> AndroidSubtitleTextSize.FixedSp("
+        errorLine2="                                ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="25"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    subtitleView: SubtitleView,"
+        errorLine2="                  ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="38"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        is AndroidSubtitleTextSize.Fractional -> subtitleView.setFractionalTextSize("
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="42"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        is AndroidSubtitleTextSize.FixedSp -> subtitleView.setFixedTextSize("
+        errorLine2="                                                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="46"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="internal fun shouldNormalizeSubripDataSpec(dataSpec: DataSpec): Boolean ="
+        errorLine2="                                                     ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="450"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    shouldNormalizeSubripPath(dataSpec.uri.path, dataSpec.position)"
+        errorLine2="                                       ~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="451"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    shouldNormalizeSubripPath(dataSpec.uri.path, dataSpec.position)"
+        errorLine2="                                                          ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="451"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val audioCapabilityManager: AudioCapabilityManager,"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DeviceSnapshotCollector.kt"
+            line="158"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        val snapshot = audioCapabilityManager.diagnosticsSnapshot()"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DeviceSnapshotCollector.kt"
+            line="190"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun hdr10ColorInfo(current: ColorInfo?): ColorInfo ="
+        errorLine2="                                    ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="481"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun hdr10ColorInfo(current: ColorInfo?): ColorInfo ="
+        errorLine2="                                                 ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="481"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    (current?.buildUpon() ?: ColorInfo.Builder())"
+        errorLine2="              ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="482"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    (current?.buildUpon() ?: ColorInfo.Builder())"
+        errorLine2="                                       ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="482"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorSpace(C.COLOR_SPACE_BT2020)"
+        errorLine2="         ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="483"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorSpace(C.COLOR_SPACE_BT2020)"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="483"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorTransfer(C.COLOR_TRANSFER_ST2084)"
+        errorLine2="         ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="484"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorTransfer(C.COLOR_TRANSFER_ST2084)"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="484"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorRange(C.COLOR_RANGE_LIMITED)"
+        errorLine2="         ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="485"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorRange(C.COLOR_RANGE_LIMITED)"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="485"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setHdrStaticInfo(current?.hdrStaticInfo ?: defaultDolbyVisionHdrStaticInfo())"
+        errorLine2="         ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="486"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setHdrStaticInfo(current?.hdrStaticInfo ?: defaultDolbyVisionHdrStaticInfo())"
+        errorLine2="                                   ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="486"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .build()"
+        errorLine2="         ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="487"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    if (chain.any { it is ParserException }) return false"
+        errorLine2="                          ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicy.kt"
+            line="206"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    headerFields.entries"
+        errorLine2="    ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicy.kt"
+            line="281"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val delegate: AudioSink,"
+        errorLine2="                          ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="55"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1=") : AudioSink by delegate {"
+        errorLine2="    ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="56"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    override fun supportsFormat(format: Format): Boolean ="
+        errorLine2="                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="57"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        getFormatSupport(format) != AudioSink.SINK_FORMAT_UNSUPPORTED"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="58"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    override fun getFormatSupport(format: Format): Int ="
+        errorLine2="                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="60"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            AudioSink.SINK_FORMAT_UNSUPPORTED"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="67"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            delegate.getFormatSupport(format)"
+        errorLine2="                     ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="69"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        Intent(context, SiloPlaybackService::class.java)"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PipActionCapability.kt"
+            line="19"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val audioCapabilityManager: AudioCapabilityManager,"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="55"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val libassBridge: LibassBridge,"
+        errorLine2="                              ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="56"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        val libassRendering = libassBridge.isRenderingSupported"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="215"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        val libassEmbeddedFonts = libassBridge.isEmbeddedFontsSupported"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="216"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                sinkType = audioCapabilityManager.currentSinkType(),"
+        errorLine2="                                                  ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="282"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        ?: if (mediaTrackGroup.length > 0) mediaTrackGroup.getFormat(0) else null"
+        errorLine2="                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="432"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        ?: if (mediaTrackGroup.length > 0) mediaTrackGroup.getFormat(0) else null"
+        errorLine2="                                                           ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="432"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoFormat?.let { json.put(&quot;videoFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="84"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoFormat?.let { json.put(&quot;videoFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                                                                  ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="84"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.audioFormat?.let { json.put(&quot;audioFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="85"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.audioFormat?.let { json.put(&quot;audioFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                                                                  ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="85"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoDecoderCounters?.let { counters ->"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="86"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoDecoderCounters?.let { counters ->"
+        errorLine2="                                            ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="86"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                json.put(&quot;droppedFrames&quot;, counters.droppedBufferCount)"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="87"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                json.put(&quot;renderedFrames&quot;, counters.renderedOutputBufferCount)"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="88"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { DefaultBandwidthMeter.Builder(androidContext()).build() }"
+        errorLine2="                                   ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="67"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { DefaultBandwidthMeter.Builder(androidContext()).build() }"
+        errorLine2="                                                             ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="67"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        PlaybackNetworkMonitor(androidContext(), get())"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="71"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { PlaybackAnalyticsListener() }"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="75"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { DelayAudioProcessor() }"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="78"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { LibassBridge(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) }"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="83"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    event: PlaybackAnalyticsListener.Event,"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="58"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.VideoDecoderInitialized ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="60"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.AudioDecoderInitialized ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="65"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.VideoFormatChanged -> current.copy("
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="67"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.AudioFormatChanged ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="82"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.DroppedFrames ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="84"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.AudioUnderrun ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="86"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.BandwidthEstimate ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="88"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.FirstFrameRendered -> current.copy("
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="90"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.SeekStarted -> current.copy(seekStartedAtMs = event.realtimeMs)"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="95"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.PlaybackStateChanged -> current.reducePlaybackState(event)"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="96"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.LoadError,"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="97"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.PlayerError,"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="98"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.TrackSnapshot,"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="99"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    event: PlaybackAnalyticsListener.Event.PlaybackStateChanged,"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="104"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorTransfer(format: Format): String? = when (format.colorInfo?.colorTransfer) {"
+        errorLine2="                                                                          ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="169"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorTransfer(format: Format): String? = when (format.colorInfo?.colorTransfer) {"
+        errorLine2="                                                                                     ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="169"
+            column="86"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_TRANSFER_ST2084 -> &quot;st2084&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="170"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_TRANSFER_HLG -> &quot;hlg&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="171"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_TRANSFER_SDR -> &quot;sdr&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="172"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorRange(format: Format): String? = when (format.colorInfo?.colorRange) {"
+        errorLine2="                                                                       ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="176"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorRange(format: Format): String? = when (format.colorInfo?.colorRange) {"
+        errorLine2="                                                                                  ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="176"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_RANGE_FULL -> &quot;full&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="177"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_RANGE_LIMITED -> &quot;limited&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="178"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    val colorInfo = format.colorInfo ?: return null"
+        errorLine2="        ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="187"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    val colorInfo = format.colorInfo ?: return null"
+        errorLine2="                           ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="187"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    return when (colorInfo.colorTransfer) {"
+        errorLine2="                           ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="188"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        C.COLOR_TRANSFER_ST2084 -> &quot;HDR10&quot;"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="189"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        C.COLOR_TRANSFER_HLG -> &quot;HLG&quot;"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="190"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        C.COLOR_TRANSFER_SDR -> &quot;SDR&quot;"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="191"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PAUSE"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="178"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PAUSE"
+        errorLine2="                                ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="178"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PLAY"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="180"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PLAY"
+        errorLine2="                                ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="180"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_BACK),"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="189"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_BACK),"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="189"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_FORWARD),"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="201"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_FORWARD),"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="201"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        AspectRatioFrameLayout.RESIZE_MODE_FIXED_WIDTH -> {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="468"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        AspectRatioFrameLayout.RESIZE_MODE_FIXED_HEIGHT -> {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="472"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        AspectRatioFrameLayout.RESIZE_MODE_FIT -> {"
+        errorLine2="                               ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="476"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AspectRatioFrameLayout.RESIZE_MODE_ZOOM,"
+        errorLine2="                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="507"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AspectRatioFrameLayout.RESIZE_MODE_FILL,"
+        errorLine2="                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="508"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        return cue.buildUpon().setSize(Cue.DIMEN_UNSET).build()"
+        errorLine2="                   ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="566"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        return cue.buildUpon().setSize(Cue.DIMEN_UNSET).build()"
+        errorLine2="                               ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="566"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        return cue.buildUpon().setSize(Cue.DIMEN_UNSET).build()"
+        errorLine2="                                                        ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="566"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    return if (changed) CueGroup(mapped, cueGroup.presentationTimeUs) else cueGroup"
+        errorLine2="                        ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="579"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    return if (changed) CueGroup(mapped, cueGroup.presentationTimeUs) else cueGroup"
+        errorLine2="                                                  ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="579"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    val frame = findViewById&lt;AspectRatioFrameLayout>("
+        errorLine2="        ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="904"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val playerFactory: SiloPlayerFactory,"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackendFactory.kt"
+            line="12"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val audioTrackManager: AudioTrackManager,"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackendFactory.kt"
+            line="13"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val subtitleManager: SubtitleManager,"
+        errorLine2="                                 ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackendFactory.kt"
+            line="14"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="SwitchIntDef"
+        message="Switch statement on an `int` with known associated constant missing case `TrackOutput.SAMPLE_DATA_PART_ENCRYPTION`"
+        errorLine1="        when (sampleDataPart) {"
+        errorLine2="        ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="279"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is never &lt; 24"
+        errorLine1="        if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.N) return HdrCapabilities()"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt"
+            line="63"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableLongStateOf` instead of `mutableStateOf`"
+        errorLine1="    var playbackVisibleStartedAt by remember { mutableStateOf(0L) }"
+        errorLine2="                                               ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/ui/components/StartupSplashVideo.kt"
+            line="59"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UsableSpace"
+        message="Consider also using `StorageManager#getAllocatableBytes` and `allocateBytes` which will consider clearable cached data"
+        errorLine1="    fun usableSpaceBytes(): Long = baseDir.usableSpace"
+        errorLine2="                                           ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="148"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit().putString(KEY_DEVICE_ID, generated).apply()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/network/AndroidDeviceMetadataProvider.kt"
+            line="20"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().putString(storageKey(serverUrl, key), value).apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidServerSettingsCache.kt"
+            line="14"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().putBoolean(migrationKey(serverUrl, scope), true).apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidServerSettingsCache.kt"
+            line="31"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                .setUri(Uri.parse(absoluteUrl))"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="327"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return null"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="708"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return null"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="750"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return 0L"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="757"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            return runCatching { resolver.delete(Uri.parse(uri), null, null) > 0 }.getOrDefault(false)"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="767"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        if (resolver.update(Uri.parse(uriString), values, null, null) &lt;= 0) return uriString"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="837"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit().putString(KEY_DEVICE_ID, it).apply()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingDeviceId.kt"
+            line="25"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            android.net.Uri.parse(absoluteUrl)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt"
+            line="466"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            RequestHeaderScope(android.net.Uri.parse(absoluteUrl), it)"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt"
+            line="471"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                ?.let { metadataBuilder.setArtworkUri(android.net.Uri.parse(it)) }"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt"
+            line="507"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            val builder = MediaItem.SubtitleConfiguration.Builder(Uri.parse(absoluteUrl))"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="99"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/ui/components/ThumbHash.kt"
+            line="136"
+            column="22"/>
+    </issue>
+
+</issues>

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
@@ -342,7 +342,7 @@ class AudioCapabilityManager(
         val encodingSupport = listOf(
             EncodingSupport("ac3", AudioFormat.ENCODING_AC3),
             EncodingSupport("eac3", AudioFormat.ENCODING_E_AC3),
-            EncodingSupport("eac3_joc", AudioFormat.ENCODING_E_AC3_JOC),
+            EncodingSupport("eac3_joc", AudioFormat.ENCODING_E_AC3_JOC, Build.VERSION_CODES.P),
             EncodingSupport("dts", AudioFormat.ENCODING_DTS),
             EncodingSupport("dts_hd", AudioFormat.ENCODING_DTS_HD, Build.VERSION_CODES.M),
             EncodingSupport("truehd", AudioFormat.ENCODING_DOLBY_TRUEHD, Build.VERSION_CODES.N_MR1),

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
@@ -209,7 +209,12 @@ class AudioCapabilityManager(
         devices.map(::sinkCategory).minByOrNull(::sinkPriority) ?: "unknown"
 
     private fun routeHash(device: AudioDeviceInfo): String {
-        val raw = "${device.type}|${device.id}|${device.address}"
+        // getAddress() is API 28; below that the route is identified by type and
+        // id alone. Unguarded this threw NoSuchMethodError on Android 7-8.1
+        // whenever diagnostics were collected.
+        val address =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) device.address else ""
+        val raw = "${device.type}|${device.id}|$address"
         return MessageDigest.getInstance("SHA-256")
             .digest(raw.encodeToByteArray())
             .take(ROUTE_HASH_BYTES)
@@ -307,8 +312,14 @@ class AudioCapabilityManager(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val support = AudioManager.getDirectPlaybackSupport(format, attributes)
             support and AudioManager.DIRECT_PLAYBACK_BITSTREAM_SUPPORTED != 0
-        } else {
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             AudioTrack.isDirectPlaybackSupported(format, attributes)
+        } else {
+            // API 29 introduced the query. Below it the platform cannot be
+            // asked, and runCatching was silently answering "no passthrough" —
+            // so pre-Q devices were transcoding audio they could have played
+            // directly. Same answer, but now it is a deliberate one.
+            false
         }
     }.getOrDefault(false)
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -243,6 +243,25 @@ android {
             excludes += "/META-INF/versions/*/OSGI-INF/MANIFEST.MF"
         }
     }
+
+    // Lint had never run on this project. The two crashes it would have caught
+    // — a Spatializer call gated at API 31 when the class arrives at 32, and a
+    // getAddress() call with no guard at all — both shipped from this module,
+    // which app-level lint does not analyse unless asked. Hence the gate here
+    // and checkDependencies in the apps.
+    //
+    // The baseline holds today's known findings (overwhelmingly desugared
+    // java.* calls and deliberate media3 @UnstableApi usage) so that only NEW
+    // violations fail. Delete it and regenerate deliberately; do not add to it
+    // to make a build pass.
+    lint {
+        // Without this, none of android-shared is examined.
+        checkDependencies = true
+        baseline = file("lint-baseline.xml")
+        abortOnError = true
+        fatal += setOf("NewApi", "InlinedApi")
+        checkReleaseBuilds = true
+    }
 }
 
 dependencies {

--- a/androidApp/lint-baseline.xml
+++ b/androidApp/lint-baseline.xml
@@ -1,0 +1,4525 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.10.1" type="baseline" client="gradle" dependencies="true" name="AGP (8.10.1)" variant="all" version="8.10.1">
+
+    <issue
+        id="MissingPermission"
+        message="Call requires permission which may be rejected by user: code should explicitly check to see if permission is available (with `checkPermission`) or explicitly handle a potential `SecurityException`"
+        errorLine1="            NotificationManagerCompat.from(context)"
+        errorLine2="            ^">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/push/PushNotificationPresenter.kt"
+            line="119"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 28 (current min is 24): `android.media.AudioFormat#ENCODING_E_AC3_JOC`"
+        errorLine1="            EncodingSupport(&quot;eac3_joc&quot;, AudioFormat.ENCODING_E_AC3_JOC),"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt"
+            line="345"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 25 (current min is 24): `android.media.AudioFormat#ENCODING_DOLBY_TRUEHD`"
+        errorLine1="            EncodingSupport(&quot;truehd&quot;, AudioFormat.ENCODING_DOLBY_TRUEHD, Build.VERSION_CODES.N_MR1),"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt"
+            line="348"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 28 (current min is 24): `android.media.AudioFormat#ENCODING_AC4`"
+        errorLine1="            EncodingSupport(&quot;ac4&quot;, AudioFormat.ENCODING_AC4, Build.VERSION_CODES.P),"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt"
+            line="349"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 25): `android.view.Display.HdrCapabilities#HDR_TYPE_HDR10_PLUS`"
+        errorLine1="            Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS in types"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt"
+            line="76"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.provider.MediaStore#VOLUME_EXTERNAL_PRIMARY`"
+        errorLine1="        Video -> MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1004"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.provider.MediaStore#VOLUME_EXTERNAL_PRIMARY`"
+        errorLine1="        Audio -> MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1005"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.provider.MediaStore#VOLUME_EXTERNAL_PRIMARY`"
+        errorLine1="        Downloads -> MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1006"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.media.MediaCodecInfo.CodecProfileLevel#AVCLevel6`"
+        errorLine1="        CodecProfileLevel.AVCLevel6 to 60,"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="497"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.media.MediaCodecInfo.CodecProfileLevel#AVCLevel61`"
+        errorLine1="        CodecProfileLevel.AVCLevel61 to 61,"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="498"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.media.MediaCodecInfo.CodecProfileLevel#AVCLevel62`"
+        errorLine1="        CodecProfileLevel.AVCLevel62 to 62,"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="499"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.channels.FileChannel#open`"
+        errorLine1="                FileChannel.open("
+        errorLine2="                            ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="380"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    file.toPath(),"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="381"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#WRITE`"
+        errorLine1="                    StandardOpenOption.WRITE,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="382"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#APPEND`"
+        errorLine1="                    StandardOpenOption.APPEND,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="383"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="                    LinkOption.NOFOLLOW_LINKS,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="384"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="        val path = target.toPath()"
+        errorLine2="                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="484"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#exists`"
+        errorLine1="        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) return false"
+        errorLine2="                   ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="485"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) return false"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="485"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#walkFileTree`"
+        errorLine1="        Files.walkFileTree(path, object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="              ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="489"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor()`"
+        errorLine1="        Files.walkFileTree(path, object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="489"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor`"
+        errorLine1="        Files.walkFileTree(path, object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="489"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                deleted = Files.deleteIfExists(file) || deleted"
+        errorLine2="                                ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="491"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                return FileVisitResult.CONTINUE"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="492"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                deleted = Files.deleteIfExists(directory) || deleted"
+        errorLine2="                                ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="497"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                return FileVisitResult.CONTINUE"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="498"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(directory.toPath())"
+        errorLine2="                                                                     ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="529"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#newDirectoryStream`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(directory.toPath())"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="529"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                if (directoryStream is SecureDirectoryStream&lt;*>) {"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="530"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                    val secure = directoryStream as SecureDirectoryStream&lt;Path>"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="532"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    val relative = directory.toPath().fileSystem.getPath(tempFile.name)"
+        errorLine2="                                             ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="533"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    val relative = directory.toPath().fileSystem.getPath(tempFile.name)"
+        errorLine2="                                                                 ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="533"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    val relative = directory.toPath().fileSystem.getPath(tempFile.name)"
+        errorLine2="                                                      ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="533"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#newByteChannel`"
+        errorLine1="                    val channel = secure.newByteChannel(relative, CREATE_NEW_NOFOLLOW)"
+        errorLine2="                                         ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="534"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    FileChannel.open(tempFile.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="552"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.channels.FileChannel#open`"
+        errorLine1="                    FileChannel.open(tempFile.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="552"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.FileAlreadyExistsException`"
+        errorLine1="            } catch (_: java.nio.file.FileAlreadyExistsException) {"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="556"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="582"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#isRegularFile`"
+        errorLine1="            Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                  ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="582"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="582"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move("
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="603"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                source.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="604"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                target.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="605"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#ATOMIC_MOVE`"
+        errorLine1="                StandardCopyOption.ATOMIC_MOVE,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="606"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="                StandardCopyOption.REPLACE_EXISTING,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="607"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.AtomicMoveNotSupportedException`"
+        errorLine1="        } catch (_: AtomicMoveNotSupportedException) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="609"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(finalFile.name))"
+        errorLine2="                                                                  ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="649"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(finalFile.name))"
+        errorLine2="                                                       ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="649"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#move`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(finalFile.name))"
+        errorLine2="                           ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="649"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            return runCatching { Files.deleteIfExists(tempFile.toPath()) }.getOrDefault(false)"
+        errorLine2="                                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="660"
+            column="64"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="            return runCatching { Files.deleteIfExists(tempFile.toPath()) }.getOrDefault(false)"
+        errorLine2="                                       ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="660"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#CREATE_NEW`"
+        errorLine1="            StandardOpenOption.CREATE_NEW,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="668"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#WRITE`"
+        errorLine1="            StandardOpenOption.WRITE,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="669"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            LinkOption.NOFOLLOW_LINKS,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="670"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.provider.MediaStore.Downloads#getContentUri`"
+        errorLine1="        Downloads -> MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                          ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1006"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getReason`"
+        errorLine1="        override val reason: Int get() = record.reason"
+        errorLine2="                                                ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="70"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getTimestamp`"
+        errorLine1="        override val timestampMs: Long get() = record.timestamp"
+        errorLine2="                                                      ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="71"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getPid`"
+        errorLine1="        override val pid: Int get() = record.pid"
+        errorLine2="                                             ~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="72"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getProcessName`"
+        errorLine1="        override val processName: String get() = record.processName.orEmpty()"
+        errorLine2="                                                        ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="73"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getStatus`"
+        errorLine1="        override val status: Int get() = record.status"
+        errorLine2="                                                ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="74"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getProcessStateSummary`"
+        errorLine1="        override val processStateSummary: ByteArray? get() = record.processStateSummary?.copyOf()"
+        errorLine2="                                                                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="75"
+            column="69"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint#covers`"
+        errorLine1="                        point.covers("
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="251"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint()`"
+        errorLine1="                            android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint("
+        errorLine2="                                                                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="252"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint()`"
+        errorLine1="                val requested = android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint("
+        errorLine2="                                                                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="267"
+            column="80"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint#covers`"
+        errorLine1="                points.any { point -> point.covers(requested) }"
+        errorLine2="                                            ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="272"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            canonicalRoot.toPath().relativize(target.canonicalFile.toPath()).first().toString()"
+        errorLine2="                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="76"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            canonicalRoot.toPath().relativize(target.canonicalFile.toPath()).first().toString()"
+        errorLine2="                                                                   ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="76"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#relativize`"
+        errorLine1="            canonicalRoot.toPath().relativize(target.canonicalFile.toPath()).first().toString()"
+        errorLine2="                                   ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="76"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.deleteIfExists(tmp.toPath())"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="117"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="            Files.deleteIfExists(tmp.toPath())"
+        errorLine2="                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="117"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            ?.let { legacy -> Files.deleteIfExists(legacy.toPath()) }"
+        errorLine2="                                                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="122"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="            ?.let { legacy -> Files.deleteIfExists(legacy.toPath()) }"
+        errorLine2="                                    ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="122"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(parent.toPath())"
+        errorLine2="                                                                  ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="151"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#newDirectoryStream`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(parent.toPath())"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="151"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                if (directoryStream is SecureDirectoryStream&lt;*>) {"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="152"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                    val secure = directoryStream as SecureDirectoryStream&lt;Path>"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="154"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    val relative = parent.toPath().fileSystem.getPath(candidate.name)"
+        errorLine2="                                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="155"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    val relative = parent.toPath().fileSystem.getPath(candidate.name)"
+        errorLine2="                                                              ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="155"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    val relative = parent.toPath().fileSystem.getPath(candidate.name)"
+        errorLine2="                                                   ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="155"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#newByteChannel`"
+        errorLine1="                    val channel = secure.newByteChannel(relative, CREATE_NEW_NOFOLLOW)"
+        errorLine2="                                         ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="156"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    FileChannel.open(candidate.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="163"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.channels.FileChannel#open`"
+        errorLine1="                    FileChannel.open(candidate.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="163"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.FileAlreadyExistsException`"
+        errorLine1="            } catch (_: java.nio.file.FileAlreadyExistsException) {"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="167"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(target.name))"
+        errorLine2="                                                                  ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="189"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(target.name))"
+        errorLine2="                                                       ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="189"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#move`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(target.name))"
+        errorLine2="                           ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="189"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move("
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="207"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                source.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="208"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                target.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="209"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#ATOMIC_MOVE`"
+        errorLine1="                StandardCopyOption.ATOMIC_MOVE,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="210"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="                StandardCopyOption.REPLACE_EXISTING,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="211"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.AtomicMoveNotSupportedException`"
+        errorLine1="        } catch (_: AtomicMoveNotSupportedException) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="213"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#CREATE_NEW`"
+        errorLine1="            StandardOpenOption.CREATE_NEW,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="223"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#WRITE`"
+        errorLine1="            StandardOpenOption.WRITE,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="224"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            LinkOption.NOFOLLOW_LINKS,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="225"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                        val relative = root.toPath().relativize(legacy.toPath())"
+        errorLine2="                                            ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="70"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                        val relative = root.toPath().relativize(legacy.toPath())"
+        errorLine2="                                                                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="70"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#relativize`"
+        errorLine1="                        val relative = root.toPath().relativize(legacy.toPath())"
+        errorLine2="                                                     ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="70"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Implicit cast from `Path` to `Iterable` requires API level 26 (current min is 24)"
+        errorLine1="                        relative.firstOrNull()?.toString()?.let(::add)"
+        errorLine2="                        ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="71"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="        val path = root.toPath()"
+        errorLine2="                        ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="86"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#isSymbolicLink`"
+        errorLine1="        if (Files.isSymbolicLink(path)) return@runCatching null"
+        errorLine2="                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="87"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#exists`"
+        errorLine1="        if (Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS) &amp;&amp;"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="88"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="        if (Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS) &amp;&amp;"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="88"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#isDirectory`"
+        errorLine1="            !Files.isDirectory(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                   ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="89"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            !Files.isDirectory(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="89"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="        val path = candidate.toPath()"
+        errorLine2="                             ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="100"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#exists`"
+        errorLine1="        if (!Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)) return"
+        errorLine2="                   ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="101"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="        if (!Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)) return"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="101"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#walkFileTree`"
+        errorLine1="        Files.walkFileTree("
+        errorLine2="              ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="102"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor()`"
+        errorLine1="            object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="104"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor`"
+        errorLine1="            object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="104"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                    Files.deleteIfExists(file)"
+        errorLine2="                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="106"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                    return FileVisitResult.CONTINUE"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="107"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                    Files.deleteIfExists(file)"
+        errorLine2="                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="113"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                    return FileVisitResult.CONTINUE"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="114"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                    Files.deleteIfExists(dir)"
+        errorLine2="                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="119"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                    return FileVisitResult.CONTINUE"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="120"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.Activity#setPictureInPictureParams`"
+        errorLine1="            activity.setPictureInPictureParams(buildParams(activity, surface, state))"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="97"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder()`"
+        errorLine1="        val builder = PictureInPictureParams.Builder()"
+        errorLine2="                                             ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="148"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#setAspectRatio`"
+        errorLine1="            .setAspectRatio(aspectRatioFor(state))"
+        errorLine2="             ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="149"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#setActions`"
+        errorLine1="            .setActions(remoteActions(context, state.isPlaying))"
+        errorLine2="             ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="150"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#setSourceRectHint`"
+        errorLine1="            builder.setSourceRectHint(rect)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="153"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#build`"
+        errorLine1="        return builder.build()"
+        errorLine2="                       ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="172"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="SpecifyForegroundServiceType"
+        message="Missing dataSync foregroundServiceType in the AndroidManifest.xml"
+        errorLine1="            ForegroundInfo(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadWorker.kt"
+            line="451"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of Gradle than 8.12 is available: 8.14.5"
+        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../gradle/wrapper/gradle-wrapper.properties"
+            line="3"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.application than 8.10.1 is available: 9.3.1"
+        errorLine1="agp = &quot;8.10.1&quot;"
+        errorLine2="      ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="3"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.library than 8.10.1 is available: 9.3.1"
+        errorLine1="agp = &quot;8.10.1&quot;"
+        errorLine2="      ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="3"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.test than 8.10.1 is available: 9.3.1"
+        errorLine1="agp = &quot;8.10.1&quot;"
+        errorLine2="      ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="3"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-common than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-common-ktx than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-container than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-datasource-okhttp than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-exoplayer than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-exoplayer-hls than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-extractor than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-session than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-test-utils than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-test-utils-robolectric than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-ui than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-ui-compose than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.tvprovider:tvprovider than 1.0.0 is available: 1.1.0"
+        errorLine1="tvprovider = &quot;1.0.0&quot;"
+        errorLine2="             ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="15"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-process than 2.10.0 is available: 2.11.0"
+        errorLine1="lifecycle = &quot;2.10.0&quot;"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-compose than 2.10.0 is available: 2.11.0"
+        errorLine1="lifecycle = &quot;2.10.0&quot;"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-compose than 2.10.0 is available: 2.11.0"
+        errorLine1="lifecycle = &quot;2.10.0&quot;"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.activity:activity-compose than 1.12.4 is available: 1.13.0"
+        errorLine1="activity-compose = &quot;1.12.4&quot;"
+        errorLine2="                   ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="22"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.tv:tv-material than 1.0.1 is available: 1.1.0"
+        errorLine1="tv-compose = &quot;1.0.1&quot;"
+        errorLine2="             ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="23"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose.ui:ui-test-junit4 than 1.9.2 is available: 1.11.4"
+        errorLine1="compose-ui-test = &quot;1.9.2&quot;"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="29"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose.ui:ui-test-manifest than 1.9.2 is available: 1.11.4"
+        errorLine1="compose-ui-test = &quot;1.9.2&quot;"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="29"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test:core-ktx than 1.6.1 is available: 1.7.0"
+        errorLine1="androidx-test-core = &quot;1.6.1&quot;"
+        errorLine2="                     ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="32"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.baselineprofile than 1.3.4 is available: 1.4.1"
+        errorLine1="benchmark = &quot;1.3.4&quot;"
+        errorLine2="            ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.benchmark:benchmark-macro-junit4 than 1.3.4 is available: 1.4.1"
+        errorLine1="benchmark = &quot;1.3.4&quot;"
+        errorLine2="            ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.ext:junit than 1.2.1 is available: 1.3.0"
+        errorLine1="androidx-test-ext-junit = &quot;1.2.1&quot;"
+        errorLine2="                          ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="37"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.uiautomator:uiautomator than 2.3.0 is available: 2.4.0"
+        errorLine1="uiautomator = &quot;2.3.0&quot;"
+        errorLine2="              ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="38"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.firebase:firebase-messaging than 25.1.0 is available: 25.1.1"
+        errorLine1="firebase-messaging = &quot;25.1.0&quot;"
+        errorLine2="                     ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="39"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.android.gms:play-services-cast-framework than 21.5.0 is available: 22.3.1"
+        errorLine1="play-services-cast-framework = &quot;21.5.0&quot;"
+        errorLine2="                               ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="45"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.mediarouter:mediarouter than 1.7.0 is available: 1.8.1"
+        errorLine1="androidx-mediarouter = &quot;1.7.0&quot;"
+        errorLine2="                       ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="46"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.window:window than 1.4.0 is available: 1.5.1"
+        errorLine1="androidx-window = &quot;1.4.0&quot;"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="47"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="NavController.getCurrentBackStack can only be called from within the same library group (referenced groupId=`androidx.navigation` from groupId=`SiloAndroid`)"
+        errorLine1="    return currentBackStack.value"
+        errorLine2="           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/BottomNavBar.kt"
+            line="90"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="RouteInfo.isDefaultOrBluetooth can only be called from within the same library (androidx.mediarouter:mediarouter)"
+        errorLine1="            .filterNot { it.isDefaultOrBluetooth }"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastSessionManager.kt"
+            line="433"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="RouteInfo.isDefaultOrBluetooth can only be called from within the same library (androidx.mediarouter:mediarouter)"
+        errorLine1="            .filterNot { it.isDefaultOrBluetooth }"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastSessionManager.kt"
+            line="433"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    presentation: AndroidSubtitlePresentation,"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="13"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AndroidSubtitlePresentation.Phone -> AndroidSubtitleTextSize.Fractional("
+        errorLine2="                                ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="16"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AndroidSubtitlePresentation.Television -> AndroidSubtitleTextSize.FixedSp("
+        errorLine2="                                ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="25"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    subtitleView: SubtitleView,"
+        errorLine2="                  ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="38"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        is AndroidSubtitleTextSize.Fractional -> subtitleView.setFractionalTextSize("
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="42"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        is AndroidSubtitleTextSize.FixedSp -> subtitleView.setFixedTextSize("
+        errorLine2="                                                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="46"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="internal fun shouldNormalizeSubripDataSpec(dataSpec: DataSpec): Boolean ="
+        errorLine2="                                                     ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="450"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    shouldNormalizeSubripPath(dataSpec.uri.path, dataSpec.position)"
+        errorLine2="                                       ~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="451"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    shouldNormalizeSubripPath(dataSpec.uri.path, dataSpec.position)"
+        errorLine2="                                                          ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="451"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val audioCapabilityManager: AudioCapabilityManager,"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DeviceSnapshotCollector.kt"
+            line="158"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        val snapshot = audioCapabilityManager.diagnosticsSnapshot()"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DeviceSnapshotCollector.kt"
+            line="190"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun hdr10ColorInfo(current: ColorInfo?): ColorInfo ="
+        errorLine2="                                    ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="481"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun hdr10ColorInfo(current: ColorInfo?): ColorInfo ="
+        errorLine2="                                                 ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="481"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    (current?.buildUpon() ?: ColorInfo.Builder())"
+        errorLine2="              ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="482"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    (current?.buildUpon() ?: ColorInfo.Builder())"
+        errorLine2="                                       ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="482"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorSpace(C.COLOR_SPACE_BT2020)"
+        errorLine2="         ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="483"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorSpace(C.COLOR_SPACE_BT2020)"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="483"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorTransfer(C.COLOR_TRANSFER_ST2084)"
+        errorLine2="         ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="484"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorTransfer(C.COLOR_TRANSFER_ST2084)"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="484"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorRange(C.COLOR_RANGE_LIMITED)"
+        errorLine2="         ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="485"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorRange(C.COLOR_RANGE_LIMITED)"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="485"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setHdrStaticInfo(current?.hdrStaticInfo ?: defaultDolbyVisionHdrStaticInfo())"
+        errorLine2="         ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="486"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setHdrStaticInfo(current?.hdrStaticInfo ?: defaultDolbyVisionHdrStaticInfo())"
+        errorLine2="                                   ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="486"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .build()"
+        errorLine2="         ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="487"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    if (chain.any { it is ParserException }) return false"
+        errorLine2="                          ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicy.kt"
+            line="206"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    headerFields.entries"
+        errorLine2="    ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicy.kt"
+            line="281"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val delegate: AudioSink,"
+        errorLine2="                          ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="55"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1=") : AudioSink by delegate {"
+        errorLine2="    ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="56"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    override fun supportsFormat(format: Format): Boolean ="
+        errorLine2="                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="57"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        getFormatSupport(format) != AudioSink.SINK_FORMAT_UNSUPPORTED"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="58"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    override fun getFormatSupport(format: Format): Int ="
+        errorLine2="                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="60"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            AudioSink.SINK_FORMAT_UNSUPPORTED"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="67"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            delegate.getFormatSupport(format)"
+        errorLine2="                     ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="69"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        Intent(context, SiloPlaybackService::class.java)"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PipActionCapability.kt"
+            line="19"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val audioCapabilityManager: AudioCapabilityManager,"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="55"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val libassBridge: LibassBridge,"
+        errorLine2="                              ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="56"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        val libassRendering = libassBridge.isRenderingSupported"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="215"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        val libassEmbeddedFonts = libassBridge.isEmbeddedFontsSupported"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="216"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                sinkType = audioCapabilityManager.currentSinkType(),"
+        errorLine2="                                                  ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="282"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        ?: if (mediaTrackGroup.length > 0) mediaTrackGroup.getFormat(0) else null"
+        errorLine2="                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="432"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        ?: if (mediaTrackGroup.length > 0) mediaTrackGroup.getFormat(0) else null"
+        errorLine2="                                                           ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="432"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoFormat?.let { json.put(&quot;videoFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="84"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoFormat?.let { json.put(&quot;videoFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                                                                  ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="84"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.audioFormat?.let { json.put(&quot;audioFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="85"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.audioFormat?.let { json.put(&quot;audioFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                                                                  ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="85"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoDecoderCounters?.let { counters ->"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="86"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoDecoderCounters?.let { counters ->"
+        errorLine2="                                            ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="86"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                json.put(&quot;droppedFrames&quot;, counters.droppedBufferCount)"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="87"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                json.put(&quot;renderedFrames&quot;, counters.renderedOutputBufferCount)"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="88"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { DefaultBandwidthMeter.Builder(androidContext()).build() }"
+        errorLine2="                                   ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="67"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { DefaultBandwidthMeter.Builder(androidContext()).build() }"
+        errorLine2="                                                             ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="67"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        PlaybackNetworkMonitor(androidContext(), get())"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="71"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { PlaybackAnalyticsListener() }"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="75"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { DelayAudioProcessor() }"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="78"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { LibassBridge(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) }"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="83"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            for (trackIndex in 0 until mediaTrackGroup.length) {"
+        errorLine2="                                                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt"
+            line="139"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                val format = mediaTrackGroup.getFormat(trackIndex)"
+        errorLine2="                                             ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt"
+            line="140"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    event: PlaybackAnalyticsListener.Event,"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="58"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.VideoDecoderInitialized ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="60"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.AudioDecoderInitialized ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="65"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.VideoFormatChanged -> current.copy("
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="67"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.AudioFormatChanged ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="82"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.DroppedFrames ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="84"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.AudioUnderrun ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="86"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.BandwidthEstimate ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="88"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.FirstFrameRendered -> current.copy("
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="90"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.SeekStarted -> current.copy(seekStartedAtMs = event.realtimeMs)"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="95"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.PlaybackStateChanged -> current.reducePlaybackState(event)"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="96"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.LoadError,"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="97"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.PlayerError,"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="98"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.TrackSnapshot,"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="99"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    event: PlaybackAnalyticsListener.Event.PlaybackStateChanged,"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="104"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorTransfer(format: Format): String? = when (format.colorInfo?.colorTransfer) {"
+        errorLine2="                                                                          ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="169"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorTransfer(format: Format): String? = when (format.colorInfo?.colorTransfer) {"
+        errorLine2="                                                                                     ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="169"
+            column="86"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_TRANSFER_ST2084 -> &quot;st2084&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="170"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_TRANSFER_HLG -> &quot;hlg&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="171"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_TRANSFER_SDR -> &quot;sdr&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="172"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorRange(format: Format): String? = when (format.colorInfo?.colorRange) {"
+        errorLine2="                                                                       ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="176"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorRange(format: Format): String? = when (format.colorInfo?.colorRange) {"
+        errorLine2="                                                                                  ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="176"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_RANGE_FULL -> &quot;full&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="177"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_RANGE_LIMITED -> &quot;limited&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="178"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    val colorInfo = format.colorInfo ?: return null"
+        errorLine2="        ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="187"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    val colorInfo = format.colorInfo ?: return null"
+        errorLine2="                           ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="187"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    return when (colorInfo.colorTransfer) {"
+        errorLine2="                           ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="188"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        C.COLOR_TRANSFER_ST2084 -> &quot;HDR10&quot;"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="189"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        C.COLOR_TRANSFER_HLG -> &quot;HLG&quot;"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="190"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        C.COLOR_TRANSFER_SDR -> &quot;SDR&quot;"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="191"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val playbackAnalytics: PlaybackAnalyticsListener,"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt"
+            line="243"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            playbackAnalytics.events.collect { event ->"
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt"
+            line="831"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            playbackAnalytics.events.collect { event ->"
+        errorLine2="                                               ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt"
+            line="831"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PAUSE"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="178"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PAUSE"
+        errorLine2="                                ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="178"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PLAY"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="180"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PLAY"
+        errorLine2="                                ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="180"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_BACK),"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="189"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_BACK),"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="189"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_FORWARD),"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="201"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_FORWARD),"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="201"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        AspectRatioFrameLayout.RESIZE_MODE_FIXED_WIDTH -> {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="468"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        AspectRatioFrameLayout.RESIZE_MODE_FIXED_HEIGHT -> {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="472"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        AspectRatioFrameLayout.RESIZE_MODE_FIT -> {"
+        errorLine2="                               ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="476"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AspectRatioFrameLayout.RESIZE_MODE_ZOOM,"
+        errorLine2="                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="507"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AspectRatioFrameLayout.RESIZE_MODE_FILL,"
+        errorLine2="                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="508"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        return cue.buildUpon().setSize(Cue.DIMEN_UNSET).build()"
+        errorLine2="                   ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="566"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        return cue.buildUpon().setSize(Cue.DIMEN_UNSET).build()"
+        errorLine2="                               ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="566"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        return cue.buildUpon().setSize(Cue.DIMEN_UNSET).build()"
+        errorLine2="                                                        ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="566"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    return if (changed) CueGroup(mapped, cueGroup.presentationTimeUs) else cueGroup"
+        errorLine2="                        ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="579"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    return if (changed) CueGroup(mapped, cueGroup.presentationTimeUs) else cueGroup"
+        errorLine2="                                                  ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="579"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    val frame = findViewById&lt;AspectRatioFrameLayout>("
+        errorLine2="        ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="904"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val playerFactory: SiloPlayerFactory,"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackendFactory.kt"
+            line="12"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val audioTrackManager: AudioTrackManager,"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackendFactory.kt"
+            line="13"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val subtitleManager: SubtitleManager,"
+        errorLine2="                                 ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackendFactory.kt"
+            line="14"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="ComposableNaming"
+        message="Composable functions that return Unit should start with an uppercase letter"
+        errorLine1="private fun renderEntry("
+        errorLine2="            ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/downloads/DownloadEntryRows.kt"
+            line="196"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenWidthDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="    val screenWidthDp = configuration.screenWidthDp.toFloat()"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/FeaturedCarousel.kt"
+            line="92"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenHeightDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="    val backdropHeight = (config.screenHeightDp.dp * 0.72f).coerceIn(420.dp, 580.dp) + 260.dp"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/components/HeroBackdropLayers.kt"
+            line="59"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenWidthDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="    val useSideRail = LocalConfiguration.current.screenWidthDp >= 600"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerSettingsSheet.kt"
+            line="115"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenHeightDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="        ?: (LocalConfiguration.current.screenHeightDp * 0.8f).dp"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerSheetSupport.kt"
+            line="72"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenHeightDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="    val paneTop = (LocalConfiguration.current.screenHeightDp.dp - tabletopPaneHeight)"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerSheetSupport.kt"
+            line="90"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="LocalContextResourcesRead"
+        message="Reading Resources using LocalContext.current.resources"
+        errorLine1="        val metrics = context.resources.displayMetrics"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/ComicReader.kt"
+            line="103"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LocalContextResourcesRead"
+        message="Reading Resources using LocalContext.current.resources"
+        errorLine1="        val density = context.resources.displayMetrics.density"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/reflow/ReflowWebView.kt"
+            line="102"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/audiobook/AudiobookDetailContent.kt"
+            line="93"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/components/aurora/AuroraBackdrop.kt"
+            line="61"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/components/BackdropCard.kt"
+            line="78"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/book/BookDetailContent.kt"
+            line="119"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt"
+            line="65"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt"
+            line="120"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt"
+            line="1035"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/components/DownloadButton.kt"
+            line="30"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/components/EmptyStateView.kt"
+            line="35"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/EpisodeList.kt"
+            line="68"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/components/ErrorView.kt"
+            line="34"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/components/GenreChip.kt"
+            line="25"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt"
+            line="104"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeSectionRow.kt"
+            line="34"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt"
+            line="91"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaCard.kt"
+            line="67"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt"
+            line="64"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt"
+            line="107"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/PlaybackSettings.kt"
+            line="74"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerControls.kt"
+            line="132"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerGestureHandler.kt"
+            line="86"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerNextUpScreen.kt"
+            line="76"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerOverlay.kt"
+            line="82"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/requests/RequestComponents.kt"
+            line="97"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/search/SearchBar.kt"
+            line="42"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/search/SearchScreen.kt"
+            line="59"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt"
+            line="79"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/ServerInfoSection.kt"
+            line="20"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SubtitleSettings.kt"
+            line="26"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="SwitchIntDef"
+        message="Switch statement on an `int` with known associated constant missing case `TrackOutput.SAMPLE_DATA_PART_ENCRYPTION`"
+        errorLine1="        when (sampleDataPart) {"
+        errorLine2="        ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="279"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="DataExtractionRules"
+        message="The attribute `android:allowBackup` is deprecated from Android 12 and higher and may be removed in future versions. Consider adding the attribute `android:dataExtractionRules` specifying an `@xml` resource which configures cloud backups and device transfers on Android 12 and higher."
+        errorLine1="        android:allowBackup=&quot;false&quot;"
+        errorLine2="                             ~~~~~">
+        <location
+            file="src/androidMain/AndroidManifest.xml"
+            line="27"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is never &lt; 24"
+        errorLine1="        if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.N) return HdrCapabilities()"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt"
+            line="63"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var homeScrollToTopTick by remember { mutableStateOf(0) }"
+        errorLine2="                                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt"
+            line="129"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableFloatStateOf` instead of `mutableStateOf`"
+        errorLine1="    var scale by remember(pageIndex) { mutableStateOf(1f) }"
+        errorLine2="                                       ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/PdfReader.kt"
+            line="211"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="        var upNextCountdownTotal by remember { mutableStateOf(0) }"
+        errorLine2="                                               ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerOverlay.kt"
+            line="410"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var pictureInPictureVideoWidth by remember { mutableStateOf(16) }"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt"
+            line="220"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var pictureInPictureVideoHeight by remember { mutableStateOf(9) }"
+        errorLine2="                                                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt"
+            line="221"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="        mutableStateOf(initialReflowLocator?.sectionIndex ?: 0)"
+        errorLine2="        ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/reflow/ReflowableReader.kt"
+            line="127"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableDoubleStateOf` instead of `mutableStateOf`"
+        errorLine1="        mutableStateOf(initialReflowLocator?.pageProgression ?: 0.0)"
+        errorLine2="        ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/reflow/ReflowableReader.kt"
+            line="130"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableDoubleStateOf` instead of `mutableStateOf`"
+        errorLine1="        mutableStateOf(pendingPageProgression)"
+        errorLine2="        ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/reflow/ReflowableReader.kt"
+            line="133"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var pageCount by remember(source) { mutableStateOf(1) }"
+        errorLine2="                                        ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/reflow/ReflowableReader.kt"
+            line="138"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var page by remember(source) { mutableStateOf(0) }"
+        errorLine2="                                   ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/reflow/ReflowableReader.kt"
+            line="139"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var webViewResetKey by remember(source) { mutableStateOf(0) }"
+        errorLine2="                                              ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/reflow/ReflowableReader.kt"
+            line="141"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableLongStateOf` instead of `mutableStateOf`"
+        errorLine1="    var playbackVisibleStartedAt by remember { mutableStateOf(0L) }"
+        errorLine2="                                               ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/ui/components/StartupSplashVideo.kt"
+            line="59"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.silo_blue` appears to be unused"
+        errorLine1="    &lt;color name=&quot;silo_blue&quot;>#FF1E88E5&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="4"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.silo_blue_light` appears to be unused"
+        errorLine1="    &lt;color name=&quot;silo_blue_light&quot;>#FF6AB7FF&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="5"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.silo_blue_dark` appears to be unused"
+        errorLine1="    &lt;color name=&quot;silo_blue_dark&quot;>#FF005CB2&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="6"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.dark_surface_variant` appears to be unused"
+        errorLine1="    &lt;color name=&quot;dark_surface_variant&quot;>#FF252528&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="12"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.light_background` appears to be unused"
+        errorLine1="    &lt;color name=&quot;light_background&quot;>#FFF8F9FC&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="15"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.light_surface` appears to be unused"
+        errorLine1="    &lt;color name=&quot;light_surface&quot;>#FFFFFFFF&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="16"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.light_surface_variant` appears to be unused"
+        errorLine1="    &lt;color name=&quot;light_surface_variant&quot;>#FFE8EAF0&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="17"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.dark_on_background` appears to be unused"
+        errorLine1="    &lt;color name=&quot;dark_on_background&quot;>#FFE8EAED&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="20"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.dark_on_surface` appears to be unused"
+        errorLine1="    &lt;color name=&quot;dark_on_surface&quot;>#FFE8EAED&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="21"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.dark_on_surface_variant` appears to be unused"
+        errorLine1="    &lt;color name=&quot;dark_on_surface_variant&quot;>#FF9AA0B0&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="22"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.light_on_background` appears to be unused"
+        errorLine1="    &lt;color name=&quot;light_on_background&quot;>#FF1A1C22&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="25"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.light_on_surface` appears to be unused"
+        errorLine1="    &lt;color name=&quot;light_on_surface&quot;>#FF1A1C22&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="26"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.light_on_surface_variant` appears to be unused"
+        errorLine1="    &lt;color name=&quot;light_on_surface_variant&quot;>#FF5A5E6B&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="27"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.error_red` appears to be unused"
+        errorLine1="    &lt;color name=&quot;error_red&quot;>#FFEF5350&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="30"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.success_green` appears to be unused"
+        errorLine1="    &lt;color name=&quot;success_green&quot;>#FF66BB6A&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="31"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.warning_amber` appears to be unused"
+        errorLine1="    &lt;color name=&quot;warning_amber&quot;>#FFFFCA28&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="32"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.tab_home` appears to be unused"
+        errorLine1="    &lt;string name=&quot;tab_home&quot;>Home&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="6"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.tab_search` appears to be unused"
+        errorLine1="    &lt;string name=&quot;tab_search&quot;>Search&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="7"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.tab_downloads` appears to be unused"
+        errorLine1="    &lt;string name=&quot;tab_downloads&quot;>Downloads&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="8"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.tab_settings` appears to be unused"
+        errorLine1="    &lt;string name=&quot;tab_settings&quot;>Settings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="9"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_retry` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_retry&quot;>Retry&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="12"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_back` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_back&quot;>Navigate back&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="13"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_cancel` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_cancel&quot;>Cancel&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="14"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_save` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_save&quot;>Save&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="15"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_done` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_done&quot;>Done&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="16"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_sign_in` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_sign_in&quot;>Sign In&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="17"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_sign_out` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_sign_out&quot;>Sign Out&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="18"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.loading` appears to be unused"
+        errorLine1="    &lt;string name=&quot;loading&quot;>Loading&amp;#8230;&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="21"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_generic` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_generic&quot;>Something went wrong&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="22"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.empty_generic` appears to be unused"
+        errorLine1="    &lt;string name=&quot;empty_generic&quot;>Nothing here yet&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="23"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.coming_soon` appears to be unused"
+        errorLine1="    &lt;string name=&quot;coming_soon&quot;>Coming soon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="26"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UsableSpace"
+        message="Consider also using `StorageManager#getAllocatableBytes` and `allocateBytes` which will consider clearable cached data"
+        errorLine1="    fun usableSpaceBytes(): Long = baseDir.usableSpace"
+        errorLine2="                                           ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="148"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/androidMain/res/mipmap-hdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/androidMain/res/mipmap-mdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/androidMain/res/mipmap-xhdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/androidMain/res/mipmap-xxhdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/androidMain/res/mipmap-xxxhdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="MonochromeLauncherIcon"
+        message="The application adaptive icon is missing a monochrome tag"
+        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/androidMain/res/mipmap-anydpi-v26/ic_launcher.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/silo_wordmark.png` in densityless folder">
+        <location
+            file="src/androidMain/res/drawable/silo_wordmark.png"/>
+    </issue>
+
+    <issue
+        id="UnnecessaryRequiredFeature"
+        message="Consider whether this feature (`android.hardware.touchscreen`) really is required for the app to function; you can set `android:required=&quot;false&quot;` to indicate that the feature is used but not required"
+        errorLine1="        android:name=&quot;android.hardware.touchscreen&quot;"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/AndroidManifest.xml"
+            line="9"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit().putString(KEY_DEVICE_ID, generated).apply()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/network/AndroidDeviceMetadataProvider.kt"
+            line="20"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().putString(storageKey(serverUrl, key), value).apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidServerSettingsCache.kt"
+            line="14"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().putBoolean(migrationKey(serverUrl, scope), true).apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidServerSettingsCache.kt"
+            line="31"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                            ?.let { mb.setArtworkUri(android.net.Uri.parse(it)) }"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/audiobook/AudiobookPlayerScreen.kt"
+            line="124"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                .setUri(Uri.parse(absoluteUrl))"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="327"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().putString(&quot;$key.state&quot;, json.encodeToString(state)).apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/BrowsePrefsStore.kt"
+            line="42"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().apply {"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/BrowsePrefsStore.kt"
+            line="53"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="    val uri = Uri.parse(uriString)"
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/downloads/DownloadExternalOpen.kt"
+            line="39"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return null"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="708"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return null"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="750"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return 0L"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="757"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            return runCatching { resolver.delete(Uri.parse(uri), null, null) > 0 }.getOrDefault(false)"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="767"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        if (resolver.update(Uri.parse(uriString), values, null, null) &lt;= 0) return uriString"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="837"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        key(serverId, profileId)?.let { prefs.edit().putBoolean(it, true).apply() }"
+        errorLine2="                                        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/onboarding/OnboardingTourLocalCache.kt"
+            line="27"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit().putString(KEY_DEVICE_ID, it).apply()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingDeviceId.kt"
+            line="25"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="                val bmp = Bitmap.createBitmap(budget.targetWidth, targetHeight, budget.config)"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/PdfReader.kt"
+            line="347"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            context.contentResolver.openAssetFileDescriptor(Uri.parse(requestUrl), &quot;r&quot;)?.use { descriptor ->"
+        errorLine2="                                                            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/ReaderFileCache.kt"
+            line="121"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            context.contentResolver.openInputStream(Uri.parse(requestUrl))?.use { input ->"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/ReaderFileCache.kt"
+            line="127"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().putString(KEY, json.encodeToString(SiloCastPersistedTarget.serializer(), target)).apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastLastTargetStore.kt"
+            line="33"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().remove(KEY).apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastLastTargetStore.kt"
+            line="42"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            spec.posterUrl?.let { addImage(WebImage(Uri.parse(it))) }"
+        errorLine2="                                                    ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastSessionManager.kt"
+            line="247"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            android.net.Uri.parse(absoluteUrl)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt"
+            line="466"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            RequestHeaderScope(android.net.Uri.parse(absoluteUrl), it)"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt"
+            line="471"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                ?.let { metadataBuilder.setArtworkUri(android.net.Uri.parse(it)) }"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt"
+            line="507"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            val builder = MediaItem.SubtitleConfiguration.Builder(Uri.parse(absoluteUrl))"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="99"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/ui/components/ThumbHash.kt"
+            line="136"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use the existing version catalog reference (`libs.androidx.palette`) instead"
+        errorLine1="            implementation(&quot;androidx.palette:palette-ktx:1.0.0&quot;)"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="98"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use version catalog instead"
+        errorLine1="            implementation(&quot;org.json:json:20240303&quot;)"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="124"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view ``WebView`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="        webView.setOnTouchListener { _, event ->"
+        errorLine2="        ^">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/reflow/ReflowWebView.kt"
+            line="187"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`onTouch` lambda should call `View#performClick` when a click is detected"
+        errorLine1="        webView.setOnTouchListener { _, event ->"
+        errorLine2="                                   ^">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/reflow/ReflowWebView.kt"
+            line="187"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view ``WebView`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="            webView.setOnTouchListener(null)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reader/reflow/ReflowWebView.kt"
+            line="198"
+            column="13"/>
+    </issue>
+
+</issues>

--- a/androidTvApp/build.gradle.kts
+++ b/androidTvApp/build.gradle.kts
@@ -233,6 +233,25 @@ android {
             excludes += "/META-INF/versions/*/OSGI-INF/MANIFEST.MF"
         }
     }
+
+    // Lint had never run on this project. The two crashes it would have caught
+    // — a Spatializer call gated at API 31 when the class arrives at 32, and a
+    // getAddress() call with no guard at all — both shipped from this module,
+    // which app-level lint does not analyse unless asked. Hence the gate here
+    // and checkDependencies in the apps.
+    //
+    // The baseline holds today's known findings (overwhelmingly desugared
+    // java.* calls and deliberate media3 @UnstableApi usage) so that only NEW
+    // violations fail. Delete it and regenerate deliberately; do not add to it
+    // to make a build pass.
+    lint {
+        // Without this, none of android-shared is examined.
+        checkDependencies = true
+        baseline = file("lint-baseline.xml")
+        abortOnError = true
+        fatal += setOf("NewApi", "InlinedApi")
+        checkReleaseBuilds = true
+    }
 }
 
 // The Robolectric suites need the test ComponentActivity in the merged

--- a/androidTvApp/lint-baseline.xml
+++ b/androidTvApp/lint-baseline.xml
@@ -1,0 +1,4198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.10.1" type="baseline" client="gradle" dependencies="true" name="AGP (8.10.1)" variant="all" version="8.10.1">
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 28 (current min is 24): `android.media.AudioFormat#ENCODING_E_AC3_JOC`"
+        errorLine1="            EncodingSupport(&quot;eac3_joc&quot;, AudioFormat.ENCODING_E_AC3_JOC),"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt"
+            line="345"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 25 (current min is 24): `android.media.AudioFormat#ENCODING_DOLBY_TRUEHD`"
+        errorLine1="            EncodingSupport(&quot;truehd&quot;, AudioFormat.ENCODING_DOLBY_TRUEHD, Build.VERSION_CODES.N_MR1),"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt"
+            line="348"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 28 (current min is 24): `android.media.AudioFormat#ENCODING_AC4`"
+        errorLine1="            EncodingSupport(&quot;ac4&quot;, AudioFormat.ENCODING_AC4, Build.VERSION_CODES.P),"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt"
+            line="349"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 25): `android.view.Display.HdrCapabilities#HDR_TYPE_HDR10_PLUS`"
+        errorLine1="            Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS in types"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt"
+            line="76"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.provider.MediaStore#VOLUME_EXTERNAL_PRIMARY`"
+        errorLine1="        Video -> MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1004"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.provider.MediaStore#VOLUME_EXTERNAL_PRIMARY`"
+        errorLine1="        Audio -> MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1005"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.provider.MediaStore#VOLUME_EXTERNAL_PRIMARY`"
+        errorLine1="        Downloads -> MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1006"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.media.MediaCodecInfo.CodecProfileLevel#AVCLevel6`"
+        errorLine1="        CodecProfileLevel.AVCLevel6 to 60,"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="497"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.media.MediaCodecInfo.CodecProfileLevel#AVCLevel61`"
+        errorLine1="        CodecProfileLevel.AVCLevel61 to 61,"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="498"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 29 (current min is 24): `android.media.MediaCodecInfo.CodecProfileLevel#AVCLevel62`"
+        errorLine1="        CodecProfileLevel.AVCLevel62 to 62,"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="499"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.channels.FileChannel#open`"
+        errorLine1="                FileChannel.open("
+        errorLine2="                            ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="380"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    file.toPath(),"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="381"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#WRITE`"
+        errorLine1="                    StandardOpenOption.WRITE,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="382"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#APPEND`"
+        errorLine1="                    StandardOpenOption.APPEND,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="383"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="                    LinkOption.NOFOLLOW_LINKS,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="384"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="        val path = target.toPath()"
+        errorLine2="                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="484"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#exists`"
+        errorLine1="        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) return false"
+        errorLine2="                   ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="485"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) return false"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="485"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#walkFileTree`"
+        errorLine1="        Files.walkFileTree(path, object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="              ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="489"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor()`"
+        errorLine1="        Files.walkFileTree(path, object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="489"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor`"
+        errorLine1="        Files.walkFileTree(path, object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="489"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                deleted = Files.deleteIfExists(file) || deleted"
+        errorLine2="                                ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="491"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                return FileVisitResult.CONTINUE"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="492"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                deleted = Files.deleteIfExists(directory) || deleted"
+        errorLine2="                                ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="497"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                return FileVisitResult.CONTINUE"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="498"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(directory.toPath())"
+        errorLine2="                                                                     ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="529"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#newDirectoryStream`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(directory.toPath())"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="529"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                if (directoryStream is SecureDirectoryStream&lt;*>) {"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="530"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                    val secure = directoryStream as SecureDirectoryStream&lt;Path>"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="532"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    val relative = directory.toPath().fileSystem.getPath(tempFile.name)"
+        errorLine2="                                             ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="533"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    val relative = directory.toPath().fileSystem.getPath(tempFile.name)"
+        errorLine2="                                                                 ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="533"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    val relative = directory.toPath().fileSystem.getPath(tempFile.name)"
+        errorLine2="                                                      ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="533"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#newByteChannel`"
+        errorLine1="                    val channel = secure.newByteChannel(relative, CREATE_NEW_NOFOLLOW)"
+        errorLine2="                                         ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="534"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    FileChannel.open(tempFile.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="552"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.channels.FileChannel#open`"
+        errorLine1="                    FileChannel.open(tempFile.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="552"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.FileAlreadyExistsException`"
+        errorLine1="            } catch (_: java.nio.file.FileAlreadyExistsException) {"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="556"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="582"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#isRegularFile`"
+        errorLine1="            Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                  ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="582"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="582"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move("
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="603"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                source.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="604"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                target.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="605"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#ATOMIC_MOVE`"
+        errorLine1="                StandardCopyOption.ATOMIC_MOVE,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="606"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="                StandardCopyOption.REPLACE_EXISTING,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="607"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.AtomicMoveNotSupportedException`"
+        errorLine1="        } catch (_: AtomicMoveNotSupportedException) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="609"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="610"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(finalFile.name))"
+        errorLine2="                                                                  ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="649"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(finalFile.name))"
+        errorLine2="                                                       ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="649"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#move`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(finalFile.name))"
+        errorLine2="                           ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="649"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            return runCatching { Files.deleteIfExists(tempFile.toPath()) }.getOrDefault(false)"
+        errorLine2="                                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="660"
+            column="64"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="            return runCatching { Files.deleteIfExists(tempFile.toPath()) }.getOrDefault(false)"
+        errorLine2="                                       ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="660"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#CREATE_NEW`"
+        errorLine1="            StandardOpenOption.CREATE_NEW,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="668"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#WRITE`"
+        errorLine1="            StandardOpenOption.WRITE,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="669"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            LinkOption.NOFOLLOW_LINKS,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="670"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.provider.MediaStore.Downloads#getContentUri`"
+        errorLine1="        Downloads -> MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)"
+        errorLine2="                                          ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="1006"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getReason`"
+        errorLine1="        override val reason: Int get() = record.reason"
+        errorLine2="                                                ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="70"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getTimestamp`"
+        errorLine1="        override val timestampMs: Long get() = record.timestamp"
+        errorLine2="                                                      ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="71"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getPid`"
+        errorLine1="        override val pid: Int get() = record.pid"
+        errorLine2="                                             ~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="72"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getProcessName`"
+        errorLine1="        override val processName: String get() = record.processName.orEmpty()"
+        errorLine2="                                                        ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="73"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getStatus`"
+        errorLine1="        override val status: Int get() = record.status"
+        errorLine2="                                                ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="74"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 30 (current min is 24): `android.app.ApplicationExitInfo#getProcessStateSummary`"
+        errorLine1="        override val processStateSummary: ByteArray? get() = record.processStateSummary?.copyOf()"
+        errorLine2="                                                                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt"
+            line="75"
+            column="69"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint#covers`"
+        errorLine1="                        point.covers("
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="251"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint()`"
+        errorLine1="                            android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint("
+        errorLine2="                                                                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="252"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint()`"
+        errorLine1="                val requested = android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint("
+        errorLine2="                                                                               ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="267"
+            column="80"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 29 (current min is 24): `android.media.MediaCodecInfo.VideoCapabilities.PerformancePoint#covers`"
+        errorLine1="                points.any { point -> point.covers(requested) }"
+        errorLine2="                                            ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt"
+            line="272"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            canonicalRoot.toPath().relativize(target.canonicalFile.toPath()).first().toString()"
+        errorLine2="                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="76"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            canonicalRoot.toPath().relativize(target.canonicalFile.toPath()).first().toString()"
+        errorLine2="                                                                   ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="76"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#relativize`"
+        errorLine1="            canonicalRoot.toPath().relativize(target.canonicalFile.toPath()).first().toString()"
+        errorLine2="                                   ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="76"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.deleteIfExists(tmp.toPath())"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="117"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="            Files.deleteIfExists(tmp.toPath())"
+        errorLine2="                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="117"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            ?.let { legacy -> Files.deleteIfExists(legacy.toPath()) }"
+        errorLine2="                                                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="122"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="            ?.let { legacy -> Files.deleteIfExists(legacy.toPath()) }"
+        errorLine2="                                    ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="122"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(parent.toPath())"
+        errorLine2="                                                                  ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="151"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#newDirectoryStream`"
+        errorLine1="                directoryStream = Files.newDirectoryStream(parent.toPath())"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="151"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                if (directoryStream is SecureDirectoryStream&lt;*>) {"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="152"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream`"
+        errorLine1="                    val secure = directoryStream as SecureDirectoryStream&lt;Path>"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="154"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    val relative = parent.toPath().fileSystem.getPath(candidate.name)"
+        errorLine2="                                          ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="155"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    val relative = parent.toPath().fileSystem.getPath(candidate.name)"
+        errorLine2="                                                              ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="155"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    val relative = parent.toPath().fileSystem.getPath(candidate.name)"
+        errorLine2="                                                   ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="155"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#newByteChannel`"
+        errorLine1="                    val channel = secure.newByteChannel(relative, CREATE_NEW_NOFOLLOW)"
+        errorLine2="                                         ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="156"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                    FileChannel.open(candidate.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="163"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.channels.FileChannel#open`"
+        errorLine1="                    FileChannel.open(candidate.toPath(), *CREATE_NEW_NOFOLLOW.toTypedArray()),"
+        errorLine2="                                ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="163"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.FileAlreadyExistsException`"
+        errorLine1="            } catch (_: java.nio.file.FileAlreadyExistsException) {"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="167"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.FileSystem#getPath`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(target.name))"
+        errorLine2="                                                                  ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="189"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#getFileSystem`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(target.name))"
+        errorLine2="                                                       ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="189"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SecureDirectoryStream#move`"
+        errorLine1="                    secure.move(source, secure, source.fileSystem.getPath(target.name))"
+        errorLine2="                           ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="189"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move("
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="207"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                source.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="208"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                target.toPath(),"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="209"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#ATOMIC_MOVE`"
+        errorLine1="                StandardCopyOption.ATOMIC_MOVE,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="210"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="                StandardCopyOption.REPLACE_EXISTING,"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="211"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Exception requires API level 26 (current min is 24): `java.nio.file.AtomicMoveNotSupportedException`"
+        errorLine1="        } catch (_: AtomicMoveNotSupportedException) {"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="213"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#move`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                  ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardCopyOption#REPLACE_EXISTING`"
+        errorLine1="            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)"
+        errorLine2="                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="214"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#CREATE_NEW`"
+        errorLine1="            StandardOpenOption.CREATE_NEW,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="223"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.StandardOpenOption#WRITE`"
+        errorLine1="            StandardOpenOption.WRITE,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="224"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            LinkOption.NOFOLLOW_LINKS,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ScopedJsonFileStore.kt"
+            line="225"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                        val relative = root.toPath().relativize(legacy.toPath())"
+        errorLine2="                                            ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="70"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="                        val relative = root.toPath().relativize(legacy.toPath())"
+        errorLine2="                                                                       ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="70"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Path#relativize`"
+        errorLine1="                        val relative = root.toPath().relativize(legacy.toPath())"
+        errorLine2="                                                     ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="70"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Implicit cast from `Path` to `Iterable` requires API level 26 (current min is 24)"
+        errorLine1="                        relative.firstOrNull()?.toString()?.let(::add)"
+        errorLine2="                        ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="71"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="        val path = root.toPath()"
+        errorLine2="                        ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="86"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#isSymbolicLink`"
+        errorLine1="        if (Files.isSymbolicLink(path)) return@runCatching null"
+        errorLine2="                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="87"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#exists`"
+        errorLine1="        if (Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS) &amp;&amp;"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="88"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="        if (Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS) &amp;&amp;"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="88"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#isDirectory`"
+        errorLine1="            !Files.isDirectory(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                   ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="89"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="            !Files.isDirectory(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="89"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.io.File#toPath`"
+        errorLine1="        val path = candidate.toPath()"
+        errorLine2="                             ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="100"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#exists`"
+        errorLine1="        if (!Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)) return"
+        errorLine2="                   ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="101"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.LinkOption#NOFOLLOW_LINKS`"
+        errorLine1="        if (!Files.exists(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)) return"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="101"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#walkFileTree`"
+        errorLine1="        Files.walkFileTree("
+        errorLine2="              ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="102"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor()`"
+        errorLine1="            object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="104"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Class requires API level 26 (current min is 24): `java.nio.file.SimpleFileVisitor`"
+        errorLine1="            object : SimpleFileVisitor&lt;Path>() {"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="104"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                    Files.deleteIfExists(file)"
+        errorLine2="                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="106"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                    return FileVisitResult.CONTINUE"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="107"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                    Files.deleteIfExists(file)"
+        errorLine2="                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="113"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                    return FileVisitResult.CONTINUE"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="114"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `java.nio.file.Files#deleteIfExists`"
+        errorLine1="                    Files.deleteIfExists(dir)"
+        errorLine2="                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="119"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Field requires API level 26 (current min is 24): `java.nio.file.FileVisitResult#CONTINUE`"
+        errorLine1="                    return FileVisitResult.CONTINUE"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/store/ServerScopedJsonStatePurger.kt"
+            line="120"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.Activity#setPictureInPictureParams`"
+        errorLine1="            activity.setPictureInPictureParams(buildParams(activity, surface, state))"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="97"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder()`"
+        errorLine1="        val builder = PictureInPictureParams.Builder()"
+        errorLine2="                                             ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="148"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#setAspectRatio`"
+        errorLine1="            .setAspectRatio(aspectRatioFor(state))"
+        errorLine2="             ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="149"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#setActions`"
+        errorLine1="            .setActions(remoteActions(context, state.isPlaying))"
+        errorLine2="             ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="150"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#setSourceRectHint`"
+        errorLine1="            builder.setSourceRectHint(rect)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="153"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 26 (current min is 24): `android.app.PictureInPictureParams.Builder#build`"
+        errorLine1="        return builder.build()"
+        errorLine2="                       ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="172"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="RedundantLabel"
+        message="Redundant label can be removed"
+        errorLine1="            android:label=&quot;@string/app_name&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/AndroidManifest.xml"
+            line="52"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SpecifyForegroundServiceType"
+        message="Missing dataSync foregroundServiceType in the AndroidManifest.xml"
+        errorLine1="            ForegroundInfo(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadWorker.kt"
+            line="451"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of Gradle than 8.12 is available: 8.14.5"
+        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../gradle/wrapper/gradle-wrapper.properties"
+            line="3"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.application than 8.10.1 is available: 9.3.1"
+        errorLine1="agp = &quot;8.10.1&quot;"
+        errorLine2="      ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="3"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.library than 8.10.1 is available: 9.3.1"
+        errorLine1="agp = &quot;8.10.1&quot;"
+        errorLine2="      ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="3"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.test than 8.10.1 is available: 9.3.1"
+        errorLine1="agp = &quot;8.10.1&quot;"
+        errorLine2="      ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="3"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-common than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-common-ktx than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-container than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-datasource-okhttp than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-exoplayer than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-exoplayer-hls than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-extractor than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-session than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-test-utils than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-test-utils-robolectric than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-ui than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.media3:media3-ui-compose than 1.10.1 is available: 1.11.0"
+        errorLine1="media3 = &quot;1.10.1&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="10"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.tvprovider:tvprovider than 1.0.0 is available: 1.1.0"
+        errorLine1="tvprovider = &quot;1.0.0&quot;"
+        errorLine2="             ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="15"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-process than 2.10.0 is available: 2.11.0"
+        errorLine1="lifecycle = &quot;2.10.0&quot;"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-compose than 2.10.0 is available: 2.11.0"
+        errorLine1="lifecycle = &quot;2.10.0&quot;"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-compose than 2.10.0 is available: 2.11.0"
+        errorLine1="lifecycle = &quot;2.10.0&quot;"
+        errorLine2="            ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.activity:activity-compose than 1.12.4 is available: 1.13.0"
+        errorLine1="activity-compose = &quot;1.12.4&quot;"
+        errorLine2="                   ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="22"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.tv:tv-material than 1.0.1 is available: 1.1.0"
+        errorLine1="tv-compose = &quot;1.0.1&quot;"
+        errorLine2="             ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="23"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose.ui:ui-test-junit4 than 1.9.2 is available: 1.11.4"
+        errorLine1="compose-ui-test = &quot;1.9.2&quot;"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="29"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose.ui:ui-test-manifest than 1.9.2 is available: 1.11.4"
+        errorLine1="compose-ui-test = &quot;1.9.2&quot;"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="29"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test:core-ktx than 1.6.1 is available: 1.7.0"
+        errorLine1="androidx-test-core = &quot;1.6.1&quot;"
+        errorLine2="                     ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="32"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.baselineprofile than 1.3.4 is available: 1.4.1"
+        errorLine1="benchmark = &quot;1.3.4&quot;"
+        errorLine2="            ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.benchmark:benchmark-macro-junit4 than 1.3.4 is available: 1.4.1"
+        errorLine1="benchmark = &quot;1.3.4&quot;"
+        errorLine2="            ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.ext:junit than 1.2.1 is available: 1.3.0"
+        errorLine1="androidx-test-ext-junit = &quot;1.2.1&quot;"
+        errorLine2="                          ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="37"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.test.uiautomator:uiautomator than 2.3.0 is available: 2.4.0"
+        errorLine1="uiautomator = &quot;2.3.0&quot;"
+        errorLine2="              ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="38"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.firebase:firebase-messaging than 25.1.0 is available: 25.1.1"
+        errorLine1="firebase-messaging = &quot;25.1.0&quot;"
+        errorLine2="                     ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="39"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.android.gms:play-services-cast-framework than 21.5.0 is available: 22.3.1"
+        errorLine1="play-services-cast-framework = &quot;21.5.0&quot;"
+        errorLine2="                               ~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="45"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.mediarouter:mediarouter than 1.7.0 is available: 1.8.1"
+        errorLine1="androidx-mediarouter = &quot;1.7.0&quot;"
+        errorLine2="                       ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="46"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.window:window than 1.4.0 is available: 1.5.1"
+        errorLine1="androidx-window = &quot;1.4.0&quot;"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="47"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    presentation: AndroidSubtitlePresentation,"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="13"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AndroidSubtitlePresentation.Phone -> AndroidSubtitleTextSize.Fractional("
+        errorLine2="                                ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="16"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AndroidSubtitlePresentation.Television -> AndroidSubtitleTextSize.FixedSp("
+        errorLine2="                                ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="25"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    subtitleView: SubtitleView,"
+        errorLine2="                  ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="38"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        is AndroidSubtitleTextSize.Fractional -> subtitleView.setFractionalTextSize("
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="42"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        is AndroidSubtitleTextSize.FixedSp -> subtitleView.setFixedTextSize("
+        errorLine2="                                                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AndroidSubtitleTextSizePolicy.kt"
+            line="46"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="internal fun shouldNormalizeSubripDataSpec(dataSpec: DataSpec): Boolean ="
+        errorLine2="                                                     ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="450"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    shouldNormalizeSubripPath(dataSpec.uri.path, dataSpec.position)"
+        errorLine2="                                       ~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="451"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    shouldNormalizeSubripPath(dataSpec.uri.path, dataSpec.position)"
+        errorLine2="                                                          ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="451"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val audioCapabilityManager: AudioCapabilityManager,"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DeviceSnapshotCollector.kt"
+            line="158"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        val snapshot = audioCapabilityManager.diagnosticsSnapshot()"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DeviceSnapshotCollector.kt"
+            line="190"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun hdr10ColorInfo(current: ColorInfo?): ColorInfo ="
+        errorLine2="                                    ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="481"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun hdr10ColorInfo(current: ColorInfo?): ColorInfo ="
+        errorLine2="                                                 ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="481"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    (current?.buildUpon() ?: ColorInfo.Builder())"
+        errorLine2="              ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="482"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    (current?.buildUpon() ?: ColorInfo.Builder())"
+        errorLine2="                                       ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="482"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorSpace(C.COLOR_SPACE_BT2020)"
+        errorLine2="         ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="483"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorSpace(C.COLOR_SPACE_BT2020)"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="483"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorTransfer(C.COLOR_TRANSFER_ST2084)"
+        errorLine2="         ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="484"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorTransfer(C.COLOR_TRANSFER_ST2084)"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="484"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorRange(C.COLOR_RANGE_LIMITED)"
+        errorLine2="         ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="485"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setColorRange(C.COLOR_RANGE_LIMITED)"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="485"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setHdrStaticInfo(current?.hdrStaticInfo ?: defaultDolbyVisionHdrStaticInfo())"
+        errorLine2="         ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="486"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .setHdrStaticInfo(current?.hdrStaticInfo ?: defaultDolbyVisionHdrStaticInfo())"
+        errorLine2="                                   ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="486"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        .build()"
+        errorLine2="         ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="487"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    if (chain.any { it is ParserException }) return false"
+        errorLine2="                          ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicy.kt"
+            line="206"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    headerFields.entries"
+        errorLine2="    ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/MediaLoadRetryPolicy.kt"
+            line="281"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val delegate: AudioSink,"
+        errorLine2="                          ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="55"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1=") : AudioSink by delegate {"
+        errorLine2="    ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="56"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    override fun supportsFormat(format: Format): Boolean ="
+        errorLine2="                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="57"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        getFormatSupport(format) != AudioSink.SINK_FORMAT_UNSUPPORTED"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="58"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    override fun getFormatSupport(format: Format): Int ="
+        errorLine2="                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="60"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            AudioSink.SINK_FORMAT_UNSUPPORTED"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="67"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            delegate.getFormatSupport(format)"
+        errorLine2="                     ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/audio/PassthroughSuppressionRegistry.kt"
+            line="69"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        Intent(context, SiloPlaybackService::class.java)"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PipActionCapability.kt"
+            line="19"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val audioCapabilityManager: AudioCapabilityManager,"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="55"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val libassBridge: LibassBridge,"
+        errorLine2="                              ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="56"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        val libassRendering = libassBridge.isRenderingSupported"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="215"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        val libassEmbeddedFonts = libassBridge.isEmbeddedFontsSupported"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="216"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                sinkType = audioCapabilityManager.currentSinkType(),"
+        errorLine2="                                                  ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="282"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        ?: if (mediaTrackGroup.length > 0) mediaTrackGroup.getFormat(0) else null"
+        errorLine2="                               ~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="432"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        ?: if (mediaTrackGroup.length > 0) mediaTrackGroup.getFormat(0) else null"
+        errorLine2="                                                           ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt"
+            line="432"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoFormat?.let { json.put(&quot;videoFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="84"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoFormat?.let { json.put(&quot;videoFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                                                                  ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="84"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.audioFormat?.let { json.put(&quot;audioFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="85"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.audioFormat?.let { json.put(&quot;audioFormat&quot;, Format.toLogString(it)) }"
+        errorLine2="                                                                  ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="85"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoDecoderCounters?.let { counters ->"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="86"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            exo.videoDecoderCounters?.let { counters ->"
+        errorLine2="                                            ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="86"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                json.put(&quot;droppedFrames&quot;, counters.droppedBufferCount)"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="87"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                json.put(&quot;renderedFrames&quot;, counters.renderedOutputBufferCount)"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/debug/PlaybackDebugReceiver.kt"
+            line="88"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { DefaultBandwidthMeter.Builder(androidContext()).build() }"
+        errorLine2="                                   ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="67"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { DefaultBandwidthMeter.Builder(androidContext()).build() }"
+        errorLine2="                                                             ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="67"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        PlaybackNetworkMonitor(androidContext(), get())"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="71"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { PlaybackAnalyticsListener() }"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="75"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { DelayAudioProcessor() }"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="78"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    single { LibassBridge(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) }"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerModule.kt"
+            line="83"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    event: PlaybackAnalyticsListener.Event,"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="58"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.VideoDecoderInitialized ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="60"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.AudioDecoderInitialized ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="65"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.VideoFormatChanged -> current.copy("
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="67"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.AudioFormatChanged ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="82"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.DroppedFrames ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="84"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.AudioUnderrun ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="86"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.BandwidthEstimate ->"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="88"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.FirstFrameRendered -> current.copy("
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="90"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.SeekStarted -> current.copy(seekStartedAtMs = event.realtimeMs)"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="95"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.PlaybackStateChanged -> current.reducePlaybackState(event)"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="96"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.LoadError,"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="97"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.PlayerError,"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="98"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    is PlaybackAnalyticsListener.Event.TrackSnapshot,"
+        errorLine2="       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="99"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    event: PlaybackAnalyticsListener.Event.PlaybackStateChanged,"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="104"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorTransfer(format: Format): String? = when (format.colorInfo?.colorTransfer) {"
+        errorLine2="                                                                          ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="169"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorTransfer(format: Format): String? = when (format.colorInfo?.colorTransfer) {"
+        errorLine2="                                                                                     ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="169"
+            column="86"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_TRANSFER_ST2084 -> &quot;st2084&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="170"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_TRANSFER_HLG -> &quot;hlg&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="171"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_TRANSFER_SDR -> &quot;sdr&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="172"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorRange(format: Format): String? = when (format.colorInfo?.colorRange) {"
+        errorLine2="                                                                       ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="176"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="private fun describeColorRange(format: Format): String? = when (format.colorInfo?.colorRange) {"
+        errorLine2="                                                                                  ~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="176"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_RANGE_FULL -> &quot;full&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="177"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    C.COLOR_RANGE_LIMITED -> &quot;limited&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="178"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    val colorInfo = format.colorInfo ?: return null"
+        errorLine2="        ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="187"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    val colorInfo = format.colorInfo ?: return null"
+        errorLine2="                           ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="187"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    return when (colorInfo.colorTransfer) {"
+        errorLine2="                           ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="188"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        C.COLOR_TRANSFER_ST2084 -> &quot;HDR10&quot;"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="189"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        C.COLOR_TRANSFER_HLG -> &quot;HLG&quot;"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="190"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        C.COLOR_TRANSFER_SDR -> &quot;SDR&quot;"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt"
+            line="191"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PAUSE"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="178"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PAUSE"
+        errorLine2="                                ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="178"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PLAY"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="180"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="            SiloPlaybackService.ACTION_PIP_PLAY"
+        errorLine2="                                ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="180"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_BACK),"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="189"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_BACK),"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="189"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_FORWARD),"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="201"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="                pendingServiceIntent(context, SiloPlaybackService.ACTION_PIP_SKIP_FORWARD),"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pip/SiloPictureInPictureCoordinator.kt"
+            line="201"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        AspectRatioFrameLayout.RESIZE_MODE_FIXED_WIDTH -> {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="468"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        AspectRatioFrameLayout.RESIZE_MODE_FIXED_HEIGHT -> {"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="472"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        AspectRatioFrameLayout.RESIZE_MODE_FIT -> {"
+        errorLine2="                               ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="476"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AspectRatioFrameLayout.RESIZE_MODE_ZOOM,"
+        errorLine2="                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="507"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    AspectRatioFrameLayout.RESIZE_MODE_FILL,"
+        errorLine2="                           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="508"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        return cue.buildUpon().setSize(Cue.DIMEN_UNSET).build()"
+        errorLine2="                   ~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="566"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        return cue.buildUpon().setSize(Cue.DIMEN_UNSET).build()"
+        errorLine2="                               ~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="566"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="        return cue.buildUpon().setSize(Cue.DIMEN_UNSET).build()"
+        errorLine2="                                                        ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="566"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    return if (changed) CueGroup(mapped, cueGroup.presentationTimeUs) else cueGroup"
+        errorLine2="                        ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="579"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    return if (changed) CueGroup(mapped, cueGroup.presentationTimeUs) else cueGroup"
+        errorLine2="                                                  ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="579"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    val frame = findViewById&lt;AspectRatioFrameLayout>("
+        errorLine2="        ~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="904"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val playerFactory: SiloPlayerFactory,"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackendFactory.kt"
+            line="12"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val audioTrackManager: AudioTrackManager,"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackendFactory.kt"
+            line="13"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnsafeOptInUsageError"
+        message="This declaration is opt-in and its usage should be marked with `@androidx.media3.common.util.UnstableApi` or `@OptIn(markerClass = androidx.media3.common.util.UnstableApi.class)`"
+        errorLine1="    private val subtitleManager: SubtitleManager,"
+        errorLine2="                                 ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackendFactory.kt"
+            line="14"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="ComposableNaming"
+        message="Composable functions with a return type should start with a lowercase letter"
+        errorLine1="private fun SettingsMonoHeaderStyle() ="
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt"
+            line="1721"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ComposableNaming"
+        message="Composable functions with a return type should start with a lowercase letter"
+        errorLine1="private fun SettingsRowTextStyle() ="
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt"
+            line="1732"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenHeightDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="    val heroHeight = LocalConfiguration.current.screenHeightDp.dp * HERO_HEIGHT_FRACTION"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt"
+            line="104"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ModifierFactoryExtensionFunction"
+        message="Modifier factory functions should be extensions on Modifier"
+        errorLine1="internal fun rememberTvContentInitialFocus("
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/focus/TvContentInitialFocus.kt"
+            line="75"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ModifierFactoryExtensionFunction"
+        message="Modifier factory functions should be extensions on Modifier"
+        errorLine1="internal fun rememberTvDialogInitialFocus("
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvDialogInitialFocus.kt"
+            line="62"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/QrCodePanel.kt"
+            line="35"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/StatusViews.kt"
+            line="41"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAlphabetRail.kt"
+            line="81"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAuroraBackdrop.kt"
+            line="68"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be named modifier"
+        errorLine1="    filterOpenerModifier: Modifier,"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/browse/TvBrowseScreen.kt"
+            line="273"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be named modifier"
+        errorLine1="    filterOpenerModifier: Modifier,"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/browse/TvBrowseScreen.kt"
+            line="324"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be named modifier"
+        errorLine1="    filterOpenerModifier: Modifier,"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/browse/TvBrowseScreen.kt"
+            line="370"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCascadeSelector.kt"
+            line="211"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be named modifier"
+        errorLine1="    cardModifier: Modifier,"
+        errorLine2="    ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvCastCrewSection.kt"
+            line="199"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsSettingsScreen.kt"
+            line="325"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarquee.kt"
+            line="56"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvHomeHeroCarousel.kt"
+            line="82"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt"
+            line="1653"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryBrowseControls.kt"
+            line="91"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryBrowseControls.kt"
+            line="195"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt"
+            line="195"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerHud.kt"
+            line="585"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScrubber.kt"
+            line="118"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerTransportCluster.kt"
+            line="76"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be named modifier"
+        errorLine1="    firstItemCardModifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestsScreen.kt"
+            line="308"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be named modifier"
+        errorLine1="    firstItemCardModifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestsScreen.kt"
+            line="327"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be named modifier"
+        errorLine1="    firstItemCardModifier: Modifier,"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt"
+            line="589"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupScreen.kt"
+            line="630"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="    modifier: Modifier = Modifier,"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt"
+            line="169"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="SwitchIntDef"
+        message="Switch statement on an `int` with known associated constant missing case `TrackOutput.SAMPLE_DATA_PART_ENCRYPTION`"
+        errorLine1="        when (sampleDataPart) {"
+        errorLine2="        ~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt"
+            line="279"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="../../../../../../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bctls-jdk18on/1.84/b70a9bcd45e26e24ba62656b2f78760ad5427fda/bctls-jdk18on-1.84.jar"/>
+    </issue>
+
+    <issue
+        id="DataExtractionRules"
+        message="The attribute `android:allowBackup` is deprecated from Android 12 and higher and may be removed in future versions. Consider adding the attribute `android:dataExtractionRules` specifying an `@xml` resource which configures cloud backups and device transfers on Android 12 and higher."
+        errorLine1="        android:allowBackup=&quot;false&quot;"
+        errorLine2="                             ~~~~~">
+        <location
+            file="src/androidMain/AndroidManifest.xml"
+            line="36"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is never &lt; 24"
+        errorLine1="        if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.N) return HdrCapabilities()"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt"
+            line="63"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableLongStateOf` instead of `mutableStateOf`"
+        errorLine1="    var playbackVisibleStartedAt by remember { mutableStateOf(0L) }"
+        errorLine2="                                               ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/ui/components/StartupSplashVideo.kt"
+            line="59"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="            var focusedIndex by remember(options) { mutableStateOf(initialSelectorMenuIndex(options)) }"
+        errorLine2="                                                    ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt"
+            line="279"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var loadMoreRequestedSize by remember { mutableStateOf(-1) }"
+        errorLine2="                                            ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt"
+            line="150"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var activeIndex by remember { mutableStateOf(0) }"
+        errorLine2="                                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFeaturedCarousel.kt"
+            line="88"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var titleLineCount by remember(content.id) { mutableStateOf(1) }"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarquee.kt"
+            line="119"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var pendingCastFocusIndex by rememberSaveable(detail.contentId) { mutableStateOf(-1) }"
+        errorLine2="                                                                      ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt"
+            line="235"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var pendingSimilarGeneration by rememberSaveable(detail.contentId) { mutableStateOf(0) }"
+        errorLine2="                                                                         ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt"
+            line="256"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var similarRestoreRequest by remember { mutableStateOf(0) }"
+        errorLine2="                                            ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt"
+            line="262"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="        var railHeightPx by remember { mutableStateOf(0) }"
+        errorLine2="                                       ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt"
+            line="1392"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var pendingCleanSeekDirection by remember { mutableStateOf(0) }"
+        errorLine2="                                                ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+            line="329"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableLongStateOf` instead of `mutableStateOf`"
+        errorLine1="    var pendingCleanSeekGeneration by remember { mutableStateOf(0L) }"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+            line="330"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var cleanSeekRate by remember { mutableStateOf(0) }"
+        errorLine2="                                    ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+            line="336"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableDoubleStateOf` instead of `mutableStateOf`"
+        errorLine1="    var cleanSeekPreviewSec by remember { mutableStateOf(0.0) }"
+        errorLine2="                                          ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+            line="337"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var cleanSeekAdjustmentDirection by remember { mutableStateOf(0) }"
+        errorLine2="                                                   ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+            line="338"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableLongStateOf` instead of `mutableStateOf`"
+        errorLine1="    var quickSkipCaptureGeneration by remember { mutableStateOf(0L) }"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+            line="340"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var pictureInPictureVideoWidth by remember { mutableStateOf(16) }"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+            line="357"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var pictureInPictureVideoHeight by remember { mutableStateOf(9) }"
+        errorLine2="                                                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+            line="358"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var currentRate by remember { mutableStateOf(0) }"
+        errorLine2="                                  ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt"
+            line="2267"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var autoSeekRate by remember { mutableStateOf(0) }"
+        errorLine2="                                   ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScrubber.kt"
+            line="132"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var lastAppliedFocusRequest by rememberSaveable { mutableStateOf(-1) }"
+        errorLine2="                                                      ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/recommendations/TvRecommendationsScreen.kt"
+            line="369"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var consumedSuccessGeneration by rememberSaveable { mutableStateOf(0) }"
+        errorLine2="                                                        ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestsScreen.kt"
+            line="110"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="    var detailFocusRequest by remember { mutableStateOf(0) }"
+        errorLine2="                                         ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt"
+            line="137"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.silo_blue` appears to be unused"
+        errorLine1="    &lt;color name=&quot;silo_blue&quot;>#FF1E88E5&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="4"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.silo_blue_light` appears to be unused"
+        errorLine1="    &lt;color name=&quot;silo_blue_light&quot;>#FF6AB7FF&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="5"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.silo_blue_dark` appears to be unused"
+        errorLine1="    &lt;color name=&quot;silo_blue_dark&quot;>#FF005CB2&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="6"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.dark_surface` appears to be unused"
+        errorLine1="    &lt;color name=&quot;dark_surface&quot;>#FF1C1C20&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="11"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.dark_surface_variant` appears to be unused"
+        errorLine1="    &lt;color name=&quot;dark_surface_variant&quot;>#FF252528&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/colors.xml"
+            line="12"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.raw.inter_license` appears to be unused">
+        <location
+            file="src/androidMain/res/raw/inter_license.txt"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.nav_home` appears to be unused"
+        errorLine1="    &lt;string name=&quot;nav_home&quot;>Home&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="6"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.nav_browse` appears to be unused"
+        errorLine1="    &lt;string name=&quot;nav_browse&quot;>Browse&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="7"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.nav_search` appears to be unused"
+        errorLine1="    &lt;string name=&quot;nav_search&quot;>Search&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="8"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.nav_settings` appears to be unused"
+        errorLine1="    &lt;string name=&quot;nav_settings&quot;>Settings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="9"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_retry` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_retry&quot;>Retry&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="12"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_cancel` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_cancel&quot;>Cancel&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="13"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_connect` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_connect&quot;>Connect&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="14"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_sign_in` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_sign_in&quot;>Sign In&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="15"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_play` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_play&quot;>Play&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="16"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.loading` appears to be unused"
+        errorLine1="    &lt;string name=&quot;loading&quot;>Loading…&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="19"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_generic` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_generic&quot;>Something went wrong&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="20"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.coming_soon` appears to be unused"
+        errorLine1="    &lt;string name=&quot;coming_soon&quot;>Coming soon&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/res/values/strings.xml"
+            line="21"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UsableSpace"
+        message="Consider also using `StorageManager#getAllocatableBytes` and `allocateBytes` which will consider clearable cached data"
+        errorLine1="    fun usableSpaceBytes(): Long = baseDir.usableSpace"
+        errorLine2="                                           ~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="148"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/androidMain/res/mipmap-hdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/androidMain/res/mipmap-mdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/androidMain/res/mipmap-xhdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/androidMain/res/mipmap-xxhdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLauncherShape"
+        message="Launcher icons should not fill every pixel of their square region; see the design guide for details">
+        <location
+            file="src/androidMain/res/mipmap-xxxhdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="MonochromeLauncherIcon"
+        message="The application adaptive icon is missing a monochrome tag"
+        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/androidMain/res/mipmap-anydpi-v26/ic_launcher.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/silo_wordmark.png` in densityless folder">
+        <location
+            file="src/androidMain/res/drawable/silo_wordmark.png"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/tv_banner.png` in densityless folder">
+        <location
+            file="src/androidMain/res/drawable/tv_banner.png"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `Bitmap.get` instead?"
+        errorLine1="            val p = bitmap.getPixel(x, y)"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/AmbientBackdropTint.kt"
+            line="170"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit().putString(KEY_DEVICE_ID, generated).apply()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/network/AndroidDeviceMetadataProvider.kt"
+            line="20"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().putString(storageKey(serverUrl, key), value).apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidServerSettingsCache.kt"
+            line="14"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="        prefs.edit().putBoolean(migrationKey(serverUrl, scope), true).apply()"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/settings/AndroidServerSettingsCache.kt"
+            line="31"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                .setUri(Uri.parse(absoluteUrl))"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/AuthenticatedDataSourceFactory.kt"
+            line="327"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return null"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="708"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return null"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="750"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return 0L"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="757"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            return runCatching { resolver.delete(Uri.parse(uri), null, null) > 0 }.getOrDefault(false)"
+        errorLine2="                                                 ~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="767"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="        if (resolver.update(Uri.parse(uriString), values, null, null) &lt;= 0) return uriString"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/downloads/DownloadStorage.kt"
+            line="837"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `SharedPreferences.edit` instead?"
+        errorLine1="            prefs.edit().putString(KEY_DEVICE_ID, it).apply()"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingDeviceId.kt"
+            line="25"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            android.net.Uri.parse(absoluteUrl)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt"
+            line="466"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            RequestHeaderScope(android.net.Uri.parse(absoluteUrl), it)"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt"
+            line="471"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                ?.let { metadataBuilder.setArtworkUri(android.net.Uri.parse(it)) }"
+        errorLine2="                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt"
+            line="507"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            val builder = MediaItem.SubtitleConfiguration.Builder(Uri.parse(absoluteUrl))"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt"
+            line="99"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/common/ui/components/ThumbHash.kt"
+            line="136"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                        state.coverUrl?.takeIf { it.isNotBlank() }?.let { mb.setArtworkUri(Uri.parse(it)) }"
+        errorLine2="                                                                                           ~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/audiobook/TvAudiobookPlayerScreen.kt"
+            line="161"
+            column="92"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="    return Bitmap.createBitmap(dim, dim, Bitmap.Config.ARGB_8888)"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAuroraBackdrop.kt"
+            line="218"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="    val bitmap = Bitmap.createBitmap(dimension, dimension, Bitmap.Config.ARGB_8888)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvRootHeroBackdrop.kt"
+            line="315"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            .setPosterArtUri(Uri.parse(posterArtUri))"
+        errorLine2="                             ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/watchnext/WatchNextRepository.kt"
+            line="112"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            .setIntentUri(Uri.parse(intentUri))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/androidMain/kotlin/org/siloserver/silo/tv/watchnext/WatchNextRepository.kt"
+            line="117"
+            column="27"/>
+    </issue>
+
+</issues>


### PR DESCRIPTION
Follow-up to #195. Two startup crashes reached users this week because nothing
in this project checked API levels — lint had never been configured, had no
baseline, and did not run in CI.

## Three API-guard bugs, all in `AudioCapabilityManager`

| Call | Level | Effect |
| --- | --- | --- |
| `AudioDeviceInfo.getAddress()` | API 28, **no guard at all** | `NoSuchMethodError` on API 24–27 whenever diagnostics were collected |
| `AudioTrack.isDirectPlaybackSupported()` | API 29, only gated for TIRAMISU | `runCatching` swallowed the resulting error on API 24–28, so **"no passthrough" was an accident rather than a decision** |
| `AudioFormat.ENCODING_E_AC3_JOC` | API 28, **no `minSdk`** | Queried on API 24–27 for an encoding that does not exist there |

The first is the same shape as #195 and is a real behaviour fix.

The second is **not** a behaviour change, and the table above previously implied
it was. Pre-Q devices reported no passthrough before this change and still do —
the platform offers no way to ask before API 29, so `false` is the only honest
answer. What changes is that the answer is now an explicit branch instead of a
swallowed `NoSuchMethodError`, which means lint can see it and a reader can tell
it was intended. Worth having, but nobody's audio improves.

The third was found by this PR's own lint run. `EncodingSupport` carries a
`minSdk` field so a constant is only queried where it exists — `dts_hd`,
`truehd` and `ac4` all use it. `eac3_joc` needs API 28 exactly as `ac4` does
and was the one entry left on the default of `1`. It cannot crash (the
constant inlines, and the platform returns false for a value it does not
know), so the result was right by accident in a table where every neighbour
is right by design.

Note that this does **not** remove a baseline entry: `InlinedApi` fires on the
constant reference, not the runtime guard, which is why correctly-guarded
`truehd` and `ac4` are baselined too. All three entries stay. The fix is about
the code being right, not about silencing lint.

## The gate

- `NewApi` and `InlinedApi` are **fatal** on `android-shared`, `androidApp` and
  `androidTvApp`.
- `checkDependencies = true` on both apps. This is the structural part:
  `android-shared` is where both crashes lived, and app-level lint does not
  analyse library sources without it — so the module holding the risk was the
  one nothing examined.
- Per-module `lint-baseline.xml` holds today's findings so only **new**
  violations fail. They are overwhelmingly desugared `java.*` calls (core
  library desugaring is enabled; lint does not model it) and deliberate media3
  `@UnstableApi` usage.
- A `Lint` job in `android-build.yml`, mirroring the unit-test job, uploading
  reports on failure.
- The job runs `lintVitalRelease` for both apps as well. `checkReleaseBuilds`
  makes that part of `assembleRelease`, which runs only from `release.yml` on a
  `v*` tag — so the release variant was gated by a check no pull request
  exercised, and its first run would have been mid-release. It also covers the
  release-only source sets `lintDebug` never analyses.

## Verification

The two fixes were made **before** generating the baselines, so neither is
baselined — grep confirms no `Spatializer`, `getAddress` or
`isDirectPlaybackSupported` entries in any of the three files. Baselining first
would have permanently accepted both.

Reintroducing the unguarded `getAddress()` call fails the build with
`Call requires API level 28 (current min is 24)`; with the fix in place lint
reports `no new issues (242 errors … filtered by baseline)`.

## Note for future contributors

If the lint job fails, fix the call. Regenerating a baseline to make it pass is
how this protection gets quietly dismantled.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older Android versions by preventing unsupported audio APIs from being called.
  * Refined audio capability detection for device routes and newer audio formats.

* **Quality Improvements**
  * Added Android lint checks across mobile and TV builds.
  * Release builds now enforce critical API compatibility checks and fail when lint errors are detected.
  * Lint reports are available for troubleshooting when checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->