### PR TITLE
fix(tv): observe focus arrival per target, not per screen

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
@@ -380,7 +380,16 @@ fun TvCalendarScreen(
 
     CompositionLocalProvider(LocalAmbientBackdropTint provides tintState) {
         Box(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                // The zone callbacks only fire when a calendar control or shelf
+                // GAINS focus, so moving Up from the filter into the top menu
+                // left the flag true with focus outside the screen entirely.
+                // A later shell handoff then read that stale true, skipped both
+                // claims, and still reported initial content focus — and only
+                // another calendar zone gaining focus could clear it, which the
+                // skipped handoff could never cause.
+                .onFocusChanged { if (!it.hasFocus) calendarFilterHasFocus = false },
         ) {
             TvRootHeroBackdrop(
                 content = null,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
@@ -436,7 +436,16 @@ fun TvCalendarScreen(
                 listState = listState,
                 controls = controls,
                 activeFilterFocusRequester = filterFocusRequesters[state.filter] ?: filterFocusRequester,
-                onControlFocused = snapControlsToInitialPosition,
+                onControlFocused = { zone ->
+                    // The flag this screen's filter claim is observed on. It was
+                    // declared and never assigned, so it read false forever: the
+                    // claim burned every attempt and reported Exhausted even when
+                    // focus had landed, which meant the reconfirm after Android's
+                    // delayed focus pass, the bar-suppression release and
+                    // onInitialContentFocus() never ran.
+                    calendarFilterHasFocus = zone == CalendarControlFocusZone.Filter
+                    if (zone != null) snapControlsToInitialPosition()
+                },
                 onFocusRequestAcknowledged = {
                     if (lastAppliedFocusRequest != focusRequest) {
                         lastAppliedFocusRequest = focusRequest
@@ -943,7 +952,14 @@ private fun CalendarList(
     listState: LazyListState,
     controls: @Composable ((CalendarControlFocusZone) -> Unit) -> Unit,
     activeFilterFocusRequester: FocusRequester,
-    onControlFocused: () -> Unit,
+    /**
+     * Which control zone holds focus, or null when the controls lose it.
+     *
+     * The zone matters: the screen's filter claim is observed on the filter row
+     * specifically, and a caller that only hears "some control took focus"
+     * cannot tell that apart from the week strip.
+     */
+    onControlFocused: (CalendarControlFocusZone?) -> Unit,
     onFocusRequestAcknowledged: () -> Unit,
     onRefresh: () -> Unit,
     onShowEverything: () -> Unit,
@@ -961,7 +977,10 @@ private fun CalendarList(
     var selectedDayHasFocus by remember { mutableStateOf(false) }
     var isReturningToControls by remember { mutableStateOf(false) }
     var focusedControlZone by remember { mutableStateOf<CalendarControlFocusZone?>(null) }
-    val clearControlFocusZone: () -> Unit = { focusedControlZone = null }
+    val clearControlFocusZone: () -> Unit = {
+        focusedControlZone = null
+        onControlFocused(null)
+    }
     val firstFocusableDayIndex = state.weekDates.indexOfFirst { state.itemsFor(it).isNotEmpty() }
     val onShelfFocused: (Int) -> Unit = { index ->
         // Item zero is the filter/week control shell.
@@ -1000,7 +1019,7 @@ private fun CalendarList(
     var focusedShelfIndex by remember { mutableStateOf<Int?>(null) }
     val onCalendarControlFocused: (CalendarControlFocusZone) -> Unit = { zone ->
         focusedControlZone = zone
-        onControlFocused()
+        onControlFocused(zone)
         onFocusRequestAcknowledged()
     }
     val currentCalendarUpFallback = rememberUpdatedState<(Boolean) -> Boolean> { isRepeat ->

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestsScreen.kt
@@ -97,7 +97,18 @@ fun TvRequestsScreen(
     val visibleSearchResults = searchState.results.filterTvRequestResults()
     val visibleDiscoverSections = state.sections.filterTvRequestSections()
     val searchFieldFocusRequester = remember { FocusRequester() }
-    var requestsScreenHasFocus by remember { mutableStateOf(false) }
+    // Observed per REGION. requestFocusUntilObserved tests isFocused() before
+    // it requests anything, so a screen-wide flag meant the post-search claim
+    // was skipped outright: you are in the search field when the results land,
+    // the flag is already true, and focus never moves to them.
+    var focusedRegion by remember { mutableStateOf<TvRequestsFocusRegion?>(null) }
+    val setFocusedRegion: (TvRequestsFocusRegion, Boolean) -> Unit = { region, focused ->
+        if (focused) {
+            focusedRegion = region
+        } else if (focusedRegion == region) {
+            focusedRegion = null
+        }
+    }
     val firstFilterChipFocusRequester = remember { FocusRequester() }
     val firstResultFocusRequester = remember { FocusRequester() }
     val hasSubmittedQuery = searchState.hasSubmittedQuery
@@ -140,7 +151,7 @@ fun TvRequestsScreen(
             maxAttempts = TvContentInitialFocusMaxAttempts,
             awaitAttempt = { withFrameNanos { } },
             requestFocus = searchFieldFocusRequester::requestFocus,
-            isFocused = { requestsScreenHasFocus },
+            isFocused = { focusedRegion == TvRequestsFocusRegion.Field },
         )
         if (landed == TvObservedFocusResult.Focused) onInitialContentFocus()
         initialFocusRequested = true
@@ -153,11 +164,16 @@ fun TvRequestsScreen(
             } else {
                 firstFilterChipFocusRequester
             }
+            val targetRegion = if (hasSearchResults) {
+                TvRequestsFocusRegion.Results
+            } else {
+                TvRequestsFocusRegion.Chips
+            }
             requestFocusUntilObserved(
                 maxAttempts = TvContentInitialFocusMaxAttempts,
                 awaitAttempt = { withFrameNanos { } },
                 requestFocus = target::requestFocus,
-                isFocused = { requestsScreenHasFocus },
+                isFocused = { focusedRegion == targetRegion },
             )
             focusResultsAfterSearch = false
         }
@@ -213,7 +229,6 @@ fun TvRequestsScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .onFocusChanged { requestsScreenHasFocus = it.hasFocus }
             .background(MaterialTheme.colorScheme.background),
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -231,6 +246,8 @@ fun TvRequestsScreen(
                 firstFilterChipFocusRequester = firstFilterChipFocusRequester,
                 firstResultFocusRequester = firstResultFocusRequester,
                 hasFocusableResult = hasFocusableResult,
+                onFieldFocusChanged = { setFocusedRegion(TvRequestsFocusRegion.Field, it) },
+                onChipsFocusChanged = { setFocusedRegion(TvRequestsFocusRegion.Chips, it) },
                 onQueryChanged = { query -> searchViewModel.onQueryChanged(query) },
                 onSearch = {
                     focusResultsAfterSearch = searchState.query.isNotBlank()
@@ -255,7 +272,11 @@ fun TvRequestsScreen(
                     message = state.error ?: "Search movies and series to request them.",
                 )
                 else -> LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .onFocusChanged {
+                            setFocusedRegion(TvRequestsFocusRegion.Results, it.hasFocus)
+                        },
                     verticalArrangement = Arrangement.spacedBy(24.dp),
                     contentPadding = PaddingValues(bottom = 56.dp),
                 ) {
@@ -396,6 +417,9 @@ private fun RequestSearchEmptyItem(message: String) {
     )
 }
 
+/** Focus regions a claim on this screen can aim at. */
+private enum class TvRequestsFocusRegion { Field, Chips, Results }
+
 @Composable
 private fun RequestsHeader(
     query: String,
@@ -406,6 +430,8 @@ private fun RequestsHeader(
     firstFilterChipFocusRequester: FocusRequester,
     firstResultFocusRequester: FocusRequester,
     hasFocusableResult: Boolean,
+    onFieldFocusChanged: (Boolean) -> Unit,
+    onChipsFocusChanged: (Boolean) -> Unit,
     onQueryChanged: (String) -> Unit,
     onSearch: () -> Unit,
     onMediaTypeChanged: (String?) -> Unit,
@@ -466,11 +492,13 @@ private fun RequestsHeader(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(48.dp)
+                    .onFocusChanged { onFieldFocusChanged(it.isFocused) }
                     .focusRequester(searchFieldFocusRequester)
                     .focusProperties { down = firstFilterChipFocusRequester },
                 colors = tvOutlinedTextFieldColors(),
             )
             LazyRow(
+                modifier = Modifier.onFocusChanged { onChipsFocusChanged(it.hasFocus) },
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
                 contentPadding = PaddingValues(end = Spacing.xs),
                 verticalAlignment = Alignment.CenterVertically,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
@@ -186,7 +186,21 @@ fun TvSearchScreen(
             action = "keyboard_dismissed",
         )
     }
-    var searchScreenHasFocus by remember { mutableStateOf(false) }
+    // Which REGION holds focus. A screen-wide flag cannot answer the question
+    // these claims actually ask. requestFocusUntilObserved tests isFocused()
+    // before it ever calls requestFocus, so "something on the search screen has
+    // focus" made every claim below a no-op the moment the screen owned focus
+    // at all — which is always, once you are on it. Back from a result never
+    // returned to the field, and a submitted search never handed you its
+    // results, because in both cases the flag was already true.
+    var focusedRegion by remember { mutableStateOf<TvSearchFocusRegion?>(null) }
+    val setFocusedRegion: (TvSearchFocusRegion, Boolean) -> Unit = { region, focused ->
+        if (focused) {
+            focusedRegion = region
+        } else if (focusedRegion == region) {
+            focusedRegion = null
+        }
+    }
     val requestMediaType = state.mediaType.toRequestMediaType()
     val visibleRequestResults = requestState.results
         .filterTvRequestResults()
@@ -246,7 +260,7 @@ fun TvSearchScreen(
                 maxAttempts = TvContentInitialFocusMaxAttempts,
                 awaitAttempt = { withFrameNanos { } },
                 requestFocus = activeSearchFieldFocusRequester::requestFocus,
-                isFocused = { searchScreenHasFocus },
+                isFocused = { focusedRegion == TvSearchFocusRegion.Field },
             )
         }
         hasEnteredSearch = true
@@ -377,7 +391,7 @@ fun TvSearchScreen(
                     maxAttempts = TvFrameRelocationMaxAttempts,
                     awaitAttempt = { androidx.compose.runtime.withFrameNanos { } },
                     requestFocus = restoreCatalogFocusRequester::requestFocus,
-                    isFocused = { searchScreenHasFocus },
+                    isFocused = { focusedRegion == TvSearchFocusRegion.CatalogResults },
                 )
             }
             TvSearchRequestSectionId -> {
@@ -386,7 +400,7 @@ fun TvSearchScreen(
                     maxAttempts = TvFrameRelocationMaxAttempts,
                     awaitAttempt = { androidx.compose.runtime.withFrameNanos { } },
                     requestFocus = restoreRequestFocusRequester::requestFocus,
-                    isFocused = { searchScreenHasFocus },
+                    isFocused = { focusedRegion == TvSearchFocusRegion.RequestResults },
                 )
             }
         }
@@ -420,7 +434,7 @@ fun TvSearchScreen(
             maxAttempts = TvFrameRelocationMaxAttempts,
             awaitAttempt = { androidx.compose.runtime.withFrameNanos { } },
             requestFocus = activeSearchFieldFocusRequester::requestFocus,
-            isFocused = { searchScreenHasFocus },
+            isFocused = { focusedRegion == TvSearchFocusRegion.Field },
         )
     }
     LaunchedEffect(
@@ -445,11 +459,17 @@ fun TvSearchScreen(
             state.error != null -> feedbackActionFocusRequester
             else -> firstFilterChipFocusRequester
         }
+        val postSearchRegion = when {
+            state.items.isNotEmpty() -> TvSearchFocusRegion.CatalogResults
+            visibleRequestResults.isNotEmpty() -> TvSearchFocusRegion.RequestResults
+            state.error != null -> TvSearchFocusRegion.Feedback
+            else -> TvSearchFocusRegion.Chips
+        }
         requestFocusUntilObserved(
             maxAttempts = TvContentInitialFocusMaxAttempts,
             awaitAttempt = { withFrameNanos { } },
             requestFocus = postSearchTarget::requestFocus,
-            isFocused = { searchScreenHasFocus },
+            isFocused = { focusedRegion == postSearchRegion },
         )
     }
     // Note: we deliberately do NOT auto-jump focus to the first result when
@@ -464,10 +484,6 @@ fun TvSearchScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            // Every focus target on this screen — field, chips, results,
-            // request rows, feedback action — lives under here, so "focus is on
-            // the search screen" is the arrival each claim below waits on.
-            .onFocusChanged { searchScreenHasFocus = it.hasFocus }
             .background(MaterialTheme.colorScheme.background),
     ) {
         TvCatalogGrid(
@@ -504,6 +520,7 @@ fun TvSearchScreen(
             restoreItemIndex = restoreCatalogIndex,
             restoreItemFocusRequester = restoreCatalogFocusRequester,
             onItemFocusedAtIndex = { item, _, focused ->
+                setFocusedRegion(TvSearchFocusRegion.CatalogResults, focused)
                 val id = tvSearchCatalogItemId(item.contentId)
                 if (focused) {
                     focusedReturnItemId = id
@@ -533,7 +550,13 @@ fun TvSearchScreen(
                     searchFieldFocusRequester = activeSearchFieldFocusRequester,
                     firstFilterChipFocusRequester = firstFilterChipFocusRequester,
                     firstContentFocusRequester = firstContentFocusRequester,
-                    onSearchFieldFocusChanged = onSearchFieldFocusChanged,
+                    onSearchFieldFocusChanged = { focused ->
+                        setFocusedRegion(TvSearchFocusRegion.Field, focused)
+                        onSearchFieldFocusChanged(focused)
+                    },
+                    onChipsFocusChanged = { focused ->
+                        setFocusedRegion(TvSearchFocusRegion.Chips, focused)
+                    },
                     onQueryChanged = viewModel::onQueryChanged,
                     onSearch = {
                         pendingSearchFocus = true
@@ -563,6 +586,7 @@ fun TvSearchScreen(
                     restoreItemIndex = restoreRequestIndex,
                     restoreItemFocusRequester = restoreRequestFocusRequester,
                     onItemFocusChanged = { item, _, focused ->
+                        setFocusedRegion(TvSearchFocusRegion.RequestResults, focused)
                         val id = tvSearchRequestItemId(item.mediaType, item.tmdbId)
                         if (focused) {
                             focusedReturnItemId = id
@@ -598,6 +622,9 @@ fun TvSearchScreen(
                         actionLabel = "Try again",
                         actionFocusRequester = feedbackActionFocusRequester,
                         actionUpFocusRequester = firstFilterChipFocusRequester,
+                        onActionFocusChanged = { focused ->
+                            setFocusedRegion(TvSearchFocusRegion.Feedback, focused)
+                        },
                         onAction = viewModel::submitSearch,
                     )
                     else -> SearchFeedbackMessage(
@@ -715,6 +742,15 @@ private fun RequestSearchFeedbackRow(
 }
 
 @OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
+/**
+ * The focus regions a claim on this screen can aim at.
+ *
+ * Each claim is observed on the region it actually asked for, so moving focus
+ * WITHIN the screen — field to results, results back to field — is a state the
+ * arrival test can distinguish. A single screen-wide hasFocus could not.
+ */
+private enum class TvSearchFocusRegion { Field, Chips, CatalogResults, RequestResults, Feedback }
+
 @Composable
 private fun SearchStage(
     query: String,
@@ -726,6 +762,7 @@ private fun SearchStage(
     firstFilterChipFocusRequester: FocusRequester,
     firstContentFocusRequester: FocusRequester,
     onSearchFieldFocusChanged: (Boolean) -> Unit,
+    onChipsFocusChanged: (Boolean) -> Unit,
     onQueryChanged: (String) -> Unit,
     onSearch: () -> Unit,
     onMediaTypeChanged: (TvSearchMediaType) -> Unit,
@@ -834,7 +871,9 @@ private fun SearchStage(
         }
 
         LazyRow(
-            modifier = Modifier.focusRestorer(firstFilterChipFocusRequester),
+            modifier = Modifier
+                .onFocusChanged { onChipsFocusChanged(it.hasFocus) }
+                .focusRestorer(firstFilterChipFocusRequester),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             contentPadding = PaddingValues(end = Spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
@@ -905,6 +944,7 @@ private fun SearchFeedbackMessage(
     actionLabel: String? = null,
     actionFocusRequester: FocusRequester? = null,
     actionUpFocusRequester: FocusRequester? = null,
+    onActionFocusChanged: (Boolean) -> Unit = {},
     onAction: (() -> Unit)? = null,
 ) {
     Row(
@@ -942,6 +982,7 @@ private fun SearchFeedbackMessage(
                     onClick = onAction,
                     modifier = Modifier
                         .padding(top = Spacing.sm)
+                        .onFocusChanged { onActionFocusChanged(it.isFocused) }
                         .then(
                             if (actionFocusRequester != null) {
                                 Modifier.focusRequester(actionFocusRequester)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
@@ -383,6 +383,11 @@ fun TvSearchScreen(
             return@LaunchedEffect
         }
 
+        // Observed on the CARD, not the region. A return is a claim on one
+        // specific item, so "some result has focus" is the same too-coarse test
+        // this file just removed everywhere else: any already-focused card in
+        // the region satisfied it and the saved card was never requested, which
+        // is precisely the case a return exists to serve.
         when (located.sectionId) {
             TvSearchCatalogSectionId -> {
                 restoreCatalogIndex = located.itemIndex
@@ -391,7 +396,7 @@ fun TvSearchScreen(
                     maxAttempts = TvFrameRelocationMaxAttempts,
                     awaitAttempt = { androidx.compose.runtime.withFrameNanos { } },
                     requestFocus = restoreCatalogFocusRequester::requestFocus,
-                    isFocused = { focusedRegion == TvSearchFocusRegion.CatalogResults },
+                    isFocused = { focusedReturnItemId == located.itemId },
                 )
             }
             TvSearchRequestSectionId -> {
@@ -400,7 +405,7 @@ fun TvSearchScreen(
                     maxAttempts = TvFrameRelocationMaxAttempts,
                     awaitAttempt = { androidx.compose.runtime.withFrameNanos { } },
                     requestFocus = restoreRequestFocusRequester::requestFocus,
-                    isFocused = { focusedRegion == TvSearchFocusRegion.RequestResults },
+                    isFocused = { focusedReturnItemId == located.itemId },
                 )
             }
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/search/TvSearchScreen.kt
@@ -520,12 +520,22 @@ fun TvSearchScreen(
             restoreItemIndex = restoreCatalogIndex,
             restoreItemFocusRequester = restoreCatalogFocusRequester,
             onItemFocusedAtIndex = { item, _, focused ->
-                setFocusedRegion(TvSearchFocusRegion.CatalogResults, focused)
+                // Guarded on item IDENTITY, not just the region. These callbacks
+                // are per card, and Compose can deliver the newly focused card
+                // before the outgoing one reports false — a bare region flag
+                // would then be cleared by the card that just lost focus, right
+                // after the new one set it. Recycling an outgoing item has the
+                // same shape. A stale false whose id is no longer the focused
+                // one is ignored here.
                 val id = tvSearchCatalogItemId(item.contentId)
                 if (focused) {
                     focusedReturnItemId = id
+                    focusedRegion = TvSearchFocusRegion.CatalogResults
                 } else if (focusedReturnItemId == id) {
                     focusedReturnItemId = null
+                    if (focusedRegion == TvSearchFocusRegion.CatalogResults) {
+                        focusedRegion = null
+                    }
                 }
             },
             // UP from the first card always lands back on the filter chip rail.
@@ -586,12 +596,18 @@ fun TvSearchScreen(
                     restoreItemIndex = restoreRequestIndex,
                     restoreItemFocusRequester = restoreRequestFocusRequester,
                     onItemFocusChanged = { item, _, focused ->
-                        setFocusedRegion(TvSearchFocusRegion.RequestResults, focused)
+                        // Identity-guarded for the same reason as the catalog
+                        // cards above: a late false from the card that just
+                        // lost focus must not clear the region the new one set.
                         val id = tvSearchRequestItemId(item.mediaType, item.tmdbId)
                         if (focused) {
                             focusedReturnItemId = id
+                            focusedRegion = TvSearchFocusRegion.RequestResults
                         } else if (focusedReturnItemId == id) {
                             focusedReturnItemId = null
+                            if (focusedRegion == TvSearchFocusRegion.RequestResults) {
+                                focusedRegion = null
+                            }
                         }
                     },
                     onItemClicked = { item, index ->


### PR DESCRIPTION
`requestFocusUntilObserved` tests `isFocused()` **before** it ever calls `requestFocus`:

```kotlin
repeat(maxAttempts) {
    awaitAttempt()
    if (isFocused()) return TvObservedFocusResult.Focused   // <- no request is made
    ...
}
```

So an arrival test broader than the thing being asked for turns the whole claim into a no-op. Five sites got this wrong, in two opposite directions. This is the same defect fixed for the player overlay in #214; these are the rest of them.

## Always true — the claim never fires

`TvSearchScreen` and `TvRequestsScreen` both waited on a screen-root `hasFocus`, which is already true the moment you are on the screen at all. The comment at the old `TvSearchScreen` observer said so outright — *"every focus target on this screen lives under here, so 'focus is on the search screen' is the arrival each claim below waits on"* — which is the wrong granularity as soon as a claim has to move focus **within** the screen.

- **Back from a result never returned to the search field.** A result holding focus is exactly the state that satisfied the test.
- **A submitted search never handed you its results.** You are in the field when they land, so the flag is already true and focus stays there.
- **Return-restoration onto the card you left from** was a coin flip on whether the root had reacquired focus yet.
- **Requests** had the same post-search failure.

## Always false — the claim can never be confirmed

`TvCalendarScreen.calendarFilterHasFocus` was declared and never assigned anywhere, so it read `false` forever. The claim burned every attempt and returned `Exhausted` even when focus had landed, so `applied` was always false — and the reconfirm after Android's delayed focus pass, the bar-suppression release, and `onInitialContentFocus()` never ran.

Fixing it needed the control-focus callback widened to carry **which** zone took focus (and `null` when the controls lose it): "some control got focus" cannot distinguish the filter row from the week strip, and the filter claim is observed on the filter row specifically.

## The shape of the fix

Each claim is observed on the region it actually asked for, so moving focus within a screen is a state the test can distinguish. Search and Requests get a small `FocusRegion` enum fed by the existing per-item and field focus callbacks, plus one observer each on the chip rail and (for Search) the feedback action.

## Verification

- `:androidTvApp:testDebugUnitTest` passes.
- Built and installed on a Google TV Streamer alongside #214/#215.
- These three screens were **not** exercised by me on the device: driving text into the Compose search field over adb does not work (neither `input text` nor hardware keyevents reach it), so the Search and Requests paths were verified by reading, not by pressing. Calendar likewise.
- Lint was **not** run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9UyH5fvug685dzUFLtdpW
