### PR TITLE
TV: increase Home poster size, reduce hero dominance

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -811,7 +811,13 @@ fun TvSkylineSectionFeed(
                             itemSpacing = TvSkylineItemSpacing,
                             rowTopPadding = TvSkylineRowCardVerticalPadding,
                             rowBottomPadding = TvSkylineRowCardVerticalPadding,
-                            posterWidth = RowDimens.DensePosterWidth,
+                            // Standard poster size, not Dense: issue #163 --
+                            // dense cards (88x132) packed 9 per row but read as
+                            // too small on a 10-ft TV screen, with rating/progress
+                            // overlays hard to make out. The larger card trades
+                            // row density (~6-7 visible instead of 9) for
+                            // legibility, matching Emby/Wholphin's balance.
+                            posterWidth = RowDimens.PosterWidth,
                             firstItemFocusRequester = resolvedFirstRowFocusRequester
                                 .takeIf { isFirstRow },
                             rowContainerFocusRequester = when {
@@ -879,8 +885,13 @@ private val TvSkylineRowCardVerticalPadding = 7.dp
 /** tvOS rowBandBottomInset 20pt maps to 10dp. */
 private val TvSkylineRowBandBottomInset = 10.dp
 
-/** Portion of the screen reserved for the row stack. */
-private const val TvSkylineRowBandHeightFraction = 0.50f
+/**
+ * Portion of the screen reserved for the row stack. Raised from 0.50 alongside
+ * the switch from [RowDimens.DensePosterWidth] to [RowDimens.PosterWidth]
+ * (issue #163): the taller standard-size poster needs more room to clear the
+ * band without clipping the next row's peek.
+ */
+private const val TvSkylineRowBandHeightFraction = 0.58f
 
 /** Gap between the marquee block and the top of the row band. */
 private val TvSkylineMarqueeBottomGap = 4.dp

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/theme/Spacing.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/theme/Spacing.kt
@@ -165,10 +165,6 @@ object RowDimens {
     val PosterHeight = 195.dp
     val PosterWidth = 130.dp
 
-    /** Dense Skyline Home/Browse poster — tvOS `densePosterCardWidth` 176pt → 88dp. */
-    val DensePosterHeight = 132.dp
-    val DensePosterWidth = 88.dp
-
     /** 16:9 episode/backdrop card — tvOS 360×200pt → 180×100dp. */
     val BackdropHeight = 100.dp
     val BackdropWidth = 180.dp


### PR DESCRIPTION
## Summary
- Fixes #163. `TvSkylineSectionFeed` (shared by Home, For You, and Library Detail) was rendering poster cards at the Dense size (88x132dp), packing ~9 tiny posters per row with rating/progress overlays hard to read from typical TV viewing distance.
- Switches poster cards to the standard size (130x195dp), landing around 6-7 posters visible per row, matching the balance described for Emby/Wholphin in the issue.
- Raises the row band height fraction (`TvSkylineRowBandHeightFraction`, 0.50 -> 0.58) so the taller cards have room without clipping against the next row's peek, which also shrinks the hero/marquee's share of the screen.
- Removes the now-unused `RowDimens.DensePosterWidth`/`DensePosterHeight` constants.

Since this layout is shared across Home, For You, and Library Detail, the change applies consistently to all three "hero + rows" screens rather than only Home.

## Test plan
- [ ] Build and run on an Android TV device/emulator (NVIDIA Shield or similar) and confirm poster size/hero balance visually
- [ ] Verify D-pad navigation and focus behavior across rows is unaffected
- [ ] Check Home, For You, and Library Detail screens for consistent poster sizing
- [ ] Confirm no clipping of the row band against the marquee/hero content at common TV resolutions (1080p, 4K override)

Note: I was unable to build or visually verify this change in my environment (no JDK/Android SDK available), so the exact `0.58` band-height fraction is a reasoned estimate based on the existing card/spacing math rather than something eyeballed on a screen. Please sanity-check on a real device before merging, and feel free to nudge the constants if the balance isn't quite right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated Android TV content rows to use standard-sized poster cards for improved visibility.
  * Adjusted row spacing so taller posters display without clipping or obscuring the next row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->