### PR TITLE
fix(phone): load More Like This eagerly with the detail page

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -389,7 +389,7 @@ val androidModule = module {
     }
     viewModel { params ->
         ItemDetailViewModel(
-            get(), get(), get(), get(), get(), get(), params.get(),
+            get(), get(), get(), get(), get(), get(), get(), params.get(),
             getOrNull<org.siloserver.silo.repository.port.UserItemStatePort>() ?: org.siloserver.silo.repository.port.NoOpUserItemStatePort,
         )
     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
@@ -556,6 +556,7 @@ fun ItemDetailScreen(
                         SeriesDetailContent(
                             translation = translationSlot,
                             detail = detail,
+                            similarItems = state.similarItems,
                             seasons = state.seasons,
                             selectedSeasonNumber = state.selectedSeasonNumber,
                             episodes = state.episodes,
@@ -754,6 +755,7 @@ fun ItemDetailScreen(
                         MovieDetailContent(
                             translation = translationSlot,
                             detail = detail,
+                            similarItems = state.similarItems,
                             portraitArtwork = portraitArtwork,
                             isFavorite = state.isFavorite,
                             isInWatchlist = state.isInWatchlist,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -23,6 +23,7 @@ import org.siloserver.silo.repository.MetadataAiRepository
 import org.siloserver.silo.repository.DownloadsRepository
 import org.siloserver.silo.repository.EbookReaderRepository
 import org.siloserver.silo.repository.PersonalDataRepository
+import org.siloserver.silo.repository.RecommendationRepository
 import org.siloserver.silo.viewmodel.applyLocalPlaybackProgress
 import org.siloserver.silo.model.download.DownloadQuality
 import org.siloserver.silo.playback.SUBTITLE_OFF_FINGERPRINT
@@ -38,6 +39,9 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -47,6 +51,7 @@ import kotlinx.coroutines.launch
 data class ItemDetailUiState(
     val isLoading: Boolean = true,
     val detail: ItemDetail? = null,
+    val similarItems: List<ItemDetail> = emptyList(),
     val seasons: List<Season> = emptyList(),
     val selectedSeasonNumber: Int = 1,
     val episodes: List<EpisodeListItem> = emptyList(),
@@ -121,6 +126,7 @@ class ItemDetailViewModel(
     private val downloadsRepository: DownloadsRepository,
     private val downloadEnqueuer: DownloadEnqueuer,
     private val ebookReaderRepository: EbookReaderRepository,
+    private val recommendationRepository: RecommendationRepository,
     metadataAiRepository: MetadataAiRepository,
     savedStateHandle: SavedStateHandle,
     private val userItemState: org.siloserver.silo.repository.port.UserItemStatePort =
@@ -352,6 +358,7 @@ class ItemDetailViewModel(
                     }
                     // Restore a persisted audio/subtitle override for this item.
                     seedPersistedTrackSelection()
+                    viewModelScope.launch { loadSimilar(detail) }
                     // For series, load seasons
                     if (detail.type == "series") {
                         loadSeasons(detail.contentId)
@@ -392,6 +399,35 @@ class ItemDetailViewModel(
                     }
                 }
             }
+        }
+    }
+
+    private suspend fun loadSimilar(detail: ItemDetail) {
+        if (detail.type == "episode" || _uiState.value.similarItems.isNotEmpty()) return
+
+        val scored = when (
+            val result = recommendationRepository.getSimilar(detail.contentId, limit = 12)
+        ) {
+            is ApiResult.Success -> result.data.items
+            else -> return
+        }
+        if (scored.isEmpty()) return
+
+        val items = coroutineScope {
+            scored
+                .map { ref ->
+                    async {
+                        when (val result = catalogRepository.getItemDetail(ref.mediaItemId)) {
+                            is ApiResult.Success -> result.data
+                            else -> null
+                        }
+                    }
+                }
+                .awaitAll()
+                .filterNotNull()
+        }
+        if (items.isNotEmpty()) {
+            _uiState.update { it.copy(similarItems = items) }
         }
     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
@@ -62,6 +62,7 @@ fun MovieDetailContent(
         url = detail.posterUrl,
         thumbhash = detail.posterThumbhash,
     ),
+    similarItems: List<ItemDetail> = emptyList(),
     isFavorite: Boolean,
     isInWatchlist: Boolean,
     selectedVersionIndex: Int,
@@ -343,7 +344,7 @@ fun MovieDetailContent(
         if (detail.type != "episode") {
             item(contentType = "detail-similar") {
                 SimilarRail(
-                    contentId = detail.contentId,
+                    items = similarItems,
                     onSelect = onItemDetailClick,
                 )
             }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
@@ -42,6 +42,7 @@ import org.siloserver.silo.model.catalog.Season
 @Composable
 fun SeriesDetailContent(
     detail: ItemDetail,
+    similarItems: List<ItemDetail> = emptyList(),
     seasons: List<Season>,
     selectedSeasonNumber: Int,
     episodes: List<EpisodeListItem>,
@@ -271,7 +272,7 @@ fun SeriesDetailContent(
 
         item(contentType = "detail-similar") {
             SimilarRail(
-                contentId = detail.contentId,
+                items = similarItems,
                 onSelect = onItemDetailClick,
             )
         }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SimilarRail.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SimilarRail.kt
@@ -7,30 +7,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.siloserver.silo.android.ui.components.MediaCard
 import org.siloserver.silo.model.catalog.ItemDetail
-import org.siloserver.silo.network.ApiResult
-import org.siloserver.silo.repository.CatalogRepository
-import org.siloserver.silo.repository.RecommendationRepository
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
-import org.koin.compose.koinInject
 
 /**
  * "More Like This" section — header plus a horizontal poster rail —
  * shown at the bottom of Movie / Series detail pages. Mirrors
- * `PhoneSimilarRail.swift`:
- *   1. Hit `/recommendations/similar/{contentId}` for scored IDs
- *   2. Resolve each ID to an `ItemDetail` in parallel
- *   3. Render a poster card per resolved item; tap opens detail
+ * `PhoneSimilarRail.swift`. Items are loaded eagerly by
+ * [ItemDetailViewModel] and rendered as poster cards that open detail.
  *
  * The whole section (header included) stays hidden until the request
  * resolves with items — servers without media embeddings return an
@@ -39,19 +25,10 @@ import org.koin.compose.koinInject
  */
 @Composable
 fun SimilarRail(
-    contentId: String,
+    items: List<ItemDetail>,
     onSelect: (String) -> Unit,
     modifier: Modifier = Modifier,
-    recommendationRepository: RecommendationRepository = koinInject(),
-    catalogRepository: CatalogRepository = koinInject(),
 ) {
-    var items by remember(contentId) { mutableStateOf<List<ItemDetail>>(emptyList()) }
-
-    LaunchedEffect(contentId) {
-        items = emptyList()
-        items = loadSimilar(contentId, recommendationRepository, catalogRepository)
-    }
-
     if (items.isNotEmpty()) {
         Column(
             verticalArrangement = Arrangement.spacedBy(14.dp),
@@ -60,34 +37,6 @@ fun SimilarRail(
             SectionHeader(title = "More Like This")
             SimilarRailContent(items = items, onSelect = onSelect)
         }
-    }
-}
-
-private suspend fun loadSimilar(
-    contentId: String,
-    recommendationRepository: RecommendationRepository,
-    catalogRepository: CatalogRepository,
-): List<ItemDetail> {
-    val scored = when (val res = recommendationRepository.getSimilar(contentId, limit = 12)) {
-        is ApiResult.Success -> res.data.items
-        else -> return emptyList()
-    }
-    if (scored.isEmpty()) return emptyList()
-
-    // Resolve detail pages in parallel — preserve engine ranking by
-    // dropping null results (failed lookups) without reordering.
-    return coroutineScope {
-        scored
-            .map { ref ->
-                async {
-                    when (val r = catalogRepository.getItemDetail(ref.mediaItemId)) {
-                        is ApiResult.Success -> r.data
-                        else -> null
-                    }
-                }
-            }
-            .awaitAll()
-            .filterNotNull()
     }
 }
 
@@ -122,4 +71,3 @@ private fun SimilarRailContent(
         }
     }
 }
-

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/MobileDetailActionsSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/MobileDetailActionsSourceTest.kt
@@ -12,10 +12,12 @@ import org.siloserver.silo.network.api.CatalogApi
 import org.siloserver.silo.network.api.DownloadsApi
 import org.siloserver.silo.network.api.EbookReaderApi
 import org.siloserver.silo.network.api.PersonalDataApi
+import org.siloserver.silo.network.api.RecommendationApi
 import org.siloserver.silo.repository.CatalogRepository
 import org.siloserver.silo.repository.DownloadsRepository
 import org.siloserver.silo.repository.EbookReaderRepository
 import org.siloserver.silo.repository.PersonalDataRepository
+import org.siloserver.silo.repository.RecommendationRepository
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -159,6 +161,7 @@ class MobileDetailActionsSourceTest {
             downloadsRepository = DownloadsRepository(EmptyDownloadsApi()),
             downloadEnqueuer = unsafeInstance(),
             ebookReaderRepository = EbookReaderRepository(EbookReaderApi(dummyHttpClient())),
+            recommendationRepository = RecommendationRepository(RecommendationApi(dummyHttpClient())),
             metadataAiRepository = org.siloserver.silo.repository.MetadataAiRepository(
                 org.siloserver.silo.network.api.DefaultMetadataAiApi(dummyHttpClient()),
             ),


### PR DESCRIPTION
## Summary

- Move More Like This loading into `ItemDetailViewModel` so recommendations begin loading with the detail page.
- Resolve recommended item details in parallel while preserving recommendation order.
- Render the rail from view-model state and keep it hidden when no recommendations are available.

## Testing

- Updated `MobileDetailActionsSourceTest` setup for the new recommendation repository dependency.
- Not run (change request content generated from the provided patch).