### PR TITLE
test(player): await the stale candidate drained by stopping its owner

### DIFF
--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionManagerStagedReplanTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionManagerStagedReplanTest.kt
@@ -1065,6 +1065,10 @@ class PlaybackSessionManagerStagedReplanTest {
         harness.awaitStopped("s1")
 
         harness.manager.stopSession("s3")
+        // Stopping s3 also drains the stale candidate s2 it still owns, and that
+        // cleanup lands asynchronously. Only s1 was awaited, so on a contended
+        // runner the count assertion below raced it and saw {s1:1, s3:1}.
+        harness.awaitStopped("s2")
 
         assertEquals(null, harness.manager.activeSessionIdForTest())
         assertEquals(


### PR DESCRIPTION
`stopping active replacement drains stale older base handle` asserts that s1, s2
and s3 each stopped exactly once, but only awaits s1. Stopping s3 also drains the
stale candidate s2 it still owns, and that cleanup lands asynchronously — so the
count assertion could run first and see `{s1:1, s3:1}`.

## Not a flake

The same tree passed on the pull-request run for #196 and then failed **twice** in
the release pipeline for `v1.0.0-rc.5+8` — once in `testDebugUnitTest`, once in
`testReleaseUnitTest`. Identical tree `f97c2bfa13a4…`, opposite results. Local
machines win the race; contended CI runners lose it consistently. Re-running does
not help, and this blocked the RC.

## The fix

The harness already exposes `awaitStopped()`, which drains `stoppedEvents` until
the named owner appears. This test just did not use it for s2.

**Placement matters.** Awaiting s2 *before* `stopSession("s3")` hangs for the full
`runTest` budget, because nothing has stopped s2 at that point — which is itself
the proof that committing the replacement does not drain it and stopping its owner
does.

## Verification

8/8 consecutive runs of the class pass with `--rerun-tasks` (44 tests, 0 failures
each).

## Follow-up, deliberately not done here

Eight sibling tests assert on `stoppedSessions` counts including an owner nothing
awaits: L821, L941, L1000, L1027, L1116, L1199, L1275, L1315. Same shape, same
ability to block a release. Each needs its cascade traced before an await is added
— `awaitStopped()` has no timeout of its own, so a misplaced one turns a random
failure into a guaranteed hang.