### PR TITLE
feat: enhance Android system media controls

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloMediaSessionBitmapLoader.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloMediaSessionBitmapLoader.kt
@@ -1,0 +1,76 @@
+package org.siloserver.silo.common.player
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
+import androidx.media3.common.util.BitmapLoader
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.common.util.Util
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.toBitmap
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.MoreExecutors
+import kotlinx.coroutines.runBlocking
+import java.io.Closeable
+import java.io.IOException
+import java.util.concurrent.Executors
+
+/**
+ * Loads Media3 notification artwork through Silo's process-wide Coil loader.
+ *
+ * Media3's default bitmap loader opens remote artwork with a bare
+ * `HttpURLConnection`. That bypasses the image pipeline used everywhere else
+ * in the app and can leave Android's media notification with a null large
+ * icon even while the same backdrop renders in Compose. Reusing Coil gives
+ * Now Playing the same network behavior and disk cache as the visible UI.
+ */
+@UnstableApi
+class SiloMediaSessionBitmapLoader(context: Context) : BitmapLoader, Closeable {
+    private val appContext = context.applicationContext
+    private val imageLoader = appContext.imageLoader
+    private val executor = MoreExecutors.listeningDecorator(
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "silo-media-artwork").apply { isDaemon = true }
+        },
+    )
+
+    override fun supportsMimeType(mimeType: String): Boolean =
+        Util.isBitmapFactorySupportedMimeType(mimeType)
+
+    override fun decodeBitmap(data: ByteArray): ListenableFuture<Bitmap> = executor.submit<Bitmap> {
+        BitmapFactory.decodeByteArray(data, 0, data.size)
+            ?: throw IOException("Silo media artwork data could not be decoded")
+    }
+
+    override fun loadBitmap(uri: Uri): ListenableFuture<Bitmap> = executor.submit<Bitmap> {
+        runBlocking {
+            val result = imageLoader.execute(
+                ImageRequest.Builder(appContext)
+                    .data(uri)
+                    .size(MAX_ARTWORK_SIZE_PX, MAX_ARTWORK_SIZE_PX)
+                    .build(),
+            )
+            if (result !is SuccessResult) {
+                throw IOException("Silo media artwork could not be loaded")
+            }
+            val bitmap = result.image.toBitmap()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && bitmap.config == Bitmap.Config.HARDWARE) {
+                bitmap.copy(Bitmap.Config.ARGB_8888, false)
+            } else {
+                bitmap
+            }
+        }
+    }
+
+    override fun close() {
+        executor.shutdownNow()
+    }
+
+    private companion object {
+        const val MAX_ARTWORK_SIZE_PX = 1_024
+    }
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlaybackService.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlaybackService.kt
@@ -124,6 +124,7 @@ class SiloPlaybackService : MediaSessionService() {
     private val subtitleOffsetHolder: SubtitleOffsetHolder by inject()
 
     private var mediaSession: MediaSession? = null
+    private var mediaSessionBitmapLoader: SiloMediaSessionBitmapLoader? = null
     private lateinit var scope: CoroutineScope
     private var positionJob: Job? = null
     private var audioSyncJob: Job? = null
@@ -168,7 +169,11 @@ class SiloPlaybackService : MediaSessionService() {
                 "extension on classpath = ${FfmpegAudioSupport.isAvailable()}",
         )
 
-        mediaSession = MediaSession.Builder(this, player).build()
+        val bitmapLoader = SiloMediaSessionBitmapLoader(this)
+        mediaSessionBitmapLoader = bitmapLoader
+        mediaSession = MediaSession.Builder(this, player)
+            .setBitmapLoader(bitmapLoader)
+            .build()
 
         positionJob = scope.launch {
             while (isActive) {
@@ -350,6 +355,8 @@ class SiloPlaybackService : MediaSessionService() {
             release()
         }
         mediaSession = null
+        mediaSessionBitmapLoader?.close()
+        mediaSessionBitmapLoader = null
         activePlayer = null
         activePlayerHolder.set(null)
         val count = playerInstanceCount.decrementAndGet()

--- a/androidApp/src/androidMain/AndroidManifest.xml
+++ b/androidApp/src/androidMain/AndroidManifest.xml
@@ -101,6 +101,14 @@
             </intent-filter>
         </service>
 
+        <!-- Phone-only Media3 projection of playback controlled on a Silo TV.
+             It is started explicitly, so it does not compete with the local
+             playback service as the package's media-button cold-start target. -->
+        <service
+            android:name=".cast.SiloCastMediaSessionService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
+
         <service
             android:name=".push.SiloFirebaseMessagingService"
             android:exported="false">

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/SiloApplication.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/SiloApplication.kt
@@ -72,6 +72,14 @@ class SiloApplication : Application(), Configuration.Provider, SingletonImageLoa
         }.onFailure {
             android.util.Log.w("SiloApplication", "SiloCast foreground starter init failed", it)
         }
+        runCatching {
+            org.siloserver.silo.android.cast.SiloCastMediaSessionStarter(
+                context = this@SiloApplication,
+                controller = koinApp.koin.get(),
+            ).start()
+        }.onFailure {
+            android.util.Log.w("SiloApplication", "SiloCast media-session starter init failed", it)
+        }
         // Configuration.Provider wasn't reliably picked up by WM's androidx.startup
         // auto-init (the auto-init seemed to win the race, leaving WM with its
         // default reflection-based WorkerFactory). Force-initialise explicitly

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/RemoteControlBatteryOptimization.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/RemoteControlBatteryOptimization.kt
@@ -1,0 +1,51 @@
+package org.siloserver.silo.android.cast
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+
+/** Android battery-policy integration for the long-lived TV control socket. */
+object RemoteControlBatteryOptimization {
+    private const val PREFERENCES_NAME = "remote_control"
+    private const val PROMPT_SHOWN_KEY = "battery_optimization_prompt_shown"
+
+    fun isExempt(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true
+        val powerManager = context.getSystemService(PowerManager::class.java) ?: return false
+        return powerManager.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    fun shouldShowPrompt(context: Context): Boolean =
+        !isExempt(context) &&
+            !context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+                .getBoolean(PROMPT_SHOWN_KEY, false)
+
+    fun markPromptShown(context: Context) {
+        context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(PROMPT_SHOWN_KEY, true)
+            .apply()
+    }
+
+    /**
+     * Opens Android's exemption list. Using the system list instead of
+     * ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS avoids the restricted
+     * REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission while still taking the
+     * user directly to the setting they need to change.
+     */
+    fun openSettings(context: Context) {
+        val flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        val batterySettings = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+            .addFlags(flags)
+        val fallback = Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.parse("package:${context.packageName}"),
+        ).addFlags(flags)
+
+        runCatching { context.startActivity(batterySettings) }
+            .recoverCatching { context.startActivity(fallback) }
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastArtworkResolver.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastArtworkResolver.kt
@@ -1,0 +1,39 @@
+package org.siloserver.silo.android.cast
+
+import org.siloserver.silo.model.catalog.ItemDetail
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.repository.CatalogRepository
+
+/** Artwork resolved locally from the content identity in Remote Control state. */
+data class SiloCastArtwork(
+    val posterUrl: String? = null,
+    val posterThumbhash: String? = null,
+    val backdropUrl: String? = null,
+    val backdropThumbhash: String? = null,
+) {
+    val isEmpty: Boolean get() = posterUrl == null && backdropUrl == null
+}
+
+/**
+ * Episodes use their series' portrait poster while retaining the episode
+ * still/backdrop for wide and blurred surfaces.
+ */
+internal suspend fun resolveCastArtwork(
+    repository: CatalogRepository,
+    contentId: String,
+): SiloCastArtwork {
+    val detail = repository.detailOrNull(contentId) ?: return SiloCastArtwork()
+    val series = detail.seriesId
+        ?.takeIf { detail.type == "episode" }
+        ?.let { repository.detailOrNull(it) }
+    return SiloCastArtwork(
+        posterUrl = series?.posterUrl ?: detail.posterUrl,
+        posterThumbhash = if (series?.posterUrl != null) series.posterThumbhash else detail.posterThumbhash,
+        backdropUrl = detail.backdropUrl ?: series?.backdropUrl,
+        backdropThumbhash = if (detail.backdropUrl != null) detail.backdropThumbhash else series?.backdropThumbhash,
+    )
+}
+
+private suspend fun CatalogRepository.detailOrNull(contentId: String): ItemDetail? =
+    getCachedItemDetail(contentId)
+        ?: (getItemDetail(contentId) as? ApiResult.Success)?.data

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastController.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastController.kt
@@ -284,6 +284,14 @@ class SiloCastController(
         clock.setOptimisticPlaying(!isPlaying(), nowMs())
     }
 
+    /** Idempotent transport command used by Android system media controls. */
+    fun setPlaying(playing: Boolean) {
+        sendControl(
+            if (playing) SiloCastControlCommand.play() else SiloCastControlCommand.pause(),
+        )
+        clock.setOptimisticPlaying(playing, nowMs())
+    }
+
     fun seek(seconds: Double) {
         sendControl(SiloCastControlCommand.seek(seconds))
         clock.setOptimisticTime(seconds, nowMs())

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastMediaSessionService.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastMediaSessionService.kt
@@ -1,0 +1,275 @@
+package org.siloserver.silo.android.cast
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Looper
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.SimpleBasePlayer
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSessionService
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
+import org.siloserver.silo.cast.SiloCastPlaybackState
+import org.siloserver.silo.common.player.SiloMediaSessionBitmapLoader
+import org.siloserver.silo.repository.CatalogRepository
+import kotlin.math.roundToLong
+
+/**
+ * Publishes Silo Remote Control as an Android Media3 session. The player is a
+ * projection of the TV's state: system play/pause/seek/next commands are sent
+ * over SiloCast and incoming TV state invalidates the Media3 timeline.
+ *
+ * Keeping this session in a MediaSessionService also gives an engaged remote
+ * session a foreground-service lifetime while the TV is playing, so swiping
+ * away the phone UI does not immediately tear down the control socket.
+ */
+@UnstableApi
+class SiloCastMediaSessionService : MediaSessionService() {
+    private val controller: SiloCastController by inject()
+    private val catalogRepository: CatalogRepository by inject()
+
+    private lateinit var player: SiloCastRemotePlayer
+    private var mediaSession: MediaSession? = null
+    private var mediaSessionBitmapLoader: SiloMediaSessionBitmapLoader? = null
+    private lateinit var scope: CoroutineScope
+    private var stateJob: Job? = null
+    private var artworkJob: Job? = null
+    private var artworkContentId: String? = null
+    private var artworkUrl: String? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        player = SiloCastRemotePlayer(Looper.getMainLooper(), controller)
+        val bitmapLoader = SiloMediaSessionBitmapLoader(this)
+        mediaSessionBitmapLoader = bitmapLoader
+        mediaSession = MediaSession.Builder(this, player)
+            .setBitmapLoader(bitmapLoader)
+            .build()
+
+        stateJob = scope.launch {
+            controller.state.collect { state ->
+                val playback = state.playbackState
+                player.update(
+                    playback = playback,
+                    targetName = state.connectedTarget?.name,
+                    artworkUrl = artworkUrl.takeIf { playback?.contentId == artworkContentId },
+                )
+                if (playback?.contentId.isNullOrBlank()) {
+                    pauseAllPlayersAndStopSelf()
+                }
+            }
+        }
+        artworkJob = scope.launch {
+            controller.state
+                .map { it.playbackState?.contentId }
+                .distinctUntilChanged()
+                .collectLatest { contentId ->
+                    artworkContentId = contentId
+                    artworkUrl = null
+                    player.updateArtwork(contentId = contentId, artworkUrl = null)
+                    if (contentId.isNullOrBlank()) return@collectLatest
+
+                    val artwork = resolveCastArtwork(catalogRepository, contentId)
+                    if (artworkContentId == contentId) {
+                        // Wide backdrop is intentional for Android's wide
+                        // system media canvas; the poster is only a fallback.
+                        artworkUrl = artwork.backdropUrl ?: artwork.posterUrl
+                        player.updateArtwork(contentId, artworkUrl)
+                    }
+                }
+        }
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+        return START_NOT_STICKY
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        // Media3's default stops a paused session as soon as Recents dismisses
+        // the Activity. Keep an active remote session for the foreground grace
+        // window; once it is no longer foreground, the platform requires stop.
+        val hasRemoteMedia = !controller.state.value.playbackState?.contentId.isNullOrBlank()
+        if (!hasRemoteMedia || !isPlaybackOngoing()) {
+            super.onTaskRemoved(rootIntent)
+        }
+    }
+
+    override fun onDestroy() {
+        stateJob?.cancel()
+        artworkJob?.cancel()
+        scope.cancel()
+        mediaSession?.release()
+        mediaSession = null
+        mediaSessionBitmapLoader?.close()
+        mediaSessionBitmapLoader = null
+        player.release()
+        super.onDestroy()
+    }
+}
+
+@UnstableApi
+internal class SiloCastRemotePlayer(
+    looper: Looper,
+    private val controller: SiloCastController,
+) : SimpleBasePlayer(looper) {
+    private var playback: SiloCastPlaybackState? = null
+    private var targetName: String? = null
+    private var artworkContentId: String? = null
+    private var artworkUrl: String? = null
+
+    fun update(
+        playback: SiloCastPlaybackState?,
+        targetName: String?,
+        artworkUrl: String?,
+    ) {
+        verifyApplicationThread()
+        this.playback = playback
+        this.targetName = targetName
+        this.artworkContentId = playback?.contentId
+        this.artworkUrl = artworkUrl
+        invalidateState()
+    }
+
+    fun updateArtwork(contentId: String?, artworkUrl: String?) {
+        verifyApplicationThread()
+        if (playback?.contentId != contentId) return
+        artworkContentId = contentId
+        this.artworkUrl = artworkUrl
+        invalidateState()
+    }
+
+    override fun getState(): State {
+        val remote = playback
+        val contentId = remote?.contentId?.takeIf(String::isNotBlank)
+            ?: return State.Builder()
+                .setAvailableCommands(Player.Commands.Builder().add(Player.COMMAND_RELEASE).build())
+                .setPlaybackState(Player.STATE_IDLE)
+                .build()
+
+        val durationMs = remote.duration
+            .takeIf { it.isFinite() && it > 0.0 }
+            ?.times(1000.0)
+            ?.roundToLong()
+            ?: C.TIME_UNSET
+        val positionMs = controller.displayTime()
+            .takeIf { it.isFinite() }
+            ?.times(1000.0)
+            ?.roundToLong()
+            ?.coerceAtLeast(0L)
+            ?.let { position ->
+                if (durationMs == C.TIME_UNSET) position else position.coerceAtMost(durationMs)
+            }
+            ?: 0L
+        val wantsToPlay = controller.isPlaying() || remote.isLoading || remote.isBuffering
+        val playbackState = if (remote.isLoading || remote.isBuffering) {
+            Player.STATE_BUFFERING
+        } else {
+            Player.STATE_READY
+        }
+        val metadata = MediaMetadata.Builder()
+            .setTitle(remote.title)
+            .setSubtitle(remote.subtitle ?: targetName?.let { "Playing on $it" })
+            .setIsPlayable(true)
+            .apply {
+                remote.subtitle?.takeIf(String::isNotBlank)?.let { setArtist(it) }
+                if (durationMs != C.TIME_UNSET) setDurationMs(durationMs)
+                artworkUrl
+                    ?.takeIf { artworkContentId == contentId && it.isNotBlank() }
+                    ?.let { setArtworkUri(Uri.parse(it)) }
+            }
+            .build()
+        val mediaItem = MediaItem.Builder()
+            .setMediaId(contentId)
+            .setMediaMetadata(metadata)
+            .build()
+        val itemData = MediaItemData.Builder(remote.sessionId ?: contentId)
+            .setMediaItem(mediaItem)
+            .setMediaMetadata(metadata)
+            .setDurationUs(if (durationMs == C.TIME_UNSET) C.TIME_UNSET else durationMs * 1_000L)
+            .setIsSeekable(durationMs != C.TIME_UNSET)
+            .build()
+        val commands = Player.Commands.Builder()
+            .addAll(
+                Player.COMMAND_PLAY_PAUSE,
+                Player.COMMAND_STOP,
+                Player.COMMAND_RELEASE,
+                Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
+                Player.COMMAND_GET_TIMELINE,
+                Player.COMMAND_GET_METADATA,
+                Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+                Player.COMMAND_SEEK_BACK,
+                Player.COMMAND_SEEK_FORWARD,
+            )
+            .apply {
+                if (remote.hasNextEpisode) add(Player.COMMAND_SEEK_TO_NEXT)
+            }
+            .build()
+
+        return State.Builder()
+            .setAvailableCommands(commands)
+            .setPlaylist(listOf(itemData))
+            .setCurrentMediaItemIndex(0)
+            .setPlaybackState(playbackState)
+            .setIsLoading(remote.isLoading || remote.isBuffering)
+            .setPlayWhenReady(wantsToPlay, Player.PLAY_WHEN_READY_CHANGE_REASON_REMOTE)
+            .setContentPositionMs(positionMs)
+            .setSeekBackIncrementMs(SEEK_BACK_MS)
+            .setSeekForwardIncrementMs(SEEK_FORWARD_MS)
+            .setPlaybackParameters(
+                PlaybackParameters(
+                    remote.playbackSpeed.toFloat().takeIf { it.isFinite() && it > 0f } ?: 1f,
+                ),
+            )
+            .build()
+    }
+
+    override fun handleSetPlayWhenReady(playWhenReady: Boolean): ListenableFuture<*> {
+        controller.setPlaying(playWhenReady)
+        return Futures.immediateVoidFuture()
+    }
+
+    override fun handleSeek(
+        mediaItemIndex: Int,
+        positionMs: Long,
+        seekCommand: Int,
+    ): ListenableFuture<*> {
+        if (seekCommand == Player.COMMAND_SEEK_TO_NEXT) {
+            controller.playNext()
+        } else if (positionMs != C.TIME_UNSET) {
+            controller.seek(positionMs.coerceAtLeast(0L) / 1000.0)
+        }
+        return Futures.immediateVoidFuture()
+    }
+
+    override fun handleStop(): ListenableFuture<*> {
+        controller.stopPlayback()
+        return Futures.immediateVoidFuture()
+    }
+
+    override fun handleRelease(): ListenableFuture<*> = Futures.immediateVoidFuture()
+
+    private companion object {
+        const val SEEK_BACK_MS = 10_000L
+        const val SEEK_FORWARD_MS = 30_000L
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastMediaSessionStarter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastMediaSessionStarter.kt
@@ -1,0 +1,54 @@
+package org.siloserver.silo.android.cast
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * Starts the phone-only Remote Control media service whenever the TV reports
+ * an active title. This is application-scoped so the service is established
+ * before the Activity can move to the background.
+ */
+class SiloCastMediaSessionStarter(
+    context: Context,
+    private val controller: SiloCastController,
+) {
+    private val appContext = context.applicationContext
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    fun start() {
+        scope.launch {
+            controller.state
+                .map { state ->
+                    val playback = state.playbackState
+                    RemoteServiceState(
+                        hasMedia = !playback?.contentId.isNullOrBlank(),
+                        needsForegroundStart = playback?.let {
+                            it.isPlaying || it.isLoading || it.isBuffering
+                        } == true,
+                    )
+                }
+                .distinctUntilChanged()
+                .collect { state ->
+                    val intent = Intent(appContext, SiloCastMediaSessionService::class.java)
+                    when {
+                        !state.hasMedia -> appContext.stopService(intent)
+                        state.needsForegroundStart -> ContextCompat.startForegroundService(appContext, intent)
+                        else -> appContext.startService(intent)
+                    }
+                }
+        }
+    }
+
+    private data class RemoteServiceState(
+        val hasMedia: Boolean,
+        val needsForegroundStart: Boolean,
+    )
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastMediaSessionStarter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/cast/SiloCastMediaSessionStarter.kt
@@ -2,7 +2,12 @@ package org.siloserver.silo.android.cast
 
 import android.content.Context
 import android.content.Intent
+import androidx.annotation.OptIn
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.media3.common.util.UnstableApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -12,43 +17,95 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 /**
- * Starts the phone-only Remote Control media service whenever the TV reports
- * an active title. This is application-scoped so the service is established
- * before the Activity can move to the background.
+ * Starts the phone-only Remote Control media service while the application is
+ * foregrounded, then leaves Media3 to maintain its foreground lifetime after
+ * the Activity moves to the background.
+ *
+ * Android 12+ rejects a new foreground-service start from the background. A
+ * TV may begin a new title while the phone is backgrounded, so those starts
+ * are deliberately deferred until [onStart]. An already-running service keeps
+ * receiving controller state directly and does not need to be started again.
  */
 class SiloCastMediaSessionStarter(
     context: Context,
     private val controller: SiloCastController,
-) {
+) : DefaultLifecycleObserver {
     private val appContext = context.applicationContext
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var appForeground = false
+    private var latestState = controller.state.value.toRemoteServiceState()
 
     fun start() {
+        ProcessLifecycleOwner.get().lifecycle.addObserver(this)
         scope.launch {
             controller.state
-                .map { state ->
-                    val playback = state.playbackState
-                    RemoteServiceState(
-                        hasMedia = !playback?.contentId.isNullOrBlank(),
-                        needsForegroundStart = playback?.let {
-                            it.isPlaying || it.isLoading || it.isBuffering
-                        } == true,
-                    )
-                }
+                .map { it.toRemoteServiceState() }
                 .distinctUntilChanged()
                 .collect { state ->
-                    val intent = Intent(appContext, SiloCastMediaSessionService::class.java)
-                    when {
-                        !state.hasMedia -> appContext.stopService(intent)
-                        state.needsForegroundStart -> ContextCompat.startForegroundService(appContext, intent)
-                        else -> appContext.startService(intent)
-                    }
+                    latestState = state
+                    applyServiceAction(resolveRemoteMediaServiceAction(state, appForeground))
                 }
         }
     }
 
-    private data class RemoteServiceState(
-        val hasMedia: Boolean,
-        val needsForegroundStart: Boolean,
+    override fun onStart(owner: LifecycleOwner) {
+        appForeground = true
+        applyServiceAction(resolveRemoteMediaServiceAction(latestState, appForeground = true))
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        appForeground = false
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun applyServiceAction(action: RemoteMediaServiceAction) {
+        val intent = Intent(appContext, SiloCastMediaSessionService::class.java)
+        runCatching {
+            when (action) {
+                RemoteMediaServiceAction.None -> Unit
+                RemoteMediaServiceAction.Stop -> appContext.stopService(intent)
+                RemoteMediaServiceAction.Start -> appContext.startService(intent)
+                RemoteMediaServiceAction.StartForeground ->
+                    ContextCompat.startForegroundService(appContext, intent)
+            }
+        }.onFailure { error ->
+            android.util.Log.w(TAG, "Could not apply Remote Control media-service action $action", error)
+        }
+    }
+
+    private companion object {
+        const val TAG = "SiloCastMediaStarter"
+    }
+}
+
+internal data class RemoteServiceState(
+    val hasMedia: Boolean,
+    val needsForegroundStart: Boolean,
+)
+
+internal enum class RemoteMediaServiceAction {
+    None,
+    Stop,
+    Start,
+    StartForeground,
+}
+
+internal fun resolveRemoteMediaServiceAction(
+    state: RemoteServiceState,
+    appForeground: Boolean,
+): RemoteMediaServiceAction = when {
+    !state.hasMedia -> RemoteMediaServiceAction.Stop
+    !appForeground -> RemoteMediaServiceAction.None
+    state.needsForegroundStart -> RemoteMediaServiceAction.StartForeground
+    else -> RemoteMediaServiceAction.Start
+}
+
+private fun SiloCastControllerState.toRemoteServiceState(): RemoteServiceState {
+    val playback = playbackState
+    return RemoteServiceState(
+        hasMedia = !playback?.contentId.isNullOrBlank(),
+        needsForegroundStart = playback?.let {
+            it.isPlaying || it.isLoading || it.isBuffering
+        } == true,
     )
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/cast/SiloCastArtwork.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/cast/SiloCastArtwork.kt
@@ -7,8 +7,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import org.koin.compose.koinInject
-import org.siloserver.silo.model.catalog.ItemDetail
-import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.android.cast.SiloCastArtwork
+import org.siloserver.silo.android.cast.resolveCastArtwork
 import org.siloserver.silo.repository.CatalogRepository
 
 /**
@@ -18,18 +18,9 @@ import org.siloserver.silo.repository.CatalogRepository
  * detail first, then the API, degrading silently to no artwork.
  *
  * Episodes use their series' portrait poster — an episode's own poster is a
- * landscape still, wrong for the remote's 2:3 card. The episode's backdrop
- * (the still) is kept for the blurred background, where it looks right.
+ * landscape still, wrong for the remote's 2:3 card. Resolution itself lives
+ * outside Compose so the Android media session can publish the same artwork.
  */
-data class SiloCastArtwork(
-    val posterUrl: String? = null,
-    val posterThumbhash: String? = null,
-    val backdropUrl: String? = null,
-    val backdropThumbhash: String? = null,
-) {
-    val isEmpty: Boolean get() = posterUrl == null && backdropUrl == null
-}
-
 @Composable
 fun rememberSiloCastArtwork(contentId: String?): SiloCastArtwork {
     val repository: CatalogRepository = koinInject()
@@ -45,23 +36,3 @@ fun rememberSiloCastArtwork(contentId: String?): SiloCastArtwork {
     }
     return artwork
 }
-
-private suspend fun resolveCastArtwork(
-    repository: CatalogRepository,
-    contentId: String,
-): SiloCastArtwork {
-    val detail = repository.detailOrNull(contentId) ?: return SiloCastArtwork()
-    val series = detail.seriesId
-        ?.takeIf { detail.type == "episode" }
-        ?.let { repository.detailOrNull(it) }
-    return SiloCastArtwork(
-        posterUrl = series?.posterUrl ?: detail.posterUrl,
-        posterThumbhash = if (series?.posterUrl != null) series.posterThumbhash else detail.posterThumbhash,
-        backdropUrl = detail.backdropUrl ?: series?.backdropUrl,
-        backdropThumbhash = if (detail.backdropUrl != null) detail.backdropThumbhash else series?.backdropThumbhash,
-    )
-}
-
-private suspend fun CatalogRepository.detailOrNull(contentId: String): ItemDetail? =
-    getCachedItemDetail(contentId)
-        ?: (getItemDetail(contentId) as? ApiResult.Success)?.data

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/cast/SiloCastRemoteScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/cast/SiloCastRemoteScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material.icons.outlined.Tv
 import androidx.compose.material.icons.outlined.TvOff
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -55,6 +56,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -72,6 +74,8 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -79,7 +83,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import org.koin.compose.koinInject
+import org.siloserver.silo.android.R
+import org.siloserver.silo.android.cast.RemoteControlBatteryOptimization
 import org.siloserver.silo.android.cast.SiloCastController
 import org.siloserver.silo.cast.SiloCastPlaybackState
 import org.siloserver.silo.common.ui.components.ThumbhashImage
@@ -107,11 +116,36 @@ fun SiloCastRemoteScreen(
     val state by controller.state.collectAsState()
     val playback = state.playbackState
     val artwork = rememberSiloCastArtwork(playback?.contentId)
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     var showTargetPicker by remember { mutableStateOf(false) }
+    var showBatteryPrompt by remember { mutableStateOf(false) }
+    var batteryExempt by remember {
+        mutableStateOf(RemoteControlBatteryOptimization.isExempt(context))
+    }
 
     DisposableEffect(controller) {
         controller.setRemoteScreenVisible(true)
         onDispose { controller.setRemoteScreenVisible(false) }
+    }
+
+    DisposableEffect(lifecycleOwner, context) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                batteryExempt = RemoteControlBatteryOptimization.isExempt(context)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LaunchedEffect(state.hasActiveSession, batteryExempt) {
+        if (state.hasActiveSession &&
+            !batteryExempt &&
+            RemoteControlBatteryOptimization.shouldShowPrompt(context)
+        ) {
+            showBatteryPrompt = true
+        }
     }
 
     Box(
@@ -129,6 +163,10 @@ fun SiloCastRemoteScreen(
                 onDisconnect = {
                     controller.disconnect()
                     onBack()
+                },
+                showBatterySettings = !batteryExempt,
+                onBatterySettings = {
+                    RemoteControlBatteryOptimization.openSettings(context)
                 },
             )
 
@@ -169,6 +207,38 @@ fun SiloCastRemoteScreen(
             controller = controller,
         )
     }
+
+    if (showBatteryPrompt) {
+        AlertDialog(
+            onDismissRequest = {
+                RemoteControlBatteryOptimization.markPromptShown(context)
+                showBatteryPrompt = false
+            },
+            title = { Text(stringResource(R.string.remote_battery_title)) },
+            text = { Text(stringResource(R.string.remote_battery_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        RemoteControlBatteryOptimization.markPromptShown(context)
+                        showBatteryPrompt = false
+                        RemoteControlBatteryOptimization.openSettings(context)
+                    },
+                ) {
+                    Text(stringResource(R.string.remote_battery_settings))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        RemoteControlBatteryOptimization.markPromptShown(context)
+                        showBatteryPrompt = false
+                    },
+                ) {
+                    Text(stringResource(R.string.remote_battery_not_now))
+                }
+            },
+        )
+    }
 }
 
 /** Full-bleed blurred-artwork backdrop, falling back to flat OLED black. */
@@ -199,6 +269,8 @@ private fun RemoteTopBar(
     onChooseTv: () -> Unit,
     onStopPlayback: () -> Unit,
     onDisconnect: () -> Unit,
+    showBatterySettings: Boolean,
+    onBatterySettings: () -> Unit,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
     Row(
@@ -241,6 +313,18 @@ private fun RemoteTopBar(
                         onStopPlayback()
                     },
                 )
+                if (showBatterySettings) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.remote_battery_settings)) },
+                        leadingIcon = {
+                            Icon(Icons.Outlined.SettingsRemote, contentDescription = null)
+                        },
+                        onClick = {
+                            menuExpanded = false
+                            onBatterySettings()
+                        },
+                    )
+                }
                 HorizontalDivider()
                 DropdownMenuItem(
                     text = { Text("Disconnect", color = MaterialTheme.colorScheme.error) },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileVideoPlaybackStarter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileVideoPlaybackStarter.kt
@@ -154,6 +154,19 @@ internal class MobileVideoPlaybackStarter(
                 )
             }
 
+            // The playback-focused /watch response currently omits artwork.
+            // Detail screens cache the full catalog item before playback in the
+            // normal flow; deep links fall back to one best-effort detail fetch.
+            // Artwork enrichment must never prevent playback from starting.
+            val artworkUrl = watchDetail.backdropUrl?.takeIf { it.isNotBlank() }
+                ?: watchDetail.posterUrl?.takeIf { it.isNotBlank() }
+                ?: (catalogRepository.getItemDetailForPrefetch(request.contentId) as? ApiResult.Success)
+                    ?.data
+                    ?.let { detail ->
+                        detail.backdropUrl?.takeIf { it.isNotBlank() }
+                            ?: detail.posterUrl?.takeIf { it.isNotBlank() }
+                    }
+
             val serverUrl = playbackSessionManager.getServerUrl()
             val preferredQuality = request.preferredQualityOverride
                 ?: playerSettingsStore.preferredQualityFlow.first()
@@ -363,8 +376,10 @@ internal class MobileVideoPlaybackStarter(
                 container = readyV3.plan.stream.container ?: effectiveVersion?.container,
                 title = watchDetail.title,
                 subtitle = buildSubtitle(watchDetail).takeIf { it.isNotBlank() },
-                artworkUrl = watchDetail.posterUrl?.takeIf { it.isNotBlank() }
-                    ?: watchDetail.backdropUrl?.takeIf { it.isNotBlank() },
+                // Android's system media controls give artwork a wide canvas.
+                // Prefer the title backdrop there; portrait posters remain the
+                // fallback for catalog entries that do not have one.
+                artworkUrl = artworkUrl,
                 startPositionSeconds = playerStartPos,
                 sourceStartPositionSeconds = sourceStartPos,
                 serverUrl = serverUrl,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileVideoPlaybackStarter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileVideoPlaybackStarter.kt
@@ -156,16 +156,17 @@ internal class MobileVideoPlaybackStarter(
 
             // The playback-focused /watch response currently omits artwork.
             // Detail screens cache the full catalog item before playback in the
-            // normal flow; deep links fall back to one best-effort detail fetch.
-            // Artwork enrichment must never prevent playback from starting.
+            // normal flow. Keep this fallback cache-only so optional artwork can
+            // never add a network request to, or prevent, playback startup.
+            val cachedDetail = runCatching {
+                catalogRepository.getCachedItemDetail(request.contentId)
+            }.onFailure { error ->
+                Log.w(TAG, "Could not read cached playback artwork", error)
+            }.getOrNull()
             val artworkUrl = watchDetail.backdropUrl?.takeIf { it.isNotBlank() }
                 ?: watchDetail.posterUrl?.takeIf { it.isNotBlank() }
-                ?: (catalogRepository.getItemDetailForPrefetch(request.contentId) as? ApiResult.Success)
-                    ?.data
-                    ?.let { detail ->
-                        detail.backdropUrl?.takeIf { it.isNotBlank() }
-                            ?: detail.posterUrl?.takeIf { it.isNotBlank() }
-                    }
+                ?: cachedDetail?.backdropUrl?.takeIf { it.isNotBlank() }
+                ?: cachedDetail?.posterUrl?.takeIf { it.isNotBlank() }
 
             val serverUrl = playbackSessionManager.getServerUrl()
             val preferredQuality = request.preferredQualityOverride

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -370,8 +370,8 @@ class PlayerViewModel(
         val subtitle: String = "",
         /**
          * Artwork URL used for the Now Playing lock-screen / Bluetooth /
-         * notification surface. Sourced from `WatchDetail.posterUrl` with
-         * `backdropUrl` fallback. Threaded into MediaItem.MediaMetadata so
+         * notification surface. Sourced from `WatchDetail.backdropUrl` with
+         * `posterUrl` fallback. Threaded into MediaItem.MediaMetadata so
          * the MediaSession publishes it to the OS. Mirrors iOS phone's
          * `NowPlayingController.setArtworkURL`.
          */
@@ -4268,8 +4268,8 @@ class PlayerViewModel(
             sessionPosition = 0.0,
             detailPosition = detailPos,
         )
-        val artworkUrl = watchDetail?.posterUrl?.takeIf { url -> url.isNotBlank() }
-            ?: watchDetail?.backdropUrl?.takeIf { url -> url.isNotBlank() }
+        val artworkUrl = watchDetail?.backdropUrl?.takeIf { url -> url.isNotBlank() }
+            ?: watchDetail?.posterUrl?.takeIf { url -> url.isNotBlank() }
             ?: sidecar.posterUrl?.takeIf { url -> url.isNotBlank() }
 
         val published = loadOwners.runIfOwned(loadOwner) {

--- a/androidApp/src/androidMain/res/values/strings.xml
+++ b/androidApp/src/androidMain/res/values/strings.xml
@@ -17,6 +17,12 @@
     <string name="action_sign_in">Sign In</string>
     <string name="action_sign_out">Sign Out</string>
 
+    <!-- Remote Control -->
+    <string name="remote_battery_title">Keep Remote Control connected</string>
+    <string name="remote_battery_message">Allow Silo to run without battery restrictions so Remote Control can stay connected after you leave the app. In Battery optimization, choose Silo and set it to Not optimized.</string>
+    <string name="remote_battery_settings">Battery settings</string>
+    <string name="remote_battery_not_now">Not now</string>
+
     <!-- Common states -->
     <string name="loading">Loading&#8230;</string>
     <string name="error_generic">Something went wrong</string>

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/cast/SiloCastMediaSessionStarterTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/cast/SiloCastMediaSessionStarterTest.kt
@@ -1,0 +1,44 @@
+package org.siloserver.silo.android.cast
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SiloCastMediaSessionStarterTest {
+    @Test
+    fun `active playback starts a foreground service only while app is foregrounded`() {
+        val active = RemoteServiceState(hasMedia = true, needsForegroundStart = true)
+
+        assertEquals(
+            RemoteMediaServiceAction.StartForeground,
+            resolveRemoteMediaServiceAction(active, appForeground = true),
+        )
+        assertEquals(
+            RemoteMediaServiceAction.None,
+            resolveRemoteMediaServiceAction(active, appForeground = false),
+        )
+    }
+
+    @Test
+    fun `paused media uses an ordinary service start only while app is foregrounded`() {
+        val paused = RemoteServiceState(hasMedia = true, needsForegroundStart = false)
+
+        assertEquals(
+            RemoteMediaServiceAction.Start,
+            resolveRemoteMediaServiceAction(paused, appForeground = true),
+        )
+        assertEquals(
+            RemoteMediaServiceAction.None,
+            resolveRemoteMediaServiceAction(paused, appForeground = false),
+        )
+    }
+
+    @Test
+    fun `cleared media stops the service even while app is backgrounded`() {
+        val empty = RemoteServiceState(hasMedia = false, needsForegroundStart = false)
+
+        assertEquals(
+            RemoteMediaServiceAction.Stop,
+            resolveRemoteMediaServiceAction(empty, appForeground = false),
+        )
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -274,8 +274,8 @@ class TvVideoPlaybackStarter(
                 container = readyV3.plan.stream.container ?: effectiveVersion?.container,
                 title = watchDetail.title,
                 subtitle = null,
-                artworkUrl = watchDetail.posterUrl?.takeIf { it.isNotBlank() }
-                    ?: watchDetail.backdropUrl?.takeIf { it.isNotBlank() },
+                artworkUrl = watchDetail.backdropUrl?.takeIf { it.isNotBlank() }
+                    ?: watchDetail.posterUrl?.takeIf { it.isNotBlank() },
                 startPositionSeconds = playerStartPos,
                 sourceStartPositionSeconds = sourceStartPos,
                 serverUrl = serverUrl,

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/catalog/CatalogModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/catalog/CatalogModels.kt
@@ -507,11 +507,9 @@ data class WatchDetail(
     @SerialName("effective_subtitle_language") val effectiveSubtitleLanguage: String? = null,
     @SerialName("effective_subtitle_mode") val effectiveSubtitleMode: String? = null,
     @SerialName("effective_show_forced_subtitles") val effectiveShowForcedSubtitles: Boolean? = null,
-    // Presigned image URLs — match the server's ItemDetail response
-    // (silo-server/internal/catalog/detail.go:100-104). Consumed by the
-    // phone player's Now Playing lock-screen metadata; TV side reads
-    // them too for the same purpose when the MediaSession-driven
-    // notification surfaces (system media controls).
+    // Optional forward-compatible artwork. Current servers expose these on
+    // ItemDetail rather than WatchDetail, so playback clients must fall back
+    // to the full catalog detail when these fields are absent.
     @SerialName("poster_url") val posterUrl: String? = null,
     @SerialName("poster_thumbhash") val posterThumbhash: String? = null,
     @SerialName("backdrop_url") val backdropUrl: String? = null,


### PR DESCRIPTION
## Summary

- publish wide catalog artwork to Android local-playback media sessions through a Coil-backed Media3 bitmap loader
- expose active Silo Remote Control sessions in Android system media controls, including transport, seek, next, metadata, and artwork
- keep the Remote Control service active while playback is engaged and guide users to disable battery optimization
- use cached or fetched item detail as a backward-compatible artwork fallback while the watch response lacks image fields

## Validation

- full Gradle test suite passed
- phone debug APK assembled successfully
- TV debug APK assembled successfully
- physical Android playback harness passed with advancing playback
- live Android notification reported a 144x81 bitmap large icon and visibly rendered the backdrop

## Follow-up

- https://github.com/Silo-Server/silo-server/issues/803 tracks adding artwork directly to the playback-oriented watch response so current clients can avoid the secondary catalog lookup while retaining compatibility with older servers.