### PR TITLE
fix(phone): preserve season chip selection during pager animation

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeasonEpisodePager.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeasonEpisodePager.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,16 +64,21 @@ internal fun SeasonEpisodePager(
         pageCount = { seasons.size },
     )
     val scope = rememberCoroutineScope()
+    val currentSelectedSeasonNumber = rememberUpdatedState(selectedSeasonNumber)
+    val currentOnSeasonSelected = rememberUpdatedState(onSeasonSelected)
 
     // A completed finger swipe becomes the shared season selection. Waiting
     // for settledPage avoids loading a season when a partial drag snaps back.
-    LaunchedEffect(pagerState, seasons, selectedSeasonNumber) {
+    // Keep this collector alive when a chip optimistically changes the shared
+    // selection: restarting it would immediately emit the still-old page and
+    // undo the chip tap before the pager animation can begin.
+    LaunchedEffect(pagerState, seasons) {
         snapshotFlow { pagerState.settledPage }
             .distinctUntilChanged()
             .collect { page ->
                 seasons.getOrNull(page)
-                    ?.takeIf { it.seasonNumber != selectedSeasonNumber }
-                    ?.let { onSeasonSelected(it.seasonNumber) }
+                    ?.takeIf { it.seasonNumber != currentSelectedSeasonNumber.value }
+                    ?.let { currentOnSeasonSelected.value(it.seasonNumber) }
             }
     }
 


### PR DESCRIPTION
## Summary

- Keep the season pager collector alive while chip selection updates optimistically.
- Read the latest selected season and callback when settled pager pages change.
- Prevent stale pager emissions from undoing a season chip tap.

## Testing

- Not run (not requested).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8d9f53b2b33713f19e2110df57d673e92a1e78cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed season selection behavior in the episode pager.
  * Season changes made through selection controls now remain active while the pager animation completes, preventing them from being unexpectedly reverted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->