### PR TITLE
docs: design an explicit focus-ownership model for the TV shell

### DIFF
--- a/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
+++ b/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
@@ -23,10 +23,13 @@ The rate of focus defects went **up** after it landed.
 | Month | focus-titled commits on `main` |
 |---|---|
 | 2026-06 | 8 |
-| 2026-07 | 26 |
-| 2026-08 (to the 10th) | **49** |
+| 2026-07 | 22 |
+| 2026-08 (to the 11th) | **48** |
 
-Of the 83 focus commits in the last 90 days, **49 are `fix:` and 9 are
+Method, so these can be re-derived rather than trusted:
+`git log main --format=%s --since=… | grep -ci focus` — commit SUBJECTS only.
+
+Of the 81 focus-subject commits in the last 90 days, **49 are `fix:` and 7 are
 `feat:`**. That ratio is the finding. This is not a feature being built out;
 it is one problem being re-cut repeatedly.
 
@@ -72,7 +75,7 @@ Neither is an acquisition bug. Both are **ownership** bugs.
 
 ## Root cause
 
-`TvShellFocusState` on `main` carries ten mutable fields:
+`TvShellFocusState` on `main` carries twelve mutable fields:
 
 ```
 menuFocusRequest        Int token
@@ -84,6 +87,8 @@ isMenuFocused           Boolean
 profileMenuOpen         Boolean
 profileMenuEntered      Boolean
 panelEntersFocus        Boolean
+panelHasFocus           Boolean
+menuFocusSuppressesDwell Boolean
 openPanel               TvTopMenuPanel?
 ```
 
@@ -191,23 +196,34 @@ Focus churn by area over 90 days, counted as file-touches by focus commits:
 | `ui/shell/` | **31** |
 
 The shell is the most-edited single *file*, but screens are five times the
-churn. And the reason is not a missing model — it is a model nobody adopted:
+churn.
 
-- **8** files use the shared bounded observed-focus policy.
-- **44** files still call `requestFocus()` directly.
-- **107** `runCatching` occurrences remain in TV screens.
+**An earlier draft of this note argued the cause was non-adoption, on figures
+that #208 has since made false.** It claimed 8 adopters against 44 direct
+callers — 18% — and 107 `runCatching` occurrences in TV screens. As of `main`
+at 7245c0f4:
 
-That is 18% adoption. Cause #1 of the 08-04 audit — *"a focus request executing
-without exception is treated as focus acquisition"* — is not a historical
-finding being worked off. It is the majority of the current code, and it is the
-same failure mode as #199 and #202.
+- **34** files use the shared observed-focus helpers
+  (`requestFocusUntilObserved` / `claimFocusOrReport`).
+- **24** still contain a raw `requestFocus()`, of which **9** also use a helper,
+  leaving **15** genuine hold-outs.
+- That is **69%** adoption, not 18%.
+- **31** `runCatching` occurrences remain in TV screens, and exactly **1**
+  wraps a `requestFocus()`.
 
-Screen churn concentrates too: `detail` 30, `player` 29, `audiobook` 21,
-`calendar` 14, `library` 12 — 106 of the 150.
+Cause #1 of the 08-04 audit — *"a focus request executing without exception is
+treated as focus acquisition"* — has therefore been substantially worked off,
+by #208's sweep of 78 sites and by the ratchet that keeps them at zero.
 
-**So the ordering is: enforcement first, migration second, shell model third.**
-A better rule that 18% of the code follows is worth less than the existing rule
-made impossible to violate.
+**So the ordering this note originally proposed is wrong, and the argument it
+leans on is gone.** Enforcement exists and adoption followed it. What remains
+is the part the sweep could not do: the shell still infers ownership by reading
+twelve flags together, and #204's `panelHasFocus` is the newest example — a
+boolean added because `panelEntersFocus` records intent rather than arrival.
+That distinction is a type, expressed as a flag pair.
+
+**The revised ordering is: shell ownership model first, hold-out migration
+second, and no new enforcement — the existing ratchet is doing its job.**
 
 ### Enforcement
 
@@ -217,8 +233,9 @@ that read source by path and assert on structure, so this is an established
 mechanism rather than a new one. Existing sites are baselined; the gate is that
 the count may only go down.
 
-That stops new instances appearing while the 36 hold-out files are migrated in
-churn order.
+That gate now exists (#208) and holds the count at zero. The 15 remaining
+hold-out files can be migrated in churn order behind it; nothing new is needed
+to stop regressions.
 
 ## Scope
 
@@ -247,7 +264,8 @@ targets. The shell stops guessing what state it is in.
 
 ## How we will know it worked
 
-- Focus `fix:` commits per month on `main` — currently 49 and rising.
+- Focus-subject `fix:` commits per month on `main` — 49 across the last 90
+  days, against 48 focus-subject commits of all types in August alone.
 - Edits to `TvMainShell.kt` per month.
 - `focus trap suspected` and `navigation struggle` per tester session in
   GlitchTip, which is where the real evidence has been coming from.

--- a/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
+++ b/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
@@ -87,7 +87,12 @@ panelEntersFocus        Boolean
 openPanel               TvTopMenuPanel?
 ```
 
-PR #204 adds two more (`barFocusFromPanelClose`, `menuFocusSuppressesDwell`).
+As merged, PR #204 added `menuFocusSuppressesDwell` and `panelHasFocus`, and
+**deleted** `barFocusFromPanelClose` — review found it unreachable from
+production UI, because the only caller that armed it was a cascade `onClose`
+callback the selector never invoked. That deletion is itself evidence for this
+document's argument: a flag existed, was carried through routing and tests, and
+described a state the app could not actually reach.
 
 Nothing in that list says *who owns focus*. Ownership is inferred by reading
 several flags together, and every combination is representable — including the
@@ -139,11 +144,19 @@ owner or an arrival reason breaks compilation everywhere a decision is made.**
 That is the enforcement the previous design lacked: the compiler, not a
 convention.
 
-`#204`'s two new flags collapse into this directly. `barFocusFromPanelClose`
-becomes `Bar(tab) + PanelDismissed`. `menuFocusSuppressesDwell` stops existing:
-`dwellEligible` returns false for `PanelDismissed` and `Leaving`, true for
-`Browsing`. The bug where an ordinary Up armed the Back-close suppression
-becomes unrepresentable rather than excluded by a flag.
+`#204`'s flags collapse into this directly. `menuFocusSuppressesDwell` stops
+existing: `dwellEligible` returns false for `PanelDismissed` and `Leaving`,
+true for `Browsing`. The bug where an ordinary Up armed the Back-close
+suppression becomes unrepresentable rather than excluded by a flag.
+
+`panelHasFocus` is the more interesting case, because it is the one flag #204
+added that this model would *keep* — under a different name. It exists because
+`panelEntersFocus` records entry INTENT, and routing that asked the intent flag
+sent the viewer into content from a bar they had never left. In these terms
+that is not a flag at all: it is the difference between `Panel(tab)` being the
+owner and `Bar(tab)` still being the owner with a preview showing. An ownership
+type makes the distinction structural; a boolean pair makes it a rule someone
+has to remember. #204 shipped the boolean because the type does not exist yet.
 
 ### Focus entry is a shell concern
 

--- a/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
+++ b/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
@@ -1,0 +1,198 @@
+# TV Focus Ownership Model — Design
+
+## Goal
+
+Stop the TV shell's focus behaviour from being an emergent property of a dozen
+independent flags, and make it a value that can be read, tested exhaustively,
+and reasoned about without running the app.
+
+This is deliberately **not** another whole-application focus audit. One already
+exists and it was largely right. This addresses the one place it explicitly
+declined to model.
+
+## Why another focus document
+
+`2026-08-04-whole-application-focus-hardening-design.md` identified six
+recurring causes and a set of principles that still hold — observed focus is
+authoritative, retries are bounded and lifecycle-cancelled, modals own focus
+for their visible lifetime, disabled means disabled everywhere. Those are
+correct and this design keeps all of them.
+
+The rate of focus defects went **up** after it landed.
+
+| Month | focus-titled commits on `main` |
+|---|---|
+| 2026-06 | 8 |
+| 2026-07 | 26 |
+| 2026-08 (to the 10th) | **49** |
+
+Of the 83 focus commits in the last 90 days, **49 are `fix:` and 9 are
+`feat:`**. That ratio is the finding. This is not a feature being built out;
+it is one problem being re-cut repeatedly.
+
+Churn is concentrated, not spread:
+
+| File | times touched by a focus commit (90d) |
+|---|---|
+| `TvMainShell.kt` | **15** |
+| `TvRecommendationsScreen.kt` | 9 |
+| `TvLibraryDetailScreen.kt` | 8 |
+| `TvCalendarScreen.kt` | 8 |
+| `TvRecommendationsFocusBridge.kt` | 7 |
+
+There are already 19 production focus files, 22 focus test files and 8 focus
+design documents. The infrastructure is not missing. Something else is wrong.
+
+### What the 2026-08-04 design got right, and the sentence that limits it
+
+> *Shared helpers encode repeated policy, but screen-specific resolution
+> remains close to the screen. This avoids a global focus coordinator with
+> hidden cross-route coupling.*
+
+That is a reasonable instinct — a global coordinator that every route reaches
+into is its own disaster. But it left the **shell** unmodelled, and the shell
+is where per-screen policies collide. Hence 15 edits to one file.
+
+It also has no enforcement half. Nothing makes a screen adopt the helpers,
+nothing detects a screen that has not, and the escape clause — *"existing
+specialized flows … remain intact unless they can adopt the helper"* — makes
+divergence compliant. Good rules with no mechanism decay into good intentions.
+
+Two defects found after it landed are not in its six causes at all:
+
+- **#202** — `focusRestorer` on the shell's content `Box` intercepts focus
+  *entry* into its subtree and redirects it to the child it remembers. Every
+  claim the crash prompt made was rerouted to the card behind it. Nothing
+  inside the subtree can win, because both retry and focus boundaries govern
+  movement *once focus is in*, and it never got in.
+- **#204** — `menuFocusTarget` meant two things at once: which bar element to
+  land on, and whether that element's dwell preview is suppressed.
+
+Neither is an acquisition bug. Both are **ownership** bugs.
+
+## Root cause
+
+`TvShellFocusState` on `main` carries ten mutable fields:
+
+```
+menuFocusRequest        Int token
+menuFocusTarget         TvTopMenuPanel?
+profileFocusRequest     Int token
+panelFocusEntryToken    Int token
+profileMenuFocusEntryToken  Int token
+isMenuFocused           Boolean
+profileMenuOpen         Boolean
+profileMenuEntered      Boolean
+panelEntersFocus        Boolean
+openPanel               TvTopMenuPanel?
+```
+
+PR #204 adds two more (`barFocusFromPanelClose`, `menuFocusSuppressesDwell`).
+
+Nothing in that list says *who owns focus*. Ownership is inferred by reading
+several flags together, and every combination is representable — including the
+many that are meaningless. Each new defect is fixed by adding a flag that
+excludes one bad combination, which enlarges the space the next defect hides
+in. That is the mechanism behind both the 15 edits and the rising trend.
+
+The insight is already written down, in `b44e1d8f`'s own commit message:
+
+> *The distinction that matters is not which call site but **why focus
+> arrived**: Up from content = browsing → the cascade should open. Back from
+> content = leaving → it must not.*
+
+Exactly right — and today "why focus arrived" is not stored anywhere. It is
+reconstructed from flags at each decision point, and each reconstruction is a
+new chance to get it wrong.
+
+## The model
+
+Replace the flag set with one value:
+
+```kotlin
+sealed interface TvFocusOwner {
+    data class Content(val route: String) : TvFocusOwner
+    data class Bar(val tab: TvTopMenuPanel) : TvFocusOwner
+    data class Panel(val panel: TvTopMenuPanel) : TvFocusOwner
+    data object ProfileMenu : TvFocusOwner
+    data class Modal(val id: String) : TvFocusOwner
+}
+
+/** Why focus arrived where it is. Governs Back and dwell, nothing else. */
+enum class TvFocusArrival { Browsing, Leaving, PanelDismissed, Restored, Explicit }
+
+data class TvFocusOwnership(val owner: TvFocusOwner, val arrival: TvFocusArrival)
+```
+
+Exactly one owner at a time, and the reason it arrived travels with it.
+
+Two pure functions replace the scattered conditionals:
+
+```kotlin
+fun backAction(ownership: TvFocusOwnership, canNavigateUp: Boolean): TvShellBackAction
+fun dwellEligible(ownership: TvFocusOwnership): Boolean
+```
+
+Both are total `when`s over a sealed type, so they are exhaustively testable in
+JVM tests with no Compose runtime, and — the part that matters — **adding an
+owner or an arrival reason breaks compilation everywhere a decision is made.**
+That is the enforcement the previous design lacked: the compiler, not a
+convention.
+
+`#204`'s two new flags collapse into this directly. `barFocusFromPanelClose`
+becomes `Bar(tab) + PanelDismissed`. `menuFocusSuppressesDwell` stops existing:
+`dwellEligible` returns false for `PanelDismissed` and `Leaving`, true for
+`Browsing`. The bug where an ordinary Up armed the Back-close suppression
+becomes unrepresentable rather than excluded by a flag.
+
+### Focus entry is a shell concern
+
+`#202` says a subtree-level fix cannot beat a `focusRestorer` on an ancestor.
+So the model must state where restorers may live: a restorer belongs to a
+**content region**, never to a container that also hosts modals or chrome.
+Modals get their own window. This is a rule about the composition tree, and it
+needs a source test to hold — the same class of check the repo already uses in
+`*SourceTest.kt`.
+
+### Failure must be loud
+
+The 08-04 design says observed focus is authoritative. Keep that, and add: a
+claim that never lands emits a diagnostic. `#199` added exactly that warning
+and `#203` is what stops it crashing the app — with those merged, the signal
+exists. `focus trap suspected` and `navigation struggle` already arrive from
+real devices, so we can measure whether this works instead of asserting it.
+
+## Scope
+
+**In:** `TvShellFocusState`, `TvMainShell`, `TvTopMenuBar`, and the Back/dwell
+decision paths — the 15-edit hotspot.
+
+**Out:** screen-local initial-focus acquisition (`TvContentInitialFocus`,
+`TvDialogInitialFocus`, the return-target adapters). That half of the 08-04
+design works; the bounded observed-focus policy is sound and stays. This is
+about who owns focus, not how a screen claims it.
+
+**Explicitly not** a global focus coordinator. Screens keep resolving their own
+targets. The shell stops guessing what state it is in.
+
+## Risks
+
+- It is a refactor of the file with the most focus history, so it will conflict
+  with anything in flight. #204 should land first; this is built on top.
+- A sealed model is only as good as its arrival reasons. If a sixth reason is
+  needed within a month, that is a signal the taxonomy is wrong, not that it
+  needs another entry.
+- Behaviour must be preserved exactly for the cases the current flags get
+  right. The existing `TvShellFocusStateTest` is the floor and should be
+  extended, not rewritten, so a regression is visible as a failing assertion
+  rather than a changed expectation.
+
+## How we will know it worked
+
+- Focus `fix:` commits per month on `main` — currently 49 and rising.
+- Edits to `TvMainShell.kt` per month.
+- `focus trap suspected` and `navigation struggle` per tester session in
+  GlitchTip, which is where the real evidence has been coming from.
+
+If those three do not fall, this document was wrong and should be replaced
+rather than supplemented.

--- a/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
+++ b/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
@@ -27,7 +27,8 @@ The rate of focus defects went **up** after it landed.
 | 2026-08 (to the 11th) | **48** |
 
 Method, so these can be re-derived rather than trusted:
-`git log main --format=%s --since=… | grep -ci focus` — commit SUBJECTS only.
+`git log main --format=%s --since=2026-06-01 --until=2026-06-30 | grep -ci focus`
+— commit SUBJECTS only, one month per row.
 
 Of the 81 focus-subject commits in the last 90 days, **49 are `fix:` and 7 are
 `feat:`**. That ratio is the finding. This is not a feature being built out;
@@ -37,11 +38,13 @@ Churn is concentrated, not spread:
 
 | File | times touched by a focus commit (90d) |
 |---|---|
-| `TvMainShell.kt` | **15** |
+| `TvMainShell.kt` | **14** |
 | `TvRecommendationsScreen.kt` | 9 |
-| `TvLibraryDetailScreen.kt` | 8 |
-| `TvCalendarScreen.kt` | 8 |
-| `TvRecommendationsFocusBridge.kt` | 7 |
+| `TvLibraryDetailScreen.kt` | 7 |
+| `TvCalendarScreen.kt` | 7 |
+| `TvRecommendationsFocusBridge.kt` | 6 |
+
+Method: `git log main --since=2026-05-13 --format=%s -- '*/<file>.kt' | grep -ci focus`
 
 There are already 19 production focus files, 22 focus test files and 8 focus
 design documents. The infrastructure is not missing. Something else is wrong.
@@ -168,9 +171,11 @@ has to remember. #204 shipped the boolean because the type does not exist yet.
 `#202` says a subtree-level fix cannot beat a `focusRestorer` on an ancestor.
 So the model must state where restorers may live: a restorer belongs to a
 **content region**, never to a container that also hosts modals or chrome.
-Modals get their own window. This is a rule about the composition tree, and it
-needs a source test to hold — the same class of check the repo already uses in
-`*SourceTest.kt`.
+Modals get their own window. This is a rule about the composition tree, so it
+needs its own check to hold — a restorer-placement source test, in the same
+style as `*SourceTest.kt`. That is a DIFFERENT check from #208's silent-claim
+ratchet, which is why the retraction above says no further enforcement is
+needed for silent focus claims specifically, rather than none at all.
 
 ### Failure must be loud
 
@@ -190,10 +195,14 @@ Focus churn by area over 90 days, counted as file-touches by focus commits:
 
 | Area | touches |
 |---|---|
-| `ui/screens/` | **150** |
-| `ui/components/` | 71 |
-| `ui/focus/` | 42 |
-| `ui/shell/` | **31** |
+| `ui/screens/` | **126** |
+| `ui/components/` | 34 |
+| `ui/focus/` | 14 |
+| `ui/shell/` | **16** |
+
+Method: file-touches by focus-subject commits since 2026-05-13 —
+`git log main --since=2026-05-13 --format='COMMIT %s' --name-only -- <dir>`,
+counting filenames under commits whose subject matches `focus`.
 
 The shell is the most-edited single *file*, but screens are five times the
 churn.
@@ -214,7 +223,9 @@ Method, so these can be re-derived rather than trusted — run against
   leaving **15** genuine hold-outs.
 - That is **69%** adoption, not 18%.
 - **31** `runCatching` occurrences remain in TV screens, and exactly **1**
-  wraps a `requestFocus()`.
+  wraps a `requestFocus()` —
+  `grep -ro runCatching …/tv/ui/screens | wc -l`, and the same grep with `-n`
+  filtered to lines also containing `requestFocus`.
 
 Cause #1 of the 08-04 audit — *"a focus request executing without exception is
 treated as focus acquisition"* — has therefore been substantially worked off,
@@ -228,7 +239,9 @@ boolean added because `panelEntersFocus` records intent rather than arrival.
 That distinction is a type, expressed as a flag pair.
 
 **The revised ordering is: shell ownership model first, hold-out migration
-second, and no new enforcement — the existing ratchet is doing its job.**
+second, and no further enforcement against silent focus claims — #208's
+ratchet is doing that job. The one check this note does still ask for is
+unrelated to it: a restorer-placement test, described below.**
 
 ### Enforcement — already done, nothing proposed here
 

--- a/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
+++ b/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
@@ -203,6 +203,11 @@ that #208 has since made false.** It claimed 8 adopters against 44 direct
 callers — 18% — and 107 `runCatching` occurrences in TV screens. As of `main`
 at 7245c0f4:
 
+Method, so these can be re-derived rather than trusted — run against
+`androidTvApp/src/androidMain`:
+`grep -rl 'requestFocusUntilObserved\|claimFocusOrReport'`,
+`grep -rl 'requestFocus()'`, and the intersection of the two.
+
 - **34** files use the shared observed-focus helpers
   (`requestFocusUntilObserved` / `claimFocusOrReport`).
 - **24** still contain a raw `requestFocus()`, of which **9** also use a helper,
@@ -225,27 +230,27 @@ That distinction is a type, expressed as a flag pair.
 **The revised ordering is: shell ownership model first, hold-out migration
 second, and no new enforcement — the existing ratchet is doing its job.**
 
-### Enforcement
+### Enforcement — already done, nothing proposed here
 
-Add a source test that fails on `runCatching { … requestFocus() … }` in
-`androidTvApp/.../ui/screens/`. The repo already uses `*SourceTest.kt` files
-that read source by path and assert on structure, so this is an established
-mechanism rather than a new one. Existing sites are baselined; the gate is that
-the count may only go down.
+An earlier draft proposed adding a source test that fails on
+`runCatching { … requestFocus() … }` in `androidTvApp/.../ui/screens/`, with
+existing sites baselined and the count only allowed to fall.
 
-That gate now exists (#208) and holds the count at zero. The 15 remaining
-hold-out files can be migrated in churn order behind it; nothing new is needed
-to stop regressions.
+**That is #208, which has merged.** The ratchet exists, it holds the count at
+zero, and `TvSilentFocusClaimSourceTest` is the file. This note proposes no new
+enforcement; the 15 remaining hold-out files can be migrated in churn order
+behind the gate that is already there.
 
 ## Scope
 
-**In:** the enforcement gate; migration of the highest-churn screens
-(`detail`, `player`, `audiobook`, `calendar`, `library`); then
-`TvShellFocusState`, `TvMainShell`, `TvTopMenuBar` and the Back/dwell decision
-paths.
+**In:** `TvShellFocusState`, `TvMainShell`, `TvTopMenuBar` and the Back/dwell
+decision paths — the ownership model, which is what a sweep cannot do. Then
+migration of the 15 hold-out files, in churn order.
 
-**Out:** the bounded observed-focus policy itself — it is sound and stays. The
-problem is that it is not used, not that it is wrong.
+**Out:** the enforcement gate, which #208 already shipped. Also out: the
+bounded observed-focus policy itself — it is sound, it stays, and at 69%
+adoption the objection that "nobody uses it" no longer holds. What remains
+wrong is not that policy but the shell inferring ownership from twelve flags.
 
 **Explicitly not** a global focus coordinator. Screens keep resolving their own
 targets. The shell stops guessing what state it is in.

--- a/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
+++ b/docs/superpowers/specs/2026-08-10-tv-focus-ownership-model-design.md
@@ -162,15 +162,60 @@ and `#203` is what stops it crashing the app — with those merged, the signal
 exists. `focus trap suspected` and `navigation struggle` already arrive from
 real devices, so we can measure whether this works instead of asserting it.
 
+## The larger half: the prescribed fix was never adopted
+
+An earlier draft of this document asserted that the screen-local half of the
+08-04 design "works" and only the shell needed modelling. That is false, and
+the correction changes the priority order.
+
+Focus churn by area over 90 days, counted as file-touches by focus commits:
+
+| Area | touches |
+|---|---|
+| `ui/screens/` | **150** |
+| `ui/components/` | 71 |
+| `ui/focus/` | 42 |
+| `ui/shell/` | **31** |
+
+The shell is the most-edited single *file*, but screens are five times the
+churn. And the reason is not a missing model — it is a model nobody adopted:
+
+- **8** files use the shared bounded observed-focus policy.
+- **44** files still call `requestFocus()` directly.
+- **107** `runCatching` occurrences remain in TV screens.
+
+That is 18% adoption. Cause #1 of the 08-04 audit — *"a focus request executing
+without exception is treated as focus acquisition"* — is not a historical
+finding being worked off. It is the majority of the current code, and it is the
+same failure mode as #199 and #202.
+
+Screen churn concentrates too: `detail` 30, `player` 29, `audiobook` 21,
+`calendar` 14, `library` 12 — 106 of the 150.
+
+**So the ordering is: enforcement first, migration second, shell model third.**
+A better rule that 18% of the code follows is worth less than the existing rule
+made impossible to violate.
+
+### Enforcement
+
+Add a source test that fails on `runCatching { … requestFocus() … }` in
+`androidTvApp/.../ui/screens/`. The repo already uses `*SourceTest.kt` files
+that read source by path and assert on structure, so this is an established
+mechanism rather than a new one. Existing sites are baselined; the gate is that
+the count may only go down.
+
+That stops new instances appearing while the 36 hold-out files are migrated in
+churn order.
+
 ## Scope
 
-**In:** `TvShellFocusState`, `TvMainShell`, `TvTopMenuBar`, and the Back/dwell
-decision paths — the 15-edit hotspot.
+**In:** the enforcement gate; migration of the highest-churn screens
+(`detail`, `player`, `audiobook`, `calendar`, `library`); then
+`TvShellFocusState`, `TvMainShell`, `TvTopMenuBar` and the Back/dwell decision
+paths.
 
-**Out:** screen-local initial-focus acquisition (`TvContentInitialFocus`,
-`TvDialogInitialFocus`, the return-target adapters). That half of the 08-04
-design works; the bounded observed-focus policy is sound and stays. This is
-about who owns focus, not how a screen claims it.
+**Out:** the bounded observed-focus policy itself — it is sound and stays. The
+problem is that it is not used, not that it is wrong.
 
 **Explicitly not** a global focus coordinator. Screens keep resolving their own
 targets. The shell stops guessing what state it is in.


### PR DESCRIPTION
Design only — no code changes. Opening it as a PR so the argument can be
disagreed with before anyone refactors the shell.

## The problem

Focus fixes are accelerating, not converging.

| Month | focus-titled commits on `main` |
|---|---|
| 2026-06 | 8 |
| 2026-07 | 26 |
| 2026-08 (to the 10th) | **49** |

Of 83 in the last 90 days, **49 are `fix:` against 9 `feat:`**. `TvMainShell.kt` has been edited by a focus commit **15 times**. There are already 19 production focus files, 22 focus test files and 8 focus design docs — the infrastructure is not missing.

## Why the last design did not stop it

`2026-08-04-whole-application-focus-hardening-design.md` was largely right and this keeps its principles. But it says:

> *Shared helpers encode repeated policy, but screen-specific resolution remains close to the screen. This avoids a global focus coordinator with hidden cross-route coupling.*

Reasonable — but it leaves the **shell** unmodelled, and the shell is where per-screen policies collide. It also has no enforcement half, and its escape clause (*"existing specialized flows … remain intact unless they can adopt the helper"*) makes divergence compliant.

Two defects found since are not among its six causes, and neither is an acquisition bug:

- **#202** — a `focusRestorer` on an ancestor intercepts focus *entry*, so no subtree-level fix can win.
- **#204** — `menuFocusTarget` meant both "which bar element" and "suppress its dwell".

Both are **ownership** bugs.

## Root cause

`TvShellFocusState` carries ten mutable fields and **none of them says who owns focus**. Ownership is inferred by reading several together; every combination is representable, including the meaningless ones. Each fix adds a flag excluding one bad combination, which enlarges the space the next defect hides in.

The insight is already in `b44e1d8f`'s commit message:

> *The distinction that matters is not which call site but **why focus arrived**.*

Correct — and that reason is stored nowhere, so it is reconstructed at each decision point, and each reconstruction is a chance to get it wrong.

## Proposal

One value: an owner (`Content` / `Bar` / `Panel` / `ProfileMenu` / `Modal`) plus **why focus arrived** there. Back routing and dwell eligibility become total functions over it — exhaustively testable without a Compose runtime, and adding an owner or reason **breaks compilation at every decision point**. That compiler enforcement is what the previous design lacked.

#204's two new flags collapse into it: `barFocusFromPanelClose` becomes `Bar + PanelDismissed`, and `menuFocusSuppressesDwell` stops existing. The bug where an ordinary Up armed Back-close suppression becomes *unrepresentable* rather than excluded by a flag.

## Scope

**In:** `TvShellFocusState`, `TvMainShell`, `TvTopMenuBar`, Back/dwell decisions — the 15-edit hotspot.
**Out:** screen-local initial-focus acquisition and the bounded observed-focus policy. That half works and stays.
**Not** a global focus coordinator — screens keep resolving their own targets; the shell stops guessing what state it is in.

## Success criteria

Stated in the doc and measurable: focus `fix:` commits per month, edits to `TvMainShell.kt` per month, and `focus trap suspected` / `navigation struggle` per tester session. If they do not fall, the document was wrong and should be replaced rather than supplemented.

Depends on #204 landing first.

---

**Supersedes #207.** That PR was stacked on the pre-merge version of #206 and
carried its original commit, which has since gained tests, per-answer
publication and targeted revalidation. Rebuilt on merged `main` so it is
docs-only, as intended.

Updated against #204 as merged: the note described `barFocusFromPanelClose` as
a flag #204 adds. Review found it unreachable from production UI — the only
caller that armed it was a cascade `onClose` the selector never invokes — and
#204 deleted it. That is evidence for this note's argument rather than against
it: the flag was carried through routing and tests while describing a state the
app could not reach. `panelHasFocus`, which #204 did add, is recorded as the
case this model would keep under a different name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9UyH5fvug685dzUFLtdpW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a design specification for a clearer TV focus ownership model.
  * Documented focus ownership across content, navigation bars, panels, profile menus, and modals.
  * Defined expected back-navigation and focus-dwell behavior for each ownership state.
  * Added guidance for focus restoration, diagnostics, migration priorities, testing safeguards, risks, and success metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->