### PR TITLE
fix(android): scale poster overlays with card width

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/overlays/CardOverlays.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/overlays/CardOverlays.kt
@@ -1,7 +1,7 @@
 package org.siloserver.silo.common.overlays
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -53,6 +53,8 @@ enum class CardOverlayVariant {
  *     CardOverlays(data = data, prefs = prefs, variant = CardOverlayVariant.Poster)
  * }
  * ```
+ *
+ * @param scale optical multiplier for wide/hero cards; posters measure their actual width.
  */
 @Composable
 fun CardOverlays(
@@ -63,8 +65,21 @@ fun CardOverlays(
     scale: Float = 1f,
     forceOpaqueBackground: Boolean = false,
 ) {
-    val preset = remember(prefs.preset, scale) { OverlayPresetStyles.style(prefs.preset).scaled(scale) }
-    Box(modifier = modifier.fillMaxSize()) {
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        // The web Home carousel's 185-unit overlay layer is the cross-platform
+        // visual reference. Reading the actual logical width also covers
+        // adaptive grids, phone density choices, TV rails, and fill-width cards.
+        val resolvedScale = if (variant == CardOverlayVariant.Poster) {
+            maxWidth.value
+                .takeIf { it.isFinite() && it > 0f }
+                ?.div(185f)
+                ?: scale
+        } else {
+            scale
+        }
+        val preset = remember(prefs.preset, resolvedScale) {
+            OverlayPresetStyles.style(prefs.preset).scaled(resolvedScale)
+        }
         for (position in OverlayPosition.entries) {
             CornerStack(
                 position = position,
@@ -72,7 +87,7 @@ fun CardOverlays(
                 prefs = prefs,
                 preset = preset,
                 variant = variant,
-                scale = scale,
+                scale = resolvedScale,
                 forceOpaqueBackground = forceOpaqueBackground,
             )
         }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/overlays/OverlayBadge.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/overlays/OverlayBadge.kt
@@ -108,14 +108,14 @@ internal fun OverlayBadge(
         box = box.background(paintedBackground, shape)
     }
     if (border != Color.Unspecified) {
-        box = box.border(1.dp, border, shape)
+        box = box.border(1.dp * preset.scale, border, shape)
     }
     box = box
         .padding(horizontal = preset.horizontalPadding, vertical = preset.verticalPadding)
 
     Row(
         modifier = box,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp * preset.scale),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         val iconId = state.iconId
@@ -176,7 +176,11 @@ private fun BadgeText(
             letterSpacing = preset.letterSpacing,
             textAlign = TextAlign.Center,
             shadow = if (preset.textShadow) {
-                Shadow(color = Color.Black.copy(alpha = 0.85f), offset = Offset(0f, 1f), blurRadius = 1f)
+                Shadow(
+                    color = Color.Black.copy(alpha = 0.85f),
+                    offset = Offset(0f, preset.scale),
+                    blurRadius = preset.scale,
+                )
             } else {
                 null
             },

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/overlays/OverlayPresetStyle.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/overlays/OverlayPresetStyle.kt
@@ -38,6 +38,8 @@ internal data class OverlayPresetStyle(
     val background: (accent: Color) -> Color,
     val foreground: (accent: Color) -> Color,
     val border: (accent: Color) -> Color,
+    /** The actual card-width multiplier applied to fixed renderer details. */
+    val scale: Float = 1f,
 ) {
     sealed interface CornerStyle {
         /** Fully rounded capsule (clamped at half the height). */
@@ -66,6 +68,7 @@ internal data class OverlayPresetStyle(
             },
             iconSize = iconSize * safeScale,
             gap = gap * safeScale,
+            scale = safeScale,
         )
     }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/personal/PersonalMediaGridContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/personal/PersonalMediaGridContent.kt
@@ -54,7 +54,11 @@ import org.siloserver.silo.android.ui.components.MediaGridDefaults
 import org.siloserver.silo.android.ui.components.WatchedBadge
 import org.siloserver.silo.android.ui.components.rememberBrowseItemCardActions
 import org.siloserver.silo.common.ui.components.ThumbhashImage
+import org.siloserver.silo.common.overlays.CardOverlayVariant
+import org.siloserver.silo.common.overlays.CardOverlays
+import org.siloserver.silo.common.overlays.LocalCardOverlayUiState
 import org.siloserver.silo.model.catalog.BrowseItem
+import org.siloserver.silo.overlays.OverlayDataExtractor
 import org.siloserver.silo.viewmodel.FavoritesViewModel
 import org.siloserver.silo.viewmodel.HistoryViewModel
 import org.siloserver.silo.viewmodel.PersonalListQuery
@@ -306,6 +310,7 @@ fun MediaGridItem(
     isInWatchlist: Boolean = false,
 ) {
     val (actions, userState) = rememberBrowseItemCardActions(item)
+    val overlayState = LocalCardOverlayUiState.current
     var menuExpanded by remember { mutableStateOf(false) }
 
     androidx.compose.foundation.layout.Column(
@@ -315,16 +320,27 @@ fun MediaGridItem(
         ),
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        Box {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(2f / 3.3f)
+                .clip(RoundedCornerShape(8.dp)),
+        ) {
             ThumbhashImage(
                 url = item.posterUrl,
                 thumbhash = item.posterThumbhash,
                 contentDescription = item.title,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(2f / 3.3f)
-                    .clip(RoundedCornerShape(8.dp)),
+                modifier = Modifier.fillMaxSize(),
             )
+
+            if (overlayState.enabled) {
+                CardOverlays(
+                    data = OverlayDataExtractor.fromBrowseItem(item),
+                    prefs = overlayState.prefs,
+                    variant = CardOverlayVariant.Poster,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
 
             if (userState.played) {
                 WatchedBadge(modifier = Modifier.align(Alignment.TopEnd))

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCard.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCard.kt
@@ -152,7 +152,6 @@ fun TvMediaCard(
                         data = overlay,
                         prefs = overlayState.prefs,
                         variant = CardOverlayVariant.Poster,
-                        scale = TvCardOverlayScale,
                         forceOpaqueBackground = false,
                         modifier = Modifier.fillMaxSize(),
                     )
@@ -236,7 +235,7 @@ fun TvMediaCard(
  */
 val TvCardWidth: Dp = RowDimens.PosterWidth
 
-/** Optical TV scale: compact like tvOS badges, still readable at sofa distance. */
+/** Optical scale for wide TV thumbnails; poster cards scale from their actual width. */
 const val TvCardOverlayScale: Float = 0.7f
 
 /** Hoisted so every card shares one instance instead of allocating a shape per composition. */


### PR DESCRIPTION
## What changed

Poster overlays on Android phone and TV used fixed or caller-supplied sizing. That could squeeze labels on compact cards and break the proportions when a mobile card preset changed the poster width. Favorites, Watchlist, History, and collection grids also skipped the shared overlay renderer.

I helped work out the sizing against the Web Home cards and confirmed the Web version live. This uses the actual Compose poster width as the reference, so type, tracking, padding, icons, gaps, insets, radii, borders, and shadows stay proportional as the card changes size.

The fixed TV poster multiplier is removed because poster width now supplies the scale. Wide episode thumbnails keep their separate optical multiplier.

## Validation

- The same implementation passed the fork Android Builds unit-test and lint jobs on [blurbery/silo-android#1](https://github.com/blurbery/silo-android/pull/1).
- The port onto current upstream main applied cleanly, and `git diff --check` passed.
- The complete phone, adaptive-grid, personal-list, collection, and TV call paths were reviewed with no unresolved material findings.
- Gradle was not rerun locally because this Mac has no Java runtime; this upstream PR CI is the exact build gate.

Related issue: N/A — narrow cross-platform UI fix.

## AI disclosure

OpenAI Codex desktop app (GPT-5) assisted with the implementation and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Media card overlays now automatically scale to match poster dimensions for more consistent presentation across layouts.
  - Poster overlays are displayed within the same clipped image area, improving alignment and visual consistency.
  - Overlay borders, spacing, and text shadows now adapt proportionally to the selected style.
  - TV wide thumbnails retain optimized optical scaling while poster cards adjust based on their actual size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->