### PR TITLE
fix(tv): give content focus entry a second frame, and stop hiding when it fails

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentation.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentation.kt
@@ -274,6 +274,24 @@ object DiagnosticsFocusLogger {
             "action" to SiloLogAttribute.Text(action),
         ),
     )
+
+    /**
+     * Content focus entry found nothing to focus, even one frame later.
+     *
+     * Every `requestFocus()` on the way into content is wrapped in
+     * `runCatching`, because a requester whose node has not composed yet throws
+     * rather than returning false. That made the failure invisible: focus went
+     * nowhere, no exception surfaced, and the viewer was simply stuck with no
+     * evidence in any log. Warn level on purpose — the telemetry builds
+     * instrument logcat at `minLevel = WARNING`, so this becomes a breadcrumb
+     * instead of vanishing.
+     */
+    fun contentEntryFailed(route: String) = SiloLog.w(
+        DiagnosticsLogCategory.FOCUS,
+        "TvShellFocus",
+        "content focus entry failed",
+        mapOf("route" to SiloLogAttribute.Text(route)),
+    )
 }
 
 private val API_VERSION = Regex("v[0-9]+")

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -104,6 +104,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 import androidx.lifecycle.compose.LifecycleResumeEffect
+import org.siloserver.silo.common.diagnostics.DiagnosticsFocusLogger
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.common.ui.components.isImageAvatar
 import org.siloserver.silo.tv.ui.theme.SiloOnSurface
@@ -609,16 +610,23 @@ fun TvMainShell(
         }
     }
 
-    val moveFocusToContent: (String) -> Unit = { route ->
-        focusState.closeProfileMenuForContent()
-        if (route == TvMainRoute.Search.route) {
-            runCatching { searchInputFocusRequester.requestFocus() }
-        } else if (route == TvMainRoute.Home.route || route == TvMainRoute.Video.route) {
-            panelScope.launch {
-                runCatching { contentFocusRequester.requestFocus() }
-                runCatching { homeFirstRowContainerFocusRequester.requestFocus() }
+    // True when a requester actually took focus. `requestFocus()` throws rather
+    // than returning false when its node has not composed yet, so each call has
+    // to be guarded — and that guard is what used to swallow the failure whole.
+    val claimContentFocus: (String) -> Boolean = { route ->
+        when {
+            route == TvMainRoute.Search.route ->
+                runCatching { searchInputFocusRequester.requestFocus() }.getOrDefault(false)
+
+            route == TvMainRoute.Home.route || route == TvMainRoute.Video.route -> {
+                val content =
+                    runCatching { contentFocusRequester.requestFocus() }.getOrDefault(false)
+                val firstRow = runCatching {
+                    homeFirstRowContainerFocusRequester.requestFocus()
+                }.getOrDefault(false)
+                content || firstRow
             }
-        } else {
+
             // Just request focus on the content group. The Box's
             // .focusRestorer() restores to the user's last-focused card
             // (e.g., card 7 of row 3) instead of slamming back to card 0.
@@ -627,7 +635,32 @@ fun TvMainShell(
             // re-focused index 0 — defeating the restorer. Initial focus
             // when a screen first loads is still handled by each screen's
             // own LaunchedEffect on its first data emission.
-            runCatching { contentFocusRequester.requestFocus() }
+            else -> runCatching { contentFocusRequester.requestFocus() }.getOrDefault(false)
+        }
+    }
+
+    val moveFocusToContent: (String) -> Unit = { route ->
+        focusState.closeProfileMenuForContent()
+        val homeLike = route == TvMainRoute.Home.route || route == TvMainRoute.Video.route
+        // Home/Video keep claiming from the scope; every other route still
+        // claims inline first, so the timing of a successful claim is exactly
+        // what it was. What is new is the second chance: a claim that finds a
+        // not-yet-composed requester now gets one more frame before it is given
+        // up on — the same allowance the detail-return path already makes for
+        // "the Home row requester was not attached during the synchronous
+        // claim". On a 2 GB Amlogic box the content group is routinely still
+        // composing when Down arrives from the menu bar, and the first claim
+        // lands on nothing.
+        val claimedInline = if (homeLike) false else claimContentFocus(route)
+        if (!claimedInline) {
+            panelScope.launch {
+                if (!claimContentFocus(route)) {
+                    withFrameNanos { }
+                    if (!claimContentFocus(route)) {
+                        DiagnosticsFocusLogger.contentEntryFailed(route)
+                    }
+                }
+            }
         }
     }
     val openForYou: (SavedListSelection?) -> Unit = { selection ->


### PR DESCRIPTION
Reported on a **TiVo Stream 4K**: from the Home rows, moving up to the menu bar
and pressing Down does not return focus to the rows. The only recovery is to
open Libraries/Search/For You and back out — which lands back on Continue
Watching.

## Why that recovery is the tell

Backing out calls `moveFocusToContent` with an explicit route, and the Home
branch requests `homeFirstRowContainerFocusRequester` **by name** — the first
row, which is Continue Watching. Down from the bar goes through the *same*
function (`onMoveDown = { moveFocusToContent(currentRoute) }`), so the
difference is not which code runs but whether the requester it names has
composed yet.

`requestFocus()` throws when its node is not attached rather than returning
false, so every call is wrapped in `runCatching`. A claim that arrived too early
therefore did nothing, reported nothing, and left the viewer stuck **with no
evidence in any log**.

The detail-return path already concedes this race and retries after
`withFrameNanos { }` for *"the disposed/recreated case where the Home row
requester was not attached during the synchronous resume claim"*. The menu-bar
path had no equivalent.

A TiVo Stream 4K is a 2 GB Amlogic S905Y2 — it loses this race routinely where a
Shield or a Google TV Streamer wins it, which is why this reproduces for a
tester and not in-house.

## Changes

- `claimContentFocus()` reports whether a requester actually took focus, instead
  of discarding that answer.
- A failed claim gets one more frame before being given up on. **Successful
  claims are unchanged**: Home/Video still claim from the scope, every other
  route still claims inline first.
- A claim that still fails logs at **WARN** via `DiagnosticsFocusLogger`. The
  telemetry builds instrument logcat at `minLevel = WARNING`, so this becomes a
  breadcrumb instead of vanishing.

## Verification

`:androidTvApp:assembleDebug` · `:android-shared:testDebugUnitTest` (1101 tests,
0 failures) · `:androidTvApp:lintDebug` (no new issues).

**Not verified on a 2 GB device** — the race is timing-dependent and no TiVo
Stream 4K was available. The retry is unconditional and cheap, so it cannot
regress the path that already worked, but confirmation should come from the
reporter. The WARN logging exists precisely so that a still-failing case reports
itself with the route attached rather than being another "I can't navigate back".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TV content focus handling across Home, Video, and other routes.
  * Added immediate and deferred focus retries to improve navigation reliability.
  * Failures are now safely handled and recorded for easier diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->