### PR TITLE
fix(tv): remove aliased hairline border on player transport controls

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerTransportCluster.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerTransportCluster.kt
@@ -3,7 +3,6 @@ package org.siloserver.silo.tv.ui.screens.player
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -177,11 +176,6 @@ private fun TransportIconButton(
             .size(buttonSize)
             .clip(CircleShape)
             .background(focusBg)
-            .border(
-                width = 0.5.dp,
-                color = if (isFocused) Color.Transparent else Color.White.copy(alpha = 0.22f),
-                shape = CircleShape,
-            )
             .let { mod -> if (focusRequester != null) mod.focusRequester(focusRequester) else mod }
             .focusable(interactionSource = interactionSource)
             .onPreviewKeyEvent { event ->


### PR DESCRIPTION
## Why

The rest-state border on the player transport controls (play/pause, skip back and forward, subtitles, options, close) is a 0.5dp translucent white stroke at 22% alpha. Because it is thinner than a device pixel and translucent, it dithers against the moving video and aliases into a jagged white fringe around each button, visible even on 4K panels where the sub-pixel stroke never lands on a whole device pixel.

## What

Drop the rest-state hairline border and let the translucent fill carry the button edge. Focus treatment (white-fill inversion) is unchanged.

## Scope

Player screen only (`TvPlayerTransportCluster.kt`). No other screens are
affected.

## Testing

Compiles clean (`:androidTvApp:compileDebugKotlinAndroid`) and manually validated that everything looks much cleaner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated TV player transport controls to use a cleaner focus highlight without a circular border.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->