### PR TITLE
test(auth): make the server-setup settle wait actually wait

### DIFF
--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/auth/ServerSetupPersistenceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/auth/ServerSetupPersistenceTest.kt
@@ -226,11 +226,34 @@ class ServerSetupPersistenceTest {
         tokenManager = tokenManager,
     )
 
+    /**
+     * Waits for a connect attempt to finish.
+     *
+     * `first { !it.isLoading }` alone is not a settle condition: `isLoading` is
+     * set to true INSIDE `viewModelScope.launch`, so until that body runs the
+     * predicate is already satisfied by the state BEFORE the load began, and
+     * the caller asserts against a view model that has not done the work.
+     * `runCurrent()` only drains what is scheduled at the current virtual time,
+     * which is not a guarantee that the body has run.
+     *
+     * `advanceUntilIdle()` is that guarantee: the launch body has at least
+     * reached its first suspension point, so the await can only be answered by
+     * a load that genuinely finished. The await stays as a backstop for any
+     * future path that leaves the test dispatcher, where virtual time alone
+     * would not settle anything.
+     *
+     * This class has been seen to fail intermittently on
+     * `cleartextApprovalIsOriginSpecific` under a loaded machine. That failure
+     * was NOT reproduced on demand — 10 isolated runs and 6 full-suite runs of
+     * the previous helper all passed — so this is a latent weakness found by
+     * reading, and it is not proven to be the cause.
+     */
     private suspend fun TestScope.awaitSettled(viewModel: ServerSetupViewModel) {
-        runCurrent()
+        advanceUntilIdle()
         withTimeout(5_000) {
             viewModel.uiState.first { !it.isLoading }
         }
+        advanceUntilIdle()
     }
 }
 


### PR DESCRIPTION
## The problem

`ServerSetupPersistenceTest.awaitSettled` awaits `first { !it.isLoading }`,
which is not a settle condition. `isLoading` is set to true **inside**
`viewModelScope.launch`:

```kotlin
viewModelScope.launch {
    pendingCleartextConnection = null
    _uiState.update { it.copy(isLoading = true, ...) }
```

so until that body runs, the predicate is already satisfied by the state from
*before* the load. `runCurrent()` only drains what is scheduled at the current
virtual time and does not guarantee the body has run — when it hasn't, the
helper returns immediately and the caller asserts against a view model that has
not done the work.

## The change

`advanceUntilIdle()` first, which guarantees the launch body has at least
reached its first suspension point, so only a load that genuinely finished can
answer the await. The await is kept as a backstop for any future path that
leaves the test dispatcher, where virtual time alone would settle nothing.

## Honest scope — please read before closing anything as fixed

`cleartextApprovalIsOriginSpecific` was observed failing twice in full-suite
runs on a heavily loaded machine. **That failure was not reproduced on demand.**
With the previous helper still in place:

- 10/10 isolated runs of the class passed
- 6/6 full-suite `:androidApp:testDebugUnitTest` runs passed

So this fixes a real weakness found by reading the code, and it is **not proven
to be the cause** of those failures. If the flake recurs, this PR should not be
treated as having ruled the helper out.

A second theory was investigated and discarded: that a real-thread hop in the
HTTP engine would let `runTest` advance virtual time past the 5s `withTimeout`.
That is a genuine kotlinx-coroutines trap, but it does not apply here — this
path uses injected `getSetupStatus` / `getSignupStatus` lambdas rather than the
client, so nothing leaves the test dispatcher.

## Verify

```
./gradlew :androidApp:testDebugUnitTest --rerun-tasks
androidApp: 606 tests, 0 failures   (five consecutive full-suite runs)
```

## AI Disclosure

Written by Claude Opus 5 (`claude-opus-5[1m]`). My own adversarial review of the
diff is what produced the honest-scope section above: the first version of this
change asserted the race *was* the flake, and stress-testing the original helper
afterwards did not support that claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9UyH5fvug685dzUFLtdpW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved synchronization in server setup persistence tests to reliably wait for completed UI states.
  * Added documentation describing the test timing behavior and synchronization guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->