### PR TITLE
fix(playback): break output-route replan loops

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
@@ -39,6 +39,31 @@ data class AudioPlaybackRouteSnapshot(
 )
 
 /**
+ * Identity used to decide whether playback must be replanned for a new output.
+ *
+ * Spatializer enablement is deliberately excluded. Android can toggle it while
+ * Media3 tears down and recreates an audio sink, so including it makes a player
+ * remount look like a physical route change and feeds the remount back into
+ * another server replan. The server does not route on this flag; it remains in
+ * the published diagnostics/capability snapshot.
+ */
+internal data class AudioPlanningRouteIdentity(
+    val sinkType: String,
+    val routeHashes: List<String>,
+    val capabilities: AudioPassthroughCapabilities,
+)
+
+internal fun audioPlanningRouteIdentity(
+    sinkType: String,
+    routeHashes: List<String>,
+    capabilities: AudioPassthroughCapabilities,
+): AudioPlanningRouteIdentity = AudioPlanningRouteIdentity(
+    sinkType = sinkType,
+    routeHashes = routeHashes.distinct().sorted(),
+    capabilities = capabilities.copy(spatializerEnabled = false),
+)
+
+/**
  * Tracks the current [AudioCapabilities] of the active audio sink (built-in
  * speaker, HDMI receiver, Bluetooth, USB DAC) and exposes them as an
  * [AudioPassthroughCapabilities] suitable for the server's playback resolver.
@@ -77,20 +102,30 @@ class AudioCapabilityManager(
         capabilities = AudioPassthroughCapabilities(),
     )
     private var routeSnapshotInitialized = false
+    private var planningRouteIdentity: AudioPlanningRouteIdentity? = null
 
     private fun publishCapabilities(next: AudioPassthroughCapabilities) {
-        val changed = _capabilities.value != next
-        if (!changed && routeSnapshotInitialized) return
-        val generation = if (changed) {
+        val capabilitiesChanged = _capabilities.value != next
+        val devices = runCatching(::currentOutputDevices).getOrDefault(emptyList())
+        val sinkType = sinkType(devices)
+        val nextRouteIdentity = audioPlanningRouteIdentity(
+            sinkType = sinkType,
+            routeHashes = devices.map(::routeHash),
+            capabilities = next,
+        )
+        val routeChanged = planningRouteIdentity != nextRouteIdentity
+        if (!capabilitiesChanged && !routeChanged && routeSnapshotInitialized) return
+        val generation = if (routeChanged) {
             generationCounter.incrementAndGet()
         } else {
             _outputRouteGeneration.value
         }
         playbackRouteSnapshot = AudioPlaybackRouteSnapshot(
-            sinkType = currentSinkType(),
+            sinkType = sinkType,
             routeGeneration = generation,
             capabilities = next.immutableCopy(),
         )
+        planningRouteIdentity = nextRouteIdentity
         routeSnapshotInitialized = true
         _capabilities.value = next
         _outputRouteGeneration.value = generation
@@ -445,4 +480,3 @@ internal val PASSTHROUGH_LAYOUT_PROBES: List<AudioCapabilityManager.AudioLayoutP
         listOf("7.1"),
     ),
 )
-

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionManager.kt
@@ -11,6 +11,7 @@ import org.siloserver.silo.model.playback.SubtitleFidelityPreference
 import org.siloserver.silo.model.playback.validateForMedia3
 import org.siloserver.silo.model.playback.PlaybackFailureV3
 import org.siloserver.silo.model.playback.PlaybackPlanV3
+import org.siloserver.silo.model.playback.PlaybackOutputContext
 import org.siloserver.silo.model.playback.PlaybackReplanRequestV3
 import org.siloserver.silo.model.playback.ProgressPersistenceV3
 import org.siloserver.silo.model.playback.PlaybackRouteEventV3
@@ -62,6 +63,24 @@ data class StagedVideoReplan(
      */
     val outputContextId: String?,
 )
+
+/**
+ * Whether two output snapshots can produce different playback recipes.
+ *
+ * The opaque context id is provenance, not a capability. Spatializer state is
+ * also excluded because the server does not route on it and Android may toggle
+ * it as a consequence of remounting the player. A callback that changes only
+ * those fields must not erase the failed-plan history and reopen a fallback
+ * route that just failed.
+ */
+internal fun PlaybackOutputContext.hasSamePlanningRouteAs(other: PlaybackOutputContext): Boolean =
+    copy(
+        outputContextId = null,
+        audioPassthrough = audioPassthrough?.copy(spatializerEnabled = false),
+    ) == other.copy(
+        outputContextId = null,
+        audioPassthrough = other.audioPassthrough?.copy(spatializerEnabled = false),
+    )
 
 /**
  * Manages the playback session lifecycle: creation, progress reporting,
@@ -826,9 +845,17 @@ open class PlaybackSessionManager(
         // An intent operation is a user's choice, not a failure: the previous
         // route stays eligible, so no attempt history is sent and the attempt
         // counter restarts. `output_route_changed` is still failure-shaped —
-        // the route the client was using genuinely stopped working — so it
-        // keeps the legacy classification path while resetting the same state.
-        val invalidation = intent || classification in USER_INVALIDATION_CLASSIFICATIONS
+        // the route the client was using genuinely stopped working — but its
+        // history restarts only when planning-relevant output capabilities
+        // changed. Android may advance an opaque context generation during a
+        // player remount; reopening failed plans for that callback creates an
+        // endless direct/remux/transcode cycle.
+        val materiallyChangedOutputRoute = classification == "output_route_changed" &&
+            !active.context.output.hasSamePlanningRouteAs(currentContext.output)
+        val invalidation = intent || (
+            classification in USER_INVALIDATION_CLASSIFICATIONS &&
+                (classification != "output_route_changed" || materiallyChangedOutputRoute)
+        )
         val attemptedKeys = if (invalidation) {
             emptyList()
         } else {

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AudioPlanningRouteIdentityTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/AudioPlanningRouteIdentityTest.kt
@@ -1,0 +1,65 @@
+package org.siloserver.silo.common.player
+
+import org.siloserver.silo.model.playback.AudioPassthroughCapabilities
+import org.siloserver.silo.model.playback.PlaybackOutputContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AudioPlanningRouteIdentityTest {
+    @Test
+    fun spatializerCallbacksDoNotCreateANewPhysicalRoute() {
+        val base = AudioPassthroughCapabilities(
+            passthroughCodecs = emptyList(),
+            spatializerEnabled = false,
+            maxChannels = 10,
+        )
+
+        assertEquals(
+            audioPlanningRouteIdentity("bluetooth", listOf("headset"), base),
+            audioPlanningRouteIdentity(
+                "bluetooth",
+                listOf("headset"),
+                base.copy(spatializerEnabled = true),
+            ),
+        )
+    }
+
+    @Test
+    fun physicalDeviceOrPlanningCapabilityChangesCreateANewRoute() {
+        val base = AudioPassthroughCapabilities(maxChannels = 2)
+        val original = audioPlanningRouteIdentity("bluetooth", listOf("headset-a"), base)
+
+        assertFalse(original == audioPlanningRouteIdentity("bluetooth", listOf("headset-b"), base))
+        assertFalse(
+            original == audioPlanningRouteIdentity(
+                "bluetooth",
+                listOf("headset-a"),
+                base.copy(maxChannels = 6),
+            ),
+        )
+    }
+
+    @Test
+    fun generationOnlyOutputChangePreservesFallbackHistoryIdentity() {
+        val original = PlaybackOutputContext(
+            sinkType = "bluetooth",
+            outputContextId = "68",
+            audioPassthrough = AudioPassthroughCapabilities(
+                spatializerEnabled = true,
+                maxChannels = 10,
+            ),
+        )
+
+        assertTrue(
+            original.hasSamePlanningRouteAs(
+                original.copy(
+                    outputContextId = "69",
+                    audioPassthrough = original.audioPassthrough?.copy(spatializerEnabled = false),
+                ),
+            ),
+        )
+        assertFalse(original.hasSamePlanningRouteAs(original.copy(sinkType = "built_in")))
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionManagerStagedReplanTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionManagerStagedReplanTest.kt
@@ -171,6 +171,42 @@ class PlaybackSessionManagerStagedReplanTest {
         ).data
 
         assertEquals("11", staged.outputContextId)
+        assertEquals(
+            listOf(basePlan().planAttemptKey),
+            harness.replanBodies.single()["attempted_plan_keys"]!!.jsonArray
+                .map { it.jsonPrimitive.content },
+        )
+    }
+
+    @Test
+    fun materialOutputRouteChangeRestartsFallbackHistory() = runTest {
+        val harness = Harness(
+            replanResponse = { _, _ -> response(sidecarPlan(sessionId = "s2")) },
+        )
+        harness.start()
+
+        assertIs<ApiResult.Success<StagedVideoReplan>>(
+            harness.manager.stageActiveVideoSessionReplan(
+                classification = "output_route_changed",
+                positionSeconds = 42.0,
+                audioTrackIndex = 0,
+                subtitleTrackIndex = 4,
+                clientPlaybackContext = ClientPlaybackContext(
+                    formFactor = "tv",
+                    appVersion = "test",
+                    output = PlaybackOutputContext(
+                        outputContextId = "11",
+                        sinkType = "hdmi",
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(
+            emptyList(),
+            harness.replanBodies.single()["attempted_plan_keys"]!!.jsonArray
+                .map { it.jsonPrimitive.content },
+        )
     }
 
     @Test


### PR DESCRIPTION
## What I changed

I split Android audio output state into two concepts: full runtime state for diagnostics and a stable planning identity for deciding whether playback must be replanned. The planning identity contains the physical sink and HDR, passthrough, and channel capabilities that can change the server recipe. It excludes Spatializer state because the server does not route on that value and Media3 can change it as a consequence of remounting.

The output-route generation now advances only when that planning identity changes. I also retain attempted-plan history when an opaque context ID changes without a material route change, so a callback cannot reopen direct, remux, and transcode routes that already failed.

## Why

I traced a live Android session that repeatedly cycled through direct play, remux, and transcode. The server transports were healthy. Media3 remounts triggered Spatializer callbacks, each callback was treated as a new physical output route, and the resulting replan cleared failed-route history. Loop detection therefore never got a stable history to act on.

This removes the false route change at its source. The companion server guard in [Silo-Server/silo-server#789](https://github.com/Silo-Server/silo-server/pull/789) protects already-installed builds that still send the legacy invalidation.

This change addresses route churn only. It does not claim to make an unsupported E-AC-3 Bluetooth path direct-play; the separate server fallback preserves the original video and converts only audio when Android genuinely reports a decoder failure.

## Validation

- Android Builds / Unit tests passed on the production-fork PR.
- Android Builds / Lint passed on the production-fork PR.
- Focused tests cover stable planning identity, real capability changes, and preserving fallback history.
- Local Gradle execution was unavailable because the validation Mac had no Java runtime; GitHub Actions supplied the repository build environment.

Source implementation and production validation: [blurbery/silo-android#4](https://github.com/blurbery/silo-android/pull/4).

Related issue: N/A — narrow fix reproduced on a live deployment.

## Scope and risk

A real sink, HDR, passthrough, or channel-capability change still advances route generation and replans normally. Only state that cannot affect the server playback recipe is filtered out. No API, schema, configuration, or Android TV product-surface changes are included.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted; I reproduced the live loop, designed the planning-identity boundary, reviewed the implementation, and validated the deployed server/client interaction
- Adversarial review: Traced the callback-to-replan path and checked each excluded field against the server planner. Focused tests verify that Spatializer-only drift is ignored while real sink, HDR, passthrough, and channel changes still invalidate the route, and attempted fallback history survives an opaque-token-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio route change detection by distinguishing meaningful physical or capability changes from spatializer and generation-only updates.
  * Prevented unnecessary playback replanning when output changes do not affect the active route.
  * Preserved fallback history for non-material route updates while restarting it for meaningful output changes.

* **Tests**
  * Added coverage for route identity changes, spatializer updates, device capabilities, and fallback-history behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->