### PR TITLE
fix(playback): decide audio decode on the decoder's real channel limit

### DIFF
--- a/android-shared/build.gradle.kts
+++ b/android-shared/build.gradle.kts
@@ -137,7 +137,7 @@ android {
         // Gate for preferring FFmpeg audio decoders over platform decoders.
         // The AAR is always on the classpath (see dependencies above); this
         // flag only controls whether DefaultRenderersFactory is set to
-        // EXTENSION_RENDERER_MODE_PREFER (true) or _MODE_OFF (false).
+        // EXTENSION_RENDERER_MODE_ON (true) or _MODE_OFF (false).
         // Flip to false at compile time to bisect regressions — with _MODE_OFF
         // FFmpeg renderers are not even instantiated, so any FFmpeg-related
         // bug can't manifest regardless of classpath presence.

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
@@ -321,6 +321,9 @@ class AudioCapabilityManager(
             AudioLayoutProbe(6, AudioFormat.CHANNEL_OUT_5POINT1, listOf("5.1", "5.1(side)")),
             AudioLayoutProbe(8, AudioFormat.CHANNEL_OUT_7POINT1_SURROUND, listOf("7.1")),
         )
+        check(layoutsToProbe.map { it.channelCount }.toSet() == PROBED_PASSTHROUGH_CHANNEL_COUNTS) {
+            "PROBED_PASSTHROUGH_CHANNEL_COUNTS must list exactly what is probed"
+        }
         return encodings.mapNotNull { support ->
             val channelCounts = sortedSetOf<Int>()
             val layouts = sortedSetOf<String>()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
@@ -314,16 +314,7 @@ class AudioCapabilityManager(
             .setUsage(android.media.AudioAttributes.USAGE_MEDIA)
             .setContentType(android.media.AudioAttributes.CONTENT_TYPE_MOVIE)
             .build()
-        val layoutsToProbe = listOf(
-            AudioLayoutProbe(2, AudioFormat.CHANNEL_OUT_STEREO, listOf("stereo")),
-            // FFprobe commonly distinguishes 5.1 and 5.1(side), while
-            // Android exposes one encoded six-channel mask to AudioTrack.
-            AudioLayoutProbe(6, AudioFormat.CHANNEL_OUT_5POINT1, listOf("5.1", "5.1(side)")),
-            AudioLayoutProbe(8, AudioFormat.CHANNEL_OUT_7POINT1_SURROUND, listOf("7.1")),
-        )
-        check(layoutsToProbe.map { it.channelCount }.toSet() == PROBED_PASSTHROUGH_CHANNEL_COUNTS) {
-            "PROBED_PASSTHROUGH_CHANNEL_COUNTS must list exactly what is probed"
-        }
+        val layoutsToProbe = PASSTHROUGH_LAYOUT_PROBES
         return encodings.mapNotNull { support ->
             val channelCounts = sortedSetOf<Int>()
             val layouts = sortedSetOf<String>()
@@ -368,7 +359,7 @@ class AudioCapabilityManager(
         }
     }.getOrDefault(false)
 
-    private data class AudioLayoutProbe(
+    internal data class AudioLayoutProbe(
         val channelCount: Int,
         val channelMask: Int,
         val layoutNames: List<String>,
@@ -429,3 +420,28 @@ private class SpatializerBridge(
 
     fun isEnabled(): Boolean = spatializer.isEnabled
 }
+
+/**
+ * The encoded layouts probed per audio format. Deliberately the single source
+ * of truth: [PROBED_PASSTHROUGH_CHANNEL_COUNTS] is derived from it, so the
+ * reader of a passthrough entry can never disagree with the writer about which
+ * counts were actually asked. A constant that merely *claimed* to match would
+ * need a runtime check, and a structural invariant is not worth crashing
+ * capability detection over.
+ */
+internal val PASSTHROUGH_LAYOUT_PROBES: List<AudioCapabilityManager.AudioLayoutProbe> = listOf(
+    AudioCapabilityManager.AudioLayoutProbe(2, AudioFormat.CHANNEL_OUT_STEREO, listOf("stereo")),
+    // FFprobe commonly distinguishes 5.1 and 5.1(side), while Android exposes
+    // one encoded six-channel mask to AudioTrack.
+    AudioCapabilityManager.AudioLayoutProbe(
+        6,
+        AudioFormat.CHANNEL_OUT_5POINT1,
+        listOf("5.1", "5.1(side)"),
+    ),
+    AudioCapabilityManager.AudioLayoutProbe(
+        8,
+        AudioFormat.CHANNEL_OUT_7POINT1_SURROUND,
+        listOf("7.1"),
+    ),
+)
+

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
@@ -429,6 +429,7 @@ private class SpatializerBridge(
  * need a runtime check, and a structural invariant is not worth crashing
  * capability detection over.
  */
+@UnstableApi
 internal val PASSTHROUGH_LAYOUT_PROBES: List<AudioCapabilityManager.AudioLayoutProbe> = listOf(
     AudioCapabilityManager.AudioLayoutProbe(2, AudioFormat.CHANNEL_OUT_STEREO, listOf("stereo")),
     // FFprobe commonly distinguishes 5.1 and 5.1(side), while Android exposes

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -120,8 +120,10 @@ class PlaybackCapabilityDetector(
         if (selectedAudio != null) {
             val mime = selectedAudio.sampleMimeType.orEmpty()
             val channels = selectedAudio.channelCount
-            val passthroughCodecs = audioCapabilityManager.capabilities.value.passthroughCodecs.toSet()
-            val maxChannels = audioCapabilityManager.capabilities.value.maxChannels
+            // ONE snapshot: read three times, a route change mid-check could
+            // mix one snapshot's codec list with another's channel limits.
+            val routeCaps = audioCapabilityManager.capabilities.value
+            val maxChannels = routeCaps.maxChannels
 
             val rendererCanDecode = canDecodeAudio(
                 mime = mime,
@@ -135,22 +137,24 @@ class PlaybackCapabilityDetector(
             // anything, but a false refusal the moment that assumption is
             // dropped — an E-AC-3-capable receiver plays 5.1 fine behind a
             // stereo-only decoder.
-            val routeCaps = audioCapabilityManager.capabilities.value
-            val passthroughCodec = when (mime) {
-                MimeTypes.AUDIO_TRUEHD -> "truehd"
-                MimeTypes.AUDIO_DTS_HD -> "dts_hd"
-                MimeTypes.AUDIO_DTS -> "dts"
-                MimeTypes.AUDIO_AC4 -> "ac4"
-                MimeTypes.AUDIO_AC3 -> "ac3"
-                MimeTypes.AUDIO_E_AC3 -> "eac3"
-                MimeTypes.AUDIO_E_AC3_JOC ->
-                    if ("eac3_joc" in passthroughCodecs) "eac3_joc" else "eac3"
-                else -> null
-            }
             // Asked per codec AND per layout: the sink carrying this codec says
-            // nothing about it carrying this many channels of it.
-            val sinkCanPassthrough = passthroughCodec != null &&
-                sinkCanPassthrough(passthroughCodec, channels, routeCaps)
+            // nothing about it carrying this many channels of it. JOC tries its
+            // own entry first and then plain E-AC-3 — picking by codec presence
+            // alone refused a JOC stream whose layout only the E-AC-3 entry
+            // covered, which Android explicitly permits.
+            val passthroughCandidates = when (mime) {
+                MimeTypes.AUDIO_TRUEHD -> listOf("truehd")
+                MimeTypes.AUDIO_DTS_HD -> listOf("dts_hd")
+                MimeTypes.AUDIO_DTS -> listOf("dts")
+                MimeTypes.AUDIO_AC4 -> listOf("ac4")
+                MimeTypes.AUDIO_AC3 -> listOf("ac3")
+                MimeTypes.AUDIO_E_AC3 -> listOf("eac3")
+                MimeTypes.AUDIO_E_AC3_JOC -> listOf("eac3_joc", "eac3")
+                else -> emptyList()
+            }
+            val sinkCanPassthrough = passthroughCandidates.any {
+                sinkCanPassthrough(it, channels, routeCaps)
+            }
 
             // Absent codec and unusable channel layout are different verdicts:
             // the first tells the viewer their device cannot play this format at
@@ -664,11 +668,31 @@ internal fun sinkCanPassthrough(
 ): Boolean {
     if (codec !in capabilities.passthroughCodecs) return false
     if (channelCount <= 0) return true
-    val entry = capabilities.entries.firstOrNull { it.codec == codec }
-    val exactCounts = entry?.channelCounts?.takeIf { it.isNotEmpty() }
+    val exactCounts = capabilities.entries
+        .firstOrNull { it.codec == codec }
+        ?.channelCounts
+        ?.takeIf { it.isNotEmpty() }
         ?: return channelCount <= capabilities.maxChannels
-    return channelCount in exactCounts
+
+    if (channelCount in exactCounts) return true
+    // An entry lists what was PROBED, not everything the sink accepts: only
+    // 2/6/8 are ever tried. Absence is a refusal for those three, because they
+    // were asked and said no. For any other layout the probe simply never
+    // asked, so falling back to the aggregate is the honest answer rather than
+    // refusing a 5- or 7-channel stream the receiver would have carried.
+    return if (channelCount in PROBED_PASSTHROUGH_CHANNEL_COUNTS) {
+        false
+    } else {
+        channelCount <= capabilities.maxChannels
+    }
 }
+
+/**
+ * Channel counts [AudioCapabilityManager] actually probes per encoded format.
+ * Only for these does an entry's silence mean "no"; anything else was never
+ * asked. Kept in step with the probe by a check() at its call site.
+ */
+internal val PROBED_PASSTHROUGH_CHANNEL_COUNTS = setOf(2, 6, 8)
 
 /** One platform decoder's claim about one MIME type. */
 internal data class PlatformAudioDecodeCapability(

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -121,8 +121,10 @@ class PlaybackCapabilityDetector(
             val passthroughCodecs = audioCapabilityManager.capabilities.value.passthroughCodecs.toSet()
             val maxChannels = audioCapabilityManager.capabilities.value.maxChannels
 
-            val rendererCanDecode = isSoftwareDecodableAudioMime(
+            val rendererCanDecode = canDecodeAudio(
                 mime = mime,
+                channelCount = channels,
+                platformDecoders = detectPlatformSoftwareAudioCodecs().decoders,
                 ffmpegAvailable = FfmpegAudioSupport.isAvailable(),
             )
             val sinkCanPassthrough = when (mime) {
@@ -136,6 +138,11 @@ class PlaybackCapabilityDetector(
             if (!rendererCanDecode && !sinkCanPassthrough) {
                 return Playability.UnsupportedAudioCodec(mime)
             }
+            // rendererCanDecode is now channel-aware, so a decoder that exists
+            // but cannot take this many channels no longer excuses the sink
+            // from having to carry the track. That was the bug: a 5.1 E-AC3
+            // track was declared playable by a two-channel decoder and failed
+            // at the codec once playback had already begun.
             if (channels > 0 && channels > maxChannels && !rendererCanDecode) {
                 return Playability.UnsupportedChannelCount(mime, channels)
             }
@@ -416,38 +423,60 @@ class PlaybackCapabilityDetector(
             ?.takeIf { it.isNotBlank() }
             ?: "unknown"
 
-    /** Returns codecs backed by an Android platform [MediaCodec] decoder. */
+    /**
+     * Returns codecs backed by an Android platform [MediaCodec] decoder,
+     * together with how many channels each decoder will actually accept.
+     *
+     * The channel limit is the point. A device can advertise an E-AC3 decoder
+     * that only takes two channels, and asking it to decode a 5.1 track fails
+     * at the codec with ERROR_CODE_DECODING_FAILED — after playback has already
+     * started. MIME presence alone cannot answer "can this device play this
+     * track", so it is not collected alone.
+     */
     private fun detectPlatformSoftwareAudioCodecs(): PlatformSoftwareAudioProbe {
         cachedPlatformSoftwareAudioProbe?.let { return it }
         val probe = runCatching {
-            val result = mutableSetOf<String>()
+            val decoders = mutableListOf<PlatformAudioDecodeCapability>()
             for (info in MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos) {
                 if (info.isEncoder) continue
                 for (type in info.supportedTypes) {
-                    when {
-                        type.equals(MediaFormat.MIMETYPE_AUDIO_AAC, ignoreCase = true) -> result += "aac"
-                        type.equals(MediaFormat.MIMETYPE_AUDIO_AC3, ignoreCase = true) -> result += "ac3"
-                        type.equals(MediaFormat.MIMETYPE_AUDIO_EAC3, ignoreCase = true) -> result += "eac3"
-                        type.equals(MediaFormat.MIMETYPE_AUDIO_EAC3_JOC, ignoreCase = true) -> result += "eac3_joc"
-                        type.equals(MediaFormat.MIMETYPE_AUDIO_FLAC, ignoreCase = true) -> result += "flac"
-                        type.equals(MediaFormat.MIMETYPE_AUDIO_OPUS, ignoreCase = true) -> result += "opus"
-                        type.equals(MediaFormat.MIMETYPE_AUDIO_VORBIS, ignoreCase = true) -> result += "vorbis"
-                        type.equals(MediaFormat.MIMETYPE_AUDIO_MPEG, ignoreCase = true) -> result += "mp3"
-                    }
+                    val codec = platformAudioCodecName(type) ?: continue
+                    // An unreadable limit is recorded as unknown rather than as
+                    // unlimited: a probe that cannot answer must not be the
+                    // reason a track is claimed playable.
+                    val maxChannels = runCatching {
+                        info.getCapabilitiesForType(type).audioCapabilities?.maxInputChannelCount
+                    }.getOrNull()?.takeIf { it > 0 }
+                    decoders += PlatformAudioDecodeCapability(
+                        mimeType = type,
+                        codec = codec,
+                        decoderName = info.name.orEmpty(),
+                        maxInputChannelCount = maxChannels,
+                    )
                 }
             }
-            PlatformSoftwareAudioProbe(codecs = result.toList(), exact = true)
+            PlatformSoftwareAudioProbe(decoders = decoders, exact = true)
         }.getOrElse {
-            PlatformSoftwareAudioProbe(codecs = listOf("aac", "mp3"), exact = false)
+            // A failed probe is a guess, and a guess must never be described as
+            // exact evidence — the server grants passthrough on that word.
+            PlatformSoftwareAudioProbe(
+                decoders = listOf(
+                    PlatformAudioDecodeCapability(MimeTypes.AUDIO_AAC, "aac", "", null),
+                    PlatformAudioDecodeCapability(MimeTypes.AUDIO_MPEG, "mp3", "", null),
+                ),
+                exact = false,
+            )
         }
         cachedPlatformSoftwareAudioProbe = probe
         return probe
     }
 
     private data class PlatformSoftwareAudioProbe(
-        val codecs: List<String>,
+        val decoders: List<PlatformAudioDecodeCapability>,
         val exact: Boolean,
-    )
+    ) {
+        val codecs: List<String> get() = decoders.map { it.codec }.distinct()
+    }
 
     private companion object {
         const val MAX_PLATFORM_DETAIL_CHARS = 128
@@ -581,20 +610,69 @@ internal fun isDirectPlayableDolbyVisionProfile(
     supportedHdr: org.siloserver.silo.model.playback.HdrCapabilities,
 ): Boolean = supportedHdr.dolbyVisionProfiles.contains(profile)
 
-internal fun isSoftwareDecodableAudioMime(
-    mime: String,
-    ffmpegAvailable: Boolean,
-): Boolean =
-    mime in platformSoftwareDecodableAudioMimes ||
-        (ffmpegAvailable && mime in FfmpegAudioSupport.mimeTypes)
-
-private val platformSoftwareDecodableAudioMimes = setOf(
-    MimeTypes.AUDIO_AAC,
-    MimeTypes.AUDIO_AC3,
-    MimeTypes.AUDIO_E_AC3,
-    MimeTypes.AUDIO_E_AC3_JOC,
-    MimeTypes.AUDIO_FLAC,
-    MimeTypes.AUDIO_OPUS,
-    MimeTypes.AUDIO_VORBIS,
-    MimeTypes.AUDIO_MPEG,
+/** One platform decoder's claim about one MIME type. */
+internal data class PlatformAudioDecodeCapability(
+    val mimeType: String,
+    val codec: String,
+    val decoderName: String,
+    /** Null when the device would not say; never treated as unlimited. */
+    val maxInputChannelCount: Int?,
 )
+
+/**
+ * Whether this device can decode [mime] at [channelCount] channels.
+ *
+ * Replaces a hardcoded MIME list that always claimed E-AC3 and E-AC3 JOC were
+ * decodable regardless of the device or the track. A Pixel whose E-AC3 decoder
+ * accepts two channels reported a 5.1 track as playable, and the failure only
+ * surfaced as ERROR_CODE_DECODING_FAILED after playback started — then the
+ * recovery replan made the same claim and chose the same route again.
+ *
+ * Any matching decoder is enough: several can expose the same MIME with
+ * different limits, and the widest one is the one that would be used. A limit
+ * is never borrowed from a different MIME, and JOC stays a separate claim from
+ * plain E-AC3 unless the device actually advertises it.
+ *
+ * An unknown [channelCount] (non-positive) asks only whether the codec exists —
+ * there is nothing to compare against, and refusing on that basis would reject
+ * tracks that play fine.
+ */
+internal fun canDecodeAudio(
+    mime: String,
+    channelCount: Int,
+    platformDecoders: List<PlatformAudioDecodeCapability>,
+    ffmpegAvailable: Boolean,
+): Boolean {
+    val platformForMime = platformDecoders.filter { it.mimeType.equals(mime, ignoreCase = true) }
+    if (platformForMime.isNotEmpty()) {
+        // FFmpeg deliberately does NOT get a vote here. The renderers are built
+        // with EXTENSION_RENDERER_MODE_ON, under which the extension only fills
+        // gaps where the platform has no decoder at all — so when a platform
+        // decoder exists it is the one that runs, and a track it refuses fails
+        // even though FFmpeg could have decoded it. Treating FFmpeg as a
+        // widening OR here is precisely how a 5.1 E-AC3 track on a two-channel
+        // Pixel decoder was reported playable: FFmpeg declares E-AC3, but was
+        // never going to be asked.
+        return platformForMime.any { decoder ->
+            when {
+                channelCount <= 0 -> true
+                decoder.maxInputChannelCount == null -> true
+                else -> decoder.maxInputChannelCount >= channelCount
+            }
+        }
+    }
+    return ffmpegAvailable && mime in FfmpegAudioSupport.mimeTypes
+}
+
+/** The wire name this project uses for a platform audio MIME, if it tracks one. */
+internal fun platformAudioCodecName(mimeType: String): String? = when {
+    mimeType.equals(MimeTypes.AUDIO_AAC, ignoreCase = true) -> "aac"
+    mimeType.equals(MimeTypes.AUDIO_AC3, ignoreCase = true) -> "ac3"
+    mimeType.equals(MimeTypes.AUDIO_E_AC3, ignoreCase = true) -> "eac3"
+    mimeType.equals(MimeTypes.AUDIO_E_AC3_JOC, ignoreCase = true) -> "eac3_joc"
+    mimeType.equals(MimeTypes.AUDIO_FLAC, ignoreCase = true) -> "flac"
+    mimeType.equals(MimeTypes.AUDIO_OPUS, ignoreCase = true) -> "opus"
+    mimeType.equals(MimeTypes.AUDIO_VORBIS, ignoreCase = true) -> "vorbis"
+    mimeType.equals(MimeTypes.AUDIO_MPEG, ignoreCase = true) -> "mp3"
+    else -> null
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -31,6 +31,8 @@ import org.siloserver.silo.model.playback.PlaybackDeviceContext
 import org.siloserver.silo.model.playback.PlaybackTransformationExecutor
 import org.siloserver.silo.model.playback.PlaybackTransformationV3
 import org.siloserver.silo.model.playback.PlaybackOutputContext
+import org.siloserver.silo.model.playback.AudioPassthroughCapabilities
+import org.siloserver.silo.model.playback.AudioPassthroughEntry
 import kotlinx.coroutines.flow.StateFlow
 import org.siloserver.silo.libass.LibassBridge
 
@@ -133,17 +135,22 @@ class PlaybackCapabilityDetector(
             // anything, but a false refusal the moment that assumption is
             // dropped — an E-AC-3-capable receiver plays 5.1 fine behind a
             // stereo-only decoder.
-            val sinkCanPassthrough = when (mime) {
-                MimeTypes.AUDIO_TRUEHD -> "truehd" in passthroughCodecs
-                MimeTypes.AUDIO_DTS_HD -> "dts_hd" in passthroughCodecs
-                MimeTypes.AUDIO_DTS -> "dts" in passthroughCodecs
-                MimeTypes.AUDIO_AC4 -> "ac4" in passthroughCodecs
-                MimeTypes.AUDIO_AC3 -> "ac3" in passthroughCodecs
-                MimeTypes.AUDIO_E_AC3 -> "eac3" in passthroughCodecs
+            val routeCaps = audioCapabilityManager.capabilities.value
+            val passthroughCodec = when (mime) {
+                MimeTypes.AUDIO_TRUEHD -> "truehd"
+                MimeTypes.AUDIO_DTS_HD -> "dts_hd"
+                MimeTypes.AUDIO_DTS -> "dts"
+                MimeTypes.AUDIO_AC4 -> "ac4"
+                MimeTypes.AUDIO_AC3 -> "ac3"
+                MimeTypes.AUDIO_E_AC3 -> "eac3"
                 MimeTypes.AUDIO_E_AC3_JOC ->
-                    "eac3_joc" in passthroughCodecs || "eac3" in passthroughCodecs
-                else -> false
+                    if ("eac3_joc" in passthroughCodecs) "eac3_joc" else "eac3"
+                else -> null
             }
+            // Asked per codec AND per layout: the sink carrying this codec says
+            // nothing about it carrying this many channels of it.
+            val sinkCanPassthrough = passthroughCodec != null &&
+                sinkCanPassthrough(passthroughCodec, channels, routeCaps)
 
             // Absent codec and unusable channel layout are different verdicts:
             // the first tells the viewer their device cannot play this format at
@@ -466,9 +473,11 @@ class PlaybackCapabilityDetector(
                 if (info.isEncoder) continue
                 for (type in info.supportedTypes) {
                     val codec = platformAudioCodecName(type) ?: continue
-                    // An unreadable limit is recorded as unknown rather than as
-                    // unlimited: a probe that cannot answer must not be the
-                    // reason a track is claimed playable.
+                    // An unreadable limit is recorded as unknown, distinct from
+                    // a stated one. The preflight then treats unknown as
+                    // permissive (see canDecodeAudio) — a filter that refused
+                    // every device which will not state a limit would reject a
+                    // great deal that plays.
                     val maxChannels = runCatching {
                         info.getCapabilitiesForType(type).audioCapabilities?.maxInputChannelCount
                     }.getOrNull()?.takeIf { it > 0 }
@@ -635,12 +644,38 @@ internal fun isDirectPlayableDolbyVisionProfile(
     supportedHdr: org.siloserver.silo.model.playback.HdrCapabilities,
 ): Boolean = supportedHdr.dolbyVisionProfiles.contains(profile)
 
+/**
+ * Whether the connected sink will carry [codec] as an encoded stream at
+ * [channelCount] channels.
+ *
+ * Uses the exact per-codec entries when the route probe produced them, because
+ * the aggregate `maxChannels` is a maximum across ALL codecs: a receiver taking
+ * eight-channel TrueHD but only six-channel E-AC-3 reports eight, which would
+ * wave through an eight-channel E-AC-3 track its own E-AC-3 entry excludes.
+ *
+ * Falls back to the aggregate where no entries exist — pre-API-29 routes cannot
+ * be probed per format, and refusing everything there would be worse than the
+ * imprecision.
+ */
+internal fun sinkCanPassthrough(
+    codec: String,
+    channelCount: Int,
+    capabilities: AudioPassthroughCapabilities,
+): Boolean {
+    if (codec !in capabilities.passthroughCodecs) return false
+    if (channelCount <= 0) return true
+    val entry = capabilities.entries.firstOrNull { it.codec == codec }
+    val exactCounts = entry?.channelCounts?.takeIf { it.isNotEmpty() }
+        ?: return channelCount <= capabilities.maxChannels
+    return channelCount in exactCounts
+}
+
 /** One platform decoder's claim about one MIME type. */
 internal data class PlatformAudioDecodeCapability(
     val mimeType: String,
     val codec: String,
     val decoderName: String,
-    /** Null when the device would not say; never treated as unlimited. */
+    /** Null when the device would not say — recorded as unknown, not as a limit. */
     val maxInputChannelCount: Int?,
 )
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -700,6 +700,7 @@ internal fun sinkCanPassthrough(
  * device if the two ever disagreed. A structural invariant is not worth
  * crashing playback setup over.
  */
+@UnstableApi
 internal val PROBED_PASSTHROUGH_CHANNEL_COUNTS: Set<Int> =
     PASSTHROUGH_LAYOUT_PROBES.mapTo(mutableSetOf()) { it.channelCount }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -676,23 +676,32 @@ internal fun sinkCanPassthrough(
 
     if (channelCount in exactCounts) return true
     // An entry lists what was PROBED, not everything the sink accepts: only
-    // 2/6/8 are ever tried. Absence is a refusal for those three, because they
-    // were asked and said no. For any other layout the probe simply never
-    // asked, so falling back to the aggregate is the honest answer rather than
-    // refusing a 5- or 7-channel stream the receiver would have carried.
-    return if (channelCount in PROBED_PASSTHROUGH_CHANNEL_COUNTS) {
-        false
-    } else {
-        channelCount <= capabilities.maxChannels
-    }
+    // 2/6/8 are ever tried. Absence is a refusal for those three — they were
+    // asked and said no. Any other layout was never put to the sink, so it is
+    // judged against THIS codec's highest known-good count.
+    //
+    // Deliberately not the aggregate maxChannels: that is a maximum across all
+    // codecs, so a receiver doing 8-channel TrueHD would have vouched for
+    // 7-channel E-AC-3 on a sink whose own E-AC-3 probe stopped at 6. Erring
+    // toward refusal here costs a transcode; erring the other way costs broken
+    // audio after playback has started.
+    if (channelCount in PROBED_PASSTHROUGH_CHANNEL_COUNTS) return false
+    return channelCount <= exactCounts.max()
 }
 
 /**
  * Channel counts [AudioCapabilityManager] actually probes per encoded format.
  * Only for these does an entry's silence mean "no"; anything else was never
- * asked. Kept in step with the probe by a check() at its call site.
+ * asked.
+ *
+ * DERIVED from the probe list rather than restated, so reader and writer cannot
+ * drift. The previous version asserted the match with a check() in the probe
+ * itself — which would have thrown inside capability detection on any API 29+
+ * device if the two ever disagreed. A structural invariant is not worth
+ * crashing playback setup over.
  */
-internal val PROBED_PASSTHROUGH_CHANNEL_COUNTS = setOf(2, 6, 8)
+internal val PROBED_PASSTHROUGH_CHANNEL_COUNTS: Set<Int> =
+    PASSTHROUGH_LAYOUT_PROBES.mapTo(mutableSetOf()) { it.channelCount }
 
 /** One platform decoder's claim about one MIME type. */
 internal data class PlatformAudioDecodeCapability(

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -127,16 +127,41 @@ class PlaybackCapabilityDetector(
                 platformDecoders = detectPlatformSoftwareAudioCodecs().decoders,
                 ffmpegAvailable = FfmpegAudioSupport.isAvailable(),
             )
+            // A sink that carries the encoded stream bypasses the decoder
+            // entirely, so its channel limit is irrelevant. AC-3/E-AC-3/JOC were
+            // missing here: harmless while the decoder was assumed able to take
+            // anything, but a false refusal the moment that assumption is
+            // dropped — an E-AC-3-capable receiver plays 5.1 fine behind a
+            // stereo-only decoder.
             val sinkCanPassthrough = when (mime) {
                 MimeTypes.AUDIO_TRUEHD -> "truehd" in passthroughCodecs
                 MimeTypes.AUDIO_DTS_HD -> "dts_hd" in passthroughCodecs
                 MimeTypes.AUDIO_DTS -> "dts" in passthroughCodecs
                 MimeTypes.AUDIO_AC4 -> "ac4" in passthroughCodecs
+                MimeTypes.AUDIO_AC3 -> "ac3" in passthroughCodecs
+                MimeTypes.AUDIO_E_AC3 -> "eac3" in passthroughCodecs
+                MimeTypes.AUDIO_E_AC3_JOC ->
+                    "eac3_joc" in passthroughCodecs || "eac3" in passthroughCodecs
                 else -> false
             }
 
-            if (!rendererCanDecode && !sinkCanPassthrough) {
+            // Absent codec and unusable channel layout are different verdicts:
+            // the first tells the viewer their device cannot play this format at
+            // all, the second that it cannot play this LAYOUT — and the server
+            // picks a different fallback for each. Deciding on the
+            // channel-aware answer alone reported every Pixel channel failure
+            // as an unsupported encoding.
+            val codecKnownAtAll = platformCanDecodeAudio(
+                mime = mime,
+                channelCount = 0,
+                platformDecoders = detectPlatformSoftwareAudioCodecs().decoders,
+            ) || (FfmpegAudioSupport.isAvailable() && mime in FfmpegAudioSupport.mimeTypes)
+
+            if (!codecKnownAtAll && !sinkCanPassthrough) {
                 return Playability.UnsupportedAudioCodec(mime)
+            }
+            if (!rendererCanDecode && !sinkCanPassthrough) {
+                return Playability.UnsupportedChannelCount(mime, channels)
             }
             // rendererCanDecode is now channel-aware, so a decoder that exists
             // but cannot take this many channels no longer excuses the sink
@@ -643,25 +668,52 @@ internal fun canDecodeAudio(
     platformDecoders: List<PlatformAudioDecodeCapability>,
     ffmpegAvailable: Boolean,
 ): Boolean {
-    val platformForMime = platformDecoders.filter { it.mimeType.equals(mime, ignoreCase = true) }
-    if (platformForMime.isNotEmpty()) {
-        // FFmpeg deliberately does NOT get a vote here. The renderers are built
-        // with EXTENSION_RENDERER_MODE_ON, under which the extension only fills
-        // gaps where the platform has no decoder at all — so when a platform
-        // decoder exists it is the one that runs, and a track it refuses fails
-        // even though FFmpeg could have decoded it. Treating FFmpeg as a
-        // widening OR here is precisely how a 5.1 E-AC3 track on a two-channel
-        // Pixel decoder was reported playable: FFmpeg declares E-AC3, but was
-        // never going to be asked.
-        return platformForMime.any { decoder ->
+    if (platformCanDecodeAudio(mime, channelCount, platformDecoders)) return true
+    // FFmpeg genuinely rescues a format the platform decoder cannot take.
+    // EXTENSION_RENDERER_MODE_ON puts the platform renderer FIRST, but order is
+    // only the tie-break: MappingTrackSelector picks the renderer reporting the
+    // greatest format support, and MediaCodecAudioRenderer answers
+    // FORMAT_EXCEEDS_CAPABILITIES for a channel count its decoder will not take
+    // while FfmpegAudioRenderer answers FORMAT_HANDLED. So the extension is not
+    // limited to codecs the platform lacks entirely.
+    return ffmpegAvailable && mime in FfmpegAudioSupport.mimeTypes
+}
+
+/**
+ * Whether a platform decoder alone can take [mime] at [channelCount].
+ *
+ * Separate from [canDecodeAudio] so a caller can tell "this device has no
+ * decoder for this codec at all" from "it has one that will not take this many
+ * channels" — those are different answers for the viewer and different
+ * fallbacks for the server.
+ *
+ * Media3 soft-matches E-AC3 JOC onto a plain E-AC3 decoder
+ * (`MediaCodecUtil.getAlternativeCodecMimeType`), so a JOC track is accepted by
+ * an E-AC3 decoder here too; refusing it would reject content Media3 plays.
+ */
+internal fun platformCanDecodeAudio(
+    mime: String,
+    channelCount: Int,
+    platformDecoders: List<PlatformAudioDecodeCapability>,
+): Boolean {
+    val acceptable = buildSet {
+        add(mime.lowercase())
+        if (mime.equals(MimeTypes.AUDIO_E_AC3_JOC, ignoreCase = true)) {
+            add(MimeTypes.AUDIO_E_AC3.lowercase())
+        }
+    }
+    return platformDecoders.any { decoder ->
+        decoder.mimeType.lowercase() in acceptable &&
             when {
                 channelCount <= 0 -> true
+                // The device would not state a limit. Not a claim of an
+                // unlimited one, but refusing every such decoder would reject a
+                // great deal that plays; the preflight is a filter, and the
+                // decoder-init failure path still exists behind it.
                 decoder.maxInputChannelCount == null -> true
                 else -> decoder.maxInputChannelCount >= channelCount
             }
-        }
     }
-    return ffmpegAvailable && mime in FfmpegAudioSupport.mimeTypes
 }
 
 /** The wire name this project uses for a platform audio MIME, if it tracks one. */

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/route/PlaybackRoute.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/route/PlaybackRoute.kt
@@ -10,7 +10,13 @@ package org.siloserver.silo.common.player.route
  * client-side route selector.
  */
 enum class PlaybackRoute(val displayName: String) {
-    /** ProgressiveMediaSource + RenderersFactory with FFmpeg audio extension (`EXTENSION_RENDERER_MODE_PREFER`). */
+    /**
+     * ProgressiveMediaSource + RenderersFactory with the FFmpeg audio extension
+     * enabled (`EXTENSION_RENDERER_MODE_ON`). The extension fills gaps where
+     * the platform has no decoder; it does NOT take precedence over one that
+     * exists, so a codec the platform claims is decoded by the platform even
+     * when FFmpeg could also carry it.
+     */
     SiloPlayer("SiloPlayer"),
 
     /** ProgressiveMediaSource + platform-only renderers (`EXTENSION_RENDERER_MODE_OFF`). Narrower codec breadth. */

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/route/PlaybackRoute.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/route/PlaybackRoute.kt
@@ -12,10 +12,10 @@ package org.siloserver.silo.common.player.route
 enum class PlaybackRoute(val displayName: String) {
     /**
      * ProgressiveMediaSource + RenderersFactory with the FFmpeg audio extension
-     * enabled (`EXTENSION_RENDERER_MODE_ON`). The extension fills gaps where
-     * the platform has no decoder; it does NOT take precedence over one that
-     * exists, so a codec the platform claims is decoded by the platform even
-     * when FFmpeg could also carry it.
+     * enabled (`EXTENSION_RENDERER_MODE_ON`). The platform renderer is ordered
+     * first, but order only breaks ties: the track selector takes whichever
+     * renderer reports the greatest format support, so FFmpeg still wins a
+     * format the platform decoder reports as exceeding its capabilities.
      */
     SiloPlayer("SiloPlayer"),
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorAudioSupportTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorAudioSupportTest.kt
@@ -266,16 +266,25 @@ class SinkPassthroughPartialEntriesTest {
     }
 
     @Test
-    fun `an unprobed layout falls back to the aggregate rather than being refused`() {
+    fun `an unprobed layout under this codecs own ceiling is allowed`() {
         assertTrue(
             sinkCanPassthrough("eac3", 5, receiver),
-            "5 channels is never probed, so the entry cannot be read as refusing it",
+            "5 channels is never probed and sits under the 6 this codec proved",
         )
-        assertTrue(sinkCanPassthrough("eac3", 7, receiver))
     }
 
+    /**
+     * The aggregate maxChannels is 8 here, but that 8 belongs to another codec.
+     * This sink was ASKED for 8-channel E-AC-3 and said no, so its E-AC-3
+     * ceiling is 6 — borrowing the aggregate would accept 7 on a path that
+     * cannot carry it, and broken audio costs more than a transcode.
+     */
     @Test
-    fun `an unprobed layout beyond the aggregate is still refused`() {
+    fun `an unprobed layout above this codecs own ceiling is refused`() {
+        assertFalse(
+            sinkCanPassthrough("eac3", 7, receiver),
+            "7 would only pass by borrowing another codec's limit",
+        )
         assertFalse(sinkCanPassthrough("eac3", 9, receiver))
     }
 
@@ -303,8 +312,17 @@ class SinkPassthroughPartialEntriesTest {
         )
     }
 
+    /**
+     * Derived from the probe list, not restated, so this asserts the value
+     * rather than a duplicate declaration. If the probe gains a layout, the
+     * reader learns about it automatically and this test is what notices.
+     */
     @Test
-    fun `the probed set matches what the capability manager probes`() {
+    fun `the probed set is exactly what the capability manager probes`() {
         assertEquals(setOf(2, 6, 8), PROBED_PASSTHROUGH_CHANNEL_COUNTS)
+        assertEquals(
+            PASSTHROUGH_LAYOUT_PROBES.map { it.channelCount }.toSet(),
+            PROBED_PASSTHROUGH_CHANNEL_COUNTS,
+        )
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorAudioSupportTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorAudioSupportTest.kt
@@ -5,6 +5,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.siloserver.silo.model.playback.AudioPassthroughCapabilities
+import org.siloserver.silo.model.playback.AudioPassthroughEntry
 
 class PlaybackCapabilityDetectorAudioSupportTest {
 
@@ -181,5 +183,63 @@ class PlaybackCapabilityDetectorAudioSupportTest {
         assertEquals("eac3", platformAudioCodecName(MimeTypes.AUDIO_E_AC3))
         assertEquals("eac3_joc", platformAudioCodecName(MimeTypes.AUDIO_E_AC3_JOC))
         assertEquals(null, platformAudioCodecName(MimeTypes.AUDIO_DTS_HD))
+    }
+}
+
+/**
+ * The sink carrying a codec says nothing about it carrying that many channels
+ * of it. maxChannels is a maximum across ALL codecs, so a receiver taking
+ * 8-channel TrueHD but only 6-channel E-AC-3 reports 8 — and would wave through
+ * an 8-channel E-AC-3 track its own entry excludes.
+ */
+class SinkPassthroughLayoutTest {
+
+    private val receiver = AudioPassthroughCapabilities(
+        passthroughCodecs = listOf("truehd", "eac3"),
+        maxChannels = 8,
+        entries = listOf(
+            AudioPassthroughEntry("truehd", channelCounts = listOf(2, 6, 8)),
+            AudioPassthroughEntry("eac3", channelCounts = listOf(2, 6)),
+        ),
+    )
+
+    @Test
+    fun `a layout the codec entry excludes is refused even under the aggregate maximum`() {
+        assertFalse(
+            sinkCanPassthrough("eac3", 8, receiver),
+            "8 <= maxChannels of 8, but this receiver's E-AC-3 entry stops at 6",
+        )
+    }
+
+    @Test
+    fun `a layout the codec entry lists is accepted`() {
+        assertTrue(sinkCanPassthrough("eac3", 6, receiver))
+        assertTrue(sinkCanPassthrough("truehd", 8, receiver))
+    }
+
+    @Test
+    fun `a codec the sink does not carry is refused`() {
+        assertFalse(sinkCanPassthrough("dts_hd", 6, receiver))
+    }
+
+    /**
+     * Pre-API-29 routes cannot be probed per format. Refusing everything there
+     * would be worse than the imprecision, so the aggregate still decides.
+     */
+    @Test
+    fun `without entries the aggregate maximum decides`() {
+        val old = AudioPassthroughCapabilities(
+            passthroughCodecs = listOf("eac3"),
+            maxChannels = 6,
+            entries = emptyList(),
+        )
+        assertTrue(sinkCanPassthrough("eac3", 6, old))
+        assertFalse(sinkCanPassthrough("eac3", 8, old))
+    }
+
+    @Test
+    fun `an unknown channel count asks only whether the codec is carried`() {
+        assertTrue(sinkCanPassthrough("eac3", 0, receiver))
+        assertFalse(sinkCanPassthrough("dts", 0, receiver))
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorAudioSupportTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorAudioSupportTest.kt
@@ -8,69 +8,135 @@ import kotlin.test.assertTrue
 
 class PlaybackCapabilityDetectorAudioSupportTest {
 
-    @Test
-    fun `DTS HD is software decodable when FFmpeg renderer is available`() {
-        assertTrue(
-            isSoftwareDecodableAudioMime(
-                mime = MimeTypes.AUDIO_DTS_HD,
-                ffmpegAvailable = true,
-            ),
-        )
-    }
+    private fun decoder(mime: String, codec: String, maxChannels: Int?, name: String = "c2.test") =
+        PlatformAudioDecodeCapability(mime, codec, name, maxChannels)
 
+    private val sixChannelEac3 = listOf(decoder(MimeTypes.AUDIO_E_AC3, "eac3", 6))
+    private val stereoOnlyEac3 = listOf(decoder(MimeTypes.AUDIO_E_AC3, "eac3", 2))
+
+    /**
+     * The live failure: four ERROR_CODE_DECODING_FAILED on Pixel 7 Pro and
+     * Pixel 10 Pro XL, every one a six-channel track, because the codec list
+     * claimed E-AC3 was decodable without ever asking how many channels the
+     * decoder took.
+     */
     @Test
-    fun `DTS HD is not software decodable without FFmpeg renderer`() {
+    fun `six channel E-AC3 is refused by a stereo-only decoder`() {
         assertFalse(
-            isSoftwareDecodableAudioMime(
-                mime = MimeTypes.AUDIO_DTS_HD,
-                ffmpegAvailable = false,
-            ),
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, stereoOnlyEac3, ffmpegAvailable = false),
         )
     }
 
     @Test
-    fun `AAC remains platform software decodable without FFmpeg renderer`() {
+    fun `two channel E-AC3 is accepted by the same decoder`() {
         assertTrue(
-            isSoftwareDecodableAudioMime(
-                mime = MimeTypes.AUDIO_AAC,
-                ffmpegAvailable = false,
-            ),
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3, 2, stereoOnlyEac3, ffmpegAvailable = false),
         )
     }
 
     @Test
-    fun `TV advertises platform decoders and leaves encoded support to passthrough`() {
-        assertEquals(
-            listOf("aac", "eac3"),
-            advertisedAudioDecodeCodecs(
-                platformCodecs = listOf("aac", "eac3"),
-                ffmpegAvailable = true,
-                isTv = true,
-            ),
+    fun `six channel E-AC3 is accepted by a six channel decoder`() {
+        assertTrue(
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, sixChannelEac3, ffmpegAvailable = false),
+        )
+    }
+
+    /** Several decoders can expose one MIME; the widest is the one that runs. */
+    @Test
+    fun `the widest decoder for a MIME decides`() {
+        val both = listOf(
+            decoder(MimeTypes.AUDIO_E_AC3, "eac3", 2, "c2.narrow"),
+            decoder(MimeTypes.AUDIO_E_AC3, "eac3", 6, "c2.wide"),
+        )
+        assertTrue(canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, both, ffmpegAvailable = false))
+    }
+
+    /** A limit must never be borrowed across MIME types. */
+    @Test
+    fun `a wide decoder for another codec does not vouch for this one`() {
+        val aacOnly = listOf(decoder(MimeTypes.AUDIO_AAC, "aac", 8))
+        assertFalse(
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, aacOnly, ffmpegAvailable = false),
+        )
+    }
+
+    /** JOC is its own claim: E-AC3 support does not imply it. */
+    @Test
+    fun `plain E-AC3 support does not advertise JOC`() {
+        assertFalse(
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3_JOC, 6, sixChannelEac3, ffmpegAvailable = false),
+        )
+    }
+
+    /**
+     * A device that will not state a limit is not thereby claiming an unlimited
+     * one, but refusing everything it reports would reject tracks that play
+     * fine. Existence answers the question; the limit does not exist to compare.
+     */
+    @Test
+    fun `an unstated limit does not refuse the codec`() {
+        val unknown = listOf(decoder(MimeTypes.AUDIO_E_AC3, "eac3", null))
+        assertTrue(canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, unknown, ffmpegAvailable = false))
+    }
+
+    @Test
+    fun `an unknown channel count asks only whether the codec exists`() {
+        assertTrue(
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3, 0, stereoOnlyEac3, ffmpegAvailable = false),
+        )
+        assertFalse(
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3, 0, emptyList(), ffmpegAvailable = false),
         )
     }
 
     @Test
-    fun `phone advertises FFmpeg audio decoders`() {
-        val codecs = advertisedAudioDecodeCodecs(
-            platformCodecs = listOf("aac", "eac3"),
-            ffmpegAvailable = true,
-            isTv = false,
+    fun `DTS HD is decodable when FFmpeg renderer is available`() {
+        assertTrue(
+            canDecodeAudio(MimeTypes.AUDIO_DTS_HD, 6, emptyList(), ffmpegAvailable = true),
         )
-
-        assertTrue("truehd" in codecs)
-        assertTrue("dts_hd" in codecs)
     }
 
     @Test
-    fun `TV does not lose codecs backed by platform decoders`() {
-        assertEquals(
-            listOf("aac", "truehd"),
-            advertisedAudioDecodeCodecs(
-                platformCodecs = listOf("aac", "truehd"),
-                ffmpegAvailable = true,
-                isTv = true,
-            ),
+    fun `DTS HD is not decodable without FFmpeg renderer`() {
+        assertFalse(
+            canDecodeAudio(MimeTypes.AUDIO_DTS_HD, 6, emptyList(), ffmpegAvailable = false),
         )
+    }
+
+    /**
+     * The subtle one. FFmpeg DOES declare E-AC3, so an "or FFmpeg" rule would
+     * call this playable — but renderers are built with
+     * EXTENSION_RENDERER_MODE_ON, where the extension only fills gaps with no
+     * platform decoder. A platform E-AC3 decoder exists, so it is the one that
+     * runs, and it refuses six channels. FFmpeg is never asked.
+     */
+    @Test
+    fun `FFmpeg does not rescue a codec the platform already claims`() {
+        assertFalse(
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, stereoOnlyEac3, ffmpegAvailable = true),
+            "FFmpeg cannot save a track the platform decoder will be handed first",
+        )
+    }
+
+    /** Where the platform has nothing at all, FFmpeg genuinely does fill the gap. */
+    @Test
+    fun `FFmpeg fills a gap the platform cannot cover`() {
+        assertTrue(
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, emptyList(), ffmpegAvailable = true),
+        )
+    }
+
+    @Test
+    fun `an absent codec is not decodable at all`() {
+        assertFalse(
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, emptyList(), ffmpegAvailable = false),
+        )
+    }
+
+    @Test
+    fun `codec names map only for MIME types this project tracks`() {
+        assertEquals("eac3", platformAudioCodecName(MimeTypes.AUDIO_E_AC3))
+        assertEquals("eac3_joc", platformAudioCodecName(MimeTypes.AUDIO_E_AC3_JOC))
+        assertEquals(null, platformAudioCodecName(MimeTypes.AUDIO_DTS_HD))
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorAudioSupportTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorAudioSupportTest.kt
@@ -60,11 +60,16 @@ class PlaybackCapabilityDetectorAudioSupportTest {
         )
     }
 
-    /** JOC is its own claim: E-AC3 support does not imply it. */
+    /** A limit is still never borrowed from an unrelated codec. */
     @Test
-    fun `plain E-AC3 support does not advertise JOC`() {
+    fun `AAC support does not vouch for E-AC3`() {
         assertFalse(
-            canDecodeAudio(MimeTypes.AUDIO_E_AC3_JOC, 6, sixChannelEac3, ffmpegAvailable = false),
+            canDecodeAudio(
+                MimeTypes.AUDIO_E_AC3,
+                6,
+                listOf(decoder(MimeTypes.AUDIO_AAC, "aac", 8)),
+                ffmpegAvailable = false,
+            ),
         )
     }
 
@@ -104,25 +109,63 @@ class PlaybackCapabilityDetectorAudioSupportTest {
     }
 
     /**
-     * The subtle one. FFmpeg DOES declare E-AC3, so an "or FFmpeg" rule would
-     * call this playable — but renderers are built with
-     * EXTENSION_RENDERER_MODE_ON, where the extension only fills gaps with no
-     * platform decoder. A platform E-AC3 decoder exists, so it is the one that
-     * runs, and it refuses six channels. FFmpeg is never asked.
+     * EXTENSION_RENDERER_MODE_ON puts the platform renderer first, but order is
+     * only the tie-break: the track selector takes whichever renderer reports
+     * the greatest format support. MediaCodecAudioRenderer answers
+     * FORMAT_EXCEEDS_CAPABILITIES for a channel count its decoder will not
+     * take, and FfmpegAudioRenderer answers FORMAT_HANDLED — so FFmpeg wins
+     * this one and the track really does play.
      */
     @Test
-    fun `FFmpeg does not rescue a codec the platform already claims`() {
-        assertFalse(
+    fun `FFmpeg rescues a channel count the platform decoder refuses`() {
+        assertTrue(
             canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, stereoOnlyEac3, ffmpegAvailable = true),
-            "FFmpeg cannot save a track the platform decoder will be handed first",
         )
     }
 
-    /** Where the platform has nothing at all, FFmpeg genuinely does fill the gap. */
+    /** Without it, the same device cannot play the track. */
+    @Test
+    fun `without FFmpeg the platform channel limit stands`() {
+        assertFalse(
+            canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, stereoOnlyEac3, ffmpegAvailable = false),
+        )
+    }
+
     @Test
     fun `FFmpeg fills a gap the platform cannot cover`() {
         assertTrue(
             canDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, emptyList(), ffmpegAvailable = true),
+        )
+    }
+
+    /**
+     * Media3 soft-matches JOC onto a plain E-AC3 decoder
+     * (MediaCodecUtil.getAlternativeCodecMimeType), so refusing it here would
+     * reject content the player would happily have handled.
+     */
+    @Test
+    fun `JOC is accepted by a plain E-AC3 decoder, as Media3 does`() {
+        assertTrue(
+            platformCanDecodeAudio(MimeTypes.AUDIO_E_AC3_JOC, 6, sixChannelEac3),
+        )
+    }
+
+    @Test
+    fun `JOC still respects that decoders channel limit`() {
+        assertFalse(
+            platformCanDecodeAudio(MimeTypes.AUDIO_E_AC3_JOC, 6, stereoOnlyEac3),
+        )
+    }
+
+    /** Codec absence and an unusable layout are different verdicts. */
+    @Test
+    fun `a channel-limited decoder still counts as having the codec`() {
+        assertTrue(
+            platformCanDecodeAudio(MimeTypes.AUDIO_E_AC3, 0, stereoOnlyEac3),
+            "asking with no channel count answers only whether the codec exists",
+        )
+        assertFalse(
+            platformCanDecodeAudio(MimeTypes.AUDIO_E_AC3, 6, stereoOnlyEac3),
         )
     }
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorAudioSupportTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorAudioSupportTest.kt
@@ -243,3 +243,68 @@ class SinkPassthroughLayoutTest {
         assertFalse(sinkCanPassthrough("dts", 0, receiver))
     }
 }
+
+/**
+ * Entries record what was PROBED, not everything the sink accepts — only
+ * 2/6/8 are ever tried. Treating that list as exhaustive turns a partial probe
+ * into a refusal of layouts nobody asked about.
+ */
+class SinkPassthroughPartialEntriesTest {
+
+    private val receiver = AudioPassthroughCapabilities(
+        passthroughCodecs = listOf("eac3", "eac3_joc"),
+        maxChannels = 8,
+        entries = listOf(AudioPassthroughEntry("eac3", channelCounts = listOf(2, 6))),
+    )
+
+    @Test
+    fun `a probed layout the entry omits is refused`() {
+        assertFalse(
+            sinkCanPassthrough("eac3", 8, receiver),
+            "8 is probed, so its absence is a real no",
+        )
+    }
+
+    @Test
+    fun `an unprobed layout falls back to the aggregate rather than being refused`() {
+        assertTrue(
+            sinkCanPassthrough("eac3", 5, receiver),
+            "5 channels is never probed, so the entry cannot be read as refusing it",
+        )
+        assertTrue(sinkCanPassthrough("eac3", 7, receiver))
+    }
+
+    @Test
+    fun `an unprobed layout beyond the aggregate is still refused`() {
+        assertFalse(sinkCanPassthrough("eac3", 9, receiver))
+    }
+
+    /**
+     * A JOC stream whose layout only the plain E-AC-3 entry covers must still
+     * pass: Android permits JOC through an E-AC-3 path.
+     */
+    @Test
+    fun `JOC falls back to the plain E-AC-3 entry for its layout`() {
+        val jocNarrow = AudioPassthroughCapabilities(
+            passthroughCodecs = listOf("eac3_joc", "eac3"),
+            maxChannels = 8,
+            entries = listOf(
+                AudioPassthroughEntry("eac3_joc", channelCounts = listOf(2)),
+                AudioPassthroughEntry("eac3", channelCounts = listOf(2, 6)),
+            ),
+        )
+        assertFalse(
+            sinkCanPassthrough("eac3_joc", 6, jocNarrow),
+            "its own entry stops at stereo",
+        )
+        assertTrue(
+            sinkCanPassthrough("eac3", 6, jocNarrow),
+            "but the E-AC-3 path carries it, which is the fallback checkPlayability uses",
+        )
+    }
+
+    @Test
+    fun `the probed set matches what the capability manager probes`() {
+        assertEquals(setOf(2, 6, 8), PROBED_PASSTHROUGH_CHANNEL_COUNTS)
+    }
+}


### PR DESCRIPTION
## The problem

`PlaybackCapabilityDetector.detect()` probes the real `MediaCodecList`, but
`checkPlayability()` asked a **hardcoded MIME set** that always claimed E-AC-3
and E-AC-3 JOC were decodable — on any device, for any track. That answer also
*gated the channel check*:

```kotlin
if (channels > 0 && channels > maxChannels && !rendererCanDecode)
```

so "the renderer can decode it" was taken to mean channels don't matter. A 5.1
E-AC-3 track on a decoder that accepts two channels was reported `Supported`,
then died at `ERROR_CODE_DECODING_FAILED` **after playback had started** — and
the recovery replan made the same claim and chose the same route again.

Live evidence: four such failures on Pixel 7 Pro and Pixel 10 Pro XL, every one
six-channel.

## What changed

- The probe records each decoder's `maxInputChannelCount` alongside its MIME.
  `canDecodeAudio` asks whether any decoder for that MIME will actually take
  this many channels. A limit is never borrowed across MIME types.
- **Codec absence and unusable layout are now different verdicts.** The Pixel
  case returns `UnsupportedChannelCount` (`unsupported_audio_layout`) rather
  than `UnsupportedAudioCodec` — different message for the viewer, different
  fallback from the server.
- **AC-3, E-AC-3 and JOC added to the passthrough sink check.** Harmless while
  the decoder was assumed limitless; a false refusal the moment it isn't, since
  an E-AC-3 receiver plays 5.1 fine behind a stereo-only decoder.
- **Passthrough is asked per codec *and* per layout.** `maxChannels` is a
  maximum across all codecs, so a receiver doing 8-channel TrueHD would
  otherwise vouch for 8-channel E-AC-3 its own entry excludes.
- A passthrough entry is read as **probed, not exhaustive** — only 2/6/8 are
  ever tried, so absence refuses only those; other layouts are judged against
  that codec's highest proven count.
- JOC is soft-matched onto a plain E-AC-3 decoder, matching Media3's
  `MediaCodecUtil.getAlternativeCodecMimeType`, and tries the E-AC-3 passthrough
  entry when its own lacks the layout.
- Route capabilities are read once; they were read three times in one check.

## Behaviour on the reported device

| | verdict | outcome |
|---|---|---|
| FFmpeg available | `Supported` | plays — FFmpeg wins renderer selection |
| FFmpeg unavailable | `UnsupportedChannelCount` | V3 replans to a downmixed stream |

## Risks

Refusing a layout the device would have played costs a transcode; accepting one
it cannot costs broken audio mid-playback. Every uncertain case here is
deliberately resolved toward refusal, except where no evidence exists at all
(an unstated decoder limit, or a pre-API-29 route that cannot be probed per
format) where refusing everything would be the worse error.

## Verify

```
./gradlew :android-shared:testDebugUnitTest :androidTvApp:testDebugUnitTest :androidApp:testDebugUnitTest --rerun-tasks
android-shared: 1160 tests, 0 failures
androidTvApp:   1033 tests, 0 failures
androidApp:      606 tests, 0 failures
```

New decision points are mutation-checked: ignoring the channel limit, treating
entries as exhaustive, and borrowing the aggregate ceiling each fail their tests.

## AI Disclosure

Written by Claude Opus 5 (`claude-opus-5[1m]`) and reviewed across five rounds
with `codex exec` (GPT-5). The review corrected me on a load-bearing point: I
had argued `EXTENSION_RENDERER_MODE_ON` confines FFmpeg to codecs the platform
lacks entirely, and built the fix on that. It is wrong — ordering is only the
tie-break, and `MappingTrackSelector` takes whichever renderer reports the
greatest format support, so FFmpeg does win a format the platform decoder
reports as exceeding its capabilities. Later rounds also caught a false accept
from the aggregate channel maximum, and a `check()` I had added that could have
thrown inside capability detection on real devices.

Adversarial review of my own diff found: the verdict-ordering bug (codec
absence reported for a layout failure), the missing E-AC-3 passthrough entry,
and the aggregate-ceiling borrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9UyH5fvug685dzUFLtdpW