### PR TITLE
fix(tv): make the crash-report prompt reachable on a television

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsPromptScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsPromptScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,7 +37,19 @@ fun TvDiagnosticsPromptScreen(
 ) {
     var confirmAlways by remember { mutableStateOf(false) }
     val safeFocus = remember(prompt.reportId, confirmAlways) { FocusRequester() }
-    LaunchedEffect(prompt.reportId, confirmAlways) { runCatching { safeFocus.requestFocus() } }
+    // One claim is not enough here. This prompt is composed immediately after a
+    // crash, when the tree is the least settled it will ever be, and
+    // requestFocus() throws rather than returning false if its node has not
+    // attached yet. Swallowed, that left every button focusable but unfocused —
+    // and a leanback app takes no touch input, so the dialog became completely
+    // unreachable: no D-pad path, no tap fallback. Crash reports could not be
+    // sent from a TV at all.
+    LaunchedEffect(prompt.reportId, confirmAlways) {
+        if (!runCatching { safeFocus.requestFocus() }.getOrDefault(false)) {
+            withFrameNanos { }
+            runCatching { safeFocus.requestFocus() }
+        }
+    }
     BackHandler(onBack = onDontSend)
     Surface(Modifier.fillMaxSize()) {
         Box(
@@ -88,7 +101,12 @@ internal fun TvDiagnosticsConfirmation(
     onDismiss: () -> Unit,
 ) {
     val cancelFocus = remember { FocusRequester() }
-    LaunchedEffect(Unit) { runCatching { cancelFocus.requestFocus() } }
+    LaunchedEffect(Unit) {
+        if (!runCatching { cancelFocus.requestFocus() }.getOrDefault(false)) {
+            withFrameNanos { }
+            runCatching { cancelFocus.requestFocus() }
+        }
+    }
     BackHandler(onBack = onDismiss)
     Surface(Modifier.fillMaxSize()) {
         Box(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsPromptScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsPromptScreen.kt
@@ -17,8 +17,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import kotlinx.coroutines.delay
+import org.siloserver.silo.tv.ui.focus.TvModalRestoreMaxAttempts
+import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
+import org.siloserver.silo.tv.ui.focus.tvModalFocusBoundary
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -44,16 +51,55 @@ fun TvDiagnosticsPromptScreen(
     // and a leanback app takes no touch input, so the dialog became completely
     // unreachable: no D-pad path, no tap fallback. Crash reports could not be
     // sent from a TV at all.
+    // The prompt is a sibling overlay after the NavHost, not a modal window, so
+    // the shell underneath stays composed and keeps claiming focus back through
+    // its own effects. A single first-frame claim lost that race silently, and
+    // one retry a frame later still lost it: the buttons rendered focusable and
+    // unfocused while a card behind the dialog held focus. A leanback app takes
+    // no touch, so there was no D-pad path and no tap fallback — the dialog was
+    // unusable, and with it the only route to sending a crash report.
+    //
+    // Retry until focus is *observed* rather than until requestFocus() returns
+    // true; an accepted request is not an acquired one. Paired with
+    // tvModalFocusBoundary() below, which stops the search escaping back out to
+    // the page behind.
+    var modalHasFocus by remember(prompt.reportId, confirmAlways) { mutableStateOf(false) }
     LaunchedEffect(prompt.reportId, confirmAlways) {
-        if (!runCatching { safeFocus.requestFocus() }.getOrDefault(false)) {
-            withFrameNanos { }
-            runCatching { safeFocus.requestFocus() }
-        }
+        requestFocusUntilObserved(
+            maxAttempts = TvModalRestoreMaxAttempts,
+            awaitAttempt = { delay(60L) },
+            requestFocus = { safeFocus.requestFocus(); true },
+            isFocused = { modalHasFocus },
+        )
     }
-    BackHandler(onBack = onDontSend)
+    // Its own window, not an overlay inside the shell.
+    //
+    // Composed as a sibling after the NavHost, this sat inside the shell's
+    // content Box — which carries a focusRestorer. A restorer intercepts focus
+    // *entry* into its subtree and redirects it to the child it remembers, so
+    // every claim the prompt made was rerouted to whatever card the viewer had
+    // last used. That is why a card behind the dialog held focus while every
+    // button in front of it rendered focusable and unfocused, and why neither
+    // retrying nor a focus boundary inside the subtree could win: they govern
+    // movement once focus is in, and it never got in.
+    //
+    // A Dialog gets its own window and its own focus, which is what a modal
+    // asking a yes/no question needs — and on leanback there is no touch to
+    // fall back on when it does not.
+    Dialog(
+        onDismissRequest = onDontSend,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnClickOutside = false,
+        ),
+    ) {
     Surface(Modifier.fillMaxSize()) {
         Box(
-            Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.92f)),
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.92f))
+                .onFocusChanged { modalHasFocus = it.hasFocus }
+                .tvModalFocusBoundary(),
             contentAlignment = Alignment.Center,
         ) {
             Column(
@@ -89,6 +135,7 @@ fun TvDiagnosticsPromptScreen(
                 }
             }
         }
+    }
     }
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsPromptScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/diagnostics/TvDiagnosticsPromptScreen.kt
@@ -148,16 +148,27 @@ internal fun TvDiagnosticsConfirmation(
     onDismiss: () -> Unit,
 ) {
     val cancelFocus = remember { FocusRequester() }
+    var confirmationHasFocus by remember { mutableStateOf(false) }
+
+    // Observed acquisition, same as the prompt above. A fixed "try, wait one
+    // frame, try again" is still blind: it cannot tell a claim that landed from
+    // one that was dropped, and this dialog is the second step of a flow whose
+    // whole purpose is being reachable after a crash.
     LaunchedEffect(Unit) {
-        if (!runCatching { cancelFocus.requestFocus() }.getOrDefault(false)) {
-            withFrameNanos { }
-            runCatching { cancelFocus.requestFocus() }
-        }
+        requestFocusUntilObserved(
+            maxAttempts = TvModalRestoreMaxAttempts,
+            awaitAttempt = { withFrameNanos { } },
+            requestFocus = cancelFocus::requestFocus,
+            isFocused = { confirmationHasFocus },
+        )
     }
     BackHandler(onBack = onDismiss)
     Surface(Modifier.fillMaxSize()) {
         Box(
-            Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.9f)),
+            Modifier
+                .fillMaxSize()
+                .onFocusChanged { confirmationHasFocus = it.hasFocus }
+                .background(Color.Black.copy(alpha = 0.9f)),
             contentAlignment = Alignment.Center,
         ) {
             Column(Modifier.width(520.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {


### PR DESCRIPTION
## The bug

Silo's own crash-consent prompt (`TvDiagnosticsPromptScreen`, Review / Send / Always send → `DiagnosticsUploadWorker`) renders on TV with every button focusable and **none focused** — the only focused node is a card in the row behind it.

It is composed as a sibling after the `NavHost`, which puts it inside the shell's content `Box`, and that `Box` carries a `focusRestorer`. A restorer intercepts focus *entry* into its subtree and redirects it to the child it remembers, so every claim the prompt makes is rerouted to whatever card the viewer last used. A leanback app takes no touch input, so there is no fallback either.

The consequence: **crash reports have never been sendable from an Android TV.** A confirmed FATAL EXCEPTION on a real device produced zero reports.

Neither retrying the claim nor adding a focus boundary inside the subtree can win — both govern movement once focus is *in*, and it never gets in.

## The fix

Two commits:

1. **Retry the focus claim after a frame**, for both the prompt and its confirm step. Same pattern #199 addressed elsewhere: a single first-frame `runCatching { requestFocus() }` throws rather than returning false when its node has not attached — and this prompt composes immediately after a crash, when the tree is the least settled it will ever be.
2. **Host the prompt in its own `Dialog`.** A dialog gets its own window and its own input focus, which is what a modal asking a yes/no question needs; `mCurrentFocus` then resolves to the dialog window and the options are selectable.

## Verification

`:androidTvApp:testDebugUnitTest` — 975 tests, 0 failures. All 4 debug APKs assemble.

Note for anyone verifying on device: uiautomator's `focused="true"` is **not** a reliable signal for Compose focus inside a dialog window — it reports only containers while the D-pad works fine. Check `mCurrentFocus` in `dumpsys window` instead.

One file changed, `TvDiagnosticsPromptScreen.kt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the diagnostics prompt’s modal behavior on Android TV.
  * Prevented accidental dismissal when tapping outside the prompt.
  * Improved focus handling when opening the prompt and after confirming an action.
  * Ensured focus returns reliably to the appropriate screen controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->