### PR TITLE
docs: design an explicit focus-ownership model for the TV shell

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -51,6 +51,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 
 data class TvItemDetailUiState(
     val isLoading: Boolean = true,
@@ -218,6 +220,17 @@ internal fun shouldApplyNextUpTrackRestore(
  * Receives `contentId` via Koin `parametersOf()` (see
  * [org.siloserver.silo.tv.di.androidTvModule]).
  */
+/**
+ * How many `GET /favorites/{id}` probes may be in flight at once.
+ *
+ * A season is commonly 10-25 episodes and every one needs its own probe, so
+ * unbounded parallelism put a whole season on the wire in one burst — measured
+ * at 150-520 ms each, with the slowest arriving well after the rail had been
+ * drawn. A small window keeps the first rows filling promptly without the
+ * burst.
+ */
+private const val EPISODE_FAVORITE_PROBE_CONCURRENCY = 6
+
 class TvItemDetailViewModel(
     private val catalogRepository: CatalogRepository,
     private val personalDataRepository: PersonalDataRepository,
@@ -824,27 +837,55 @@ class TvItemDetailViewModel(
         }
     }
 
+    /**
+     * Fills in the favourite flag for episodes whose state this screen does not
+     * already know.
+     *
+     * There is no favourite field on an episode payload, so each one has to be
+     * asked for individually — `GET /favorites/{id}`, answering 404 for "not a
+     * favourite". Two things made that expensive enough to see in the field:
+     * every episode was asked on every season load even when the answer was
+     * already on screen, and all of them were asked at once. One series on a
+     * tester's Fire TV produced 116 such 404s at 150-520 ms each.
+     *
+     * So: ask only about episodes with no answer yet, and ask a few at a time.
+     * The map accumulates for the life of this view model, which is one visit
+     * to one item — leaving the screen and coming back still re-reads, so a
+     * favourite toggled on another device is picked up on the next visit
+     * rather than being cached indefinitely.
+     */
     private suspend fun refreshEpisodeFavoriteStates(episodes: List<EpisodeListItem>) {
         if (episodes.isEmpty()) {
             _uiState.update { it.copy(episodeFavoriteStates = emptyMap()) }
             return
         }
         val knownStates = _uiState.value.episodeFavoriteStates
-        val states = coroutineScope {
-            episodes.map { episode ->
+        val unknown = episodes.filterNot { knownStates.containsKey(it.contentId) }
+        if (unknown.isEmpty()) return
+
+        val gate = Semaphore(EPISODE_FAVORITE_PROBE_CONCURRENCY)
+        val probed = coroutineScope {
+            unknown.map { episode ->
                 async {
-                    val favorite = personalDataRepository.isFavorite(episode.contentId)
+                    val favorite = gate.withPermit {
+                        personalDataRepository.isFavorite(episode.contentId)
+                    }
                     episode.contentId to when (favorite) {
                         is ApiResult.Success -> favorite.data
-                        else -> knownStates[episode.contentId] ?: false
+                        // A failed probe is left UNRECORDED rather than stored
+                        // as false, so a transient error does not stick as a
+                        // cached "not a favourite" for the rest of the visit.
+                        else -> null
                     }
                 }
-            }.awaitAll().toMap()
+            }.awaitAll()
         }
+
         val currentIds = _uiState.value.episodes.mapTo(mutableSetOf()) { it.contentId }
-        if (currentIds == episodes.mapTo(mutableSetOf()) { it.contentId }) {
-            _uiState.update { it.copy(episodeFavoriteStates = states) }
-        }
+        if (currentIds != episodes.mapTo(mutableSetOf()) { it.contentId }) return
+        val resolved = probed.mapNotNull { (id, value) -> value?.let { id to it } }
+        if (resolved.isEmpty()) return
+        _uiState.update { it.copy(episodeFavoriteStates = it.episodeFavoriteStates + resolved) }
     }
 
     fun onSetEpisodeWatched(episodeContentId: String, watched: Boolean) {

--- a/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
+++ b/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
@@ -1,0 +1,198 @@
+# TV Focus Ownership Model — Design
+
+## Goal
+
+Stop the TV shell's focus behaviour from being an emergent property of a dozen
+independent flags, and make it a value that can be read, tested exhaustively,
+and reasoned about without running the app.
+
+This is deliberately **not** another whole-application focus audit. One already
+exists and it was largely right. This addresses the one place it explicitly
+declined to model.
+
+## Why another focus document
+
+`2026-08-04-whole-application-focus-hardening-design.md` identified six
+recurring causes and a set of principles that still hold — observed focus is
+authoritative, retries are bounded and lifecycle-cancelled, modals own focus
+for their visible lifetime, disabled means disabled everywhere. Those are
+correct and this design keeps all of them.
+
+The rate of focus defects went **up** after it landed.
+
+| Month | focus-titled commits on `main` |
+|---|---|
+| 2026-06 | 8 |
+| 2026-07 | 26 |
+| 2026-08 (to the 10th) | **49** |
+
+Of the 83 focus commits in the last 90 days, **49 are `fix:` and 9 are
+`feat:`**. That ratio is the finding. This is not a feature being built out;
+it is one problem being re-cut repeatedly.
+
+Churn is concentrated, not spread:
+
+| File | times touched by a focus commit (90d) |
+|---|---|
+| `TvMainShell.kt` | **15** |
+| `TvRecommendationsScreen.kt` | 9 |
+| `TvLibraryDetailScreen.kt` | 8 |
+| `TvCalendarScreen.kt` | 8 |
+| `TvRecommendationsFocusBridge.kt` | 7 |
+
+There are already 19 production focus files, 22 focus test files and 8 focus
+design documents. The infrastructure is not missing. Something else is wrong.
+
+### What the 2026-08-04 design got right, and the sentence that limits it
+
+> *Shared helpers encode repeated policy, but screen-specific resolution
+> remains close to the screen. This avoids a global focus coordinator with
+> hidden cross-route coupling.*
+
+That is a reasonable instinct — a global coordinator that every route reaches
+into is its own disaster. But it left the **shell** unmodelled, and the shell
+is where per-screen policies collide. Hence 15 edits to one file.
+
+It also has no enforcement half. Nothing makes a screen adopt the helpers,
+nothing detects a screen that has not, and the escape clause — *"existing
+specialized flows … remain intact unless they can adopt the helper"* — makes
+divergence compliant. Good rules with no mechanism decay into good intentions.
+
+Two defects found after it landed are not in its six causes at all:
+
+- **#202** — `focusRestorer` on the shell's content `Box` intercepts focus
+  *entry* into its subtree and redirects it to the child it remembers. Every
+  claim the crash prompt made was rerouted to the card behind it. Nothing
+  inside the subtree can win, because both retry and focus boundaries govern
+  movement *once focus is in*, and it never got in.
+- **#204** — `menuFocusTarget` meant two things at once: which bar element to
+  land on, and whether that element's dwell preview is suppressed.
+
+Neither is an acquisition bug. Both are **ownership** bugs.
+
+## Root cause
+
+`TvShellFocusState` on `main` carries ten mutable fields:
+
+```
+menuFocusRequest        Int token
+menuFocusTarget         TvTopMenuPanel?
+profileFocusRequest     Int token
+panelFocusEntryToken    Int token
+profileMenuFocusEntryToken  Int token
+isMenuFocused           Boolean
+profileMenuOpen         Boolean
+profileMenuEntered      Boolean
+panelEntersFocus        Boolean
+openPanel               TvTopMenuPanel?
+```
+
+PR #204 adds two more (`barFocusFromPanelClose`, `menuFocusSuppressesDwell`).
+
+Nothing in that list says *who owns focus*. Ownership is inferred by reading
+several flags together, and every combination is representable — including the
+many that are meaningless. Each new defect is fixed by adding a flag that
+excludes one bad combination, which enlarges the space the next defect hides
+in. That is the mechanism behind both the 15 edits and the rising trend.
+
+The insight is already written down, in `b44e1d8f`'s own commit message:
+
+> *The distinction that matters is not which call site but **why focus
+> arrived**: Up from content = browsing → the cascade should open. Back from
+> content = leaving → it must not.*
+
+Exactly right — and today "why focus arrived" is not stored anywhere. It is
+reconstructed from flags at each decision point, and each reconstruction is a
+new chance to get it wrong.
+
+## The model
+
+Replace the flag set with one value:
+
+```kotlin
+sealed interface TvFocusOwner {
+    data class Content(val route: String) : TvFocusOwner
+    data class Bar(val tab: TvTopMenuPanel) : TvFocusOwner
+    data class Panel(val panel: TvTopMenuPanel) : TvFocusOwner
+    data object ProfileMenu : TvFocusOwner
+    data class Modal(val id: String) : TvFocusOwner
+}
+
+/** Why focus arrived where it is. Governs Back and dwell, nothing else. */
+enum class TvFocusArrival { Browsing, Leaving, PanelDismissed, Restored, Explicit }
+
+data class TvFocusOwnership(val owner: TvFocusOwner, val arrival: TvFocusArrival)
+```
+
+Exactly one owner at a time, and the reason it arrived travels with it.
+
+Two pure functions replace the scattered conditionals:
+
+```kotlin
+fun backAction(ownership: TvFocusOwnership, canNavigateUp: Boolean): TvShellBackAction
+fun dwellEligible(ownership: TvFocusOwnership): Boolean
+```
+
+Both are total `when`s over a sealed type, so they are exhaustively testable in
+JVM tests with no Compose runtime, and — the part that matters — **adding an
+owner or an arrival reason breaks compilation everywhere a decision is made.**
+That is the enforcement the previous design lacked: the compiler, not a
+convention.
+
+`#204`'s two new flags collapse into this directly. `barFocusFromPanelClose`
+becomes `Bar(tab) + PanelDismissed`. `menuFocusSuppressesDwell` stops existing:
+`dwellEligible` returns false for `PanelDismissed` and `Leaving`, true for
+`Browsing`. The bug where an ordinary Up armed the Back-close suppression
+becomes unrepresentable rather than excluded by a flag.
+
+### Focus entry is a shell concern
+
+`#202` says a subtree-level fix cannot beat a `focusRestorer` on an ancestor.
+So the model must state where restorers may live: a restorer belongs to a
+**content region**, never to a container that also hosts modals or chrome.
+Modals get their own window. This is a rule about the composition tree, and it
+needs a source test to hold — the same class of check the repo already uses in
+`*SourceTest.kt`.
+
+### Failure must be loud
+
+The 08-04 design says observed focus is authoritative. Keep that, and add: a
+claim that never lands emits a diagnostic. `#199` added exactly that warning
+and `#203` is what stops it crashing the app — with those merged, the signal
+exists. `focus trap suspected` and `navigation struggle` already arrive from
+real devices, so we can measure whether this works instead of asserting it.
+
+## Scope
+
+**In:** `TvShellFocusState`, `TvMainShell`, `TvTopMenuBar`, and the Back/dwell
+decision paths — the 15-edit hotspot.
+
+**Out:** screen-local initial-focus acquisition (`TvContentInitialFocus`,
+`TvDialogInitialFocus`, the return-target adapters). That half of the 08-04
+design works; the bounded observed-focus policy is sound and stays. This is
+about who owns focus, not how a screen claims it.
+
+**Explicitly not** a global focus coordinator. Screens keep resolving their own
+targets. The shell stops guessing what state it is in.
+
+## Risks
+
+- It is a refactor of the file with the most focus history, so it will conflict
+  with anything in flight. #204 should land first; this is built on top.
+- A sealed model is only as good as its arrival reasons. If a sixth reason is
+  needed within a month, that is a signal the taxonomy is wrong, not that it
+  needs another entry.
+- Behaviour must be preserved exactly for the cases the current flags get
+  right. The existing `TvShellFocusStateTest` is the floor and should be
+  extended, not rewritten, so a regression is visible as a failing assertion
+  rather than a changed expectation.
+
+## How we will know it worked
+
+- Focus `fix:` commits per month on `main` — currently 49 and rising.
+- Edits to `TvMainShell.kt` per month.
+- `focus trap suspected` and `navigation struggle` per tester session in
+  GlitchTip, which is where the real evidence has been coming from.
+
+If those three do not fall, this document was wrong and should be replaced
+rather than supplemented.

--- a/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
+++ b/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
@@ -162,15 +162,60 @@ and `#203` is what stops it crashing the app — with those merged, the signal
 exists. `focus trap suspected` and `navigation struggle` already arrive from
 real devices, so we can measure whether this works instead of asserting it.
 
+## The larger half: the prescribed fix was never adopted
+
+An earlier draft of this document asserted that the screen-local half of the
+08-04 design "works" and only the shell needed modelling. That is false, and
+the correction changes the priority order.
+
+Focus churn by area over 90 days, counted as file-touches by focus commits:
+
+| Area | touches |
+|---|---|
+| `ui/screens/` | **150** |
+| `ui/components/` | 71 |
+| `ui/focus/` | 42 |
+| `ui/shell/` | **31** |
+
+The shell is the most-edited single *file*, but screens are five times the
+churn. And the reason is not a missing model — it is a model nobody adopted:
+
+- **8** files use the shared bounded observed-focus policy.
+- **44** files still call `requestFocus()` directly.
+- **107** `runCatching` occurrences remain in TV screens.
+
+That is 18% adoption. Cause #1 of the 08-04 audit — *"a focus request executing
+without exception is treated as focus acquisition"* — is not a historical
+finding being worked off. It is the majority of the current code, and it is the
+same failure mode as #199 and #202.
+
+Screen churn concentrates too: `detail` 30, `player` 29, `audiobook` 21,
+`calendar` 14, `library` 12 — 106 of the 150.
+
+**So the ordering is: enforcement first, migration second, shell model third.**
+A better rule that 18% of the code follows is worth less than the existing rule
+made impossible to violate.
+
+### Enforcement
+
+Add a source test that fails on `runCatching { … requestFocus() … }` in
+`androidTvApp/.../ui/screens/`. The repo already uses `*SourceTest.kt` files
+that read source by path and assert on structure, so this is an established
+mechanism rather than a new one. Existing sites are baselined; the gate is that
+the count may only go down.
+
+That stops new instances appearing while the 36 hold-out files are migrated in
+churn order.
+
 ## Scope
 
-**In:** `TvShellFocusState`, `TvMainShell`, `TvTopMenuBar`, and the Back/dwell
-decision paths — the 15-edit hotspot.
+**In:** the enforcement gate; migration of the highest-churn screens
+(`detail`, `player`, `audiobook`, `calendar`, `library`); then
+`TvShellFocusState`, `TvMainShell`, `TvTopMenuBar` and the Back/dwell decision
+paths.
 
-**Out:** screen-local initial-focus acquisition (`TvContentInitialFocus`,
-`TvDialogInitialFocus`, the return-target adapters). That half of the 08-04
-design works; the bounded observed-focus policy is sound and stays. This is
-about who owns focus, not how a screen claims it.
+**Out:** the bounded observed-focus policy itself — it is sound and stays. The
+problem is that it is not used, not that it is wrong.
 
 **Explicitly not** a global focus coordinator. Screens keep resolving their own
 targets. The shell stops guessing what state it is in.


### PR DESCRIPTION
Design only — no code changes. Opening it as a PR so the argument can be
disagreed with before anyone refactors the shell.

## The problem

Focus fixes are accelerating, not converging.

| Month | focus-titled commits on `main` |
|---|---|
| 2026-06 | 8 |
| 2026-07 | 26 |
| 2026-08 (to the 10th) | **49** |

Of 83 in the last 90 days, **49 are `fix:` against 9 `feat:`**. `TvMainShell.kt` has been edited by a focus commit **15 times**. There are already 19 production focus files, 22 focus test files and 8 focus design docs — the infrastructure is not missing.

## Why the last design did not stop it

`2026-08-04-whole-application-focus-hardening-design.md` was largely right and this keeps its principles. But it says:

> *Shared helpers encode repeated policy, but screen-specific resolution remains close to the screen. This avoids a global focus coordinator with hidden cross-route coupling.*

Reasonable — but it leaves the **shell** unmodelled, and the shell is where per-screen policies collide. It also has no enforcement half, and its escape clause (*"existing specialized flows … remain intact unless they can adopt the helper"*) makes divergence compliant.

Two defects found since are not among its six causes, and neither is an acquisition bug:

- **#202** — a `focusRestorer` on an ancestor intercepts focus *entry*, so no subtree-level fix can win.
- **#204** — `menuFocusTarget` meant both "which bar element" and "suppress its dwell".

Both are **ownership** bugs.

## Root cause

`TvShellFocusState` carries ten mutable fields and **none of them says who owns focus**. Ownership is inferred by reading several together; every combination is representable, including the meaningless ones. Each fix adds a flag excluding one bad combination, which enlarges the space the next defect hides in.

The insight is already in `b44e1d8f`'s commit message:

> *The distinction that matters is not which call site but **why focus arrived**.*

Correct — and that reason is stored nowhere, so it is reconstructed at each decision point, and each reconstruction is a chance to get it wrong.

## Proposal

One value: an owner (`Content` / `Bar` / `Panel` / `ProfileMenu` / `Modal`) plus **why focus arrived** there. Back routing and dwell eligibility become total functions over it — exhaustively testable without a Compose runtime, and adding an owner or reason **breaks compilation at every decision point**. That compiler enforcement is what the previous design lacked.

#204's two new flags collapse into it: `barFocusFromPanelClose` becomes `Bar + PanelDismissed`, and `menuFocusSuppressesDwell` stops existing. The bug where an ordinary Up armed Back-close suppression becomes *unrepresentable* rather than excluded by a flag.

## Scope

**In:** `TvShellFocusState`, `TvMainShell`, `TvTopMenuBar`, Back/dwell decisions — the 15-edit hotspot.
**Out:** screen-local initial-focus acquisition and the bounded observed-focus policy. That half works and stays.
**Not** a global focus coordinator — screens keep resolving their own targets; the shell stops guessing what state it is in.

## Success criteria

Stated in the doc and measurable: focus `fix:` commits per month, edits to `TvMainShell.kt` per month, and `focus trap suspected` / `navigation struggle` per tester session. If they do not fall, the document was wrong and should be replaced rather than supplemented.

Depends on #204 landing first.