### PR TITLE
fix(browse): stop the library sort resetting to its default

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
@@ -146,7 +146,21 @@ enum class LibraryBrowseSort(
 ) {
     RecentlyAdded("Recently Added", "added_at", "desc"),
     Title("Title", "title", "asc"),
-    ReleaseDate("Release Date", "release_date", "desc"),
+    ReleaseDate("Release Date", "release_date", "desc");
+
+    companion object {
+        /**
+         * The sort rides the persisted [CatalogFilterState] (same as
+         * BrowseViewModel), so restoring saved browse prefs also restores the
+         * chip label. [CatalogFilterState]'s own defaults are exactly
+         * [RecentlyAdded]'s pair, so a state saved before the sort travelled
+         * with it — or one naming a field this client does not offer — falls
+         * back to [RecentlyAdded].
+         */
+        fun fromFilterState(state: CatalogFilterState): LibraryBrowseSort =
+            entries.firstOrNull { it.sortField == state.sort && it.sortOrder == state.order }
+                ?: RecentlyAdded
+    }
 }
 
 data class LibrariesUiState(
@@ -248,6 +262,13 @@ class LibrariesViewModel(
                     // whatever filters are already active.
                     val restoreBrowsePrefs =
                         selectedLibraryId != null && selectedLibraryId != previousLibraryId
+                    // Null when there is nothing to restore, so the branches
+                    // below keep the live state untouched.
+                    val restoredFilterState = if (restoreBrowsePrefs) {
+                        browsePrefs?.savedState(selectedLibraryId) ?: CatalogFilterState()
+                    } else {
+                        null
+                    }
 
                     _uiState.update {
                         it.copy(
@@ -255,9 +276,12 @@ class LibrariesViewModel(
                             libraries = libraries,
                             selectedLibraryId = selectedLibraryId,
                             librariesError = null,
-                            filterState = if (restoreBrowsePrefs)
-                                (browsePrefs?.savedState(selectedLibraryId) ?: CatalogFilterState())
-                            else it.filterState,
+                            filterState = restoredFilterState ?: it.filterState,
+                            // The sort lives inside the persisted filter state,
+                            // so derive the chip from what was restored.
+                            browseSort = restoredFilterState
+                                ?.let(LibraryBrowseSort::fromFilterState)
+                                ?: it.browseSort,
                             preserveFilters = if (restoreBrowsePrefs)
                                 (browsePrefs?.preserveEnabled(selectedLibraryId) ?: true)
                             else it.preserveFilters,
@@ -297,6 +321,10 @@ class LibrariesViewModel(
         recommendedLoadedLibraryId = null
         browseLoadedLibraryId = null
         collectionsLoadedLibraryId = null
+        // Restore this library's persisted filter/sort state (iOS parity) so a
+        // preserved selection doesn't flash the unfiltered grid; default to a
+        // clean filter — and therefore RecentlyAdded — when nothing is saved.
+        val restoredFilterState = browsePrefs?.savedState(libraryId) ?: CatalogFilterState()
         _uiState.update {
             it.copy(
                 selectedLibraryId = libraryId,
@@ -305,10 +333,8 @@ class LibrariesViewModel(
                 catalogItems = emptyList(),
                 catalogTotal = 0,
                 catalogHasMore = false,
-                // Restore this library's persisted filter/preserve state (iOS
-                // parity) so a preserved selection doesn't flash the unfiltered
-                // grid; default to a clean filter when nothing is saved.
-                filterState = browsePrefs?.savedState(libraryId) ?: CatalogFilterState(),
+                filterState = restoredFilterState,
+                browseSort = LibraryBrowseSort.fromFilterState(restoredFilterState),
                 availableFilters = null,
                 preserveFilters = browsePrefs?.preserveEnabled(libraryId) ?: true,
                 selectedNamePrefix = null,
@@ -329,16 +355,22 @@ class LibrariesViewModel(
     /** Apply a new facet/match filter selection, persist it (when preserve is
      *  on), and reload the catalog. Mirrors BrowseViewModel.applyFilterState. */
     fun applyFilterState(state: CatalogFilterState) {
-        if (state == _uiState.value.filterState) return
+        val current = _uiState.value.filterState
+        // [selectBrowseSort] owns sort/order. Callers derive `state` from a
+        // composition snapshot that can be a frame stale — the Reset control
+        // changes the sort and clears the facets in the same frame — so take
+        // only the facet/match parts and keep the sort already committed here.
+        val reconciled = state.copy(sort = current.sort, order = current.order)
+        if (reconciled == current) return
         _uiState.update {
             it.copy(
-                filterState = state,
+                filterState = reconciled,
                 catalogItems = emptyList(),
                 catalogTotal = 0,
                 catalogHasMore = false,
             )
         }
-        browsePrefs?.saveState(_uiState.value.selectedLibraryId, state)
+        browsePrefs?.saveState(_uiState.value.selectedLibraryId, reconciled)
         _uiState.value.selectedLibraryId?.let { loadCatalog(it, reset = true, force = true) }
     }
 
@@ -350,14 +382,23 @@ class LibrariesViewModel(
     }
 
     fun selectBrowseSort(sort: LibraryBrowseSort) {
+        // The sort rides the persisted filter state so "Preserve sort & filters"
+        // actually restores it, instead of the chips coming back while the sort
+        // snaps to Recently Added.
+        val nextFilterState = _uiState.value.filterState.copy(
+            sort = sort.sortField,
+            order = sort.sortOrder,
+        )
         _uiState.update {
             it.copy(
                 browseSort = sort,
+                filterState = nextFilterState,
                 catalogItems = emptyList(),
                 catalogTotal = 0,
                 catalogHasMore = false,
             )
         }
+        browsePrefs?.saveState(_uiState.value.selectedLibraryId, nextFilterState)
         _uiState.value.selectedLibraryId?.let { loadCatalog(it, reset = true, force = true) }
     }
 

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesViewModelTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesViewModelTest.kt
@@ -23,9 +23,18 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withTimeout
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import androidx.test.core.app.ApplicationProvider
+import org.siloserver.silo.android.ui.screens.browse.BrowsePrefsStore
 import org.siloserver.silo.catalog.filter.CatalogFacet
 import org.siloserver.silo.catalog.filter.CatalogFilterState
+import org.siloserver.silo.model.server.ServerEntry
+import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.SiloJson
 import org.siloserver.silo.network.api.CatalogApi
 import org.siloserver.silo.network.api.PersonalDataApi
@@ -37,6 +46,10 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
+// BrowsePrefsStore writes through real SharedPreferences, so the persistence
+// regression below needs an Android context.
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = android.app.Application::class)
 class LibrariesViewModelTest {
     @Test
     fun recommendedResponseFromPreviousLibraryCannotReplaceCurrentLibraryRows() = runTest {
@@ -226,6 +239,46 @@ class LibrariesViewModelTest {
         }
     }
 
+    @Test
+    fun browseSortIsPersistedAndRestoredOnAFreshViewModel() = runTest {
+        val fixture = DeferredLibrariesFixture(deferredKeys = emptySet())
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        val browsePrefs = BrowsePrefsStore(
+            context = ApplicationProvider.getApplicationContext(),
+            serverRegistry = FakeServerRegistry(),
+        )
+        val viewModel = fixture.viewModel(browsePrefs = browsePrefs)
+        val store = ViewModelStore().also { it.put("libraries", viewModel) }
+        try {
+            fixture.awaitRequest("sections:1")
+            viewModel.uiState.first { !it.isLoadingSections }
+            viewModel.selectTab(LibrariesSubtab.Browse)
+            fixture.awaitRequest("catalog:1:added_at:desc")
+
+            viewModel.selectBrowseSort(LibraryBrowseSort.Title)
+            // The sort is persisted before the reload is issued, so awaiting
+            // the re-sorted request is a sufficient sync point.
+            fixture.awaitRequest("catalog:1:title:asc")
+
+            val restored = fixture.viewModel(browsePrefs = browsePrefs)
+            val restoredStore = ViewModelStore().also { it.put("libraries-restored", restored) }
+            try {
+                val state = restored.uiState.first {
+                    !it.isLoadingLibraries && it.selectedLibraryId == 1
+                }
+                assertEquals(LibraryBrowseSort.Title, state.browseSort)
+                assertEquals("title", state.filterState.sort)
+                assertEquals("asc", state.filterState.order)
+            } finally {
+                restoredStore.clear()
+            }
+        } finally {
+            store.clear()
+            Dispatchers.resetMain()
+            fixture.close()
+        }
+    }
+
     private suspend fun LibrariesViewModel.onlyActiveRequest(): Job = withTimeout(5_000) {
         while (true) {
             val activeRequests = viewModelScope.coroutineContext[Job]
@@ -240,6 +293,26 @@ class LibrariesViewModelTest {
             }
         }
         error("Unreachable")
+    }
+
+    /** BrowsePrefsStore persists nothing without an active server + profile. */
+    private class FakeServerRegistry : ServerRegistry {
+        private val entry = ServerEntry(
+            id = "server-1",
+            url = "https://silo.test",
+            profileId = "profile-1",
+        )
+        override val entries: StateFlow<List<ServerEntry>> = MutableStateFlow(listOf(entry))
+        override val activeServerId: StateFlow<String?> = MutableStateFlow(entry.id)
+        override val activeEntry: StateFlow<ServerEntry?> = MutableStateFlow(entry)
+        override suspend fun addOrUpdate(url: String, fetchedName: String?): String = entry.id
+        override suspend fun rename(serverId: String, userOverrideName: String?) = Unit
+        override suspend fun setFetchedName(serverId: String, fetchedName: String?) = Unit
+        override suspend fun setProfileId(serverId: String, profileId: String?) = Unit
+        override suspend fun remove(serverId: String) = Unit
+        override suspend fun signOut(serverId: String) = Unit
+        override suspend fun switchTo(serverId: String) = Unit
+        override suspend fun touchActive() = Unit
     }
 
     private class DeferredLibrariesFixture(
@@ -285,10 +358,11 @@ class LibrariesViewModelTest {
             install(ContentNegotiation) { json(SiloJson) }
         }
 
-        fun viewModel() = LibrariesViewModel(
+        fun viewModel(browsePrefs: BrowsePrefsStore? = null) = LibrariesViewModel(
             personalDataRepository = PersonalDataRepository(PersonalDataApi(client)),
             sectionRepository = SectionRepository(SectionApi(client)),
             catalogRepository = CatalogRepository(CatalogApi(client)),
+            browsePrefs = browsePrefs,
         )
 
         suspend fun awaitRequest(expected: String) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
@@ -107,9 +107,9 @@ fun TvLibraryDetailScreen(
     // Collections). Null leaves the ViewModel's default (Recommended) and any
     // user-driven tab changes alone.
     initialSection: TvLibraryTab? = null,
-    // Monotonic nonce bumped by the host on every cascade commit. Keying the
-    // section-apply effect on it (not just initialSection) makes re-committing
-    // the SAME pill re-apply the section instead of being a silent no-op.
+    // Monotonic nonce bumped by the host on every cascade commit, so the
+    // section-apply effect below re-runs when the SAME pill is committed
+    // again rather than being keyed on the section value alone.
     sectionRequestNonce: Int = 0,
     onContentUpFallbackChanged: ((((Boolean) -> Boolean)?) -> Unit)? = null,
     viewModel: TvLibraryDetailViewModel = koinViewModel(
@@ -121,9 +121,10 @@ fun TvLibraryDetailScreen(
 
     // Apply the committed cascade section on entry / whenever the commit
     // changes it. Keyed on sectionRequestNonce (bumped on every commit) AND the
-    // section value, so re-committing the SAME pill re-applies the section
-    // rather than being a silent no-op, while a non-commit recomposition leaves
-    // manual in-screen tab moves untouched.
+    // section value, so a non-commit recomposition leaves manual in-screen tab
+    // moves untouched. This fires again on every re-entry — backing out of item
+    // detail returns to a surviving ViewModel — so onTabSelected treats the
+    // already-active section as a no-op and keeps the viewer's sort/filters.
     LaunchedEffect(sectionRequestNonce, initialSection) {
         initialSection?.let(viewModel::onTabSelected)
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailViewModel.kt
@@ -248,7 +248,14 @@ class TvLibraryDetailViewModel(
         val nextFilter = state.browseFilter.forTab(tab)
         val filterChanged = nextFilter != state.browseFilter
         val audiobookGroupBy = tab.audiobookGroupBy
-        if (state.selectedTab == tab && !filterChanged) return
+        // Re-selecting the section that is already active is a no-op. The
+        // screen re-issues the committed section every time it re-enters
+        // composition — backing out of item detail / the player returns to a
+        // surviving ViewModel and fires the section-apply effect again — so
+        // re-applying `forTab` here would reset the viewer's customised sort
+        // and facets back to the tab's defaults (Title A–Z). Only a genuine
+        // tab CHANGE applies the new tab's defaults.
+        if (state.selectedTab == tab) return
         _uiState.update {
             it.copy(
                 selectedTab = tab,

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibrarySubdestinationViewModelTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibrarySubdestinationViewModelTest.kt
@@ -94,6 +94,28 @@ class TvLibrarySubdestinationViewModelTest {
         assertEquals(null, viewModel.uiState.value.selectedAudiobookGroup)
     }
 
+    @Test
+    fun reselectingTheActiveBrowseTabKeepsTheViewersSort() = runLibraryTest {
+        val requests = mutableListOf<RequestRecord>()
+        val viewModel = viewModelFor(requests, libraryType = "movies")
+
+        viewModel.onTabSelected(TvLibraryTab.Browse)
+        awaitState { requests.catalogRequestCount() >= 1 }
+        viewModel.onSortKeySelected(TvLibrarySortOption.ReleaseDate)
+        awaitState { requests.lastCatalogRequestOrNull()?.query?.get("sort") == "year" }
+        val requestsBeforeReentry = requests.catalogRequestCount()
+
+        // Re-entering the screen (back out of item detail) re-issues the
+        // already-committed section against this same ViewModel. That must not
+        // reset the sort the viewer picked.
+        viewModel.onTabSelected(TvLibraryTab.Browse)
+        settle()
+
+        assertEquals("year", viewModel.uiState.value.browseFilter.sort)
+        assertEquals("desc", viewModel.uiState.value.browseFilter.order)
+        assertEquals(requestsBeforeReentry, requests.catalogRequestCount())
+    }
+
     private val createdViewModels = mutableListOf<androidx.lifecycle.ViewModel>()
 
     private fun runLibraryTest(block: suspend () -> Unit) = runTest {
@@ -109,6 +131,11 @@ class TvLibrarySubdestinationViewModelTest {
             createdViewModels.clear()
             Dispatchers.resetMain()
         }
+    }
+
+    /** Real-time window for any spurious request to land before asserting none did. */
+    private suspend fun settle() {
+        withContext(Dispatchers.IO) { delay(200) }
     }
 
     private suspend fun awaitState(predicate: () -> Boolean) {


### PR DESCRIPTION
Fixes #236.

The reported symptom — "SORT goes back to default so have to start from scratch" — turned out to be two independent defects, one per client. Filters survive in both cases; only the sort is lost.

## Android TV — sort lost on Back from item detail

`TvLibraryDetailScreen` re-issues the committed cascade section every time it re-enters composition:

```kotlin
LaunchedEffect(sectionRequestNonce, initialSection) { initialSection?.let(viewModel::onTabSelected) }
```

The ViewModel *survives* the Back (verified with a temporary log — same instance either side), but `onTabSelected` guarded with `if (state.selectedTab == tab && !filterChanged) return`. On re-entry the tab is unchanged and `filterChanged` is true *precisely because the viewer customised the sort*, so the guard fell through and `forTab(Browse)` reset sort and facets to Title A–Z.

Re-selecting the already-active tab is now a no-op. A genuine tab change still applies the new tab's defaults, and `forTab` / `onAudiobookGroupCleared` are untouched.

## Android phone — sort lost on relaunch

`LibrariesViewModel` kept the sort in `LibrariesUiState.browseSort`, outside the `CatalogFilterState` that `BrowsePrefsStore` persists — so "Preserve sort & filters" restored the chips while the sort snapped back to Recently Added.

The sort now rides the persisted filter state, the way `BrowseViewModel` already does it, and is derived back out on restore via `LibraryBrowseSort.fromFilterState`. `applyFilterState` keeps the sort already committed here and takes only the facet/match parts from its argument: the Reset control changes the sort and clears the facets off the same composition frame, so trusting the incoming state's sort would reinstate the one just cleared.

## Verified

On the local phone and TV emulators against the dev server, with builds from this branch:

- **TV**: Movies → Browse → sort **Year** → open a title → Back → chip still reads `Sort · Year Newest`, grid still 2026-first. Before the fix it returned to Title A–Z.
- **Phone**: Library subtab → sort **Title** + filter Unwatched → force-stop → relaunch → chip reads **Title**, grid alphabetical, Unwatched restored. Persisted state now carries the sort: `{"selections":{"WatchStatus":["unwatched"]},"sort":"title","order":"asc"}`.
- **Phone Reset** still clears both — sort back to Recently Added, chips gone, saved state `{}`.
- `./gradlew :androidApp:assembleDebug :androidTvApp:assembleDebug` and `:androidApp:testDebugUnitTest :androidTvApp:testDebugUnitTest` pass.

## Tests

One focused regression test per app, in the existing files. Each was confirmed to fail with its fix reverted, so neither is vacuous. `LibrariesViewModelTest` now runs under Robolectric because `BrowsePrefsStore` writes through real `SharedPreferences` (precedent: `ReaderViewModelReaderTargetSourceTest`, `WatchTogetherEntryViewModelTest`); all pre-existing tests in the file still pass.

## Behavioural deltas worth a reviewer's eye

- **TV**: re-selecting Authors/Series while drilled into an audiobook group no longer clears the group as a side effect. Exiting a drill-in now relies solely on `onAudiobookGroupCleared`, which has its own dedicated UI affordance (`onClearAudiobookGroup`), so nothing is trapped.
- **Phone**: `selectLibrary` previously carried the previous library's sort across a library switch. Sort now travels with the per-library persisted state, so switching to a library with nothing saved lands on Recently Added.
- TV sort still lives only in memory — it survives Back and in-session navigation, but not an app restart. The phone's per-library persistence has no TV counterpart; left as-is rather than widened into this fix.
- Two comments in `TvLibraryDetailScreen.kt` (the `sectionRequestNonce` doc and the `LaunchedEffect` comment) still claim re-committing the same pill "re-applies the section rather than being a silent no-op". That is now false when the tab is already selected — which is the fix. Left alone to keep the diff to the defect; happy to update them here if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library browsing now restores selected sort and filter settings when reopening a library or restarting the app.
  * Sort and filter changes are saved together and applied when the catalog reloads.

* **Bug Fixes**
  * Re-selecting the active TV browsing tab no longer resets sorting or triggers an unnecessary catalog reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->