### PR TITLE
fix(playback): handle rejected cleartext media origin

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerOkHttpClient.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerOkHttpClient.kt
@@ -9,9 +9,9 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import kotlinx.coroutines.runBlocking
 import org.siloserver.silo.network.CleartextOriginConsent
-import org.siloserver.silo.network.CleartextOriginNotApprovedException
 import org.siloserver.silo.network.isSameHttpOrigin
 import org.siloserver.silo.network.requiresApproval
+import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 /**
@@ -58,11 +58,14 @@ internal class CleartextConsentNetworkInterceptor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val url = chain.request().url.toString()
         if (runBlocking { consent?.requiresApproval(url) == true }) {
-            throw CleartextOriginNotApprovedException(url)
+            throw CleartextMediaOriginNotApprovedException()
         }
         return chain.proceed(chain.request())
     }
 }
+
+internal class CleartextMediaOriginNotApprovedException :
+    IOException("Cleartext media origin is not approved")
 
 private fun Request.withoutCrossOriginCredentials(): Request =
     newBuilder()

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/MediaAuthInterceptorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/MediaAuthInterceptorTest.kt
@@ -3,7 +3,6 @@ package org.siloserver.silo.common.player
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.network.TokenManagerImpl
 import org.siloserver.silo.network.CleartextOriginConsent
-import org.siloserver.silo.network.CleartextOriginNotApprovedException
 import org.siloserver.silo.network.canonicalHttpOrigin
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -11,7 +10,9 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.runBlocking
 import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.Connection
+import okhttp3.Dispatcher
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -21,7 +22,11 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -53,7 +58,7 @@ class MediaAuthInterceptorTest {
                 .header("X-Stream-Signature", "secret-plan-header")
                 .build()
 
-            assertFailsWith<CleartextOriginNotApprovedException> {
+            assertFailsWith<CleartextMediaOriginNotApprovedException> {
                 client.newCall(request).execute().close()
             }
             assertEquals(1, origin.requestCount)
@@ -64,6 +69,67 @@ class MediaAuthInterceptorTest {
         }
     }
 
+    @Test
+    fun `async cleartext redirect rejection reaches the failure callback`() {
+        val origin = MockWebServer()
+        val downstream = MockWebServer()
+        val uncaught = AtomicReference<Throwable?>()
+        val executor = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "cleartext-callback-test").apply {
+                uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, error ->
+                    uncaught.set(error)
+                }
+            }
+        }
+        origin.start()
+        downstream.start()
+        try {
+            origin.enqueue(
+                MockResponse()
+                    .setResponseCode(302)
+                    .setHeader("Location", downstream.url("/asset")),
+            )
+            val approvedOrigin = canonicalHttpOrigin(origin.url("/").toString())
+            val consent = object : CleartextOriginConsent {
+                override suspend fun isApproved(origin: String): Boolean =
+                    canonicalHttpOrigin(origin) == approvedOrigin
+            }
+            val client = buildPlayerOkHttpClient(consent).newBuilder()
+                .dispatcher(Dispatcher(executor))
+                .build()
+            val completed = CountDownLatch(1)
+            var failure: IOException? = null
+
+            client.newCall(Request.Builder().url(origin.url("/redirect")).build())
+                .enqueue(object : Callback {
+                    override fun onFailure(call: Call, error: IOException) {
+                        failure = error
+                        completed.countDown()
+                    }
+
+                    override fun onResponse(call: Call, response: Response) {
+                        response.close()
+                        completed.countDown()
+                    }
+                })
+
+            assertTrue(
+                completed.await(2, TimeUnit.SECONDS),
+                "unchecked interceptor failure escaped the OkHttp dispatcher",
+            )
+            executor.shutdown()
+            assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+            assertNull(uncaught.get(), "interceptor failure escaped the OkHttp dispatcher")
+            assertTrue(failure is CleartextMediaOriginNotApprovedException)
+            assertEquals("Cleartext media origin is not approved", failure?.message)
+            assertEquals(1, origin.requestCount)
+            assertEquals(0, downstream.requestCount)
+        } finally {
+            executor.shutdownNow()
+            origin.shutdown()
+            downstream.shutdown()
+        }
+    }
 
     @Test
     fun `adds auth and active profile headers to media and reader requests`() {


### PR DESCRIPTION
## Problem

The media cleartext-origin guard threw an unchecked `IllegalStateException` from an OkHttp network interceptor. OkHttp delivered a cancellation to the callback and then rethrew the unchecked exception on its dispatcher thread, terminating the Android process when playback encountered an unapproved cleartext redirect.

## Approach

- Convert the media-interceptor rejection into a dedicated `IOException` so OkHttp and Media3 handle it as a normal playback failure.
- Keep the origin check before downstream transport, preserving the existing fail-closed credential boundary.
- Use a generic error message that does not expose the rejected origin.
- Add synchronous and asynchronous redirect coverage, including proof that the downstream server is not contacted and no exception escapes the dispatcher thread.

## Verification

- `./gradlew :android-shared:testDebugUnitTest --tests org.siloserver.silo.common.player.MediaAuthInterceptorTest --no-daemon --max-workers=2`
- `./gradlew :android-shared:testDebugUnitTest :androidApp:assembleDebug :androidTvApp:assembleDebug --no-daemon --max-workers=2`
- `git diff --check`

All tests passed, and both phone and TV debug APKs assembled successfully. An independent review found no correctness, privacy, or security issues.

Closes #233

## AI-use disclosure

- Tools: OpenAI Codex
- Models: GPT-5 and GPT-5.6-Sol
- Involvement: AI-assisted diagnosis, implementation, regression testing, privacy review, and independent code review under maintainer direction.

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)
