### PR TITLE
fix(tv): anchor chapter ticks to the start of the scrubber

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScrubber.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScrubber.kt
@@ -452,7 +452,9 @@ fun TvPlayerScrubber(
                     if (frac > 0.001f) {
                         Box(
                             modifier = Modifier
-                                .align(Alignment.Center)
+                                // CenterStart, not Center: `offset` is anchor-relative,
+                                // so Center adds half the bar width to every tick.
+                                .align(Alignment.CenterStart)
                                 .offset(x = barWidthDp * frac - 1.5.dp)
                                 .width(if (isTimelineScrubbing) 3.dp else 2.dp)
                                 .height(trackHeight + 8.dp)


### PR DESCRIPTION
The chapter ticks used `align(Alignment.Center)` while every other positioned element on the track (intro band, buffered sliver, played fill, puck) uses `align(Alignment.CenterStart)`.

`offset` is applied relative to the alignment anchor, so centering put each tick at `0.5 * barWidth + frac * barWidth` instead of `frac * barWidth`. Every tick was pushed right by half the bar: the left half of the timeline was empty, ticks bunched into the right half, and any chapter past the 50% mark ran off the end of the track entirely.

Switch to CenterStart so the offset is measured from the bar's leading edge. CenterStart keeps the vertical centering, so the tick's 4dp overhang above and below the track is unchanged.

Verified on a Shield against a few ripped BR, every tick now lands within the correct position relative to it's timestamp.

Old:
<img width="3840" height="2160" alt="shield_screen" src="https://github.com/user-attachments/assets/bb7745c8-7255-422f-8491-3a3066ef75e2" />

New:
<img width="3840" height="2160" alt="shield_home" src="https://github.com/user-attachments/assets/39f3dc22-c04e-44ae-a666-bae79c8837a9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected chapter marker positioning on the TV player scrubber.
  * Markers now align accurately with the start of the playback track.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->