### PR TITLE
fix(tv): make the player controls reachable, and Center mean pause

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -2289,6 +2289,15 @@ private fun TvPlayerIdleOverlay(
     val scrubberFocus = remember { FocusRequester() }
     val playPauseFocus = remember { FocusRequester() }
     var idleOverlayHasFocus by remember { mutableStateOf(false) }
+    // Observed per ROW, not for the overlay as a whole. `idleOverlayHasFocus` is
+    // hasFocus on the overlay's root, so it is already true whenever ANY control
+    // holds focus — including the scrubber. Using it as the arrival test made
+    // every request from inside the overlay a no-op: D-pad Down on the scrub bar
+    // asks for the transport, the retry loop sees "already focused" and never
+    // requests, and focus stays on the bar. That is why reaching the controls
+    // needed a Back (which hides the overlay, clearing the flag) before Down.
+    var scrubberHasFocus by remember { mutableStateOf(false) }
+    var transportHasFocus by remember { mutableStateOf(false) }
     var currentRate by remember { mutableStateOf(0) }
     LaunchedEffect(focusRequest.nonce) {
         val overlayTarget = when (focusRequest.target) {
@@ -2299,7 +2308,12 @@ private fun TvPlayerIdleOverlay(
             maxAttempts = TvContentInitialFocusMaxAttempts,
             awaitAttempt = { withFrameNanos { } },
             requestFocus = overlayTarget::requestFocus,
-            isFocused = { idleOverlayHasFocus },
+            isFocused = {
+                when (focusRequest.target) {
+                    TvIdleOverlayFocusTarget.Scrubber -> scrubberHasFocus
+                    TvIdleOverlayFocusTarget.Transport -> transportHasFocus
+                }
+            },
         )
     }
 
@@ -2369,6 +2383,7 @@ private fun TvPlayerIdleOverlay(
             // Interactive scrubber — capsule track with chapter ticks, ±10s
             // skip, hold-to-auto-seek, and Select to commit. tvOS spec §4.1.
             TvPlayerScrubber(
+                modifier = Modifier.onFocusChanged { scrubberHasFocus = it.hasFocus },
                 positionSec = positionSec,
                 durationSec = durationSec,
                 bufferedAheadSec = bufferedAheadSec,
@@ -2391,6 +2406,7 @@ private fun TvPlayerIdleOverlay(
                 onCommitScrub = onCommitScrub,
                 onCancelScrub = onCancelScrub,
                 onRequestFocus = scrubberFocus,
+                onPlayPause = onPlayPause,
                 onMoveDownToTransport = {
                     playPauseFocus.claimFocusOrReport(
                         target = "player_transport",
@@ -2404,6 +2420,7 @@ private fun TvPlayerIdleOverlay(
             Spacer(modifier = Modifier.height(8.dp))
 
             TvPlayerTransportCluster(
+                modifier = Modifier.onFocusChanged { transportHasFocus = it.hasFocus },
                 isPlaying = !isPaused,
                 onSkipBack = onSkipBack,
                 onPlayPause = onPlayPause,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1941,6 +1941,7 @@ fun TvPlayerScreen(
                         // playback seeks the MediaController directly.
                         transportEnabled = canSeekInRoom,
                         playPauseEnabled = canPlayPauseInRoom,
+                        canToggleAfterCommit = roomController == null,
                         onSkipBack = {
                             if (canSeekInRoom) {
                                 performRelativeSeek(
@@ -2285,6 +2286,16 @@ private fun TvPlayerIdleOverlay(
     // play/pause (host_only policy) gets a no-op play/pause.
     transportEnabled: Boolean = true,
     playPauseEnabled: Boolean = true,
+    /**
+     * Whether Center may toggle playback after committing a scrub.
+     *
+     * False in a Watch Together room. There, the commit and the play/pause are
+     * two independently launched room requests, and the play/pause carries the
+     * live position rather than the committed one — so it can land after the
+     * seek and pull every participant back to where the scrub started. Solo
+     * playback applies both locally and in order, so it keeps the behaviour.
+     */
+    canToggleAfterCommit: Boolean = true,
 ) {
     val scrubberFocus = remember { FocusRequester() }
     val playPauseFocus = remember { FocusRequester() }
@@ -2407,6 +2418,7 @@ private fun TvPlayerIdleOverlay(
                 onCancelScrub = onCancelScrub,
                 onRequestFocus = scrubberFocus,
                 onPlayPause = onPlayPause,
+                canToggleAfterCommit = canToggleAfterCommit,
                 onMoveDownToTransport = {
                     playPauseFocus.claimFocusOrReport(
                         target = "player_transport",

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScrubber.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScrubber.kt
@@ -114,6 +114,14 @@ fun TvPlayerScrubber(
     onCommitScrub: () -> Unit,
     onCancelScrub: () -> Unit,
     onRequestFocus: FocusRequester,
+    /**
+     * Toggle play/pause. Center on the bar is bound to this, not to entering a
+     * scrub: the Google TV remote has no dedicated play/pause key, so Center
+     * with the overlay up is the only one-press pause a viewer has — and it is
+     * what every other TV player does. Scrubbing does not need it; Left/Right
+     * skip and long-press engages auto-seek.
+     */
+    onPlayPause: () -> Unit,
     onMoveDownToTransport: () -> Unit,
     onExitWhenIdle: () -> Unit,
     onRateChanged: (Int) -> Unit = {},
@@ -347,13 +355,20 @@ fun TvPlayerScrubber(
                         Key.DirectionCenter, Key.Enter, Key.NumPadEnter -> {
                             if (isUp) {
                                 stopAutoSeek()
+                                // Center means "here": land any scrub in
+                                // flight, then flip playback. Racing forward at
+                                // 32x it stops on the frame you asked for;
+                                // hunting a spot while paused it plays on from
+                                // it. Entering a scrub MODE here — what this
+                                // used to do — spent the viewer's only
+                                // one-press pause on something Left/Right
+                                // already do, and the Google TV remote has no
+                                // dedicated play/pause key to fall back on.
                                 if (isTimelineScrubbing || isScrubbing) {
                                     isTimelineScrubbing = false
                                     onCommitScrub()
-                                } else {
-                                    onBeginScrub()
-                                    isTimelineScrubbing = true
                                 }
+                                onPlayPause()
                                 true
                             } else if (isDown) true else false
                         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScrubber.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScrubber.kt
@@ -122,6 +122,8 @@ fun TvPlayerScrubber(
      * skip and long-press engages auto-seek.
      */
     onPlayPause: () -> Unit,
+    /** See TvPlayerIdleOverlay.canToggleAfterCommit. */
+    canToggleAfterCommit: Boolean = true,
     onMoveDownToTransport: () -> Unit,
     onExitWhenIdle: () -> Unit,
     onRateChanged: (Int) -> Unit = {},
@@ -364,11 +366,12 @@ fun TvPlayerScrubber(
                                 // one-press pause on something Left/Right
                                 // already do, and the Google TV remote has no
                                 // dedicated play/pause key to fall back on.
-                                if (isTimelineScrubbing || isScrubbing) {
+                                val committed = isTimelineScrubbing || isScrubbing
+                                if (committed) {
                                     isTimelineScrubbing = false
                                     onCommitScrub()
                                 }
-                                onPlayPause()
+                                if (!committed || canToggleAfterCommit) onPlayPause()
                                 true
                             } else if (isDown) true else false
                         }


### PR DESCRIPTION
Two things stopped a viewer on the scrub bar from doing the obvious thing. Both were found on a Google TV Streamer and the fixes were verified there.

## D-pad Down did not reach the controls

Down inside the player is consumed by the activity-level remote-key bridge, which maps it to `FocusTransport` and asks the overlay to focus the transport row. That request is retried until observed — but the arrival test was `idleOverlayHasFocus`, which is `hasFocus` on the overlay **root**, and that is already `true` whenever any control holds focus, the scrub bar included. The retry loop therefore concluded focus had already arrived and never issued a request, so Down did nothing at all.

It also explains the workaround people found: Back hides the controls, which clears the flag, so the next Down took the "controls hidden" branch and genuinely requested focus. Hence "hit Back, then Down".

Focus is now observed per control row, and the retry loop tests the row it actually asked for.

## Center on the bar entered a scrub mode instead of pausing

The Google TV remote has no dedicated play/pause key, so Center with the overlay up is the only one-press pause a viewer has. It was bound to entering a scrub mode — something Left/Right already cover (skip, and long-press auto-seek).

Center now lands any scrub in flight and then toggles playback. Racing forward it stops on the frame you asked for; hunting a spot while paused it plays on from it. Same key, one meaning.

## Verification

- `:androidTvApp:testDebugUnitTest` passes.
- On a Google TV Streamer: scrub bar focused → Down → play/pause focused in one press; Center on the bar toggles playback.
- Lint was **not** run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9UyH5fvug685dzUFLtdpW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved D-pad navigation between the player’s scrubber and transport controls.
  * Fixed focus handling so controls receive and retain focus reliably.
  * Updated the scrubber’s center/Enter action to commit seeking and toggle playback correctly.
  * Prevented idle scrubber activation when center/Enter is pressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->