### PR TITLE
fix(tv): Back out of a cascade lands on its own tab, without flashing through search

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -922,6 +922,9 @@ fun TvMainShell(
         // Must match what onBack() will decide, or the shell would decline the
         // press and let navigation take it while handleShellBack expected it.
         panelEntered = focusState.panelHasFocus,
+        // Must match what onBack() will decide, or the shell declines a press
+        // it would then have handled.
+        barHandoffAttempted = focusState.barHandoffAttempted,
     )
     val shellHandlesBack = currentRoute != TvMainRoute.Settings.route && when (pendingShellBackAction) {
         TvShellBackAction.ClosePanel,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -879,7 +879,9 @@ fun TvMainShell(
             // onBack() closed the panel without claiming focus; put the viewer
             // back where they came from in the same press.
             TvShellBackAction.ClosePanel -> {
-                moveFocusToContent(currentRoute)
+                // onBack() already put focus on the anchor tab with dwell
+                // suppressed. Claiming content here fought that and lost —
+                // focus ended up on the bar anyway, just without suppression.
                 true
             }
             // Preview only: focus never left the bar, so dismissing it must not

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -344,6 +344,11 @@ fun TvMainShell(
     val searchInputFocusRequester = remember { FocusRequester() }
     var searchInputHasFocus by remember { mutableStateOf(false) }
     var searchBackToInputRequest by remember { mutableIntStateOf(0) }
+    // Same failure as the bar handoff: Back asks the search field to take
+    // focus and consumes the press. If the field never reports focus, every
+    // Back repeats that forever and Search cannot be left. Records the attempt
+    // so the next Back falls through to navigation instead.
+    var searchBackToInputAttempted by remember { mutableStateOf(false) }
     // Opening an outer item-detail route pauses/removes this shell. Remember the
     // pending hand-back in the Main back-stack entry so it survives either form,
     // then re-enter the existing content focusRestorer when Main resumes.
@@ -897,7 +902,11 @@ fun TvMainShell(
             // Secondary screens: pop the flat inner NavHost when possible;
             // otherwise let the activity-level callback finish the app.
             TvShellBackAction.DelegateToNav -> {
-                if (currentRoute == TvMainRoute.Search.route && !searchInputHasFocus) {
+                if (currentRoute == TvMainRoute.Search.route &&
+                    !searchInputHasFocus &&
+                    !searchBackToInputAttempted
+                ) {
+                    searchBackToInputAttempted = true
                     searchBackToInputRequest += 1
                     true
                 } else if (nestedNav.previousBackStackEntry != null) {
@@ -933,7 +942,11 @@ fun TvMainShell(
         TvShellBackAction.MoveFocusToMenu -> true
         TvShellBackAction.MenuBack -> selectedRoot != TvRootDestination.Home
         TvShellBackAction.DelegateToNav ->
-            (currentRoute == TvMainRoute.Search.route && !searchInputHasFocus) ||
+            (
+                currentRoute == TvMainRoute.Search.route &&
+                    !searchInputHasFocus &&
+                    !searchBackToInputAttempted
+                ) ||
                 nestedNav.previousBackStackEntry != null
     }
     // NavHost installs its own predictive-back callback before composing the
@@ -1109,7 +1122,11 @@ fun TvMainShell(
                         onOpenLibraryItem = onOpenItemDetail,
                         searchFieldFocusRequester = searchInputFocusRequester,
                         backToSearchFieldRequest = searchBackToInputRequest,
-                        onSearchFieldFocusChanged = { searchInputHasFocus = it },
+                        onSearchFieldFocusChanged = {
+                            searchInputHasFocus = it
+                            // The field answered; the outstanding attempt is settled.
+                            if (it) searchBackToInputAttempted = false
+                        },
                     )
                 }
                 shellComposable(TvMainRoute.Audio.route) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -1459,6 +1459,9 @@ fun TvMainShell(
             focusRequest = focusState.menuFocusRequest,
             focusRequestTarget = focusState.menuFocusTarget,
             focusRequestSuppressesDwell = focusState.menuFocusSuppressesDwell,
+            // Lets Back move focus to the anchor tab while the cascade is still
+            // composed — removing it afterwards then has no focus to recover.
+            onInstallAnchorFocus = { hook -> focusState.focusBarAnchorNow = hook },
             profileFocusRequest = focusState.profileFocusRequest,
             isSearchActive = currentRoute == TvMainRoute.Search.route,
             visibility = if (currentRoute == TvMainRoute.Settings.route) 0f else menuVisibility.value,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -873,6 +873,7 @@ fun TvMainShell(
         return when (focusState.onBack(
             onTabRoot = selectedRoot != null,
             menuFocusTarget = selectedMenuFocusTarget,
+            onHome = selectedRoot == TvRootDestination.Home,
         )) {
             // Panel/dropdown already closed by onBack(): just consume.
             // onBack() closed the panel without claiming focus; put the viewer
@@ -934,6 +935,7 @@ fun TvMainShell(
         // Must match what onBack() will decide, or the shell declines a press
         // it would then have handled.
         barHandoffAttempted = focusState.barHandoffAttempted,
+        onHome = selectedRoot == TvRootDestination.Home,
     )
     val shellHandlesBack = currentRoute != TvMainRoute.Settings.route && when (pendingShellBackAction) {
         TvShellBackAction.ClosePanel,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusState.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusState.kt
@@ -99,6 +99,7 @@ internal fun tvShellBackAction(
     onTabRoot: Boolean,
     panelEntered: Boolean = true,
     barHandoffAttempted: Boolean = false,
+    onHome: Boolean = false,
 ): TvShellBackAction = when {
     // A panel the viewer never entered is a dwell preview: focus is still on
     // the bar, so dismissing it must leave focus there. Routing this through
@@ -117,7 +118,10 @@ internal fun tvShellBackAction(
     // consecutive "focus request -> menu" with no "focused -> menu" between
     // them. Progress matters more than tidiness here, so the second Back goes
     // Home regardless of where focus actually is.
-    onTabRoot && barHandoffAttempted -> TvShellBackAction.MenuBack
+    // Escalate only where MenuBack actually NAVIGATES. On Home, MenuBack means
+    // "exit the app", so escalating there turns a Back the viewer expected to
+    // move focus into quitting Silo — which is worse than the loop it fixes.
+    onTabRoot && barHandoffAttempted && !onHome -> TvShellBackAction.MenuBack
     onTabRoot -> TvShellBackAction.MoveFocusToMenu
     else -> TvShellBackAction.DelegateToNav
 }
@@ -376,6 +380,7 @@ class TvShellFocusState {
     fun onBack(
         onTabRoot: Boolean,
         menuFocusTarget: TvTopMenuPanel? = null,
+        onHome: Boolean = false,
     ): TvShellBackAction {
         val action = tvShellBackAction(
             panelOpen = openPanel != null,
@@ -384,6 +389,7 @@ class TvShellFocusState {
             onTabRoot = onTabRoot,
             panelEntered = panelHasFocus,
             barHandoffAttempted = barHandoffAttempted,
+            onHome = onHome,
         )
         when (action) {
             // Back out of a cascade the viewer ENTERED hands focus to content,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusState.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusState.kt
@@ -249,6 +249,18 @@ class TvShellFocusState {
 
     // --- Menu-bar focus signals -------------------------------------------------
 
+    /**
+     * Moves bar focus to a panel's anchor RIGHT NOW, installed by the bar.
+     *
+     * Closing a cascade removes the focused node, and Compose recovers focus a
+     * frame before any request of ours can land — it picks the bar's first
+     * child, so Back visibly flashed through the search icon on its way to the
+     * anchor. Nothing written to state can win that frame; the fix is to move
+     * focus while the panel is still composed, leaving no recovery to lose.
+     * Returns whether focus actually moved.
+     */
+    var focusBarAnchorNow: ((TvTopMenuPanel?) -> Boolean)? = null
+
     /** Route focus to the bar's selected tab (content → bar Up, or panel close). */
     fun requestMenuFocus(target: TvTopMenuPanel? = null, suppressDwellPreview: Boolean = false) {
         DiagnosticsFocusLogger.transition(target?.diagnosticsTarget() ?: "menu", "request")
@@ -395,28 +407,13 @@ class TvShellFocusState {
             // Back out of a cascade the viewer ENTERED hands focus to content,
             // not back to the anchor tab. Parking them one level up in the
             // chrome is what "back doesn't exit the menus" meant.
-            TvShellBackAction.ClosePanel -> {
-                // Focus returns to the anchor tab whether we ask for it or not
-                // — Compose restores it when the panel leaves composition, and
-                // the telemetry shows "focused -> menu" with no preceding
-                // "request". Requesting it explicitly is what ARMS dwell
-                // suppression: without it the anchor re-previews ~250ms later
-                // and the next Back is spent closing that preview instead of
-                // reaching MenuBack, so Home stays unreachable.
-                val anchor = openPanel
-                closePanel()
-                requestMenuFocus(anchor, suppressDwellPreview = true)
-            }
-            // Focus is on the bar, but not necessarily on the ANCHOR: without an
-            // explicit request the bar falls back to selectedEntryRequester(),
-            // which is the selected tab (Home) — or the search icon when the
-            // route is Search. Backing out of Movies' cascade therefore landed
-            // on Home. Request the anchor so the viewer stays where they were.
-            TvShellBackAction.ClosePanelPreview -> {
-                val anchor = openPanel
-                closePanel()
-                requestMenuFocus(anchor, suppressDwellPreview = true)
-            }
+            TvShellBackAction.ClosePanel -> closePanelOntoAnchor()
+            // The preview case looks like focus never left the bar, but it is
+            // not necessarily on the ANCHOR: with no explicit target the bar
+            // falls back to selectedEntryRequester(), which is the selected tab
+            // — Home, or the search icon on the Search route. Backing out of
+            // Movies' cascade therefore landed on Home.
+            TvShellBackAction.ClosePanelPreview -> closePanelOntoAnchor()
             TvShellBackAction.CloseProfileMenu -> dismissProfileMenu()
             // Back from content climbs to the bar, and must NOT pop that tab's
             // cascade on arrival: the viewer is leaving, not browsing. Without
@@ -432,6 +429,27 @@ class TvShellFocusState {
             TvShellBackAction.DelegateToNav -> Unit
         }
         return action
+    }
+
+    /**
+     * Close the open panel and leave focus on ITS anchor tab, with that tab's
+     * dwell preview suppressed.
+     *
+     * Order matters: focus moves first, while the panel is still composed, so
+     * removing it never triggers Compose's focus recovery. The state request is
+     * the fallback for when the bar has not installed its hook, or the anchor is
+     * not focusable yet — it lands a frame later, which is exactly the window
+     * that made Back flash through the search icon.
+     *
+     * The suppression is the other half: without it the anchor re-previews its
+     * cascade ~250ms later and the next Back is spent closing that preview
+     * instead of reaching MenuBack, so Home stays unreachable.
+     */
+    private fun closePanelOntoAnchor() {
+        val anchor = openPanel
+        val moved = focusBarAnchorNow?.invoke(anchor) ?: false
+        closePanel()
+        if (!moved) requestMenuFocus(anchor, suppressDwellPreview = true)
     }
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusState.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusState.kt
@@ -407,8 +407,16 @@ class TvShellFocusState {
                 closePanel()
                 requestMenuFocus(anchor, suppressDwellPreview = true)
             }
-            // Focus never left the bar, so there is nothing to restore.
-            TvShellBackAction.ClosePanelPreview -> closePanel()
+            // Focus is on the bar, but not necessarily on the ANCHOR: without an
+            // explicit request the bar falls back to selectedEntryRequester(),
+            // which is the selected tab (Home) — or the search icon when the
+            // route is Search. Backing out of Movies' cascade therefore landed
+            // on Home. Request the anchor so the viewer stays where they were.
+            TvShellBackAction.ClosePanelPreview -> {
+                val anchor = openPanel
+                closePanel()
+                requestMenuFocus(anchor, suppressDwellPreview = true)
+            }
             TvShellBackAction.CloseProfileMenu -> dismissProfileMenu()
             // Back from content climbs to the bar, and must NOT pop that tab's
             // cascade on arrival: the viewer is leaving, not browsing. Without

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusState.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusState.kt
@@ -98,6 +98,7 @@ internal fun tvShellBackAction(
     menuFocused: Boolean,
     onTabRoot: Boolean,
     panelEntered: Boolean = true,
+    barHandoffAttempted: Boolean = false,
 ): TvShellBackAction = when {
     // A panel the viewer never entered is a dwell preview: focus is still on
     // the bar, so dismissing it must leave focus there. Routing this through
@@ -109,6 +110,14 @@ internal fun tvShellBackAction(
     // the bar; Back on the bar goes Home (or exits from Home). Secondary
     // screens (Settings, Search, …) still pop navigation.
     menuFocused -> TvShellBackAction.MenuBack
+    // The handoff to the bar was already asked for and the bar never reported
+    // taking focus. Asking again is what strands the viewer: every Back
+    // re-evaluates to MoveFocusToMenu, MenuBack is never reached, and Home and
+    // exit become unreachable — observed on a Google TV Streamer as four
+    // consecutive "focus request -> menu" with no "focused -> menu" between
+    // them. Progress matters more than tidiness here, so the second Back goes
+    // Home regardless of where focus actually is.
+    onTabRoot && barHandoffAttempted -> TvShellBackAction.MenuBack
     onTabRoot -> TvShellBackAction.MoveFocusToMenu
     else -> TvShellBackAction.DelegateToNav
 }
@@ -175,6 +184,18 @@ class TvShellFocusState {
 
     /** Nudge the menu bar to return focus to the profile avatar. */
     var profileFocusRequest by mutableIntStateOf(0)
+        private set
+
+    /**
+     * True once Back has asked the bar to take focus and the bar has not yet
+     * reported doing so.
+     *
+     * [requestMenuFocus] only bumps a token — it cannot know whether the claim
+     * landed, and nothing corrected it when it did not. This records the
+     * attempt so a second Back can escalate instead of repeating a request that
+     * is evidently not working.
+     */
+    var barHandoffAttempted by mutableStateOf(false)
         private set
 
     /** Re-fire the cascade selector's focus-entry effect when a panel is entered. */
@@ -254,6 +275,8 @@ class TvShellFocusState {
         }
         isMenuFocused = focused
         if (focused) {
+            // The bar answered, so the outstanding handoff is settled.
+            barHandoffAttempted = false
             panelEntersFocus = false
             if (profileMenuOpen && !profileMenuEntered) profileMenuOpen = false
         }
@@ -332,6 +355,9 @@ class TvShellFocusState {
      * raced back to the bar by a focus bump from here.
      */
     fun closePanel() {
+        // Closing hands focus somewhere deliberate, so any stale unanswered
+        // handoff no longer describes the current situation.
+        barHandoffAttempted = false
         val closingPanel = openPanel
         openPanel = null
         panelEntersFocus = false
@@ -357,6 +383,7 @@ class TvShellFocusState {
             menuFocused = isMenuFocused,
             onTabRoot = onTabRoot,
             panelEntered = panelHasFocus,
+            barHandoffAttempted = barHandoffAttempted,
         )
         when (action) {
             // Back out of a cascade the viewer ENTERED hands focus to content,
@@ -372,8 +399,10 @@ class TvShellFocusState {
             // content, so Back ping-pongs and never reaches MenuBack — Home and
             // exit become unreachable. Up from content is the browsing case and
             // stays unsuppressed, which is what makes the cascade openable.
-            TvShellBackAction.MoveFocusToMenu ->
+            TvShellBackAction.MoveFocusToMenu -> {
+                barHandoffAttempted = true
                 requestMenuFocus(menuFocusTarget, suppressDwellPreview = true)
+            }
             TvShellBackAction.MenuBack,
             TvShellBackAction.DelegateToNav -> Unit
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusState.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusState.kt
@@ -395,7 +395,18 @@ class TvShellFocusState {
             // Back out of a cascade the viewer ENTERED hands focus to content,
             // not back to the anchor tab. Parking them one level up in the
             // chrome is what "back doesn't exit the menus" meant.
-            TvShellBackAction.ClosePanel -> closePanel()
+            TvShellBackAction.ClosePanel -> {
+                // Focus returns to the anchor tab whether we ask for it or not
+                // — Compose restores it when the panel leaves composition, and
+                // the telemetry shows "focused -> menu" with no preceding
+                // "request". Requesting it explicitly is what ARMS dwell
+                // suppression: without it the anchor re-previews ~250ms later
+                // and the next Back is spent closing that preview instead of
+                // reaching MenuBack, so Home stays unreachable.
+                val anchor = openPanel
+                closePanel()
+                requestMenuFocus(anchor, suppressDwellPreview = true)
+            }
             // Focus never left the bar, so there is nothing to restore.
             TvShellBackAction.ClosePanelPreview -> closePanel()
             TvShellBackAction.CloseProfileMenu -> dismissProfileMenu()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -69,6 +70,17 @@ import org.siloserver.silo.tv.ui.theme.navRailLabel
 
 private const val TopMenuInitialPreviewDelayMillis = 180L
 private const val TopMenuPanelSwitchDelayMillis = 80L
+
+/**
+ * How long a non-anchor focus must hold before it disarms dwell suppression.
+ * Shorter than [TopMenuInitialPreviewDelayMillis] so a real move still previews
+ * promptly, long enough to outlast the one-frame focus blip Compose emits while
+ * an explicit bar focus request is being applied.
+ */
+private const val TopMenuSuppressionHandoffGraceMillis = 120L
+
+/** Upper bound on the single-focusable handoff window. */
+private const val TopMenuHandoffTimeoutMillis = 500L
 
 
 /**
@@ -166,6 +178,12 @@ fun TvTopMenuBar(
      * TvShellFocusState.menuFocusSuppressesDwell.
      */
     focusRequestSuppressesDwell: Boolean = false,
+    /**
+     * Receives a hook that moves bar focus to a panel's anchor synchronously,
+     * so a closing cascade never leaves focus for Compose to recover. See
+     * TvShellFocusState.focusBarAnchorNow.
+     */
+    onInstallAnchorFocus: ((TvTopMenuPanel?) -> Boolean) -> Unit = {},
     profileFocusRequest: Int = 0,
     isSearchActive: Boolean = false,
     visibility: Float = 1f,
@@ -195,6 +213,26 @@ fun TvTopMenuBar(
     // that tab's dwell preview until focus leaves it. Android additionally
     // uses the first Down from that state as a direct handoff to content.
     var dwellSuppressedButton by remember { mutableStateOf<TvTopMenuFocus?>(null) }
+
+    // While a Back-close handoff is in flight, the anchor is the ONLY focusable
+    // bar element. Compose recovers focus the instant the cascade's node leaves
+    // composition and picks the bar's FIRST child — the search icon — a frame
+    // before the explicit request lands, so Back visibly flashed through search
+    // on its way to the anchor. Taking the other buttons out of focus search for
+    // that one window leaves the recovery nowhere to go but the anchor itself.
+    val handoffAnchor = dwellSuppressedButton?.takeIf { it != focusedButton }
+    fun canFocusButton(focus: TvTopMenuFocus): Boolean =
+        !isFocusSuppressed && (handoffAnchor == null || handoffAnchor == focus)
+
+    // The anchor focusing clears handoffAnchor and cancels this. If the request
+    // never lands, release the restriction rather than leaving the bar with a
+    // single focusable button.
+    LaunchedEffect(handoffAnchor) {
+        if (handoffAnchor != null) {
+            delay(TopMenuHandoffTimeoutMillis)
+            if (dwellSuppressedButton == handoffAnchor) dwellSuppressedButton = null
+        }
+    }
 
     fun focusForRoot(root: TvRootDestination): TvTopMenuFocus = when (root) {
         TvRootDestination.Home -> TvTopMenuFocus.Home
@@ -321,6 +359,15 @@ fun TvTopMenuBar(
             // so an ordinary content-to-bar Up arrives unsuppressed and opens
             // the cascade.
             if (focus == null || focus == suppressed) return@LaunchedEffect
+            // A DIFFERENT button may still be the handoff in flight rather than
+            // a real move: while the requested anchor is being applied, Compose
+            // briefly focuses the bar's first child (the Search icon). Clearing
+            // on that blip disarmed the suppression, so the anchor re-previewed
+            // the moment it actually landed — Back out of a cascade reopened it
+            // and the viewer was left one Back short of Home. Wait out the blip;
+            // this effect is keyed on focusedButton, so the anchor arriving
+            // cancels the delay and leaves the suppression armed.
+            delay(TopMenuSuppressionHandoffGraceMillis)
             // Moving anywhere else re-arms normal dwell behavior, matching
             // tvOS's dwellSuppressedElement lifecycle.
             dwellSuppressedButton = null
@@ -358,6 +405,21 @@ fun TvTopMenuBar(
     // trailing cluster). On non-tab routes (Search) we enter the search icon.
     val barEntryRequester = selectedEntryRequester()
 
+    // Publish the synchronous anchor-focus hook. This runs on the composition
+    // thread, so a Back handler can move focus BEFORE it removes the panel.
+    SideEffect {
+        onInstallAnchorFocus { panel ->
+            val target = panel?.let(::focusForPanel)
+            val requester = target?.let(::requesterForFocus) ?: selectedEntryRequester()
+            val moved = runCatching { requester.requestFocus() }.isSuccess
+            // Arm the suppression only if focus actually moved; otherwise the
+            // state-request fallback will arm it a frame later.
+            if (moved) dwellSuppressedButton = target
+            moved
+        }
+    }
+
+
     // Single full-width Row (wordmark · flexible gap · search+centered tabs ·
     // flexible gap · trailing profile) so D-pad Left/Right traverse the whole bar
     // in one ordered focus group — the three-zone `align` layout couldn't be
@@ -385,7 +447,15 @@ fun TvTopMenuBar(
                 // ignore explicit requester bumps. Otherwise Android's initial
                 // focus pass can still choose Home while content is composing.
                 canFocus = !isFocusSuppressed
-                enter = { barEntryRequester }
+                // While a Back-close handoff is in flight, the anchor is the
+                // entry point — not the selected tab. Closing a cascade removes
+                // the focused node and Compose recovers focus into the bar; if
+                // that recovery uses the group's first child it lands on the
+                // search icon and Back visibly flashes through search before the
+                // explicit request lands.
+                enter = {
+                    dwellSuppressedButton?.let(::requesterForFocus) ?: barEntryRequester
+                }
             }
             .onPreviewKeyEvent { event ->
                 val focus = focusedButton
@@ -451,7 +521,7 @@ fun TvTopMenuBar(
                 icon = Icons.Outlined.Search,
                 contentDescription = "Search",
                 isFocused = focusedButton == TvTopMenuFocus.Search,
-                canFocus = !isFocusSuppressed,
+                canFocus = canFocusButton(TvTopMenuFocus.Search),
                 focusRequester = searchFocusRequester,
                 onFocusChanged = { hasFocus ->
                     focusedButton = if (hasFocus) {
@@ -469,7 +539,7 @@ fun TvTopMenuBar(
                         label = "Home",
                         isSelected = selectedRoot == TvRootDestination.Home,
                         isFocused = focusedButton == TvTopMenuFocus.Home,
-                        canFocus = !isFocusSuppressed,
+                        canFocus = canFocusButton(TvTopMenuFocus.Home),
                         focusRequester = homeFocusRequester,
                         onFocusChanged = { hasFocus ->
                             focusedButton = if (hasFocus) {
@@ -488,7 +558,7 @@ fun TvTopMenuBar(
                             label = type.title,
                             isSelected = selectedRoot == destination,
                             isFocused = focusedButton == TvTopMenuFocus.Tab(type),
-                            canFocus = !isFocusSuppressed,
+                            canFocus = canFocusButton(TvTopMenuFocus.Tab(type)),
                             focusRequester = tabFocusRequesters[type] ?: homeFocusRequester,
                             onFocusChanged = { hasFocus ->
                                 focusedButton = if (hasFocus) {
@@ -512,7 +582,7 @@ fun TvTopMenuBar(
                         label = "For You",
                         isSelected = selectedRoot == TvRootDestination.ForYou,
                         isFocused = focusedButton == TvTopMenuFocus.ForYou,
-                        canFocus = !isFocusSuppressed,
+                        canFocus = canFocusButton(TvTopMenuFocus.ForYou),
                         focusRequester = forYouFocusRequester,
                         onFocusChanged = { hasFocus ->
                             focusedButton = if (hasFocus) {
@@ -534,7 +604,7 @@ fun TvTopMenuBar(
                         label = "Calendar",
                         isSelected = selectedRoot == TvRootDestination.Calendar,
                         isFocused = focusedButton == TvTopMenuFocus.Calendar,
-                        canFocus = !isFocusSuppressed,
+                        canFocus = canFocusButton(TvTopMenuFocus.Calendar),
                         focusRequester = calendarFocusRequester,
                         onFocusChanged = { hasFocus ->
                             focusedButton = if (hasFocus) {
@@ -566,7 +636,7 @@ fun TvTopMenuBar(
             TvTopMenuProfileButton(
                 accountState = accountState,
                 isFocused = focusedButton == TvTopMenuFocus.Profile,
-                canFocus = !isFocusSuppressed,
+                canFocus = canFocusButton(TvTopMenuFocus.Profile),
                 focusRequester = profileFocusRequester,
                 onFocusChanged = { hasFocus ->
                     focusedButton = if (hasFocus) TvTopMenuFocus.Profile else focusedButton.takeUnless { it == TvTopMenuFocus.Profile }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
@@ -253,9 +253,17 @@ fun TvTopMenuBar(
             requestIdentity = focusRequestIdentity,
             lastHandledRequest = lastHandledFocusRequest,
             isFocusSuppressed = isFocusSuppressed,
-            isTargetAvailable = focusRequestTargetAvailable,
+            // Availability gates only the EXPLICIT target, never the request
+            // itself. Skipping the whole request left nothing focused, so
+            // Compose's default search landed on the first bar element — the
+            // search icon — and Back out of a cascade appeared to "go to
+            // search". Falling back to the selected entry keeps the viewer on
+            // the tab they came from.
+            isTargetAvailable = true,
             requestFocus = {
-                val explicitFocus = focusRequestTarget?.let(::focusForPanel)
+                val explicitFocus = focusRequestTarget
+                    ?.takeIf { focusRequestTargetAvailable }
+                    ?.let(::focusForPanel)
                 // The target names which bar element to land on; it does NOT by
                 // itself mean the preview should be suppressed. Only a panel
                 // Back-close wants that. Arming it for every targeted request

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
@@ -417,14 +417,16 @@ fun TvTopMenuBar(
             // for any call that merely did not throw. That made a refused
             // claim look like a move, which armed suppression, closed the
             // panel and skipped the deferred fallback, leaving focus nowhere.
-            val moved = requester.claimFocusOrReport(
+            val accepted = requester.claimFocusOrReport(
                 target = "menu_anchor",
                 action = "back_close_anchor",
             )
-            // Arm the suppression only if focus actually moved; otherwise the
-            // state-request fallback will arm it a frame later.
-            if (moved) dwellSuppressedButton = target
-            moved
+            // Accepted is not arrival — the helper says so itself — but it
+            // does separate a claim that took from one that definitely needs
+            // the deferred retry. Arm the suppression only on acceptance;
+            // otherwise the state-request fallback arms it a frame later.
+            if (accepted) dwellSuppressedButton = target
+            accepted
         }
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
@@ -58,6 +58,7 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
+import org.siloserver.silo.tv.ui.focus.claimFocusOrReport
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.common.ui.components.profileAvatarDisplayText
 import org.siloserver.silo.tv.ui.theme.ChromeSelectedBorder
@@ -411,7 +412,15 @@ fun TvTopMenuBar(
         onInstallAnchorFocus { panel ->
             val target = panel?.let(::focusForPanel)
             val requester = target?.let(::requesterForFocus) ?: selectedEntryRequester()
-            val moved = runCatching { requester.requestFocus() }.isSuccess
+            // requestFocus() RETURNS whether the claim was accepted, so
+            // runCatching{}.isSuccess threw the real answer away — it is true
+            // for any call that merely did not throw. That made a refused
+            // claim look like a move, which armed suppression, closed the
+            // panel and skipped the deferred fallback, leaving focus nowhere.
+            val moved = requester.claimFocusOrReport(
+                target = "menu_anchor",
+                action = "back_close_anchor",
+            )
             // Arm the suppression only if focus actually moved; otherwise the
             // state-request fallback will arm it a frame later.
             if (moved) dwellSuppressedButton = target

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusStateTest.kt
@@ -196,7 +196,57 @@ class TvShellFocusStateTest {
 
         assertEquals(TvShellBackAction.ClosePanelPreview, action)
         assertNull(s.openPanel)
-        assertEquals(menuBefore, s.menuFocusRequest, "focus was already on the bar; nothing to move")
+        // Focus is on the bar, but not necessarily on the ANCHOR: with no
+        // target named, the bar falls back to the SELECTED tab — Home, or the
+        // search icon on the Search route — so backing out of Movies' cascade
+        // landed on Home. Name the anchor, and suppress its dwell so it does
+        // not immediately re-preview the cascade Back just dismissed.
+        assertEquals(menuBefore + 1, s.menuFocusRequest)
+        assertEquals(moviesPanel, s.menuFocusTarget)
+        assertTrue(s.menuFocusSuppressesDwell)
+    }
+
+    /**
+     * When the bar has installed its synchronous hook, focus moves while the
+     * panel is still composed and the state request is not needed. Ordering is
+     * the whole point: closing first lets Compose recover focus onto the bar's
+     * first child (the search icon) a frame before any request of ours lands,
+     * which is a visible flash through search on every Back.
+     */
+    @Test
+    fun theSynchronousAnchorHookReplacesTheDeferredFocusRequest() {
+        val s = TvShellFocusState()
+        val anchors = mutableListOf<TvTopMenuPanel?>()
+        var panelStillOpenWhenFocusMoved: TvTopMenuPanel? = null
+        s.focusBarAnchorNow = { anchor ->
+            anchors += anchor
+            panelStillOpenWhenFocusMoved = s.openPanel
+            true
+        }
+        s.previewPanel(moviesPanel)
+        val menuBefore = s.menuFocusRequest
+
+        assertEquals(TvShellBackAction.ClosePanelPreview, s.onBack(onTabRoot = true))
+
+        assertEquals(listOf<TvTopMenuPanel?>(moviesPanel), anchors)
+        assertEquals(moviesPanel, panelStillOpenWhenFocusMoved)
+        assertNull(s.openPanel)
+        assertEquals(menuBefore, s.menuFocusRequest, "the hook moved focus; no deferred request needed")
+    }
+
+    /** A hook that could not move focus still falls back to the request. */
+    @Test
+    fun aFailedAnchorHookFallsBackToTheDeferredRequest() {
+        val s = TvShellFocusState()
+        s.focusBarAnchorNow = { false }
+        s.previewPanel(moviesPanel)
+        val menuBefore = s.menuFocusRequest
+
+        s.onBack(onTabRoot = true)
+
+        assertEquals(menuBefore + 1, s.menuFocusRequest)
+        assertEquals(moviesPanel, s.menuFocusTarget)
+        assertTrue(s.menuFocusSuppressesDwell)
     }
 
     /**
@@ -426,9 +476,8 @@ class TvShellFocusStateTest {
     fun onBackAppliesTheStateHalfAndReportsTheAction() {
         val s = TvShellFocusState()
 
-        // Panel open → ClosePanel, panel cleared, and the bar deliberately NOT
-        // nudged: Back out of a cascade hands focus to content, so the holder
-        // must not claim it for the bar. The caller performs that move.
+        // Panel open → ClosePanel, panel cleared, and focus returned to the
+        // anchor tab.
         s.enterPanel(moviesPanel)
         // Entry INTENT is not entry: routing waits for the panel to report that
         // something inside it actually holds focus.
@@ -436,7 +485,11 @@ class TvShellFocusStateTest {
         val menuBefore = s.menuFocusRequest
         assertEquals(TvShellBackAction.ClosePanel, s.onBack(onTabRoot = true))
         assertNull(s.openPanel)
-        assertEquals(menuBefore, s.menuFocusRequest)
+        // Back out of an ENTERED cascade also returns to the anchor tab rather
+        // than diving into content — the tab the viewer was browsing, with its
+        // dwell suppressed so the cascade does not spring straight back open.
+        assertEquals(menuBefore + 1, s.menuFocusRequest)
+        assertEquals(moviesPanel, s.menuFocusTarget)
 
         // Profile open → CloseProfileMenu, dropdown closed and avatar nudged.
         s.previewProfileMenu()

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusStateTest.kt
@@ -266,6 +266,57 @@ class TvShellFocusStateTest {
         )
     }
 
+    /**
+     * The stranding bug, reproduced on a Google TV Streamer: Back from content
+     * asks the bar to take focus, the bar never reports taking it, and every
+     * subsequent Back re-evaluates to the same request. Four consecutive
+     * "focus request -> menu" with no "focused -> menu" between them, and Home
+     * and exit unreachable for as long as it lasts.
+     */
+    @Test
+    fun aSecondBackGoesHomeWhenTheBarNeverTookFocus() {
+        val s = TvShellFocusState()
+
+        // First Back climbs toward the bar.
+        assertEquals(TvShellBackAction.MoveFocusToMenu, s.onBack(onTabRoot = true))
+        assertTrue(s.barHandoffAttempted)
+
+        // The bar never answers — updateMenuFocused(true) never arrives.
+        assertEquals(
+            TvShellBackAction.MenuBack,
+            s.onBack(onTabRoot = true),
+            "a repeat request is what stranded the viewer; the second Back must progress",
+        )
+    }
+
+    /** When the bar DOES answer, the ladder is unchanged. */
+    @Test
+    fun aBarThatTakesFocusStillGetsTheNormalLadder() {
+        val s = TvShellFocusState()
+
+        assertEquals(TvShellBackAction.MoveFocusToMenu, s.onBack(onTabRoot = true))
+        s.updateMenuFocused(true)
+        assertFalse(s.barHandoffAttempted, "the bar answered, so nothing is outstanding")
+
+        assertEquals(TvShellBackAction.MenuBack, s.onBack(onTabRoot = true))
+    }
+
+    @Test
+    fun closingAPanelForgetsAnUnansweredHandoff() {
+        val s = TvShellFocusState()
+        s.onBack(onTabRoot = true)
+        assertTrue(s.barHandoffAttempted)
+
+        s.closePanel()
+
+        assertFalse(s.barHandoffAttempted)
+        assertEquals(
+            TvShellBackAction.MoveFocusToMenu,
+            s.onBack(onTabRoot = true),
+            "a fresh Back after a deliberate focus move should climb again, not skip to Home",
+        )
+    }
+
     @Test
     fun dwellPreviewNeverOverridesAnEnteredPanel() {
         val s = TvShellFocusState()

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusStateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvShellFocusStateTest.kt
@@ -339,6 +339,26 @@ class TvShellFocusStateTest {
         )
     }
 
+    /**
+     * The escalation must never fire on Home, because MenuBack there means
+     * EXIT. An earlier cut of this branch escalated unconditionally, so a bar
+     * that never answered on Home turned the second Back into a silent app
+     * exit — a worse failure than the stranding it was meant to fix.
+     */
+    @Test
+    fun theEscalationNeverExitsTheAppFromHome() {
+        val s = TvShellFocusState()
+
+        assertEquals(TvShellBackAction.MoveFocusToMenu, s.onBack(onTabRoot = true, onHome = true))
+        assertTrue(s.barHandoffAttempted, "the handoff is outstanding, exactly as off Home")
+
+        assertEquals(
+            TvShellBackAction.MoveFocusToMenu,
+            s.onBack(onTabRoot = true, onHome = true),
+            "on Home the unanswered handoff repeats rather than escalating to exit",
+        )
+    }
+
     /** When the bar DOES answer, the ladder is unchanged. */
     @Test
     fun aBarThatTakesFocusStillGetsTheNormalLadder() {


### PR DESCRIPTION
Back out of a top-bar cascade did not leave the viewer where they expected, and Home could be unreachable. Found and fixed against a Google TV Streamer, using the focus telemetry to see what actually happened rather than what the code implied.

## What was wrong

**Back landed on the wrong tab.** Backing out of an entered cascade took a path that moved no focus at all, so the bar fell back to `selectedEntryRequester()` — the *selected* tab. Back out of Movies' cascade and you landed on Home. On the Search route the same fallback is the search icon, which is where the "Back goes to search" reports came from.

**The cascade sprang straight back open.** Once the anchor was named, its dwell preview re-opened ~250ms later, so the next Back was spent closing that preview instead of reaching `MenuBack` — and Home stayed unreachable. The suppression that should have prevented this was armed, then disarmed by a transient focus on the bar's first child while the request was still being applied.

**Back visibly flashed through the search icon.** Closing a cascade removes the focused node, and Compose recovers focus a frame before any request of ours can land — it picks the bar's first child. Nothing written to state can win that frame. Arming the suppression, restricting focusability during the handoff, and pointing the focus group's `enter` at the anchor were each applied a recomposition too late; making the retry helper's first attempt immediate did remove the flash but regressed where focus comes to rest, so it was reverted.

## The fix

Move focus to the anchor tab **while the panel is still composed**, then close it. There is no recovery left to lose, so there is no intermediate claim to flash through. The existing deferred request stays as the fallback for when the bar has not installed its hook or the anchor is not focusable yet, and a short grace period keeps a non-anchor focus from disarming the suppression during the handoff.

## Verification

- `:androidTvApp:testDebugUnitTest` passes, including new cases covering the synchronous hook, the fallback when it cannot move focus, and the anchor/suppression contract. Two existing tests asserted the old "do not move focus" contract and were updated deliberately.
- On a Google TV Streamer, isolated to the Back press: `close -> root_panel`, `dwelleff -> f_null_s_Tab(Movies)`, `focused -> menu`, `dwelleff -> f_Tab(Movies)_s_Tab(Movies)`. No search in the trace, no re-preview, and Back rests on the Movies tab.
- Lint was **not** run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9UyH5fvug685dzUFLtdpW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Back-button navigation when search or menu focus cannot be restored.
  - Repeated Back presses now reliably navigate away instead of becoming unresponsive.
  - Closing panels returns focus to the appropriate menu anchor without immediately reopening previews.
  - Improved focus recovery during transitions between the search bar, panels, and top menu.

- **Tests**
  - Added coverage for focus recovery, repeated Back presses, and panel dismissal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->