### PR TITLE
ci: cache Robolectric's Android runtimes

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -43,6 +43,24 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
+      # Robolectric does NOT resolve its Android runtimes through Gradle. At test
+      # execution time it fetches android-all-instrumented straight from Maven
+      # Central into ~/.m2, which setup-gradle's cache does not cover — so every
+      # run re-downloaded 85-204 MB per SDK level. On 2026-08-11 Maven Central
+      # answered 403 and took out 31 unrelated tests in android-shared, and the
+      # download time is a large part of this job.
+      #
+      # Keyed on the version catalogue so bumping Robolectric repopulates; the
+      # restore-key still seeds a bump from the previous cache rather than
+      # starting cold.
+      - name: Cache Robolectric Android runtimes
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.m2/repository/org/robolectric
+          key: robolectric-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: |
+            robolectric-${{ runner.os }}-
+
       - name: Run unit tests
         shell: bash
         run: |

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -50,14 +50,23 @@ jobs:
       # answered 403 and took out 31 unrelated tests in android-shared, and the
       # download time is a large part of this job.
       #
-      # Keyed on the version catalogue so bumping Robolectric repopulates; the
-      # restore-key still seeds a bump from the previous cache rather than
-      # starting cold.
+      # Which runtimes get fetched depends on the Robolectric version AND on the
+      # SDK each test resolves to, so the key hashes the version catalogue and
+      # the module build files (min/target SDK) together. A new @Config(sdk=NN)
+      # in a test is deliberately NOT in the key: hashing test sources would
+      # bust this cache on nearly every pull request, which costs more than it
+      # saves. The residual gap is bounded — that one runtime is re-fetched each
+      # run until something else moves the key — and the restore-key prefix
+      # still seeds from the previous cache rather than starting cold.
+      #
+      # A run-id-suffixed key would close the gap by saving every run, but this
+      # cache is hundreds of MB; a new entry per run would evict the Gradle
+      # cache against the repository's 10 GB budget.
       - name: Cache Robolectric Android runtimes
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository/org/robolectric
-          key: robolectric-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          key: robolectric-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', '**/build.gradle.kts') }}
           restore-keys: |
             robolectric-${{ runner.os }}-
 


### PR DESCRIPTION
## The problem

Robolectric does not resolve its Android runtimes through Gradle. At **test execution** time it reaches out to Maven Central itself (`MavenArtifactFetcher`) and downloads `android-all-instrumented` into `~/.m2/repository`. `setup-gradle` caches `~/.gradle`, which does not cover that path — so every CI run re-downloads them.

They are not small:

| API | Size |
|---|---|
| 24 | 85 MB |
| 32 / 33 | 148 / 156 MB |
| 34 | 145 MB |
| 35 | 191 MB |
| 36 | 204 MB |

On 2026-08-11 Maven Central answered **403** for one of these fetches:

```
java.io.IOException: Server returned HTTP response code: 403 for URL:
https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/7.0.0_r1-robolectric-r1-i7/...pom.sha512
```

31 tests failed in `android-shared` — sync, PiP, DB migration, downloads, pairing — on a pull request that touched none of them. Re-running the job was the only remedy. The download time is also a large part of why the unit-test job takes 4–5 minutes when the tests themselves run in seconds.

## The change

One `actions/cache` step on `~/.m2/repository/org/robolectric`, keyed on `gradle/libs.versions.toml` so bumping Robolectric repopulates, with a `restore-keys` prefix so a bump seeds from the previous cache instead of starting cold.

This does not make a genuinely cold cache safe — it moves that exposure from *every run* to *when Robolectric is bumped*.

## Verification

The workflow change is exercised by this PR's own run: for `pull_request` events the workflow is taken from the branch, so the cache step runs here. Worth checking on the run: the step appears, and the unit-test job gets faster on the second run once the cache is populated.

## Noticed while investigating, not addressed here

`android-shared`'s Robolectric tests are running on **API 24**. It is a library module with no `targetSdkVersion` in its manifest, so Robolectric falls back to `minSdk`. The app modules pin `@Config(sdk = [34])` / `[35]` explicitly; the shared module's 31 test classes do not, and validate against a 2016 runtime by default. That may be deliberate minSdk-floor coverage — but if it is not, it is worth a separate decision, and pinning it would also collapse the number of runtimes CI needs at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9UyH5fvug685dzUFLtdpW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Android build performance and reliability through enhanced build caching.
  * Added smarter cache restoration to help maintain faster build times when build configurations change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->