### PR TITLE
feat(android): server-driven card presentation presets on phone and TV

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/cards/CardPresentationLocals.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/cards/CardPresentationLocals.kt
@@ -1,0 +1,50 @@
+package org.siloserver.silo.common.cards
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import org.siloserver.silo.common.settings.CardPresentationStore
+import org.siloserver.silo.model.settings.CardPresentation
+
+/**
+ * Ambient card-presentation preference (poster size + caption style),
+ * published once near each app shell and consumed by every poster/backdrop
+ * card. Same pattern as [org.siloserver.silo.common.overlays.LocalCardOverlayUiState]:
+ * the shell hydrates the store once and provides the resolved value down the
+ * tree, so cards read `LocalCardPresentation.current.posterSize.posterScale`
+ * and the caption flags without injecting the store per instance.
+ *
+ * Default is [CardPresentation.DEFAULT], so any card rendered outside a
+ * [ProvideCardPresentation] scope draws at the standard size with full
+ * captions.
+ */
+val LocalCardPresentation: ProvidableCompositionLocal<CardPresentation> =
+    staticCompositionLocalOf { CardPresentation.DEFAULT }
+
+/**
+ * Hydrates the [store], collects its state, and publishes the resolved
+ * [CardPresentation] via [LocalCardPresentation] for the [content] subtree.
+ *
+ * [sessionKey] is the authenticated identity the preference belongs to (the
+ * active profile id). Hydration is keyed on it rather than a one-shot `Unit`
+ * for the same reason as `ProvideCardOverlays`: this mounts above the whole
+ * nav graph and is first composed on the unauthenticated Login screen, where
+ * the settings calls fail; the key flipping from null to a profile id (or to
+ * a different profile) re-runs hydration for the new identity.
+ */
+@Composable
+fun ProvideCardPresentation(
+    store: CardPresentationStore,
+    sessionKey: Any? = null,
+    content: @Composable () -> Unit,
+) {
+    LaunchedEffect(store, sessionKey) {
+        if (sessionKey != null) store.hydrateIfNeeded()
+    }
+    val state by store.state.collectAsState()
+    CompositionLocalProvider(LocalCardPresentation provides state.presentation, content = content)
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerInfraModule.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/di/PlayerInfraModule.kt
@@ -9,6 +9,8 @@ import org.siloserver.silo.common.player.PlaybackSessionLifecycle
 import org.siloserver.silo.common.diagnostics.DiagnosticsPlaybackSessionTracker
 import org.siloserver.silo.common.player.SleepTimerController
 import org.siloserver.silo.common.settings.AndroidPlayerSettingsStore
+import org.siloserver.silo.common.settings.CardPresentationStore
+import org.siloserver.silo.common.settings.DefaultCardPresentationStore
 import org.siloserver.silo.common.settings.DefaultLibraryPlaybackPrefsStore
 import org.siloserver.silo.common.settings.DefaultOverlayPrefsStore
 import org.siloserver.silo.common.settings.DefaultServerSettingsFlusher
@@ -126,9 +128,24 @@ val playerInfraModule = module {
         )
     }
 
+    // Card-presentation preference (poster size + captions). Same lifetime
+    // rationale as the overlay store; the extra lambdas feed the last-known
+    // SharedPreferences cache identity (server|profile|family|device).
+    single<CardPresentationStore> {
+        DefaultCardPresentationStore(
+            context = androidContext(),
+            repository = get<SettingsRepository>(),
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+            getActiveProfileId = { get<ProfileRepository>().getActiveProfileId() },
+            getServerUrl = { get<TokenManager>().getServerUrl() },
+            getDeviceMetadata = { get<DeviceMetadataProvider>().current() },
+        )
+    }
+
     single {
         ServerDrivenConfigRefresher(
             overlayPrefsStore = get(),
+            cardPresentationStore = get(),
             libraryPlaybackPrefsStore = get(),
             playerSettingsStore = get(),
             hasAuthenticatedProfile = {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsCoordinator.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsCoordinator.kt
@@ -443,6 +443,8 @@ class DefaultDiagnosticsCoordinator(
                     // identity mutation either waits and purges this work, or wins first and
                     // prevents this block from running.
                     runtimePublisher.publish(liveCaptureContext)
+                    // Collect the previous process before enabling this process's journal:
+                    // false -> true rotates persistent breadcrumbs and removes the prior run.
                     incidentCollector.collect(liveCaptureContext, consent.mode)
                     capture.setDebugLogging(
                         liveCaptureContext,

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsImageHealth.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsImageHealth.kt
@@ -1,0 +1,195 @@
+package org.siloserver.silo.common.diagnostics
+
+import android.os.SystemClock
+import java.io.IOException
+import java.net.SocketTimeoutException
+import org.siloserver.silo.model.diagnostics.DiagnosticsLogCategory
+
+enum class DiagnosticsImageSource(internal val wireValue: String) {
+    MEMORY("memory"),
+    DISK("disk"),
+    NETWORK("network"),
+}
+
+enum class DiagnosticsImageStage(internal val wireValue: String) {
+    FETCH("fetch"),
+    DECODE("decode"),
+    UNKNOWN("unknown"),
+}
+
+enum class DiagnosticsImageFailureKind(internal val wireValue: String) {
+    HTTP("http"),
+    TIMEOUT("timeout"),
+    OUT_OF_MEMORY("out_of_memory"),
+    DECODE("decode"),
+    IO("io"),
+    OTHER("other"),
+}
+
+internal data class DiagnosticsImageWindow(
+    val completed: Int,
+    val failures: Int,
+    val memorySuccesses: Int,
+    val diskSuccesses: Int,
+    val networkSuccesses: Int,
+)
+
+internal data class DiagnosticsImageFailure(
+    val stage: DiagnosticsImageStage,
+    val kind: DiagnosticsImageFailureKind,
+)
+
+internal data class DiagnosticsImageEvents(
+    val failure: DiagnosticsImageFailure?,
+    val window: DiagnosticsImageWindow?,
+)
+
+internal class DiagnosticsImageHealthAccumulator(
+    private val windowSize: Int = 50,
+    private val failureIntervalMs: Long = 60_000,
+    private val nowMs: () -> Long = SystemClock::elapsedRealtime,
+) {
+    private var completed = 0
+    private var failures = 0
+    private var memorySuccesses = 0
+    private var diskSuccesses = 0
+    private var networkSuccesses = 0
+    private var lastFailureEmissionMs: Long? = null
+
+    init {
+        require(windowSize > 0)
+        require(failureIntervalMs > 0)
+    }
+
+    @Synchronized
+    fun success(source: DiagnosticsImageSource): DiagnosticsImageEvents {
+        completed += 1
+        when (source) {
+            DiagnosticsImageSource.MEMORY -> memorySuccesses += 1
+            DiagnosticsImageSource.DISK -> diskSuccesses += 1
+            DiagnosticsImageSource.NETWORK -> networkSuccesses += 1
+        }
+        return DiagnosticsImageEvents(failure = null, window = completeWindowIfReady())
+    }
+
+    @Synchronized
+    fun failure(
+        stage: DiagnosticsImageStage,
+        kind: DiagnosticsImageFailureKind,
+    ): DiagnosticsImageEvents {
+        completed += 1
+        failures += 1
+        val now = nowMs()
+        val previous = lastFailureEmissionMs
+        val shouldEmit = previous == null || now < previous || now - previous >= failureIntervalMs
+        val emission = if (shouldEmit) {
+            lastFailureEmissionMs = now
+            DiagnosticsImageFailure(stage, kind)
+        } else {
+            null
+        }
+        return DiagnosticsImageEvents(emission, completeWindowIfReady())
+    }
+
+    private fun completeWindowIfReady(): DiagnosticsImageWindow? {
+        if (completed < windowSize) return null
+        val snapshot = DiagnosticsImageWindow(
+            completed = completed,
+            failures = failures,
+            memorySuccesses = memorySuccesses,
+            diskSuccesses = diskSuccesses,
+            networkSuccesses = networkSuccesses,
+        )
+        completed = 0
+        failures = 0
+        memorySuccesses = 0
+        diskSuccesses = 0
+        networkSuccesses = 0
+        return snapshot
+    }
+}
+
+object DiagnosticsImageHealth {
+    private val accumulator = DiagnosticsImageHealthAccumulator()
+
+    fun success(source: DiagnosticsImageSource) = emit(accumulator.success(source))
+
+    fun failure(stage: DiagnosticsImageStage, throwable: Throwable) = emit(
+        accumulator.failure(stage, classifyImageFailure(stage, throwable)),
+    )
+
+    private fun emit(events: DiagnosticsImageEvents) {
+        events.failure?.let(DiagnosticsImageLogger::failure)
+        events.window?.let(DiagnosticsImageLogger::window)
+    }
+}
+
+internal object DiagnosticsImageLogger {
+    fun failure(failure: DiagnosticsImageFailure) = SiloLog.breadcrumb(
+        DiagnosticsLogCategory.LIFECYCLE,
+        "ImagePipeline",
+        "image pipeline failure",
+        mapOf(
+            "phase" to SiloLogAttribute.Text("image_failure"),
+            "outcome" to SiloLogAttribute.Text(failure.stage.wireValue),
+            "reason" to SiloLogAttribute.Text(failure.kind.wireValue),
+        ),
+    )
+
+    fun window(window: DiagnosticsImageWindow) = SiloLog.breadcrumb(
+        DiagnosticsLogCategory.LIFECYCLE,
+        "ImagePipeline",
+        "image pipeline health snapshot",
+        mapOf(
+            "phase" to SiloLogAttribute.Text("image_pipeline"),
+            "outcome" to SiloLogAttribute.Text(failureRateBucket(window.failures, window.completed)),
+            "reason" to SiloLogAttribute.Text(sourceMix(window)),
+        ),
+    )
+}
+
+internal fun classifyImageFailure(
+    stage: DiagnosticsImageStage,
+    throwable: Throwable,
+): DiagnosticsImageFailureKind {
+    val causes = generateSequence(throwable) { it.cause }.take(8).toList()
+    return when {
+        causes.any { it is OutOfMemoryError } -> DiagnosticsImageFailureKind.OUT_OF_MEMORY
+        causes.any { it is SocketTimeoutException } -> DiagnosticsImageFailureKind.TIMEOUT
+        causes.any { cause ->
+            val name = cause.javaClass.name
+            name.contains("HttpException") || name.contains("HttpResponse")
+        } -> DiagnosticsImageFailureKind.HTTP
+        stage == DiagnosticsImageStage.DECODE -> DiagnosticsImageFailureKind.DECODE
+        causes.any { it is IOException } -> DiagnosticsImageFailureKind.IO
+        else -> DiagnosticsImageFailureKind.OTHER
+    }
+}
+
+private fun failureRateBucket(failures: Int, completed: Int): String {
+    if (completed <= 0 || failures <= 0) return "no_failures"
+    val percent = failures * 100 / completed
+    return when (percent) {
+        in 0..9 -> "failure_rate_under_10"
+        in 10..24 -> "failure_rate_10_24"
+        else -> "failure_rate_25_plus"
+    }
+}
+
+private fun sourceMix(window: DiagnosticsImageWindow): String {
+    val successes = (window.completed - window.failures).coerceAtLeast(0)
+    return "memory_${shareBucket(window.memorySuccesses, successes)}_" +
+        "disk_${shareBucket(window.diskSuccesses, successes)}_" +
+        "network_${shareBucket(window.networkSuccesses, successes)}"
+}
+
+private fun shareBucket(count: Int, total: Int): String {
+    if (total <= 0 || count <= 0) return "0"
+    val percent = (count.toLong() * 100 / total).coerceAtLeast(1)
+    return when (percent) {
+        in 1L..24L -> "1_24"
+        in 25L..49L -> "25_49"
+        in 50L..74L -> "50_74"
+        else -> "75_plus"
+    }
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentation.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentation.kt
@@ -2,10 +2,13 @@ package org.siloserver.silo.common.diagnostics
 
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import java.util.Locale
 import org.siloserver.silo.common.player.PlayerStatsSnapshot
 import org.siloserver.silo.common.player.video.PlaybackDiagnosticsCode
 import org.siloserver.silo.model.diagnostics.DiagnosticsLogCategory
 import org.siloserver.silo.network.NetworkDiagnosticsObserver
+import org.siloserver.silo.viewmodel.HomeDiagnosticsObserver
+import org.siloserver.silo.viewmodel.HomeLoadObservation
 
 object DiagnosticsCaptureDetailState {
     private val enabled = AtomicBoolean(false)
@@ -225,6 +228,248 @@ object DiagnosticsLifecycleLogger {
     }
 }
 
+enum class DiagnosticsHomeContentState(internal val wireValue: String) {
+    LOADING("loading"),
+    ERROR("error"),
+    EMPTY("empty"),
+    READY("ready"),
+}
+
+enum class DiagnosticsHomeScrollRegion(internal val wireValue: String) {
+    UNKNOWN("unknown"),
+    TOP("top"),
+    CONTENT("content"),
+    END("end"),
+}
+
+enum class DiagnosticsListSurface(internal val wireValue: String) {
+    PHONE_HOME("phone_home"),
+    PHONE_FOR_YOU("phone_for_you"),
+    PHONE_LIBRARY_RECOMMENDED("phone_lib_rec"),
+    TV_HOME("tv_home"),
+    TV_FOR_YOU("tv_for_you"),
+    TV_LIBRARY_RECOMMENDED("tv_lib_rec"),
+}
+
+enum class DiagnosticsKeyCollection(internal val wireValue: String) {
+    PHONE_MEDIA_ROW("phone_media_row"),
+    PHONE_CATALOG_GRID("phone_catalog_grid"),
+    TV_MEDIA_ROW("tv_media_row"),
+}
+
+/** Only aggregate counts escape this factory; the input keys are never logged. */
+data class DiagnosticsListSnapshot(
+    val itemCount: Int,
+    val duplicateKeyCount: Int,
+    val duplicateItemRowCount: Int,
+    val maxRowItemCount: Int,
+    val fullyResolved: Boolean?,
+) {
+    companion object {
+        fun fromKeys(
+            keys: List<String>,
+            rowKeys: List<List<String>> = emptyList(),
+            fullyResolved: Boolean? = null,
+        ): DiagnosticsListSnapshot = DiagnosticsListSnapshot(
+            itemCount = keys.size,
+            duplicateKeyCount = keys.size - keys.distinct().size,
+            duplicateItemRowCount = rowKeys.count { row -> row.size != row.distinct().size },
+            maxRowItemCount = rowKeys.maxOfOrNull(List<String>::size) ?: 0,
+            fullyResolved = fullyResolved,
+        )
+    }
+}
+
+object DiagnosticsListLogger {
+    fun snapshot(surface: DiagnosticsListSurface, snapshot: DiagnosticsListSnapshot) {
+        SiloLog.breadcrumb(
+            DiagnosticsLogCategory.LIFECYCLE,
+            "UiList",
+            "list integrity snapshot",
+            mapOf(
+                "phase" to SiloLogAttribute.Text("${surface.wireValue}_list"),
+                "outcome" to SiloLogAttribute.Text(
+                    diagnosticsDuplicateOutcome(snapshot.duplicateKeyCount, "keys"),
+                ),
+                "reason" to SiloLogAttribute.Text("items_${diagnosticsCountBucket(snapshot.itemCount)}"),
+            ),
+        )
+        SiloLog.breadcrumb(
+            DiagnosticsLogCategory.LIFECYCLE,
+            "UiList",
+            "row integrity snapshot",
+            mapOf(
+                "phase" to SiloLogAttribute.Text("${surface.wireValue}_rows"),
+                "outcome" to SiloLogAttribute.Text(
+                    diagnosticsDuplicateOutcome(snapshot.duplicateItemRowCount, "rows"),
+                ),
+                "reason" to SiloLogAttribute.Text(
+                    "max_items_${diagnosticsCountBucket(snapshot.maxRowItemCount)}",
+                ),
+            ),
+        )
+        snapshot.fullyResolved?.let { fullyResolved ->
+            SiloLog.breadcrumb(
+                DiagnosticsLogCategory.LIFECYCLE,
+                "UiList",
+                "list resolution snapshot",
+                mapOf(
+                    "phase" to SiloLogAttribute.Text("${surface.wireValue}_resolution"),
+                    "outcome" to SiloLogAttribute.Text(if (fullyResolved) "complete" else "partial"),
+                ),
+            )
+        }
+        DiagnosticsResourceCheckpoints.request(surface)
+    }
+
+}
+
+object DiagnosticsKeyAnomalyLogger {
+    /** Healthy reusable rows/grids stay silent; only a duplicate-key hazard is persisted. */
+    fun snapshot(collection: DiagnosticsKeyCollection, snapshot: DiagnosticsListSnapshot) {
+        val duplicateCount = snapshot.duplicateKeyCount
+        if (duplicateCount <= 0) return
+        SiloLog.breadcrumb(
+            DiagnosticsLogCategory.LIFECYCLE,
+            "UiKeys",
+            "duplicate lazy keys detected",
+            mapOf(
+                "phase" to SiloLogAttribute.Text("${collection.wireValue}_keys"),
+                "outcome" to SiloLogAttribute.Text(
+                    if (duplicateCount == 1) "duplicate_one" else "duplicate_multiple",
+                ),
+                "reason" to SiloLogAttribute.Text("items_${diagnosticsCountBucket(snapshot.itemCount)}"),
+            ),
+        )
+    }
+}
+
+object DiagnosticsHomeLoadObserver : HomeDiagnosticsObserver {
+    override fun completed(observation: HomeLoadObservation) {
+        SiloLog.breadcrumb(
+            DiagnosticsLogCategory.LIFECYCLE,
+            "HomeData",
+            "home data source completed",
+            mapOf(
+                "phase" to SiloLogAttribute.Text(
+                    "home_${observation.source.name.lowercase(Locale.ROOT)}_" +
+                        observation.trigger.name.lowercase(Locale.ROOT),
+                ),
+                "duration_ms" to SiloLogAttribute.Integer(observation.durationMs.coerceAtLeast(0)),
+                "outcome" to SiloLogAttribute.Text(observation.outcome.name.lowercase(Locale.ROOT)),
+                "reason" to SiloLogAttribute.Text(
+                    "sections_${diagnosticsCountBucket(observation.sectionCount)}",
+                ),
+            ),
+        )
+        if (observation.outcome in HOME_CONTENT_OUTCOMES) {
+            SiloLog.breadcrumb(
+                DiagnosticsLogCategory.LIFECYCLE,
+                "HomeData",
+                "home source integrity snapshot",
+                mapOf(
+                    "phase" to SiloLogAttribute.Text("home_source_keys"),
+                    "outcome" to SiloLogAttribute.Text(
+                        diagnosticsDuplicateOutcome(observation.duplicateSectionKeyCount, "section_keys"),
+                    ),
+                    "reason" to SiloLogAttribute.Text(
+                        diagnosticsDuplicateOutcome(observation.duplicateItemRowCount, "item_rows"),
+                    ),
+                ),
+            )
+        }
+    }
+}
+
+/**
+ * Curated, identifier-free context for diagnosing phone-homepage failures.
+ * Scroll evidence records state transitions and broad regions, never offsets,
+ * section names, media titles, or item identifiers.
+ */
+object DiagnosticsHomeLogger {
+    fun content(state: DiagnosticsHomeContentState) = SiloLog.breadcrumb(
+        DiagnosticsLogCategory.LIFECYCLE,
+        "HomeScreen",
+        "home content state changed",
+        mapOf(
+            "phase" to SiloLogAttribute.Text("home_content"),
+            "outcome" to SiloLogAttribute.Text(state.wireValue),
+        ),
+    )
+
+    fun scroll(
+        scrolling: Boolean,
+        region: DiagnosticsHomeScrollRegion,
+        visibleRowOrdinal: Int? = null,
+        rawSectionType: String? = null,
+    ) {
+        SiloLog.breadcrumb(
+            DiagnosticsLogCategory.LIFECYCLE,
+            "HomeScreen",
+            "home scroll state changed",
+            mapOf(
+                "phase" to SiloLogAttribute.Text("home_scroll"),
+                "outcome" to SiloLogAttribute.Text(if (scrolling) "scrolling" else "idle"),
+                "reason" to SiloLogAttribute.Text(
+                    homeScrollReason(region, visibleRowOrdinal, rawSectionType),
+                ),
+            ),
+        )
+        if (scrolling) {
+            DiagnosticsResourceCheckpoints.request(
+                DiagnosticsListSurface.PHONE_HOME,
+                DiagnosticsResourceCheckpointCause.SCROLL_START,
+            )
+        }
+    }
+}
+
+internal fun homeScrollReason(
+    region: DiagnosticsHomeScrollRegion,
+    visibleRowOrdinal: Int?,
+    rawSectionType: String?,
+): String {
+    if (visibleRowOrdinal == null && rawSectionType == null) return region.wireValue
+    val ordinal = visibleRowOrdinal?.let(::diagnosticsOrdinalBucket) ?: "row_unknown"
+    return "${region.wireValue}:$ordinal:${safeHomeSectionType(rawSectionType)}"
+}
+
+private fun safeHomeSectionType(raw: String?): String {
+    val normalized = raw
+        ?.lowercase(Locale.ROOT)
+        ?.replace('-', '_')
+        ?.replace(' ', '_')
+        ?.take(64)
+        ?: return "unknown"
+    return normalized.takeIf(KNOWN_HOME_SECTION_TYPES::contains) ?: "unknown"
+}
+
+private fun diagnosticsOrdinalBucket(value: Int): String = when (value.coerceAtLeast(0)) {
+    0 -> "row_1"
+    1 -> "row_2"
+    in 2..3 -> "row_3_4"
+    in 4..7 -> "row_5_8"
+    in 8..15 -> "row_9_16"
+    else -> "row_17_plus"
+}
+
+internal fun diagnosticsCountBucket(value: Int): String = when (value.coerceAtLeast(0)) {
+    0 -> "0"
+    1 -> "1"
+    in 2..4 -> "2_4"
+    in 5..8 -> "5_8"
+    in 9..16 -> "9_16"
+    in 17..32 -> "17_32"
+    in 33..64 -> "33_64"
+    else -> "65_plus"
+}
+
+private fun diagnosticsDuplicateOutcome(count: Int, unit: String): String = when (count.coerceAtLeast(0)) {
+    0 -> "unique_$unit"
+    1 -> "duplicate_${unit}_one"
+    else -> "duplicate_${unit}_multiple"
+}
+
 private object DiagnosticsPerformanceRoute {
     private val route = AtomicReference("unknown")
 
@@ -339,6 +584,28 @@ private val KNOWN_ROUTE_ROOTS = setOf(
     "silocast",
     "watch_together",
     "watchlist",
+)
+private val KNOWN_HOME_SECTION_TYPES = setOf(
+    "continue_watching",
+    "favorites",
+    "featured",
+    "genre",
+    "history",
+    "in_progress",
+    "latest",
+    "next_up",
+    "popular",
+    "recently_added",
+    "recommendations",
+    "recommended",
+    "trending",
+    "up_next",
+    "watchlist",
+)
+private val HOME_CONTENT_OUTCOMES = setOf(
+    org.siloserver.silo.viewmodel.HomeLoadOutcome.HIT,
+    org.siloserver.silo.viewmodel.HomeLoadOutcome.SUCCESS,
+    org.siloserver.silo.viewmodel.HomeLoadOutcome.PARTIAL,
 )
 private const val DYNAMIC_ROUTE_SEGMENT = "{id}"
 private val API_ROUTE_TEMPLATES: Map<String, List<List<String>>> = mapOf(

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsManualCapture.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsManualCapture.kt
@@ -56,6 +56,7 @@ class FileDiagnosticsCaptureController(
             error("diagnostics capture started concurrently")
         }
         SiloLog.installSink(FanOutDiagnosticsLogSink(logBuffer, fileLogger))
+        breadcrumbJournal?.setEnabled(context.identityKey)
         setDetailedCaptureEnabled(true)
         return capture
     }
@@ -117,6 +118,7 @@ class FileDiagnosticsCaptureController(
             error("diagnostics debug logging started concurrently")
         }
         SiloLog.installSink(FanOutDiagnosticsLogSink(logBuffer, fileLogger))
+        breadcrumbJournal?.setEnabled(context.identityKey)
         setDetailedCaptureEnabled(true)
     }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsModule.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsModule.kt
@@ -30,6 +30,7 @@ private val HOSTED_DIAGNOSTICS_HTTP = named("hosted-diagnostics-http")
 
 val diagnosticsModule = module {
     single<NetworkDiagnosticsObserver> { DiagnosticsNetworkLogger }
+    single<org.siloserver.silo.viewmodel.HomeDiagnosticsObserver> { DiagnosticsHomeLoadObserver }
     single<DataStore<Preferences>>(DIAGNOSTICS_DATA_STORE) {
         PreferenceDataStoreFactory.create(
             produceFile = { androidContext().preferencesDataStoreFile("silo_diagnostics") },

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPerformanceRecorder.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPerformanceRecorder.kt
@@ -17,6 +17,7 @@ import android.view.Window
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 data class PerformanceWindowSnapshot(
     val frameCount: Long,
@@ -108,6 +109,51 @@ interface DiagnosticsPerformanceCapture {
     }
 }
 
+enum class DiagnosticsResourceCheckpointCause(internal val wireValue: String) {
+    LIST_READY("list_ready"),
+    SCROLL_START("scroll_start"),
+}
+
+object DiagnosticsResourceCheckpoints {
+    private val handler = AtomicReference<(DiagnosticsListSurface, DiagnosticsResourceCheckpointCause) -> Unit>(
+        { _, _ -> },
+    )
+
+    internal fun install(value: (DiagnosticsListSurface, DiagnosticsResourceCheckpointCause) -> Unit) {
+        handler.set(value)
+    }
+
+    fun request(
+        surface: DiagnosticsListSurface,
+        cause: DiagnosticsResourceCheckpointCause = DiagnosticsResourceCheckpointCause.LIST_READY,
+    ) {
+        handler.get().invoke(surface, cause)
+    }
+}
+
+internal class DiagnosticsCheckpointCadence(
+    private val intervalMs: Long = 30_000,
+) {
+    private val lastEmissionByKey = mutableMapOf<String, Long>()
+
+    init {
+        require(intervalMs > 0)
+    }
+
+    @Synchronized
+    fun shouldEmit(
+        surface: DiagnosticsListSurface,
+        cause: DiagnosticsResourceCheckpointCause,
+        nowMs: Long,
+    ): Boolean {
+        val key = "${surface.wireValue}:${cause.wireValue}"
+        val previous = lastEmissionByKey[key]
+        if (previous != null && nowMs >= previous && nowMs - previous < intervalMs) return false
+        lastEmissionByKey[key] = nowMs
+        return true
+    }
+}
+
 class AndroidDiagnosticsPerformanceRecorder(
     private val application: Application,
     private val nowElapsedMs: () -> Long = SystemClock::elapsedRealtime,
@@ -124,6 +170,7 @@ class AndroidDiagnosticsPerformanceRecorder(
     private var resumedActivity = WeakReference<Activity>(null)
     private var attachedWindow: Window? = null
     private val startupReported = AtomicBoolean(false)
+    private val checkpointCadence = DiagnosticsCheckpointCadence()
     private var heartbeatExpectedMs = 0L
 
     private val frameListener = Window.OnFrameMetricsAvailableListener { _, metrics, _ ->
@@ -148,7 +195,10 @@ class AndroidDiagnosticsPerformanceRecorder(
     }
 
     fun install() {
-        if (installed.compareAndSet(false, true)) application.registerActivityLifecycleCallbacks(this)
+        if (installed.compareAndSet(false, true)) {
+            application.registerActivityLifecycleCallbacks(this)
+            DiagnosticsResourceCheckpoints.install(::requestResourceCheckpoint)
+        }
     }
 
     override fun setDetailedCaptureEnabled(enabled: Boolean) {
@@ -218,6 +268,17 @@ class AndroidDiagnosticsPerformanceRecorder(
         DiagnosticsPerformanceLogger.snapshot(frameSnapshot, memory, startup)
     }
 
+    private fun requestResourceCheckpoint(
+        surface: DiagnosticsListSurface,
+        cause: DiagnosticsResourceCheckpointCause,
+    ) {
+        val now = nowElapsedMs()
+        if (!checkpointCadence.shouldEmit(surface, cause, now)) return
+        worker.post {
+            DiagnosticsResourceLogger.checkpoint(surface, cause, memorySnapshot())
+        }
+    }
+
     private fun memorySnapshot(): DiagnosticsResourceSnapshot {
         val runtime = Runtime.getRuntime()
         val javaHeapMb = ((runtime.totalMemory() - runtime.freeMemory()) / BYTES_PER_MIB).coerceAtLeast(0)
@@ -254,3 +315,39 @@ data class DiagnosticsResourceSnapshot(
     val lowMemory: Boolean,
     val thermalStatus: Int?,
 )
+
+object DiagnosticsResourceLogger {
+    fun checkpoint(
+        surface: DiagnosticsListSurface,
+        cause: DiagnosticsResourceCheckpointCause,
+        resources: DiagnosticsResourceSnapshot,
+    ) = SiloLog.breadcrumb(
+        org.siloserver.silo.model.diagnostics.DiagnosticsLogCategory.LIFECYCLE,
+        "AppResources",
+        "resource pressure checkpoint",
+        mapOf(
+            "phase" to SiloLogAttribute.Text("resource_pressure"),
+            "outcome" to SiloLogAttribute.Text(resourceOutcome(resources)),
+            "reason" to SiloLogAttribute.Text(
+                "${surface.wireValue}_${cause.wireValue}_" +
+                    "heap_${memoryBucket(resources.javaHeapMb)}_pss_${memoryBucket(resources.processPssMb)}",
+            ),
+        ),
+    )
+}
+
+private fun resourceOutcome(resources: DiagnosticsResourceSnapshot): String = when {
+    resources.lowMemory -> "low_memory"
+    (resources.thermalStatus ?: 0) >= 4 -> "thermal_severe"
+    (resources.thermalStatus ?: 0) >= 2 -> "thermal_elevated"
+    else -> "normal"
+}
+
+internal fun memoryBucket(valueMb: Long): String = when (valueMb.coerceAtLeast(0)) {
+    in 0..63 -> "0_63"
+    in 64..127 -> "64_127"
+    in 128..255 -> "128_255"
+    in 256..511 -> "256_511"
+    in 512..1_023 -> "512_1023"
+    else -> "1024_plus"
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt
@@ -372,6 +372,7 @@ class ExitInfoCollector(
         run: DiagnosticsRunRecord,
         fingerprint: String,
     ): PendingReport? {
+        val exceptionCode = classifyJvmFailure(marker.throwableType, marker.stack)
         val redactor = DiagnosticsRedactor(
             sensitiveValues = redactionTokens().filter(String::isNotEmpty).toSet(),
         )
@@ -388,18 +389,26 @@ class ExitInfoCollector(
             processName = null,
             pid = null,
             status = null,
+            exceptionCode = exceptionCode.wireValue,
         )
         artifacts[CRASH_STACK_FILE] = safeStack.encodeToByteArray()
         sanitizedLogBytes(marker.logLines, redactor)?.let { artifacts[LOGS_FILE] = it }
+        val captureSessionId = requireNotNull(marker.captureSessionId) {
+            "a matched JVM crash marker must identify its capture session"
+        }
+        runCatching { breadcrumbs.linesForRun(captureSessionId, run.identityKey()) }
+            .getOrDefault(emptyList())
+            .let { lines -> sanitizedLogBytes(lines, redactor) }
+            ?.let { artifacts[BREADCRUMBS_FILE] = it }
         val manifest = manifest(
             reportType = DiagnosticsReportType.CRASH,
             crashSource = DiagnosticsCrashSource.UEH,
             provenance = DiagnosticsCrashProvenance.PRE_FAILURE,
             capturedAtEpochMs = marker.occurredAtEpochMs,
-            captureSessionId = marker.captureSessionId ?: run.captureSessionId,
+            captureSessionId = captureSessionId,
             profileId = run.profileId,
             binding = binding,
-            summary = safeThrowableType,
+            summary = "${safeThrowableType.ifBlank { "Android JVM crash" }} [${exceptionCode.wireValue}]",
             stackExcerpt = safeStack.truncateUtf8ForExit(MAX_STACK_EXCERPT_BYTES),
             thread = safeThreadName,
             foreground = marker.foreground,
@@ -450,6 +459,9 @@ class ExitInfoCollector(
         val classification = classify(exit.reason) ?: return null
         val trace = collected.trace
         val binding = run.pendingBinding()
+        val redactor = DiagnosticsRedactor(
+            sensitiveValues = redactionTokens().filter(String::isNotEmpty).toSet(),
+        )
         val artifacts = linkedMapOf<String, ByteArray>()
         artifacts[DEVICE_FILE] = deviceSnapshotBytes() ?: fallbackDeviceSnapshot(exit.timestampMs)
         artifacts[CRASH_SUMMARY_FILE] = crashSummaryBytes(
@@ -460,17 +472,14 @@ class ExitInfoCollector(
         )
         runCatching { breadcrumbs.linesForRun(run.captureSessionId, run.identityKey()) }
             .getOrDefault(emptyList())
-            .takeIf(List<String>::isNotEmpty)?.let { lines ->
-            artifacts[BREADCRUMBS_FILE] = (lines.joinToString("\n") + "\n").encodeToByteArray()
-        }
+            .let { lines -> sanitizedLogBytes(lines, redactor) }
+            ?.let { artifacts[BREADCRUMBS_FILE] = it }
         var stackExcerpt: String? = null
         when {
             classification.reportType == DiagnosticsReportType.NATIVE_CRASH && trace != null ->
                 artifacts[CRASH_TOMBSTONE_FILE] = trace
             trace != null -> {
-                val text = strictUtf8(trace)?.let {
-                    DiagnosticsRedactor(sensitiveValues = redactionTokens().filter(String::isNotEmpty).toSet()).sanitize(it)
-                } ?: REDACTION_FAILURE_SENTINEL
+                val text = strictUtf8(trace)?.let(redactor::sanitize) ?: REDACTION_FAILURE_SENTINEL
                 val bytes = text.truncateUtf8ForExit(MAX_TEXT_TRACE_BYTES).encodeToByteArray()
                 artifacts[CRASH_STACK_FILE] = bytes
                 stackExcerpt = text.truncateUtf8ForExit(MAX_STACK_EXCERPT_BYTES)
@@ -635,6 +644,53 @@ private fun classify(reason: Int): ExitInfoCollector.ExitClassification? = when 
     else -> null
 }
 
+internal enum class DiagnosticsJvmFailureCode(internal val wireValue: String) {
+    DUPLICATE_LAZY_KEY("duplicate_lazy_key"),
+    INVALID_LAYOUT_CONSTRAINTS("invalid_layout_constraints"),
+    INVALID_SCROLL_POSITION("invalid_scroll_position"),
+    IMAGE_PIPELINE("image_pipeline"),
+    OUT_OF_MEMORY("out_of_memory"),
+    STACK_OVERFLOW("stack_overflow"),
+    ILLEGAL_ARGUMENT_OTHER("illegal_argument_other"),
+    ILLEGAL_STATE_OTHER("illegal_state_other"),
+    NULL_POINTER("null_pointer"),
+    UNKNOWN("unknown"),
+}
+
+/** Classifies raw marker text locally; only the fixed code is persisted or uploaded. */
+internal fun classifyJvmFailure(
+    throwableType: String,
+    rawStack: String,
+): DiagnosticsJvmFailureCode {
+    val type = throwableType.lowercase(Locale.ROOT)
+    val stack = rawStack.take(MAX_CLASSIFICATION_TEXT_CHARS).lowercase(Locale.ROOT)
+    return when {
+        "outofmemoryerror" in type -> DiagnosticsJvmFailureCode.OUT_OF_MEMORY
+        "stackoverflowerror" in type -> DiagnosticsJvmFailureCode.STACK_OVERFLOW
+        ("lazycolumn" in stack || "lazyrow" in stack || "lazygrid" in stack) &&
+            ("was already used" in stack || "duplicate key" in stack) ->
+            DiagnosticsJvmFailureCode.DUPLICATE_LAZY_KEY
+        "constraints" in stack && (
+            "can't represent" in stack ||
+                "cannot represent" in stack ||
+                "must be non-negative" in stack ||
+                "is out of range" in stack
+            ) -> DiagnosticsJvmFailureCode.INVALID_LAYOUT_CONSTRAINTS
+        "scroll" in stack && (
+            "index should be non-negative" in stack ||
+                "index must be non-negative" in stack ||
+                "offset should be non-negative" in stack ||
+                "offset must be non-negative" in stack
+            ) -> DiagnosticsJvmFailureCode.INVALID_SCROLL_POSITION
+        ("coil3." in stack || "coil." in stack) && ("decode" in stack || "image" in stack) ->
+            DiagnosticsJvmFailureCode.IMAGE_PIPELINE
+        "illegalargumentexception" in type -> DiagnosticsJvmFailureCode.ILLEGAL_ARGUMENT_OTHER
+        "illegalstateexception" in type -> DiagnosticsJvmFailureCode.ILLEGAL_STATE_OTHER
+        "nullpointerexception" in type -> DiagnosticsJvmFailureCode.NULL_POINTER
+        else -> DiagnosticsJvmFailureCode.UNKNOWN
+    }
+}
+
 private fun exitFingerprint(exit: ExitInfoCollector.CollectedExit): String {
     val record = exit.record
     val traceHash = exit.trace?.let(::sha256Hex).orEmpty()
@@ -656,15 +712,24 @@ private fun strictUtf8(bytes: ByteArray): String? = runCatching {
         .toString()
 }.getOrNull()
 
-private fun crashSummaryBytes(kind: String, processName: String?, pid: Int?, status: Int?): ByteArray =
+private fun crashSummaryBytes(
+    kind: String,
+    processName: String?,
+    pid: Int?,
+    status: Int?,
+    exceptionCode: String? = null,
+): ByteArray =
     Json.encodeToString(
         buildJsonObject {
             put("kind", kind)
+            exceptionCode?.let { put("exception_code", it) }
             processName?.let { put("process_hash", sha256Hex(it.encodeToByteArray()).take(32)) }
             pid?.let { put("pid", it) }
             status?.let { put("status", it) }
         },
     ).encodeToByteArray()
+
+private const val MAX_CLASSIFICATION_TEXT_CHARS = 64 * 1_024
 
 private fun fallbackDeviceSnapshot(capturedAtEpochMs: Long): ByteArray = Json.encodeToString(
     buildJsonObject {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/images/SiloImageLoader.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/images/SiloImageLoader.kt
@@ -1,12 +1,23 @@
 package org.siloserver.silo.common.images
 
 import coil3.ImageLoader
+import coil3.EventListener
 import coil3.PlatformContext
+import coil3.decode.DataSource
+import coil3.decode.Decoder
 import coil3.disk.DiskCache
+import coil3.fetch.Fetcher
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import coil3.request.ErrorResult
+import coil3.request.ImageRequest
+import coil3.request.Options
+import coil3.request.SuccessResult
 import coil3.request.crossfade
 import okio.Path.Companion.toOkioPath
 import org.siloserver.silo.network.SiloOkHttp
+import org.siloserver.silo.common.diagnostics.DiagnosticsImageHealth
+import org.siloserver.silo.common.diagnostics.DiagnosticsImageSource
+import org.siloserver.silo.common.diagnostics.DiagnosticsImageStage
 import java.io.File
 
 /**
@@ -25,6 +36,7 @@ import java.io.File
 fun buildSiloImageLoader(context: PlatformContext, cacheDir: File): ImageLoader =
     ImageLoader.Builder(context)
         .crossfade(true)
+        .eventListenerFactory { DiagnosticsImageEventListener() }
         .components {
             add(OkHttpNetworkFetcherFactory(callFactory = { SiloOkHttp.imageClient }))
         }
@@ -35,3 +47,28 @@ fun buildSiloImageLoader(context: PlatformContext, cacheDir: File): ImageLoader 
                 .build()
         }
         .build()
+
+private class DiagnosticsImageEventListener : EventListener() {
+    private var stage = DiagnosticsImageStage.UNKNOWN
+
+    override fun fetchStart(request: ImageRequest, fetcher: Fetcher, options: Options) {
+        stage = DiagnosticsImageStage.FETCH
+    }
+
+    override fun decodeStart(request: ImageRequest, decoder: Decoder, options: Options) {
+        stage = DiagnosticsImageStage.DECODE
+    }
+
+    override fun onSuccess(request: ImageRequest, result: SuccessResult) {
+        val source = when (result.dataSource) {
+            DataSource.MEMORY_CACHE, DataSource.MEMORY -> DiagnosticsImageSource.MEMORY
+            DataSource.DISK -> DiagnosticsImageSource.DISK
+            DataSource.NETWORK -> DiagnosticsImageSource.NETWORK
+        }
+        DiagnosticsImageHealth.success(source)
+    }
+
+    override fun onError(request: ImageRequest, result: ErrorResult) {
+        DiagnosticsImageHealth.failure(stage, result.throwable)
+    }
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/network/AndroidDeviceMetadataProvider.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/network/AndroidDeviceMetadataProvider.kt
@@ -25,6 +25,7 @@ class AndroidDeviceMetadataProvider(
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val cachedClientName: String by lazy { clientNameFor(platform) }
     private val cachedClientVersion: String? by lazy { appVersionName() }
+    private val cachedClientFamily: String by lazy { clientFamilyFor(platform) }
 
     override suspend fun current(): SiloDeviceMetadata {
         val deviceId = prefs.getString(KEY_DEVICE_ID, null) ?: UUID.randomUUID().toString().also { generated ->
@@ -43,6 +44,7 @@ class AndroidDeviceMetadataProvider(
             clientVersion = cachedClientVersion,
             clientBuild = buildIdentity.reportedBuildNumber,
             clientChannel = buildIdentity.reportedChannel,
+            clientFamily = cachedClientFamily,
         )
     }
 
@@ -51,6 +53,26 @@ class AndroidDeviceMetadataProvider(
             "android-tv" -> "Silo Android TV"
             "android" -> "Silo Android"
             else -> "Silo Android"
+        }
+
+    /**
+     * Closed `X-Silo-Client-Family` identity for `profile_client`-scoped
+     * settings. Rides the platform string each app already passes in, so the
+     * TV build is `tv` and the phone build splits mobile/tablet on the same
+     * sw600dp line the platform's resource system uses. Computed once per
+     * process deliberately: the family must not follow a foldable's posture
+     * mid-session, or a preference written as `tablet` would resolve as
+     * `mobile` after folding.
+     */
+    private fun clientFamilyFor(platform: String): String =
+        when (platform) {
+            "android-tv" -> "tv"
+            else ->
+                if (context.resources.configuration.smallestScreenWidthDp >= 600) {
+                    "tablet"
+                } else {
+                    "mobile"
+                }
         }
 
     @Suppress("DEPRECATION")

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -28,6 +28,7 @@ import org.siloserver.silo.model.playback.CLIENT_SURFACE_RECOVERY
 import org.siloserver.silo.model.playback.CLIENT_DV7_TO_DV81
 import org.siloserver.silo.model.playback.CLIENT_DV7_TO_HDR10
 import org.siloserver.silo.model.playback.CLIENT_DV_TRANSFORM_RECIPE_VERSION
+import org.siloserver.silo.model.playback.NATIVE_HLS_PLAYBACK_V1_FEATURE
 import org.siloserver.silo.model.playback.PlaybackDeviceContext
 import org.siloserver.silo.model.playback.PlaybackTransformationExecutor
 import org.siloserver.silo.model.playback.PlaybackTransformationV3
@@ -411,6 +412,11 @@ class PlaybackCapabilityDetector(
                     ),
                     features = buildList {
                         addAll(listOf("hls", "track_switching", "buffer_reporting"))
+                        // This delivery is consumed by Media3's native HLS
+                        // pipeline, not a MediaSource implementation such as
+                        // hls.js. The server can therefore use the hvc1/dvh1
+                        // sample-entry recipes that Media3 accepts.
+                        add(NATIVE_HLS_PLAYBACK_V1_FEATURE)
                         add(CLIENT_DV8_HDR10_PLUS_SANITIZER)
                         add(CLIENT_POST_RESUME_VIDEO_RECOVERY)
                         add(CLIENT_SURFACE_RECOVERY)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/seek/PlaybackTimelineSeekPolicy.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/seek/PlaybackTimelineSeekPolicy.kt
@@ -143,9 +143,19 @@ fun PlaybackTimeline.seekRestorationMode(): PlaybackSeekRestoration = when (seek
  * [PlaybackTimeline.canSeekAnywhere] is false. With no complete window, the
  * server's explicit `can_seek_anywhere` claim is required; a false claim plus
  * an absent or partial window is deliberately treated as unknown and reanchored.
- * Known bounds remain authoritative even when `can_seek_anywhere` is true.
+ * Known bounds remain authoritative even when `canSeekAnywhere` is true.
+ *
+ * Exception: the caller may prove local seekability itself by passing
+ * [mountedSeekableSourceRange] — the source-time extent the currently mounted
+ * transport provably covers (e.g. an append-only HLS manifest's produced head,
+ * or a stream the player reports as seekable with a known length). A target
+ * inside that extent is a plain `Player.seekTo` even when the published window
+ * is open-ended; only targets the mounted transport cannot serve reanchor.
  */
-fun PlaybackTimeline.decideSeek(targetSourcePositionSeconds: Double): PlaybackSeekDecision {
+fun PlaybackTimeline.decideSeek(
+    targetSourcePositionSeconds: Double,
+    mountedSeekableSourceRange: ClosedRange<Double>? = null,
+): PlaybackSeekDecision {
     require(targetSourcePositionSeconds.isFinite() && targetSourcePositionSeconds >= 0.0) {
         "Seek target must be a finite, non-negative source position."
     }
@@ -175,11 +185,13 @@ fun PlaybackTimeline.decideSeek(targetSourcePositionSeconds: Double): PlaybackSe
         )
     }
     if (!window.complete && !canSeekAnywhere) {
-        return PlaybackSeekDecision.ServerReanchor(
-            targetSourcePositionSeconds = targetSourcePositionSeconds,
-            restoration = restoration,
-            reason = ServerReanchorReason.UnknownSeekWindow,
-        )
+        if (mountedSeekableSourceRange?.contains(targetSourcePositionSeconds) != true) {
+            return PlaybackSeekDecision.ServerReanchor(
+                targetSourcePositionSeconds = targetSourcePositionSeconds,
+                restoration = restoration,
+                reason = ServerReanchorReason.UnknownSeekWindow,
+            )
+        }
     }
 
     val playerPosition = playerPositionForSource(targetSourcePositionSeconds)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/CardPresentationStore.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/CardPresentationStore.kt
@@ -1,0 +1,543 @@
+package org.siloserver.silo.common.settings
+
+import android.content.Context
+import org.siloserver.silo.model.settings.CardPresentation
+import org.siloserver.silo.model.settings.EffectiveSettingValue
+import org.siloserver.silo.model.settings.SettingKeys
+import org.siloserver.silo.model.settings.SettingScope
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.SiloDeviceMetadata
+import org.siloserver.silo.network.api.SettingsCapabilitiesResult
+import org.siloserver.silo.repository.SettingsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/** Where the effective `ui.card_presentation` value resolved from. */
+enum class CardPresentationSource {
+    /** `profile_device` — "Only this device" override. */
+    DeviceOverride,
+
+    /** `profile_client` — roams among this profile's like-family devices. */
+    ClientFamily,
+
+    /** `profile` — profile-wide value (written by another client). */
+    Profile,
+
+    /** Contract default; nothing stored at any scope. */
+    Default,
+
+    /** Not resolved yet, or an unrecognized wire scope. */
+    Unknown,
+}
+
+/** Whether the connected server supports the canonical card-presentation key. */
+enum class CardPresentationSupport {
+    Supported,
+
+    /** Server too old (capabilities gate failed or contract routes 404). */
+    Unsupported,
+
+    /** No definitive capability answer yet (cold start / offline). */
+    Unknown,
+}
+
+data class CardPresentationUiState(
+    val presentation: CardPresentation = CardPresentation.DEFAULT,
+    val source: CardPresentationSource = CardPresentationSource.Unknown,
+    val support: CardPresentationSupport = CardPresentationSupport.Unknown,
+)
+
+/**
+ * Cached card-presentation (poster size + caption) state for the signed-in
+ * profile. Same shape as [OverlayPrefsStore]: lazy hydration, refresh on
+ * foreground/reconnect via [ServerDrivenConfigRefresher], optimistic writes
+ * with rollback, and [clear] at sign-out boundaries.
+ *
+ * Unlike overlays this key resolves through the like-client layer
+ * (`profile_device > profile_client > profile > default`), so the store also
+ * reports the resolved [CardPresentationSource] — the settings UI derives the
+ * "Only this device" toggle and "Use profile default" action from it.
+ */
+interface CardPresentationStore {
+    val state: StateFlow<CardPresentationUiState>
+    val isLoading: StateFlow<Boolean>
+    val lastError: StateFlow<String?>
+
+    /** Idempotent first-load. Safe to call from every provider mount. */
+    suspend fun hydrateIfNeeded()
+
+    /** Re-probe capabilities + re-resolve the effective value. */
+    suspend fun refresh()
+
+    /**
+     * Optimistically apply [presentation] locally, then persist — at
+     * `profile_device` when [deviceOnly], else `profile_client`. Rolls back
+     * to the last confirmed state when the write fails.
+     */
+    fun set(presentation: CardPresentation, deviceOnly: Boolean)
+
+    /** DELETE the `profile_device` row so resolution falls back, then refresh. */
+    suspend fun clearDeviceOverride()
+
+    /** DELETE the `profile_client` row ("Use profile default"), then refresh. */
+    suspend fun useProfileDefault()
+
+    /** Wipe in-memory state on sign-out so the next user re-hydrates clean. */
+    fun clear()
+}
+
+class DefaultCardPresentationStore(
+    context: Context,
+    private val repository: SettingsRepository,
+    private val scope: CoroutineScope,
+    private val getActiveProfileId: suspend () -> String?,
+    private val getServerUrl: suspend () -> String?,
+    private val getDeviceMetadata: suspend () -> SiloDeviceMetadata?,
+) : CardPresentationStore {
+
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private val _state = MutableStateFlow(CardPresentationUiState())
+    private val _isLoading = MutableStateFlow(false)
+    private val _lastError = MutableStateFlow<String?>(null)
+
+    override val state: StateFlow<CardPresentationUiState> = _state.asStateFlow()
+    override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+    override val lastError: StateFlow<String?> = _lastError.asStateFlow()
+
+    @Volatile
+    private var hasHydrated: Boolean = false
+
+    // The last state confirmed by a canonical read or write; the rollback
+    // target for a failed optimistic edit.
+    private var confirmedState: CardPresentationUiState = _state.value
+
+    // Guards the short state commits so a refresh response captured before a
+    // newer optimistic edit cannot replace that edit after it succeeds.
+    private val stateLock = Any()
+
+    // Bumped by every mutation; a refresh only commits its user-value half
+    // when the epoch it started at is still current.
+    private var canonicalEpoch: Long = 0L
+
+    // Bumped by every [set]. A queued drain persists its snapshot unless a
+    // NEWER edit was staged behind it (latest-wins coalescing). Deliberately
+    // not a comparison against `_state.value`: an interleaved refresh can
+    // commit a server value over the optimistic state, and that must not
+    // cancel the user's pending write.
+    private var editSequence: Long = 0L
+
+    // Bumped by [clear] — a session boundary. `@Volatile` so a queued write
+    // coroutine sees the bump without taking a lock and bails before its PUT.
+    @Volatile
+    private var writeGeneration: Int = 0
+
+    private val refreshLock = Mutex()
+
+    // Serializes PUT/DELETE drains so the wire order matches user intent.
+    private val mutationMutex = Mutex()
+
+    override suspend fun hydrateIfNeeded() {
+        if (hasHydrated || _isLoading.value) return
+        // Seed from the last-known cache for this exact identity so cold start
+        // renders at the right size without a resize jump once the network
+        // answer lands.
+        currentIdentity()?.let { identity ->
+            readCachedState(identity)?.let { cached ->
+                synchronized(stateLock) {
+                    // Only paint the cache over untouched (pre-hydration,
+                    // pre-edit) state.
+                    if (!hasHydrated && _state.value == confirmedState) {
+                        confirmedState = cached
+                        _state.value = cached
+                    }
+                }
+            }
+        }
+        refresh()
+    }
+
+    /**
+     * Capability probe + effective read. Failure semantics:
+     * - Probe/read transport failure keeps the current (cached) state active
+     *   and leaves [hasHydrated] false so the next [hydrateIfNeeded] retries.
+     * - A definitive "unsupported" answer renders the default presentation
+     *   and completes hydration; the settings UI shows the upgrade row.
+     */
+    override suspend fun refresh(): Unit = refreshLock.withLock {
+        val startGeneration: Int
+        val startEpoch: Long
+        synchronized(stateLock) {
+            startGeneration = writeGeneration
+            _isLoading.value = true
+            _lastError.value = null
+            startEpoch = canonicalEpoch
+        }
+        try {
+            val identity = currentIdentity() ?: return
+
+            val support = when (val caps = repository.contractCapabilities()) {
+                is SettingsCapabilitiesResult.Available ->
+                    if (
+                        caps.capabilities.apiVersion == 1 &&
+                        caps.capabilities.revision >= MIN_CONTRACT_REVISION &&
+                        caps.capabilities.supportsBatchedEffective &&
+                        caps.capabilities.supportsIdempotentWrites
+                    ) {
+                        CardPresentationSupport.Supported
+                    } else {
+                        CardPresentationSupport.Unsupported
+                    }
+                is SettingsCapabilitiesResult.ServerUpgradeRequired ->
+                    CardPresentationSupport.Unsupported
+                is SettingsCapabilitiesResult.Error -> {
+                    commitError(caps.message, startGeneration)
+                    return
+                }
+                is SettingsCapabilitiesResult.NetworkError -> {
+                    commitError(caps.exception.message, startGeneration)
+                    return
+                }
+            }
+
+            if (support == CardPresentationSupport.Unsupported) {
+                val resolved = CardPresentationUiState(
+                    presentation = CardPresentation.DEFAULT,
+                    source = CardPresentationSource.Default,
+                    support = CardPresentationSupport.Unsupported,
+                )
+                commitResolved(resolved, identity, startGeneration, startEpoch)
+                return
+            }
+
+            when (val result = repository.getEffectiveValues(listOf(SETTING_KEY))) {
+                is ApiResult.Success -> {
+                    val entry = result.data[SETTING_KEY]
+                    if (entry == null) {
+                        commitError(
+                            "The server did not resolve $SETTING_KEY",
+                            startGeneration,
+                        )
+                        return
+                    }
+                    val resolved = CardPresentationUiState(
+                        presentation = CardPresentation.decodeOrDefault(entry.value),
+                        source = sourceFromWire(entry.source),
+                        support = CardPresentationSupport.Supported,
+                    )
+                    commitResolved(resolved, identity, startGeneration, startEpoch)
+                }
+                is ApiResult.Error -> commitError(result.message, startGeneration)
+                is ApiResult.NetworkError ->
+                    commitError(result.exception.message, startGeneration)
+            }
+        } finally {
+            _isLoading.value = false
+        }
+    }
+
+    private fun commitResolved(
+        resolved: CardPresentationUiState,
+        identity: Identity,
+        startGeneration: Int,
+        startEpoch: Long,
+    ) {
+        val persisted = synchronized(stateLock) {
+            if (writeGeneration != startGeneration) return@synchronized false
+            // A mutation landed after this refresh started; its optimistic
+            // state (or its own refresh) is newer than this response.
+            if (canonicalEpoch != startEpoch) return@synchronized false
+            confirmedState = resolved
+            _state.value = resolved
+            hasHydrated = true
+            true
+        }
+        if (persisted) writeCachedState(identity, resolved)
+    }
+
+    private fun commitError(message: String?, startGeneration: Int) {
+        synchronized(stateLock) {
+            if (writeGeneration == startGeneration) {
+                _lastError.value = message
+            }
+        }
+    }
+
+    override fun set(presentation: CardPresentation, deviceOnly: Boolean) {
+        val optimistic = CardPresentationUiState(
+            presentation = presentation,
+            source = if (deviceOnly) {
+                CardPresentationSource.DeviceOverride
+            } else {
+                CardPresentationSource.ClientFamily
+            },
+            support = CardPresentationSupport.Supported,
+        )
+        var edit = 0L
+        val generation = synchronized(stateLock) {
+            canonicalEpoch += 1
+            editSequence += 1
+            edit = editSequence
+            _state.value = optimistic
+            writeGeneration
+        }
+        scope.launch {
+            mutationMutex.withLock {
+                if (writeGeneration != generation) return@withLock
+                val superseded = synchronized(stateLock) {
+                    // Latest-wins coalescing: a newer optimistic edit was
+                    // staged behind this one and its own queued drain will
+                    // persist it — skip the stale PUT.
+                    if (editSequence != edit) {
+                        true
+                    } else {
+                        // Re-assert the optimistic state while staging the
+                        // write (OverlayPrefsStore precedent): a refresh may
+                        // have committed a server value over it since, and
+                        // that must not silently cancel the user's edit.
+                        _state.value = optimistic
+                        false
+                    }
+                }
+                if (superseded) return@withLock
+                val value = presentation.toJsonElement()
+                val result = if (deviceOnly) {
+                    repository.setProfileDeviceValue(SETTING_KEY, value)
+                } else {
+                    repository.setProfileClientValue(SETTING_KEY, value)
+                }
+                when (result) {
+                    is ApiResult.Success -> {
+                        val identity = currentIdentity()
+                        val persisted = synchronized(stateLock) {
+                            if (writeGeneration != generation) return@synchronized false
+                            // Invalidate any refresh captured before this PUT.
+                            canonicalEpoch += 1
+                            confirmedState = optimistic
+                            // Do not paint a confirmed write over a newer edit
+                            // that is already staged.
+                            if (editSequence == edit) {
+                                _state.value = optimistic
+                                _lastError.value = null
+                            }
+                            true
+                        }
+                        if (persisted && identity != null) {
+                            writeCachedState(identity, optimistic)
+                        }
+                    }
+                    is ApiResult.Error ->
+                        rollbackFailedWrite(edit, generation, result.message)
+                    is ApiResult.NetworkError ->
+                        rollbackFailedWrite(edit, generation, result.exception.message)
+                }
+            }
+        }
+    }
+
+    private fun rollbackFailedWrite(
+        edit: Long,
+        generation: Int,
+        message: String?,
+    ) {
+        synchronized(stateLock) {
+            if (writeGeneration != generation) return
+            canonicalEpoch += 1
+            // A newer edit is the optimistic state the user should still see;
+            // only restore the confirmed state when this edit is the latest.
+            if (editSequence == edit) {
+                _state.value = confirmedState
+            }
+            _lastError.value = message
+        }
+    }
+
+    override suspend fun clearDeviceOverride() =
+        // "Only this device" is off the moment the row is deleted, so demote
+        // the source right away rather than leaving it at DeviceOverride until
+        // the refresh lands: the toggle would snap back, and a preset picked
+        // in between would be written at `profile_device` again — resurrecting
+        // the override the user just removed.
+        deleteScope(optimisticSource = CardPresentationSource.ClientFamily) {
+            repository.clearProfileDeviceValue(SETTING_KEY)
+        }
+
+    override suspend fun useProfileDefault() =
+        deleteScope { repository.clearProfileClientValue(SETTING_KEY) }
+
+    /**
+     * DELETE one scope row, then refresh so the state reflects whatever the
+     * resolution falls back to. The presentation itself is not updated
+     * optimistically — the fallback value is unknowable locally (it lives at
+     * another scope), so the current cards hold until the refresh answers —
+     * but [optimisticSource] lets a caller pin the scope the deletion moves
+     * resolution to, rolled back if the DELETE never lands.
+     */
+    private suspend fun deleteScope(
+        optimisticSource: CardPresentationSource? = null,
+        delete: suspend () -> ApiResult<Unit>,
+    ) {
+        val generation = writeGeneration
+        // The pre-delete state and the state we optimistically painted, so a
+        // failed DELETE restores the former only while the latter is still on
+        // screen (a newer edit outranks both).
+        var previous: CardPresentationUiState? = null
+        var optimistic: CardPresentationUiState? = null
+        if (optimisticSource != null) {
+            synchronized(stateLock) {
+                val current = _state.value
+                if (writeGeneration == generation && current.source != optimisticSource) {
+                    val next = current.copy(source = optimisticSource)
+                    canonicalEpoch += 1
+                    previous = current
+                    optimistic = next
+                    _state.value = next
+                }
+            }
+        }
+        val deleted = mutationMutex.withLock {
+            if (writeGeneration != generation) return@withLock false
+            when (val result = delete()) {
+                is ApiResult.Success -> {
+                    synchronized(stateLock) {
+                        if (writeGeneration == generation) canonicalEpoch += 1
+                    }
+                    true
+                }
+                is ApiResult.Error -> {
+                    restoreSource(previous, optimistic, generation)
+                    commitError(result.message, generation)
+                    false
+                }
+                is ApiResult.NetworkError -> {
+                    restoreSource(previous, optimistic, generation)
+                    commitError(result.exception.message, generation)
+                    false
+                }
+            }
+        }
+        if (deleted && writeGeneration == generation) refresh()
+    }
+
+    /** Undoes [deleteScope]'s optimistic source when the DELETE never landed. */
+    private fun restoreSource(
+        previous: CardPresentationUiState?,
+        optimistic: CardPresentationUiState?,
+        generation: Int,
+    ) {
+        if (previous == null || optimistic == null) return
+        synchronized(stateLock) {
+            if (writeGeneration != generation) return
+            canonicalEpoch += 1
+            if (_state.value == optimistic) _state.value = previous
+        }
+    }
+
+    override fun clear() {
+        synchronized(stateLock) {
+            writeGeneration += 1
+            canonicalEpoch += 1
+            _state.value = CardPresentationUiState()
+            confirmedState = _state.value
+            hasHydrated = false
+            // Let the next session's hydrateIfNeeded run instead of observing
+            // the previous session's loading flag and returning early.
+            _isLoading.value = false
+            _lastError.value = null
+        }
+    }
+
+    /**
+     * The identity the last-known cache is keyed by. The client family is
+     * part of it deliberately: a backup restored from a tablet to a phone
+     * must not cold-start with the tablet family's cached choice.
+     */
+    private data class Identity(
+        val serverUrl: String,
+        val profileId: String,
+        val clientFamily: String,
+        val deviceId: String,
+    ) {
+        val cacheKeyPrefix: String =
+            "cp_" + sha256Hex("$serverUrl|$profileId|$clientFamily|$deviceId").take(24)
+    }
+
+    private suspend fun currentIdentity(): Identity? {
+        val profileId = getActiveProfileId() ?: return null
+        val device = getDeviceMetadata()
+        return Identity(
+            serverUrl = getServerUrl().orEmpty(),
+            profileId = profileId,
+            clientFamily = device?.clientFamily.orEmpty(),
+            deviceId = device?.id.orEmpty(),
+        )
+    }
+
+    private fun readCachedState(identity: Identity): CardPresentationUiState? {
+        val support = when (prefs.getString("${identity.cacheKeyPrefix}.support", null)) {
+            SUPPORT_SUPPORTED -> CardPresentationSupport.Supported
+            SUPPORT_UNSUPPORTED -> CardPresentationSupport.Unsupported
+            else -> return null
+        }
+        val presentation = CardPresentation.decodeOrNull(
+            prefs.getString("${identity.cacheKeyPrefix}.value", null),
+        ) ?: CardPresentation.DEFAULT
+        return CardPresentationUiState(
+            presentation = presentation,
+            source = sourceFromWire(prefs.getString("${identity.cacheKeyPrefix}.source", null)),
+            support = support,
+        )
+    }
+
+    private fun writeCachedState(identity: Identity, state: CardPresentationUiState) {
+        prefs.edit()
+            .putString("${identity.cacheKeyPrefix}.value", state.presentation.serialize())
+            .putString("${identity.cacheKeyPrefix}.source", sourceToWire(state.source))
+            .putString(
+                "${identity.cacheKeyPrefix}.support",
+                if (state.support == CardPresentationSupport.Unsupported) {
+                    SUPPORT_UNSUPPORTED
+                } else {
+                    SUPPORT_SUPPORTED
+                },
+            )
+            .apply()
+    }
+
+    private companion object {
+        const val SETTING_KEY = SettingKeys.UI_CARD_PRESENTATION
+
+        /** Contract revision that introduced `ui.card_presentation`. */
+        const val MIN_CONTRACT_REVISION = 5
+
+        const val PREFS_NAME = "silo_card_presentation"
+        const val SUPPORT_SUPPORTED = "supported"
+        const val SUPPORT_UNSUPPORTED = "unsupported"
+
+        fun sourceFromWire(source: String?): CardPresentationSource = when (source) {
+            SettingScope.PROFILE_DEVICE.wire -> CardPresentationSource.DeviceOverride
+            SettingScope.PROFILE_CLIENT.wire -> CardPresentationSource.ClientFamily
+            SettingScope.PROFILE.wire -> CardPresentationSource.Profile
+            EffectiveSettingValue.SOURCE_DEFAULT -> CardPresentationSource.Default
+            else -> CardPresentationSource.Unknown
+        }
+
+        fun sourceToWire(source: CardPresentationSource): String? = when (source) {
+            CardPresentationSource.DeviceOverride -> SettingScope.PROFILE_DEVICE.wire
+            CardPresentationSource.ClientFamily -> SettingScope.PROFILE_CLIENT.wire
+            CardPresentationSource.Profile -> SettingScope.PROFILE.wire
+            CardPresentationSource.Default -> EffectiveSettingValue.SOURCE_DEFAULT
+            CardPresentationSource.Unknown -> null
+        }
+
+        fun sha256Hex(s: String): String =
+            java.security.MessageDigest.getInstance("SHA-256")
+                .digest(s.toByteArray(Charsets.UTF_8))
+                .joinToString(separator = "") { "%02x".format(it) }
+    }
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/ServerDrivenConfigRefresher.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/settings/ServerDrivenConfigRefresher.kt
@@ -12,6 +12,7 @@ import android.os.SystemClock
  */
 class ServerDrivenConfigRefresher(
     private val overlayPrefsStore: OverlayPrefsStore,
+    private val cardPresentationStore: CardPresentationStore,
     private val libraryPlaybackPrefsStore: LibraryPlaybackPrefsStore,
     private val playerSettingsStore: PlayerSettingsStore,
     private val hasAuthenticatedProfile: suspend () -> Boolean,
@@ -34,6 +35,7 @@ class ServerDrivenConfigRefresher(
         if (!force && last != null && now - last < minIntervalMs) return false
 
         overlayPrefsStore.refresh()
+        cardPresentationStore.refresh()
         libraryPlaybackPrefsStore.refresh()
         playerSettingsStore.refreshFromServer()
         lastRefreshAtMs = now

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsBundleBuilderTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsBundleBuilderTest.kt
@@ -172,10 +172,12 @@ class DiagnosticsBundleBuilderTest {
         val playbackLine = """{"ts":"2026-08-11T00:00:00Z","run":"run-1","lvl":"I","cat":"playback","tag":"Player","msg":"stats playback_session_id=private-playback-correlation","attrs":{"decoder":"c2.android.avc","buffered_ms":1200,"failure_code":"source-private"}}"""
         val lifecycleLine = """{"ts":"2026-08-11T00:00:01Z","run":"run-1","lvl":"I","cat":"lifecycle","tag":"Lifecycle","msg":"performance","attrs":{"state":"foreground","p95_frame_ms":22,"startup_first_frame_ms":400}}"""
         val focusLine = """{"ts":"2026-08-11T00:00:02Z","run":"run-1","lvl":"I","cat":"focus","tag":"Focus","msg":"moved","attrs":{"target":"send","action":"enter","route":"private-route"}}"""
+        val homeContentLine = """{"ts":"2026-08-11T00:00:03Z","run":"run-1","lvl":"I","cat":"lifecycle","tag":"HomeScreen","msg":"home content state changed","attrs":{"phase":"home_content","outcome":"ready"}}"""
+        val homeScrollLine = """{"ts":"2026-08-11T00:00:04Z","run":"run-1","lvl":"I","cat":"lifecycle","tag":"HomeScreen","msg":"home scroll state changed","attrs":{"phase":"home_scroll","outcome":"scrolling","reason":"content"}}"""
         val artifacts = mapOf(
             "device.json" to "{}".encodeToByteArray(),
             "logs.jsonl" to "$playbackLine\n$lifecycleLine\n".encodeToByteArray(),
-            "breadcrumbs.jsonl" to "$focusLine\n".encodeToByteArray(),
+            "breadcrumbs.jsonl" to "$focusLine\n$homeContentLine\n$homeScrollLine\n".encodeToByteArray(),
             "crash/tombstone.pb" to "opaque-private-native-trace".encodeToByteArray(),
         )
 
@@ -186,9 +188,8 @@ class DiagnosticsBundleBuilderTest {
         val hostedEntries = untar(gunzip(hosted.bytes)).associateBy(TarEntry::name)
         val hostedLogs = hostedEntries.getValue("logs.jsonl").bytes.decodeToString()
             .lineSequence().filter(String::isNotBlank).map { Json.parseToJsonElement(it).jsonObject }.toList()
-        val hostedBreadcrumb = Json.parseToJsonElement(
-            hostedEntries.getValue("breadcrumbs.jsonl").bytes.decodeToString().trim(),
-        ).jsonObject
+        val hostedBreadcrumbs = hostedEntries.getValue("breadcrumbs.jsonl").bytes.decodeToString()
+            .lineSequence().filter(String::isNotBlank).map { Json.parseToJsonElement(it).jsonObject }.toList()
 
         assertEquals(
             "android-c2-platform-decoder",
@@ -199,7 +200,15 @@ class DiagnosticsBundleBuilderTest {
         assertFalse(hostedLogs[0].getValue("msg").jsonPrimitive.content.contains("private-playback-correlation"))
         assertTrue(hostedLogs[0].getValue("msg").jsonPrimitive.content.contains("[redacted_private_id]"))
         assertEquals(setOf("state"), hostedLogs[1].getValue("attrs").jsonObject.keys)
-        assertEquals(setOf("target", "action"), hostedBreadcrumb.getValue("attrs").jsonObject.keys)
+        assertEquals(setOf("target", "action"), hostedBreadcrumbs[0].getValue("attrs").jsonObject.keys)
+        assertEquals(
+            mapOf("phase" to "home_content", "outcome" to "ready"),
+            hostedBreadcrumbs[1].getValue("attrs").jsonObject.mapValues { it.value.jsonPrimitive.content },
+        )
+        assertEquals(
+            mapOf("phase" to "home_scroll", "outcome" to "scrolling", "reason" to "content"),
+            hostedBreadcrumbs[2].getValue("attrs").jsonObject.mapValues { it.value.jsonPrimitive.content },
+        )
         assertFalse(hostedEntries.containsKey("crash/tombstone.pb"))
         assertFalse(hosted.manifest.archive.entries.contains("crash/tombstone.pb"))
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsCoordinatorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsCoordinatorTest.kt
@@ -1356,6 +1356,34 @@ class DiagnosticsCoordinatorTest {
     }
 
     @Test
+    fun priorIncidentCollectionPrecedesEnablingCurrentRunBreadcrumbs() = runTest {
+        val events = mutableListOf<String>()
+        val capture = RecordingCaptureController().apply {
+            onPersistentBreadcrumbsChanged = { enabled ->
+                if (enabled) events += "breadcrumbs-enabled"
+            }
+        }
+        val fixture = fixture(
+            identity = MutableIdentityResolver(ADULT_A),
+            transitions = DefaultIdentityTransitionBarrier(),
+            capture = capture,
+            scope = backgroundScope,
+            actorDispatcher = UnconfinedTestDispatcher(testScheduler),
+            incidentCollectorFactory = {
+                DiagnosticsIncidentCollector { _, _ ->
+                    events += "incidents-collected"
+                    emptyList()
+                }
+            },
+        )
+
+        fixture.coordinator.start()
+        fixture.coordinator.refresh()
+
+        assertTrue(events.indexOf("incidents-collected") in 0 until events.indexOf("breadcrumbs-enabled"), events.toString())
+    }
+
+    @Test
     fun detachedRawGenerationCleanupFailureKeepsActorClosedUntilRetrySucceeds() = runTest {
         val capture = RecordingCaptureController().apply {
             hasPersistentEvidence = true
@@ -1798,6 +1826,7 @@ class DiagnosticsCoordinatorTest {
         var purgeFailuresRemaining = 0
         var reconciliationFailuresRemaining = 0
         var captureNowCalls = 0
+        var onPersistentBreadcrumbsChanged: ((Boolean) -> Unit)? = null
         var captureNowAction: suspend (DiagnosticsCaptureContext) -> PendingReport? = { null }
         private var nextGeneration = 0L
 
@@ -1836,6 +1865,7 @@ class DiagnosticsCoordinatorTest {
 
         override suspend fun setPersistentBreadcrumbs(context: DiagnosticsCaptureContext?, enabled: Boolean) {
             persistentBreadcrumbsEnabled = context != null && enabled
+            onPersistentBreadcrumbsChanged?.invoke(persistentBreadcrumbsEnabled)
             if (persistentBreadcrumbsEnabled) hasPersistentEvidence = true
         }
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsImageHealthTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsImageHealthTest.kt
@@ -1,0 +1,103 @@
+package org.siloserver.silo.common.diagnostics
+
+import java.io.IOException
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DiagnosticsImageHealthTest {
+    @AfterTest
+    fun tearDown() {
+        SiloLog.installSink(null)
+    }
+
+    @Test
+    fun accumulatorEmitsRateLimitedFailuresAndAggregateSourceMix() {
+        var nowMs = 10_000L
+        val accumulator = DiagnosticsImageHealthAccumulator(
+            windowSize = 4,
+            failureIntervalMs = 60_000,
+            nowMs = { nowMs },
+        )
+
+        assertNull(accumulator.success(DiagnosticsImageSource.MEMORY).window)
+        val firstFailure = accumulator.failure(
+            DiagnosticsImageStage.FETCH,
+            DiagnosticsImageFailureKind.HTTP,
+        )
+        assertNotNull(firstFailure.failure)
+        assertNull(firstFailure.window)
+        assertNull(
+            accumulator.failure(
+                DiagnosticsImageStage.DECODE,
+                DiagnosticsImageFailureKind.DECODE,
+            ).failure,
+        )
+        val window = assertNotNull(accumulator.success(DiagnosticsImageSource.NETWORK).window)
+
+        assertEquals(4, window.completed)
+        assertEquals(2, window.failures)
+        assertEquals(1, window.memorySuccesses)
+        assertEquals(1, window.networkSuccesses)
+
+        nowMs += 60_000
+        assertNotNull(
+            accumulator.failure(
+                DiagnosticsImageStage.DECODE,
+                DiagnosticsImageFailureKind.DECODE,
+            ).failure,
+        )
+    }
+
+    @Test
+    fun imageFailureClassificationAndLogsNeverUseThrowableMessages() {
+        val privateMessage = "https://private.example/media/private-title.jpg"
+        val kind = classifyImageFailure(
+            DiagnosticsImageStage.DECODE,
+            IOException(privateMessage),
+        )
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+
+        DiagnosticsImageLogger.failure(
+            DiagnosticsImageFailure(DiagnosticsImageStage.DECODE, kind),
+        )
+        DiagnosticsImageLogger.window(
+            DiagnosticsImageWindow(
+                completed = 50,
+                failures = 5,
+                memorySuccesses = 20,
+                diskSuccesses = 15,
+                networkSuccesses = 10,
+            ),
+        )
+
+        assertEquals(DiagnosticsImageFailureKind.DECODE, kind)
+        assertTrue(lines[0].contains("\"reason\":\"decode\""), lines[0])
+        assertTrue(lines[1].contains("failure_rate_10_24"), lines[1])
+        assertTrue(lines[1].contains("memory_25_49_disk_25_49_network_1_24"), lines[1])
+        assertFalse(lines.any { it.contains(privateMessage) })
+    }
+
+    @Test
+    fun subOnePercentImageShareStaysInTheSmallestNonzeroBucket() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+
+        DiagnosticsImageLogger.window(
+            DiagnosticsImageWindow(
+                completed = 200,
+                failures = 0,
+                memorySuccesses = 1,
+                diskSuccesses = 99,
+                networkSuccesses = 100,
+            ),
+        )
+
+        assertTrue(lines.single().contains("memory_1_24_disk_25_49_network_50_74"), lines.single())
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentationTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentationTest.kt
@@ -5,6 +5,10 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.siloserver.silo.viewmodel.HomeLoadObservation
+import org.siloserver.silo.viewmodel.HomeLoadOutcome
+import org.siloserver.silo.viewmodel.HomeLoadSource
+import org.siloserver.silo.viewmodel.HomeLoadTrigger
 
 class DiagnosticsInstrumentationTest {
     @AfterTest
@@ -144,5 +148,137 @@ class DiagnosticsInstrumentationTest {
         assertTrue(line.contains("slow_frame_count"), line)
         assertTrue(line.contains("process_pss_mb"), line)
         assertFalse(line.contains("view_text"), line)
+    }
+
+    @Test
+    fun homeBreadcrumbsContainOnlyBoundedStateAndRegion() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+
+        DiagnosticsHomeLogger.content(DiagnosticsHomeContentState.READY)
+        DiagnosticsHomeLogger.scroll(scrolling = true, DiagnosticsHomeScrollRegion.CONTENT)
+
+        assertEquals(2, lines.size)
+        assertTrue(lines[0].contains("home content state changed"), lines[0])
+        assertTrue(lines[0].contains("\"outcome\":\"ready\""), lines[0])
+        assertTrue(lines[1].contains("home scroll state changed"), lines[1])
+        assertTrue(lines[1].contains("\"outcome\":\"scrolling\""), lines[1])
+        assertTrue(lines[1].contains("\"reason\":\"content\""), lines[1])
+        assertFalse(lines.any { it.contains("title", ignoreCase = true) })
+        assertFalse(lines.any { it.contains("content_id", ignoreCase = true) })
+    }
+
+    @Test
+    fun listIntegrityBucketsCountsWithoutLoggingKeys() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+        val snapshot = DiagnosticsListSnapshot.fromKeys(
+            keys = listOf("private-section-a", "private-section-a", "private-section-b"),
+            rowKeys = listOf(
+                listOf("private-title-a", "private-title-a"),
+                listOf("private-title-b"),
+            ),
+            fullyResolved = false,
+        )
+
+        DiagnosticsListLogger.snapshot(DiagnosticsListSurface.PHONE_HOME, snapshot)
+
+        assertEquals(3, lines.size)
+        assertTrue(lines[0].contains("duplicate_keys_one"), lines[0])
+        assertTrue(lines[0].contains("items_2_4"), lines[0])
+        assertTrue(lines[1].contains("duplicate_rows_one"), lines[1])
+        assertTrue(lines[2].contains("\"outcome\":\"partial\""), lines[2])
+        assertFalse(lines.any { it.contains("private-section") || it.contains("private-title") })
+    }
+
+    @Test
+    fun librarySurfaceLabelsDoNotResemblePrivateLibraryIdentifiers() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+        val snapshot = DiagnosticsListSnapshot.fromKeys(listOf("private-title"))
+
+        listOf(
+            DiagnosticsListSurface.PHONE_LIBRARY_RECOMMENDED,
+            DiagnosticsListSurface.TV_LIBRARY_RECOMMENDED,
+        ).forEach { surface ->
+            DiagnosticsListLogger.snapshot(surface, snapshot)
+            DiagnosticsResourceLogger.checkpoint(
+                surface = surface,
+                cause = DiagnosticsResourceCheckpointCause.LIST_READY,
+                resources = DiagnosticsResourceSnapshot(82, 140, lowMemory = false, thermalStatus = 1),
+            )
+        }
+
+        assertTrue(lines.any { it.contains("phone_lib_rec_list") }, lines.joinToString("\n"))
+        assertTrue(lines.any { it.contains("tv_lib_rec_list") }, lines.joinToString("\n"))
+        assertFalse(lines.any { it.contains("library_recommended") }, lines.joinToString("\n"))
+        assertFalse(lines.any { it.contains("private-title") }, lines.joinToString("\n"))
+    }
+
+    @Test
+    fun reusableKeyLoggerStaysSilentWhenHealthyAndNeverLogsTheDuplicateKey() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+
+        DiagnosticsKeyAnomalyLogger.snapshot(
+            DiagnosticsKeyCollection.PHONE_MEDIA_ROW,
+            DiagnosticsListSnapshot.fromKeys(listOf("one", "two")),
+        )
+        DiagnosticsKeyAnomalyLogger.snapshot(
+            DiagnosticsKeyCollection.PHONE_MEDIA_ROW,
+            DiagnosticsListSnapshot.fromKeys(listOf("private-title-id", "private-title-id")),
+        )
+
+        assertEquals(1, lines.size)
+        assertTrue(lines.single().contains("duplicate_one"), lines.single())
+        assertFalse(lines.single().contains("private-title-id"), lines.single())
+    }
+
+    @Test
+    fun scrollContextAllowListsSectionTypesAndBucketsTheOrdinal() {
+        assertEquals(
+            "content:row_3_4:recently_added",
+            homeScrollReason(DiagnosticsHomeScrollRegion.CONTENT, 3, "Recently Added"),
+        )
+        assertEquals(
+            "content:row_17_plus:unknown",
+            homeScrollReason(DiagnosticsHomeScrollRegion.CONTENT, 42, "Private Shelf Name"),
+        )
+    }
+
+    @Test
+    fun homeLoadAndResourceCheckpointsContainOnlyAggregateEvidence() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+
+        DiagnosticsHomeLoadObserver.completed(
+            HomeLoadObservation(
+                trigger = HomeLoadTrigger.INITIAL,
+                source = HomeLoadSource.NETWORK,
+                outcome = HomeLoadOutcome.PARTIAL,
+                durationMs = 1_234,
+                sectionCount = 9,
+            ),
+        )
+        DiagnosticsResourceLogger.checkpoint(
+            surface = DiagnosticsListSurface.PHONE_HOME,
+            cause = DiagnosticsResourceCheckpointCause.SCROLL_START,
+            resources = DiagnosticsResourceSnapshot(
+                javaHeapMb = 173,
+                processPssMb = 419,
+                lowMemory = false,
+                thermalStatus = 2,
+            ),
+        )
+
+        assertTrue(lines[0].contains("home_network_initial"), lines[0])
+        assertTrue(lines[0].contains("\"duration_ms\":1234"), lines[0])
+        assertTrue(lines[0].contains("sections_9_16"), lines[0])
+        assertTrue(lines[1].contains("unique_section_keys"), lines[1])
+        assertTrue(lines[1].contains("unique_item_rows"), lines[1])
+        assertTrue(lines[2].contains("thermal_elevated"), lines[2])
+        assertTrue(lines[2].contains("heap_128_255_pss_256_511"), lines[2])
+        assertFalse(lines[2].contains("173"), lines[2])
+        assertFalse(lines[2].contains("419"), lines[2])
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPerformanceRecorderTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPerformanceRecorderTest.kt
@@ -2,6 +2,8 @@ package org.siloserver.silo.common.diagnostics
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class DiagnosticsPerformanceRecorderTest {
     @Test
@@ -37,5 +39,39 @@ class DiagnosticsPerformanceRecorderTest {
 
         assertEquals(60_000, snapshot.worstFrameMs)
         assertEquals(60_000, snapshot.longestMainThreadStallMs)
+    }
+
+    @Test
+    fun resourceCheckpointsAreRateLimitedPerSurfaceAndCause() {
+        val cadence = DiagnosticsCheckpointCadence(intervalMs = 30_000)
+
+        assertTrue(
+            cadence.shouldEmit(
+                DiagnosticsListSurface.PHONE_HOME,
+                DiagnosticsResourceCheckpointCause.LIST_READY,
+                nowMs = 100_000,
+            ),
+        )
+        assertFalse(
+            cadence.shouldEmit(
+                DiagnosticsListSurface.PHONE_HOME,
+                DiagnosticsResourceCheckpointCause.LIST_READY,
+                nowMs = 129_999,
+            ),
+        )
+        assertTrue(
+            cadence.shouldEmit(
+                DiagnosticsListSurface.PHONE_HOME,
+                DiagnosticsResourceCheckpointCause.SCROLL_START,
+                nowMs = 100_001,
+            ),
+        )
+        assertTrue(
+            cadence.shouldEmit(
+                DiagnosticsListSurface.PHONE_HOME,
+                DiagnosticsResourceCheckpointCause.LIST_READY,
+                nowMs = 130_000,
+            ),
+        )
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPrivacyIntegrationTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPrivacyIntegrationTest.kt
@@ -120,6 +120,41 @@ class DiagnosticsPrivacyIntegrationTest {
     }
 
     @Test
+    fun debugAndTimedCaptureImmediatelyReenablePersistentBreadcrumbs() = runTest {
+        val root = temporaryFolder.newFolder()
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val journal = BreadcrumbJournal(root, writerDispatcher = dispatcher, directorySync = {})
+        val capture = FileDiagnosticsCaptureController(
+            logBuffer = LogRing(),
+            fileLogger = DiagnosticsFileLogger(root, dispatcher, directorySync = {}),
+            breadcrumbJournal = journal,
+            reports = FilePendingReportStore(
+                root,
+                nowMs = { CAPTURED_AT },
+                directorySync = {},
+                atomicRename = ::testAtomicRename,
+            ),
+            deviceSnapshots = DeviceSnapshotCollector(StableProbe, nowRfc3339 = { "2026-07-22T00:00:00Z" }),
+            deviceSnapshotCache = DeviceSnapshotCache(),
+            environment = ENVIRONMENT,
+            nowMs = { CAPTURED_AT },
+        )
+
+        capture.setPersistentBreadcrumbs(ADULT, true)
+        capture.setDebugLogging(ADULT, true)
+        val debugLine = diagnosticsLine("debug-run", "debug capture breadcrumb")
+        journal.offer(debugLine)
+
+        assertEquals(listOf(debugLine), journal.linesForRun("debug-run", ADULT.identityKey))
+
+        capture.start(ADULT)
+        val timedLine = diagnosticsLine("timed-run", "timed capture breadcrumb")
+        journal.offer(timedLine)
+
+        assertEquals(listOf(timedLine), journal.linesForRun("timed-run", ADULT.identityKey))
+    }
+
+    @Test
     fun hostedManualBundleOmitsSourceServerAccountAndProfileIdentity() = runTest {
         val root = temporaryFolder.newFolder()
         val ring = LogRing()
@@ -273,6 +308,7 @@ class DiagnosticsPrivacyIntegrationTest {
         )
         val outerManifest = bundle.manifestBytes.decodeToString()
         val archive = GZIPInputStream(ByteArrayInputStream(bundle.bytes)).use { it.readBytes() }.decodeToString()
+        assertTrue(archive.contains("illegal_state_other"), archive)
         listOf(
             SOURCE_SERVER_ID,
             SOURCE_PROFILE_ID,
@@ -484,6 +520,9 @@ class DiagnosticsPrivacyIntegrationTest {
         override val processStateSummary = RUN_TOKEN.encodeToByteArray()
         override fun trace(maxBytes: Int): ByteArray? = null
     }
+
+    private fun diagnosticsLine(run: String, message: String): String =
+        """{"ts":"2026-07-22T00:00:00Z","run":"$run","lvl":"I","cat":"lifecycle","tag":"Test","msg":"$message"}"""
 
     private class MutableIdentity(var current: DiagnosticsCaptureContext?) : DiagnosticsIdentityResolver {
         override suspend fun resolve(requirePersistentCapture: Boolean): DiagnosticsCaptureContext? = current

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollectorTest.kt
@@ -84,7 +84,7 @@ class ExitInfoCollectorTest {
 
     @Test
     fun anrIncludesPersistedBreadcrumbsFromTheExitedRun() = runTest {
-        val breadcrumb = "{\"run\":\"capture-1\",\"msg\":\"foreground\"}"
+        val breadcrumb = """{"ts":"2026-07-22T00:00:01Z","run":"capture-1","lvl":"I","cat":"lifecycle","tag":"AppLifecycle","msg":"foreground secret-token"}"""
         val fixture = fixture(
             records = listOf(exit(reason = AndroidExitReason.ANR, trace = "main blocked".encodeToByteArray())),
             breadcrumbs = DiagnosticsBreadcrumbSource { captureSessionId, _ ->
@@ -94,12 +94,15 @@ class ExitInfoCollectorTest {
 
         val report = fixture.collector.collect().single()
 
-        assertEquals("$breadcrumb\n", report.directory.resolve("breadcrumbs.jsonl").readText())
+        val persisted = report.directory.resolve("breadcrumbs.jsonl").readText()
+        assertFalse(persisted.contains("secret-token"))
+        assertTrue(persisted.contains("foreground [REDACTED]"), persisted)
         assertTrue("breadcrumbs.jsonl" in report.manifest.archive.entries)
     }
 
     @Test
     fun matchingJvmMarkerWinsOverDuplicateExitRecord() = runTest {
+        val breadcrumb = """{"ts":"2026-07-22T00:00:01Z","run":"capture-1","lvl":"I","cat":"lifecycle","tag":"HomeScreen","msg":"home scroll state changed secret-token","attrs":{"phase":"home_scroll","outcome":"scrolling","reason":"content"}}"""
         val marker = JvmCrashMarkerRecord(
             occurredAtEpochMs = EXIT_AT,
             threadName = "main-secret-token",
@@ -124,6 +127,9 @@ class ExitInfoCollectorTest {
         val fixture = fixture(
             records = listOf(exit(reason = AndroidExitReason.JVM_CRASH, timestampMs = EXIT_AT + 100)),
             markers = markers,
+            breadcrumbs = DiagnosticsBreadcrumbSource { captureSessionId, _ ->
+                if (captureSessionId == "capture-1") listOf(breadcrumb) else emptyList()
+            },
         )
 
         val reports = fixture.collector.collect()
@@ -131,14 +137,44 @@ class ExitInfoCollectorTest {
         assertEquals(1, reports.size)
         assertEquals(DiagnosticsCrashSource.UEH, reports.single().manifest.crash?.source)
         assertFalse(reports.single().manifest.crash?.summary.orEmpty().contains("secret-token"))
+        assertTrue(reports.single().manifest.crash?.summary.orEmpty().contains("illegal_state_other"))
         assertFalse(reports.single().manifest.crash?.thread.orEmpty().contains("secret-token"))
         assertFalse(reports.single().directory.resolve("crash/stack.txt").readText().contains("secret-token"))
         assertTrue(reports.single().directory.resolve("crash/stack.txt").readText().contains("[REDACTED]"))
         assertFalse(reports.single().directory.resolve("logs.jsonl").readText().contains("secret-token"))
         assertTrue(reports.single().directory.resolve("logs.jsonl").readText().contains("[REDACTED]"))
+        val breadcrumbs = reports.single().directory.resolve("breadcrumbs.jsonl").readText()
+        assertFalse(breadcrumbs.contains("secret-token"))
+        assertTrue(breadcrumbs.contains("[REDACTED]"))
+        assertTrue(breadcrumbs.contains("home scroll state changed"))
+        assertTrue("breadcrumbs.jsonl" in reports.single().manifest.archive.entries)
+        val crashSummary = reports.single().directory.resolve("crash/summary.json").readText()
+        assertTrue(crashSummary.contains("\"exception_code\":\"illegal_state_other\""), crashSummary)
+        assertFalse(crashSummary.contains("secret-token"), crashSummary)
         assertEquals(listOf(marker), markers.deleted)
         assertTrue(fixture.collector.collect().isEmpty())
         assertEquals(1, fixture.store.list(BINDING).size)
+    }
+
+    @Test
+    fun jvmCrashClassificationUsesRawMessageOnlyToProduceAFixedCode() {
+        val duplicate = classifyJvmFailure(
+            throwableType = "java.lang.IllegalArgumentException",
+            rawStack = """java.lang.IllegalArgumentException: Key \"private-title-123\" was already used. If you are using LazyColumn/Row, use a unique key.""",
+        )
+        val constraints = classifyJvmFailure(
+            throwableType = "java.lang.IllegalArgumentException",
+            rawStack = "java.lang.IllegalArgumentException: Can't represent width in Constraints",
+        )
+        val scroll = classifyJvmFailure(
+            throwableType = "java.lang.IllegalArgumentException",
+            rawStack = "java.lang.IllegalArgumentException: scroll index should be non-negative",
+        )
+
+        assertEquals(DiagnosticsJvmFailureCode.DUPLICATE_LAZY_KEY, duplicate)
+        assertEquals(DiagnosticsJvmFailureCode.INVALID_LAYOUT_CONSTRAINTS, constraints)
+        assertEquals(DiagnosticsJvmFailureCode.INVALID_SCROLL_POSITION, scroll)
+        assertFalse(duplicate.wireValue.contains("private-title-123"))
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -1,14 +1,58 @@
 package org.siloserver.silo.common.player
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.siloserver.silo.common.network.SiloClientBuildIdentity
+import org.siloserver.silo.libass.LibassBridge
 import org.siloserver.silo.model.playback.HdrCapabilities
 import org.siloserver.silo.model.playback.CLIENT_DV7_TO_DV81
 import org.siloserver.silo.model.playback.CLIENT_DV7_TO_HDR10
+import org.siloserver.silo.model.playback.ClientCodecCapabilities
+import org.siloserver.silo.model.playback.DELIVERY_CLASS_HLS
+import org.siloserver.silo.model.playback.DELIVERY_CLASS_ORIGINAL_HTTP
+import org.siloserver.silo.model.playback.DELIVERY_CLASS_PROGRESSIVE
+import org.siloserver.silo.model.playback.NATIVE_HLS_PLAYBACK_V1_FEATURE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@RunWith(RobolectricTestRunner::class)
 class PlaybackCapabilityDetectorDolbyVisionTest {
+
+    @Test
+    fun phoneAndTvAdvertiseNativeHlsOnlyOnMedia3HlsDelivery() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val detector = PlaybackCapabilityDetector(
+            context = context,
+            audioCapabilityManager = AudioCapabilityManager(context),
+            libassBridge = LibassBridge(false),
+            buildIdentity = SiloClientBuildIdentity(buildNumber = "test", channel = "test"),
+        )
+
+        listOf("mobile", "tv").forEach { formFactor ->
+            val playbackContext = detector.detectPlaybackContext(
+                formFactor = formFactor,
+                appVersion = "test",
+                capabilities = ClientCodecCapabilities(),
+            )
+
+            assertTrue(
+                NATIVE_HLS_PLAYBACK_V1_FEATURE in playbackContext.deliveries.getValue(DELIVERY_CLASS_HLS).features,
+                "$formFactor must identify its local Media3 HLS pipeline",
+            )
+            assertFalse(
+                NATIVE_HLS_PLAYBACK_V1_FEATURE in playbackContext.deliveries.getValue(DELIVERY_CLASS_ORIGINAL_HTTP).features,
+                "$formFactor must not apply the HLS sample-entry contract to original HTTP",
+            )
+            assertFalse(
+                NATIVE_HLS_PLAYBACK_V1_FEATURE in playbackContext.deliveries.getValue(DELIVERY_CLASS_PROGRESSIVE).features,
+                "$formFactor must not apply the HLS sample-entry contract to progressive delivery",
+            )
+        }
+    }
 
     @Test
     fun profile8DirectPlayRequiresAValidatedNativeOutputRoute() {

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/seek/PlaybackTimelineSeekPolicyTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/seek/PlaybackTimelineSeekPolicyTest.kt
@@ -160,4 +160,47 @@ class PlaybackTimelineSeekPolicyTest {
         val reanchor = assertIs<PlaybackSeekDecision.ServerReanchor>(decision)
         assertEquals(ServerReanchorReason.InvalidTimelineMapping, reanchor.reason)
     }
+
+    /** An open server window cannot override a proven mounted extent: targets inside it seek natively. */
+    @Test
+    fun mountedExtentHintAllowsNativeSeekInsideAnOpenWindow() {
+        val decision = PlaybackTimeline(
+            timelineOffsetSeconds = 120.0,
+            canSeekAnywhere = false,
+            seekWindowStartSeconds = 120.0,
+            seekRestoration = "source_position",
+        ).decideSeek(150.0, mountedSeekableSourceRange = 120.0..240.0)
+
+        val native = assertIs<PlaybackSeekDecision.NativeSeek>(decision)
+        assertEquals(30.0, native.targetPlayerPositionSeconds)
+        assertEquals(PlaybackSeekRestoration.SourcePosition, native.restoration)
+    }
+
+    /** Beyond the mounted extent the hint proves nothing, so the conservative server reanchor applies. */
+    @Test
+    fun mountedExtentHintDoesNotCoverTargetsBeyondTheProvedExtent() {
+        val decision = PlaybackTimeline(
+            timelineOffsetSeconds = 120.0,
+            canSeekAnywhere = false,
+            seekWindowStartSeconds = 120.0,
+            seekRestoration = "source_position",
+        ).decideSeek(300.0, mountedSeekableSourceRange = 120.0..240.0)
+
+        val reanchor = assertIs<PlaybackSeekDecision.ServerReanchor>(decision)
+        assertEquals(ServerReanchorReason.UnknownSeekWindow, reanchor.reason)
+    }
+
+    /** The hint never overrides published window bounds: below the window start still reanchors. */
+    @Test
+    fun mountedExtentHintCannotRescueTargetsOutsideThePublishedWindow() {
+        val decision = PlaybackTimeline(
+            timelineOffsetSeconds = 120.0,
+            canSeekAnywhere = false,
+            seekWindowStartSeconds = 120.0,
+            seekRestoration = "source_position",
+        ).decideSeek(60.0, mountedSeekableSourceRange = 0.0..240.0)
+
+        val reanchor = assertIs<PlaybackSeekDecision.ServerReanchor>(decision)
+        assertEquals(ServerReanchorReason.OutsideSeekWindow, reanchor.reason)
+    }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/ServerDrivenConfigRefresherTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/settings/ServerDrivenConfigRefresherTest.kt
@@ -21,10 +21,12 @@ class ServerDrivenConfigRefresherTest {
     @Test
     fun `refreshIfStale skips when no authenticated profile is active`() = runTest {
         val overlay = FakeOverlayPrefsStore()
+        val cards = FakeCardPresentationStore()
         val library = FakeLibraryPlaybackPrefsStore()
         val player = FakePlayerSettingsStore()
         val refresher = ServerDrivenConfigRefresher(
             overlayPrefsStore = overlay,
+            cardPresentationStore = cards,
             libraryPlaybackPrefsStore = library,
             playerSettingsStore = player,
             hasAuthenticatedProfile = { false },
@@ -35,6 +37,7 @@ class ServerDrivenConfigRefresherTest {
 
         assertFalse(refreshed)
         assertEquals(0, overlay.refreshCalls)
+        assertEquals(0, cards.refreshCalls)
         assertEquals(0, library.refreshCalls)
         assertEquals(0, player.refreshCalls)
     }
@@ -42,10 +45,12 @@ class ServerDrivenConfigRefresherTest {
     @Test
     fun `refreshIfStale refreshes all server-driven stores on first foreground`() = runTest {
         val overlay = FakeOverlayPrefsStore()
+        val cards = FakeCardPresentationStore()
         val library = FakeLibraryPlaybackPrefsStore()
         val player = FakePlayerSettingsStore()
         val refresher = ServerDrivenConfigRefresher(
             overlayPrefsStore = overlay,
+            cardPresentationStore = cards,
             libraryPlaybackPrefsStore = library,
             playerSettingsStore = player,
             hasAuthenticatedProfile = { true },
@@ -56,6 +61,7 @@ class ServerDrivenConfigRefresherTest {
 
         assertTrue(refreshed)
         assertEquals(1, overlay.refreshCalls)
+        assertEquals(1, cards.refreshCalls)
         assertEquals(1, library.refreshCalls)
         assertEquals(1, player.refreshCalls)
     }
@@ -64,10 +70,12 @@ class ServerDrivenConfigRefresherTest {
     fun `refreshIfStale throttles repeated foreground refreshes`() = runTest {
         var now = 1_000L
         val overlay = FakeOverlayPrefsStore()
+        val cards = FakeCardPresentationStore()
         val library = FakeLibraryPlaybackPrefsStore()
         val player = FakePlayerSettingsStore()
         val refresher = ServerDrivenConfigRefresher(
             overlayPrefsStore = overlay,
+            cardPresentationStore = cards,
             libraryPlaybackPrefsStore = library,
             playerSettingsStore = player,
             hasAuthenticatedProfile = { true },
@@ -81,6 +89,7 @@ class ServerDrivenConfigRefresherTest {
         assertTrue(refresher.refreshIfStale(minIntervalMs = 30_000L))
 
         assertEquals(2, overlay.refreshCalls)
+        assertEquals(2, cards.refreshCalls)
         assertEquals(2, library.refreshCalls)
         assertEquals(2, player.refreshCalls)
     }
@@ -88,10 +97,12 @@ class ServerDrivenConfigRefresherTest {
     @Test
     fun `forceRefresh bypasses throttle for reconnect edge`() = runTest {
         val overlay = FakeOverlayPrefsStore()
+        val cards = FakeCardPresentationStore()
         val library = FakeLibraryPlaybackPrefsStore()
         val player = FakePlayerSettingsStore()
         val refresher = ServerDrivenConfigRefresher(
             overlayPrefsStore = overlay,
+            cardPresentationStore = cards,
             libraryPlaybackPrefsStore = library,
             playerSettingsStore = player,
             hasAuthenticatedProfile = { true },
@@ -102,6 +113,7 @@ class ServerDrivenConfigRefresherTest {
         assertTrue(refresher.forceRefresh())
 
         assertEquals(2, overlay.refreshCalls)
+        assertEquals(2, cards.refreshCalls)
         assertEquals(2, library.refreshCalls)
         assertEquals(2, player.refreshCalls)
     }
@@ -121,6 +133,25 @@ private class FakeOverlayPrefsStore : OverlayPrefsStore {
     }
     override fun setPrefs(next: CardOverlayPrefs) = Unit
     override suspend fun resetToDefaults() = Unit
+    override fun clear() = Unit
+}
+
+private class FakeCardPresentationStore : CardPresentationStore {
+    override val state: StateFlow<CardPresentationUiState> = MutableStateFlow(CardPresentationUiState())
+    override val isLoading: StateFlow<Boolean> = MutableStateFlow(false)
+    override val lastError: StateFlow<String?> = MutableStateFlow(null)
+    var refreshCalls = 0
+
+    override suspend fun hydrateIfNeeded() = Unit
+    override suspend fun refresh() {
+        refreshCalls++
+    }
+    override fun set(
+        presentation: org.siloserver.silo.model.settings.CardPresentation,
+        deviceOnly: Boolean,
+    ) = Unit
+    override suspend fun clearDeviceOverride() = Unit
+    override suspend fun useProfileDefault() = Unit
     override fun clear() = Unit
 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -363,7 +363,7 @@ val androidModule = module {
             castPlaybackPreparer = get(),
         )
     }
-    viewModel { HomeViewModel(get(), get(), get(), get(), getOrNull(), get()) }
+    viewModel { HomeViewModel(get(), get(), get(), get(), getOrNull(), get(), get()) }
     viewModel { MainHeaderViewModel(get()) }
     viewModel {
         LibrariesViewModel(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -432,7 +432,7 @@ val androidModule = module {
             tmdbId = args.second,
         )
     }
-    viewModel { SettingsViewModel(get(), get(), get(), get(), get(), get()) }
+    viewModel { SettingsViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { DiagnosticsViewModel(get()) }
     viewModel { DownloadsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { org.siloserver.silo.android.ui.screens.pairing.CompanionPairingViewModel(get(), get()) }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/BackdropCard.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/BackdropCard.kt
@@ -41,22 +41,25 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.model.catalog.MediaItemUserState
 
 /**
  * Reserved height for the text block under a backdrop card: title (bodySmall)
- * plus up to two label lines (episode subtitle + "Xm left"). Computed from the
- * ACTUAL line heights at the current density & font scale — a fixed dp constant
- * doesn't grow with fontScale, so accessibility text sizes (>=~1.25) sheared the
- * last line. Every card in a row resolves the identical value (theme-driven, not
+ * plus up to two label lines (episode subtitle + "Xm left") when the caption
+ * preference shows metadata. Computed from the ACTUAL line heights at the
+ * current density & font scale — a fixed dp constant doesn't grow with
+ * fontScale, so accessibility text sizes (>=~1.25) sheared the last line.
+ * Every card in a row resolves the identical value (theme-driven, not
  * content-driven), so mixed rows still align. Reserves the tallest stack (an
  * episode card with a remaining-time line) so shorter movie cards fit too.
  */
-private val backdropInfoBlockHeight: Dp
-    @Composable get() = with(LocalDensity.current) {
+@Composable
+private fun backdropInfoBlockHeight(showsMetadata: Boolean): Dp =
+    with(LocalDensity.current) {
         val typography = MaterialTheme.typography
         typography.bodySmall.lineHeight.toDp() +
-            typography.labelSmall.lineHeight.toDp() * 2
+            if (showsMetadata) typography.labelSmall.lineHeight.toDp() * 2 else 0.dp
     }
 
 /**
@@ -76,7 +79,7 @@ fun BackdropCard(
     remainingMinutes: Int? = null,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    width: Dp = 280.dp,
+    width: Dp = 280.dp * LocalCardPresentation.current.posterSize.posterScale,
     userState: MediaItemUserState? = null,
     actions: MediaCardActions = MediaCardActions(),
     // Center overlay glyph — play for watch/listen, a book for reading.
@@ -165,13 +168,15 @@ fun BackdropCard(
             }
         }
 
+        val cardCaption = LocalCardPresentation.current.caption
+        if (cardCaption.showsTitle) {
         Spacer(modifier = Modifier.height(6.dp))
 
         // Fixed-height info block: episode cards draw up to three text lines,
         // movie cards as few as one. In a mixed row (Continue Watching) the
         // LazyRow's height would otherwise change with whichever items are
         // visible, bouncing every row below it during horizontal scrolls.
-        Column(modifier = Modifier.height(backdropInfoBlockHeight)) {
+        Column(modifier = Modifier.height(backdropInfoBlockHeight(cardCaption.showsMetadata))) {
         if (seriesTitle != null) {
             // Episode card: show series title, then episode tag + episode title
             Text(
@@ -183,16 +188,18 @@ fun BackdropCard(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.fillMaxWidth(),
             )
-            val episodeTag = formatEpisodeTag(seasonNumber, episodeNumber)
-            val subtitle = if (episodeTag != null) "$episodeTag \u2022 $title" else title
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth(),
-            )
+            if (cardCaption.showsMetadata) {
+                val episodeTag = formatEpisodeTag(seasonNumber, episodeNumber)
+                val subtitle = if (episodeTag != null) "$episodeTag \u2022 $title" else title
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         } else {
             // Movie card: just show the title
             Text(
@@ -206,7 +213,7 @@ fun BackdropCard(
         }
 
         // Remaining time
-        if (remainingMinutes != null && remainingMinutes > 0) {
+        if (cardCaption.showsMetadata && remainingMinutes != null && remainingMinutes > 0) {
             Text(
                 text = "${remainingMinutes}m left",
                 style = MaterialTheme.typography.labelSmall,
@@ -214,6 +221,7 @@ fun BackdropCard(
             )
         }
 
+        }
         }
 
         MediaCardContextMenu(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaCard.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaCard.kt
@@ -32,6 +32,7 @@ import org.siloserver.silo.android.ui.navigation.LocalHeroSourceHandoff
 import org.siloserver.silo.android.ui.navigation.heroSharedKeyPrefix
 import org.siloserver.silo.android.ui.navigation.heroSource
 import java.util.UUID
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.overlays.CardOverlayVariant
 import org.siloserver.silo.common.overlays.CardOverlays
 import org.siloserver.silo.common.overlays.LocalCardOverlayUiState
@@ -46,6 +47,16 @@ object MediaGridDefaults {
     val PosterGridMinWidth = 104.dp
     val PosterGridHorizontalSpacing = 12.dp
     val PosterGridVerticalSpacing = 16.dp
+
+    /**
+     * [PosterGridMinWidth] scaled by the card-presentation poster size.
+     * Adaptive grids scale the *minimum* cell width, so the preference
+     * shifts the column count rather than the card width (a smaller min
+     * width fits more columns).
+     */
+    val scaledPosterGridMinWidth: Dp
+        @Composable get() =
+            PosterGridMinWidth * LocalCardPresentation.current.posterSize.posterScale
 }
 
 /**
@@ -69,7 +80,7 @@ fun MediaCard(
     progress: Float? = null,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    width: Dp = 120.dp,
+    width: Dp = 120.dp * LocalCardPresentation.current.posterSize.posterScale,
     artworkAspectRatio: Float = 2f / 3.3f,
     overlay: OverlayData? = null,
     actions: MediaCardActions = MediaCardActions(),
@@ -165,18 +176,21 @@ fun MediaCard(
             }
         }
 
-        // iOS titleText: .siloSubheadline (14sp), 2 lines.
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        val cardCaption = LocalCardPresentation.current.caption
+        if (cardCaption.showsTitle) {
+            // iOS titleText: .siloSubheadline (14sp), 2 lines.
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
 
         val caption = subtitle ?: year?.takeIf { it > 0 }?.toString()
-        if (caption != null) {
+        if (cardCaption.showsMetadata && caption != null) {
             // iOS yearText: .siloCaption (12sp) at secondary text.
             Text(
                 text = caption,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.runtime.remember
@@ -30,6 +31,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyAnomalyLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyCollection
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
 import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.overlays.OverlayData
 import org.siloserver.silo.overlays.OverlayDataExtractor
@@ -68,6 +72,15 @@ fun MediaRow(
     modifier: Modifier = Modifier,
     cardActions: (SectionItem) -> MediaCardActions = { MediaCardActions() },
 ) {
+    val diagnosticsKeySnapshot = remember(items) {
+        DiagnosticsListSnapshot.fromKeys(items.map { it.contentId })
+    }
+    LaunchedEffect(diagnosticsKeySnapshot) {
+        DiagnosticsKeyAnomalyLogger.snapshot(
+            DiagnosticsKeyCollection.PHONE_MEDIA_ROW,
+            diagnosticsKeySnapshot,
+        )
+    }
     val rowItems = remember(items, showProgress, cardStyle) {
         items.map { item ->
             val pos = item.positionSeconds

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/Skeleton.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/Skeleton.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -28,6 +29,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.siloserver.silo.android.ui.theme.SiloSurfaceElevated
+import org.siloserver.silo.common.cards.LocalCardPresentation
 
 private val ShimmerHighlight = Color.White.copy(alpha = 0.06f)
 
@@ -79,8 +81,10 @@ fun Modifier.skeleton(
 fun MediaRowSkeleton(
     progress: Float,
     modifier: Modifier = Modifier,
-    posterWidth: Dp = 120.dp,
-    posterHeight: Dp = 180.dp,
+    // Scaled like MediaCard's default so the placeholder boxes match the
+    // real cards that replace them (height follows the 2:3 aspect).
+    posterWidth: Dp = 120.dp * LocalCardPresentation.current.posterSize.posterScale,
+    posterHeight: Dp = posterWidth * 1.5f,
     count: Int = 5,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
@@ -109,36 +113,51 @@ fun MediaRowSkeleton(
 }
 
 /**
- * Skeleton for a poster grid: fixed rows of poster-shaped boxes that fill the
- * width. Used for catalog / browse / "similar" loading states so the grid is
- * laid out from frame one and only the pixels resolve in.
+ * Skeleton for a poster grid: rows of poster-shaped boxes that fill the width.
+ * Used for catalog / browse / "similar" loading states so the grid is laid out
+ * from frame one and only the pixels resolve in.
+ *
+ * The column count is derived the way `GridCells.Adaptive` derives it, from
+ * [minCellWidth] — scaled by the card-presentation poster size like the real
+ * grids — so the placeholder breaks into the same number of columns the cards
+ * will land in instead of reflowing on the first frame of real content.
  */
 @Composable
 fun PosterGridSkeleton(
     progress: Float,
     modifier: Modifier = Modifier,
-    columns: Int = 3,
+    minCellWidth: Dp = MediaGridDefaults.scaledPosterGridMinWidth,
     rows: Int = 4,
     posterAspect: Float = 2f / 3.3f,
 ) {
-    Column(
-        modifier = modifier.fillMaxWidth().padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        repeat(rows) {
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                repeat(columns) {
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .aspectRatio(posterAspect)
-                            .skeleton(progress),
-                    )
+    val spacing = MediaGridDefaults.PosterGridHorizontalSpacing
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val available = (maxWidth - GridSkeletonInset * 2).coerceAtLeast(0.dp)
+        val columns = ((available + spacing) / (minCellWidth + spacing))
+            .toInt()
+            .coerceAtLeast(1)
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(GridSkeletonInset),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            repeat(rows) {
+                Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+                    repeat(columns) {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .aspectRatio(posterAspect)
+                                .skeleton(progress),
+                        )
+                    }
                 }
             }
         }
     }
 }
+
+/** Matches the 16dp content padding of the grids this skeleton stands in for. */
+private val GridSkeletonInset = 16.dp
 
 /**
  * Loading skeleton for a media detail page: a hero band, a couple of title /

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
@@ -86,8 +86,10 @@ import org.siloserver.silo.android.ui.screens.settings.diagnostics.DiagnosticsRe
 import org.siloserver.silo.android.ui.screens.settings.diagnostics.DiagnosticsSettingsScreen
 import org.siloserver.silo.android.ui.screens.settings.diagnostics.DiagnosticsViewModel
 import org.siloserver.silo.cast.SiloCastPlaybackRequest
+import org.siloserver.silo.common.cards.ProvideCardPresentation
 import org.siloserver.silo.common.overlays.ProvideCardOverlays
 import org.siloserver.silo.common.player.video.VideoPlayerRouteArgs
+import org.siloserver.silo.common.settings.CardPresentationStore
 import org.siloserver.silo.common.settings.OverlayPrefsStore
 import org.siloserver.silo.network.TokenManager
 import org.koin.compose.koinInject
@@ -128,7 +130,12 @@ fun AppNavigation(
     val tokenManager: TokenManager = koinInject()
     val serverRegistry: org.siloserver.silo.network.ServerRegistry = koinInject()
     val overlayPrefsStore: OverlayPrefsStore = koinInject()
+    val cardPresentationStore: CardPresentationStore = koinInject()
     val siloCastController: SiloCastController = koinInject()
+    // Lives as long as the nav host, so work started from a destination that is
+    // popped in the same gesture (re-hydrating after a profile switch) is not
+    // cancelled with that destination's own scope.
+    val navScope = rememberCoroutineScope()
     val diagnosticsViewModel = koinViewModel<DiagnosticsViewModel>()
     val diagnosticsState by diagnosticsViewModel.state.collectAsState()
     var activePlayerTargetProvider by remember {
@@ -275,6 +282,7 @@ fun AppNavigation(
     }
 
     ProvideCardOverlays(store = overlayPrefsStore, sessionKey = overlaySessionKey) {
+    ProvideCardPresentation(store = cardPresentationStore, sessionKey = overlaySessionKey) {
     // Shared-element host: lets a tapped poster morph into the item-detail
     // backdrop. The scope is published via CompositionLocal so deep descendants
     // (a poster card, the detail hero) can opt in without threading it through
@@ -553,6 +561,13 @@ fun AppNavigation(
                         ServerSwitchDestination.ProfileSelection -> Route.ProfileSelection.route
                         ServerSwitchDestination.Login -> Route.Login.route
                     }
+                    // Overlays and card presentation are cached per profile on
+                    // the old server. Drop them so the new server's shell can't
+                    // render — or write back — the previous identity's values;
+                    // the providers above re-hydrate for the new session.
+                    // Parity with the TV shell's server-switch path.
+                    overlayPrefsStore.clear()
+                    cardPresentationStore.clear()
                     navController.navigate(target) {
                         popUpTo(0) { inclusive = true }
                         launchSingleTop = true
@@ -566,6 +581,16 @@ fun AppNavigation(
         composable(Route.ProfileSelection.route) {
             ProfileSelectionScreen(
                 onNavigateToHome = {
+                    // The switch-profile paths dropped the per-profile card
+                    // caches; re-hydrate for the profile just picked. The
+                    // providers above the graph only re-run when the profile id
+                    // itself changes, so re-selecting the SAME profile would
+                    // otherwise render cleared (default) cards until the next
+                    // foreground refresh. Idempotent when they already ran.
+                    navScope.launch {
+                        overlayPrefsStore.hydrateIfNeeded()
+                        cardPresentationStore.hydrateIfNeeded()
+                    }
                     // Route through the tour gate: OnboardingTourScreen checks
                     // server-side state and immediately hands off to Home when
                     // the profile has already completed or skipped the tour.
@@ -684,7 +709,13 @@ fun AppNavigation(
                 onPairDevice = {
                     navController.navigate(Route.PairDevice().route)
                 },
-                onSwitchProfile = { navController.navigate(Route.ProfileSelection.route) },
+                onSwitchProfile = {
+                    // Leave the shell first, then drop the per-profile caches
+                    // (see the profile-menu path in MainScreen).
+                    navController.navigate(Route.ProfileSelection.route)
+                    overlayPrefsStore.clear()
+                    cardPresentationStore.clear()
+                },
                 onNavigateToWatchlist = { navController.navigate(Route.Watchlist.route) },
                 onNavigateToFavorites = { navController.navigate(Route.Favorites.route) },
                 onNavigateToHistory = { navController.navigate(Route.History.route) },
@@ -1196,6 +1227,7 @@ fun AppNavigation(
                     .padding(bottom = if (currentRoute in tabRoutes) 80.dp else 0.dp),
             )
         }
+    }
     }
     }
     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt
@@ -71,6 +71,8 @@ import org.siloserver.silo.model.feature.MetadataAiFeatureStore
 import org.siloserver.silo.model.feature.RequestsFeatureStore
 import org.siloserver.silo.common.network.ServerReachabilityMonitor
 import org.siloserver.silo.common.network.ServerReachabilityStatus
+import org.siloserver.silo.common.settings.CardPresentationStore
+import org.siloserver.silo.common.settings.OverlayPrefsStore
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.repository.AuthRepository
@@ -146,6 +148,8 @@ fun MainScreen(
     val reachabilityMonitor: ServerReachabilityMonitor = koinInject()
     val requestsFeatureStore: RequestsFeatureStore = koinInject()
     val metadataAiFeatureStore: MetadataAiFeatureStore = koinInject()
+    val overlayPrefsStore: OverlayPrefsStore = koinInject()
+    val cardPresentationStore: CardPresentationStore = koinInject()
     val reachabilityState by reachabilityMonitor.state.collectAsState()
     val requestsEnabled by requestsFeatureStore.isEnabled.collectAsState()
     val reachabilityScope = rememberCoroutineScope()
@@ -262,11 +266,30 @@ fun MainScreen(
             authRepository.logout()
             requestsFeatureStore.reset()
             metadataAiFeatureStore.reset()
+            // Per-profile card caches, same teardown the Settings sign-out
+            // does — otherwise the next user's shell renders (and can write
+            // back) the previous profile's overlays and card presentation.
+            overlayPrefsStore.clear()
+            cardPresentationStore.clear()
             navController.navigate(Route.Login.route) {
                 popUpTo(0) { inclusive = true }
                 launchSingleTop = true
             }
         }
+    }
+
+    /**
+     * Profile-menu "Switch Profile". Overlays and card presentation are cached
+     * per profile and the app never backgrounds during an in-app switch, so
+     * drop them here or the next profile keeps rendering — and writing back —
+     * the previous one's values. Navigate first: clearing while the shell is
+     * still composed repaints it with default cards behind the picker (the
+     * TV shell's switch-profile path takes the same order).
+     */
+    fun switchProfileFromMenu() {
+        navController.navigate(Route.ProfileSelection.route)
+        overlayPrefsStore.clear()
+        cardPresentationStore.clear()
     }
     val requestsMenuAction: (() -> Unit)? = if (requestsEnabled) {
         { navController.navigate(Route.Requests.route) }
@@ -377,9 +400,7 @@ fun MainScreen(
                             onRequestsClick = requestsMenuAction,
                             onWatchTogetherClick = watchTogetherMenuAction,
                             onSettingsClick = { navController.navigate(Route.Settings.route) },
-                            onSwitchProfileClick = {
-                                navController.navigate(Route.ProfileSelection.route)
-                            },
+                            onSwitchProfileClick = ::switchProfileFromMenu,
                             onSwitchServerClick = {
                                 navController.navigate(Route.ServerList.route)
                             },
@@ -401,9 +422,7 @@ fun MainScreen(
                             onRequestsClick = requestsMenuAction,
                             onWatchTogetherClick = watchTogetherMenuAction,
                             onSettingsClick = { navController.navigate(Route.Settings.route) },
-                            onSwitchProfileClick = {
-                                navController.navigate(Route.ProfileSelection.route)
-                            },
+                            onSwitchProfileClick = ::switchProfileFromMenu,
                             onSwitchServerClick = {
                                 navController.navigate(Route.ServerList.route)
                             },
@@ -435,9 +454,7 @@ fun MainScreen(
                                     onRequestsClick = requestsMenuAction,
                                     onWatchTogetherClick = watchTogetherMenuAction,
                                     onSettingsClick = { navController.navigate(Route.Settings.route) },
-                                    onSwitchProfileClick = {
-                                        navController.navigate(Route.ProfileSelection.route)
-                                    },
+                                    onSwitchProfileClick = ::switchProfileFromMenu,
                                     onSwitchServerClick = {
                                         navController.navigate(Route.ServerList.route)
                                     },
@@ -496,9 +513,7 @@ fun MainScreen(
                     onRequestsClick = requestsMenuAction,
                     onWatchTogetherClick = watchTogetherMenuAction,
                     onSettingsClick = { navController.navigate(Route.Settings.route) },
-                    onSwitchProfileClick = {
-                        navController.navigate(Route.ProfileSelection.route)
-                    },
+                    onSwitchProfileClick = ::switchProfileFromMenu,
                     onSwitchServerClick = {
                         navController.navigate(Route.ServerList.route)
                     },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
@@ -64,6 +64,9 @@ import org.siloserver.silo.android.ui.components.MediaCard
 import org.siloserver.silo.android.ui.components.MediaGridDefaults
 import org.siloserver.silo.android.ui.components.rememberBrowseItemCardActions
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyAnomalyLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyCollection
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
 import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.overlays.OverlayDataExtractor
 
@@ -99,6 +102,15 @@ fun CatalogGrid(
 ) {
     val gridState = rememberLazyGridState()
     val cardWidth = viewDensity.minCardWidth
+    val diagnosticsKeySnapshot = remember(items) {
+        DiagnosticsListSnapshot.fromKeys(items.map { it.contentId })
+    }
+    LaunchedEffect(diagnosticsKeySnapshot) {
+        DiagnosticsKeyAnomalyLogger.snapshot(
+            DiagnosticsKeyCollection.PHONE_CATALOG_GRID,
+            diagnosticsKeySnapshot,
+        )
+    }
 
     // Trigger load more when scrolled near bottom. Keyed on the flags: a
     // keyless remember would freeze their first-composition values inside the

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.launch
 import org.siloserver.silo.android.ui.components.MediaCard
 import org.siloserver.silo.android.ui.components.MediaGridDefaults
 import org.siloserver.silo.android.ui.components.rememberBrowseItemCardActions
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
 import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.overlays.OverlayDataExtractor
@@ -98,7 +99,9 @@ fun CatalogGrid(
     header: (@Composable () -> Unit)? = null,
 ) {
     val gridState = rememberLazyGridState()
-    val cardWidth = viewDensity.minCardWidth
+    // The session density picks the base cell; the server-driven poster-size
+    // preference multiplies it, shifting the adaptive column count.
+    val cardWidth = viewDensity.minCardWidth * LocalCardPresentation.current.posterSize.posterScale
 
     // Trigger load more when scrolled near bottom. Keyed on the flags: a
     // keyless remember would freeze their first-composition values inside the

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/calendar/CalendarScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/calendar/CalendarScreen.kt
@@ -76,6 +76,7 @@ import dev.chrisbanes.haze.rememberHazeState
 import org.siloserver.silo.android.ui.components.ErrorView
 import org.siloserver.silo.android.ui.navigation.LocalBottomChromeInset
 import org.siloserver.silo.common.calendar.localDisplayAirTime
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.calendar.CalendarBadge
@@ -671,16 +672,21 @@ private fun CalendarEventCard(
     item: CalendarItem,
     onClick: () -> Unit,
 ) {
+    // Poster-size preference scales the whole card; height keeps the 120:198
+    // base ratio. The caption preference gates the title + subtitle block the
+    // same way CalendarEventCard.swift does (showsTitle / showsMetadata).
+    val cardPresentation = LocalCardPresentation.current
+    val posterScale = cardPresentation.posterSize.posterScale
     Column(
         modifier = Modifier
-            .width(PosterCardWidth)
+            .width(PosterCardWidth * posterScale)
             .clickable(onClick = onClick),
         verticalArrangement = Arrangement.spacedBy(4.dp), // iOS VStack spacing = 4
     ) {
         Box(
             modifier = Modifier
-                .width(PosterCardWidth)
-                .height(PosterCardHeight)
+                .width(PosterCardWidth * posterScale)
+                .height(PosterCardHeight * posterScale)
                 .clip(RoundedCornerShape(CornerRadius)),
         ) {
             ThumbhashImage(
@@ -744,23 +750,27 @@ private fun CalendarEventCard(
         }
 
         // Caption: two-line title reserved + context subtitle.
-        Text(
-            text = item.title,
-            fontSize = 14.sp, // iOS siloSubheadline = 14 bold
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f),
-            minLines = 2, // iOS lineLimit(2, reservesSpace: true)
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
-        cardSubtitle(item)?.let { subtitle ->
+        if (cardPresentation.caption.showsTitle) {
             Text(
-                text = subtitle,
-                fontSize = 12.sp, // iOS siloCaption = 12
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
+                text = item.title,
+                fontSize = 14.sp, // iOS siloSubheadline = 14 bold
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f),
+                minLines = 2, // iOS lineLimit(2, reservesSpace: true)
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
+            if (cardPresentation.caption.showsMetadata) {
+                cardSubtitle(item)?.let { subtitle ->
+                    Text(
+                        text = subtitle,
+                        fontSize = 12.sp, // iOS siloCaption = 12
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
         }
     }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/collections/CollectionDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/collections/CollectionDetailScreen.kt
@@ -103,7 +103,7 @@ fun CollectionDetailScreen(
                 ) {
                     DeferImagePresentationWhileScrolling(gridState) {
                     LazyVerticalGrid(
-                        columns = GridCells.Adaptive(MediaGridDefaults.PosterGridMinWidth),
+                        columns = GridCells.Adaptive(MediaGridDefaults.scaledPosterGridMinWidth),
                         state = gridState,
                         contentPadding = PaddingValues(16.dp),
                         horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/collections/LibraryCollectionsScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/collections/LibraryCollectionsScreen.kt
@@ -44,6 +44,7 @@ import org.siloserver.silo.android.ui.components.EmptyStateView
 import org.siloserver.silo.android.ui.components.ErrorView
 import org.siloserver.silo.android.ui.components.LoadingIndicator
 import org.siloserver.silo.android.ui.components.MediaGridDefaults
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.section.LibraryCollection
@@ -238,7 +239,7 @@ fun LibraryCollectionsScreen(
                     val gridState = rememberLazyGridState()
                     DeferImagePresentationWhileScrolling(gridState) {
                     LazyVerticalGrid(
-                        columns = GridCells.Adaptive(MediaGridDefaults.PosterGridMinWidth),
+                        columns = GridCells.Adaptive(MediaGridDefaults.scaledPosterGridMinWidth),
                         state = gridState,
                         contentPadding = PaddingValues(16.dp),
                         horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),
@@ -283,6 +284,10 @@ private fun LibraryCollectionCard(
     collection: LibraryCollection,
     onClick: () -> Unit,
 ) {
+    // Caption gating mirrors CollectionsView.swift: the name line follows
+    // showsTitle, the type line showsMetadata. The count badge sits on the
+    // artwork, so it stays either way.
+    val caption = LocalCardPresentation.current.caption
     val countLabel = collection.itemCount?.takeIf { it > 0 }?.toString() ?: "Smart"
     val typeLabel = when {
         collection.kind == "user_collections" -> "User collection"
@@ -340,20 +345,24 @@ private fun LibraryCollectionCard(
             )
         }
 
-        Text(
-            text = collection.name,
-            fontSize = 12.sp,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
+        if (caption.showsTitle) {
+            Text(
+                text = collection.name,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
 
-        Text(
-            text = typeLabel,
-            fontSize = 12.sp,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        if (caption.showsMetadata) {
+            Text(
+                text = typeLabel,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
@@ -40,7 +40,9 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -56,6 +58,7 @@ import org.siloserver.silo.android.ui.components.topBarGlass
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
+import kotlinx.coroutines.flow.distinctUntilChanged
 import org.siloserver.silo.android.ui.components.EmptyStateView
 import org.siloserver.silo.android.ui.components.ErrorView
 import org.siloserver.silo.android.ui.components.MediaRowSkeleton
@@ -64,6 +67,12 @@ import org.siloserver.silo.android.ui.components.rememberShimmerProgress
 import org.siloserver.silo.android.ui.screens.pairing.CompanionPairingViewModel
 import org.siloserver.silo.android.ui.screens.pairing.CompanionPairingBottomOverlay
 import org.siloserver.silo.android.ui.screens.profiles.ProfileAvatar
+import org.siloserver.silo.common.diagnostics.DiagnosticsHomeContentState
+import org.siloserver.silo.common.diagnostics.DiagnosticsHomeLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsHomeScrollRegion
+import org.siloserver.silo.common.diagnostics.DiagnosticsListLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSurface
 import org.siloserver.silo.common.pairing.CompanionPairingStatus
 import org.siloserver.silo.common.pairing.CompanionPairingTarget
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
@@ -122,10 +131,54 @@ fun HomeScreen(
     val regularSections = remember(sections) {
         sections.filter { it.items.isNotEmpty() }
     }
+    val diagnosticsContentState = when {
+        state.isLoading && regularSections.isEmpty() -> DiagnosticsHomeContentState.LOADING
+        state.error != null && regularSections.isEmpty() -> DiagnosticsHomeContentState.ERROR
+        regularSections.isEmpty() -> DiagnosticsHomeContentState.EMPTY
+        else -> DiagnosticsHomeContentState.READY
+    }
+    LaunchedEffect(diagnosticsContentState) {
+        DiagnosticsHomeLogger.content(diagnosticsContentState)
+    }
+    val diagnosticsListSnapshot = remember(regularSections, state.sectionsFullyResolved) {
+        DiagnosticsListSnapshot.fromKeys(
+            keys = regularSections.map { it.id },
+            rowKeys = regularSections.map { section -> section.items.map { it.contentId } },
+            fullyResolved = state.sectionsFullyResolved,
+        )
+    }
+    LaunchedEffect(diagnosticsListSnapshot, diagnosticsContentState) {
+        if (diagnosticsContentState == DiagnosticsHomeContentState.READY) {
+            DiagnosticsListLogger.snapshot(DiagnosticsListSurface.PHONE_HOME, diagnosticsListSnapshot)
+        }
+    }
 
     val listState = rememberLazyListState()
+    val currentDiagnosticsSections by rememberUpdatedState(regularSections)
     LaunchedEffect(scrollToTopTick) {
         if (scrollToTopTick > 0) listState.animateScrollToItem(0)
+    }
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.isScrollInProgress }
+            .distinctUntilChanged()
+            .collect { scrolling ->
+                val currentSections = currentDiagnosticsSections
+                val sectionCount = currentSections.size
+                val firstVisibleItem = listState.firstVisibleItemIndex
+                val visibleRowOrdinal = (firstVisibleItem - 1).takeIf(currentSections.indices::contains)
+                val region = when {
+                    sectionCount == 0 -> DiagnosticsHomeScrollRegion.UNKNOWN
+                    firstVisibleItem <= 1 -> DiagnosticsHomeScrollRegion.TOP
+                    firstVisibleItem >= sectionCount -> DiagnosticsHomeScrollRegion.END
+                    else -> DiagnosticsHomeScrollRegion.CONTENT
+                }
+                DiagnosticsHomeLogger.scroll(
+                    scrolling = scrolling,
+                    region = region,
+                    visibleRowOrdinal = visibleRowOrdinal,
+                    rawSectionType = visibleRowOrdinal?.let { currentSections[it].sectionType },
+                )
+            }
     }
     LaunchedEffect(companionTargets, companionStatus, dismissedPairingSessions) {
         if (companionStatus is CompanionPairingStatus.Idle) {
@@ -435,4 +488,3 @@ private fun HomeFloatingChrome(
 
 /** How far the Home chrome's glass runs past its action row to feather out. */
 private val HomeChromeFeatherExtension = 40.dp
-

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
@@ -108,6 +108,7 @@ import org.siloserver.silo.catalog.filter.BrowseFacetMediaType
 import org.siloserver.silo.catalog.filter.CatalogFacet
 import org.siloserver.silo.catalog.filter.CatalogFilterQueryBuilder
 import org.siloserver.silo.catalog.filter.CatalogFilterState
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.avatarRef
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
 import org.siloserver.silo.model.catalog.CatalogFiltersResponse
@@ -1198,7 +1199,10 @@ private fun CollectionsTabContent(
             val gridState = rememberLazyGridState()
             DeferImagePresentationWhileScrolling(gridState) {
             LazyVerticalGrid(
-                columns = GridCells.Adaptive(state.catalogDensity.minCardWidth),
+                columns = GridCells.Adaptive(
+                    state.catalogDensity.minCardWidth *
+                        LocalCardPresentation.current.posterSize.posterScale,
+                ),
                 state = gridState,
                 horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),
                 verticalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridVerticalSpacing),
@@ -1234,7 +1238,9 @@ private fun InlineLibraryCollectionCard(
     // iOS `LibraryCollectionCard`: VStack(spacing: 6) of a 2:3.3 poster
     // (smallCornerRadius = 6) carrying a bottom-trailing count badge, a
     // siloCaption (12) name (2 lines), and a siloSmall (11) secondary
-    // type label.
+    // type label. The two text lines follow the caption preference
+    // (showsTitle / showsMetadata); the count badge rides the artwork.
+    val caption = LocalCardPresentation.current.caption
     Column(
         modifier = Modifier.clickable(onClick = onClick),
         verticalArrangement = Arrangement.spacedBy(6.dp),
@@ -1265,20 +1271,24 @@ private fun InlineLibraryCollectionCard(
                     .padding(horizontal = 8.dp, vertical = 5.dp),
             )
         }
-        Text(
-            text = collection.name,
-            fontSize = 12.sp,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
-        Text(
-            text = collection.itemCount?.let { "$it items" } ?: "Collection",
-            fontSize = 12.sp,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        if (caption.showsTitle) {
+            Text(
+                text = collection.name,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (caption.showsMetadata) {
+            Text(
+                text = collection.itemCount?.let { "$it items" } ?: "Collection",
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -110,6 +111,9 @@ import org.siloserver.silo.catalog.filter.CatalogFilterQueryBuilder
 import org.siloserver.silo.catalog.filter.CatalogFilterState
 import org.siloserver.silo.common.ui.components.avatarRef
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
+import org.siloserver.silo.common.diagnostics.DiagnosticsListLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSurface
 import org.siloserver.silo.model.catalog.CatalogFiltersResponse
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.android.ui.screens.home.HomeSectionRow
@@ -941,6 +945,20 @@ private fun RecommendedTabContent(
     onItemClick: (String) -> Unit,
     onRetry: () -> Unit,
 ) {
+    val diagnosticsListSnapshot = remember(state.sections) {
+        DiagnosticsListSnapshot.fromKeys(
+            keys = state.sections.map { it.id },
+            rowKeys = state.sections.map { section -> section.items.map { it.contentId } },
+        )
+    }
+    LaunchedEffect(diagnosticsListSnapshot, state.isLoadingSections) {
+        if (!state.isLoadingSections && state.sections.isNotEmpty()) {
+            DiagnosticsListLogger.snapshot(
+                DiagnosticsListSurface.PHONE_LIBRARY_RECOMMENDED,
+                diagnosticsListSnapshot,
+            )
+        }
+    }
     when {
         state.isLoadingSections && state.sections.isEmpty() -> {
             MediaRowsSkeleton(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/people/PersonDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/people/PersonDetailScreen.kt
@@ -59,6 +59,7 @@ import org.siloserver.silo.android.ui.theme.SiloSecondaryText
 import org.siloserver.silo.android.ui.theme.SiloSurfaceElevated
 import org.siloserver.silo.android.ui.theme.SiloSurfaceVariant
 import org.siloserver.silo.android.ui.theme.PillShape
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.catalog.BrowseItem
@@ -164,7 +165,10 @@ private fun PersonDetailContent(
     val gridState = rememberLazyGridState()
     DeferImagePresentationWhileScrolling(gridState) {
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = 110.dp),
+        // Filmography cards only — the person portrait keeps its fixed size.
+        columns = GridCells.Adaptive(
+            minSize = 110.dp * LocalCardPresentation.current.posterSize.posterScale,
+        ),
         state = gridState,
         contentPadding = PaddingValues(
             start = SafePadding,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/personal/PersonalMediaGridContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/personal/PersonalMediaGridContent.kt
@@ -53,6 +53,7 @@ import org.siloserver.silo.android.ui.components.MediaCardContextMenu
 import org.siloserver.silo.android.ui.components.MediaGridDefaults
 import org.siloserver.silo.android.ui.components.WatchedBadge
 import org.siloserver.silo.android.ui.components.rememberBrowseItemCardActions
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.common.overlays.CardOverlayVariant
@@ -253,7 +254,7 @@ private fun PersonalMediaGridContent(
                 // edge under any chrome the caller reserved space for.
                 DeferImagePresentationWhileScrolling(gridState) {
                 LazyVerticalGrid(
-                    columns = GridCells.Adaptive(MediaGridDefaults.PosterGridMinWidth),
+                    columns = GridCells.Adaptive(MediaGridDefaults.scaledPosterGridMinWidth),
                     state = gridState,
                     contentPadding = PaddingValues(
                         start = 16.dp + contentPadding.calculateStartPadding(layoutDirection),
@@ -350,17 +351,20 @@ fun MediaGridItem(
             }
         }
 
-        androidx.compose.material3.Text(
-            text = item.title,
-            fontSize = 14.sp,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface,
-            minLines = 2,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
+        val cardCaption = LocalCardPresentation.current.caption
+        if (cardCaption.showsTitle) {
+            androidx.compose.material3.Text(
+                text = item.title,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                minLines = 2,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
 
-        if (item.year > 0) {
+        if (cardCaption.showsMetadata && item.year > 0) {
             androidx.compose.material3.Text(
                 text = item.year.toString(),
                 fontSize = 12.sp,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reading/ReadingHubScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/reading/ReadingHubScreen.kt
@@ -63,6 +63,7 @@ import org.siloserver.silo.android.ui.screens.browse.CatalogViewDensity
 import org.siloserver.silo.android.ui.screens.home.HomeSectionRow
 import org.siloserver.silo.android.ui.screens.libraries.LibrariesSubtab
 import org.siloserver.silo.android.ui.screens.libraries.LibraryBrowseSort
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.navigation.ReadingFormatFilter
@@ -558,7 +559,9 @@ private fun ReadingCollectionsTab(
             DeferImagePresentationWhileScrolling(gridState) {
             LazyVerticalGrid(
                 state = gridState,
-                columns = GridCells.Adaptive(minSize = 140.dp),
+                columns = GridCells.Adaptive(
+                    minSize = 140.dp * LocalCardPresentation.current.posterSize.posterScale,
+                ),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier.fillMaxSize(),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/recommendations/RecommendationsScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/recommendations/RecommendationsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -60,6 +61,9 @@ import org.siloserver.silo.viewmodel.RecommendationsViewModel
 import org.siloserver.silo.android.ui.components.MediaRowsSkeleton
 import org.siloserver.silo.android.ui.navigation.LocalBottomChromeInset
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
+import org.siloserver.silo.common.diagnostics.DiagnosticsListLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSurface
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
@@ -96,6 +100,20 @@ fun RecommendationsScreen(
     val inFallback = !state.isLoading && state.error == null && state.sections.isEmpty()
     val displayedList = if (inFallback) savedListSelection ?: ForYouList.Watchlist else savedListSelection
     LaunchedEffect(displayedList) { onDisplayedListChange(displayedList) }
+    val diagnosticsListSnapshot = remember(state.sections) {
+        DiagnosticsListSnapshot.fromKeys(
+            keys = state.sections.map { it.id },
+            rowKeys = state.sections.map { section -> section.items.map { it.contentId } },
+        )
+    }
+    LaunchedEffect(diagnosticsListSnapshot, state.isLoading) {
+        if (!state.isLoading && state.sections.isNotEmpty()) {
+            DiagnosticsListLogger.snapshot(
+                DiagnosticsListSurface.PHONE_FOR_YOU,
+                diagnosticsListSnapshot,
+            )
+        }
+    }
 
     // Self-heal the "For You" fallback. The shared VM loads only in init{} and
     // survives tab switches (saveState/restoreState), so an empty server
@@ -395,4 +413,3 @@ private fun SavedShortcutPill(
         )
     }
 }
-

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/requests/RequestComponents.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/requests/RequestComponents.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.request.MediaRequest
 import org.siloserver.silo.model.request.RequestMediaResult
@@ -48,9 +49,12 @@ fun RequestMediaCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Caption gating mirrors RequestMediaCard.swift: showsTitle wraps the
+    // whole caption block, showsMetadata the type/year line inside it.
+    val cardPresentation = LocalCardPresentation.current
     Column(
         modifier = modifier
-            .width(132.dp)
+            .width(132.dp * cardPresentation.posterSize.posterScale)
             .clickable(onClick = onClick),
     ) {
         Box(
@@ -74,18 +78,24 @@ fun RequestMediaCard(
                     .padding(6.dp),
             )
         }
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = item.title,
-            style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
-        RequestMetaLine(
-            mediaType = item.mediaType,
-            year = item.year,
-        )
+        if (cardPresentation.caption.showsTitle) {
+            // The spacer belongs to the caption: artwork-only cards must not
+            // leave a gap under the poster.
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (cardPresentation.caption.showsMetadata) {
+                RequestMetaLine(
+                    mediaType = item.mediaType,
+                    year = item.year,
+                )
+            }
+        }
     }
 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/search/SearchResults.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/search/SearchResults.kt
@@ -81,9 +81,10 @@ fun SearchResults(
         if (shouldLoadMore) onLoadMore()
     }
 
+    val gridCellMinWidth = MediaGridDefaults.scaledPosterGridMinWidth
     DeferImagePresentationWhileScrolling(gridState) {
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(MediaGridDefaults.PosterGridMinWidth),
+        columns = GridCells.Adaptive(gridCellMinWidth),
         state = gridState,
         contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 24.dp),
         horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),
@@ -116,7 +117,7 @@ fun SearchResults(
                 type = item.type,
                 userState = userState,
                 onClick = { onItemClick(item.contentId) },
-                width = MediaGridDefaults.PosterGridMinWidth,
+                width = gridCellMinWidth,
                 overlay = org.siloserver.silo.overlays.OverlayDataExtractor.fromBrowseItem(item),
                 actions = actions,
             )

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/MediaCardsSettings.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/MediaCardsSettings.kt
@@ -1,0 +1,102 @@
+package org.siloserver.silo.android.ui.screens.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.siloserver.silo.common.settings.CardPresentationSource
+import org.siloserver.silo.common.settings.CardPresentationSupport
+import org.siloserver.silo.common.settings.CardPresentationUiState
+import org.siloserver.silo.model.settings.CardCaption
+import org.siloserver.silo.model.settings.CardPosterSize
+import org.siloserver.silo.model.settings.CardPresentationPreset
+
+private const val CustomPresetLabel = "Custom"
+
+/**
+ * "Media Cards" section — the cross-client `ui.card_presentation` preference
+ * (poster size + caption style, plus the client-side presets over the pair).
+ *
+ * Writes go to `profile_client` so the choice roams among this profile's
+ * phones/tablets, unless "Only this device" pins a `profile_device` override.
+ * Servers that predate the setting get a single read-only upgrade notice.
+ */
+@Composable
+fun MediaCardsSettings(
+    state: CardPresentationUiState,
+    onPresetSelected: (CardPresentationPreset) -> Unit,
+    onPosterSizeSelected: (CardPosterSize) -> Unit,
+    onCaptionSelected: (CardCaption) -> Unit,
+    onDeviceOnlyChanged: (Boolean) -> Unit,
+    onUseProfileDefault: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingsSection(title = "Media Cards", modifier = modifier) {
+        if (state.support == CardPresentationSupport.Unsupported) {
+            SettingsProse(body = "Update your Silo server to customize media cards.")
+            return@SettingsSection
+        }
+
+        val presentation = state.presentation
+        val activePreset = presentation.preset
+        // "Custom" is a synthetic display state (the pair matches no preset),
+        // not a choice — it appears in the menu only while it is active.
+        val presetOptions = CardPresentationPreset.entries.map { it.displayName } +
+            listOfNotNull(CustomPresetLabel.takeIf { activePreset == null })
+        SettingsDropdownRow(
+            label = "Preset",
+            description = "A starting point for poster size and captions.",
+            value = activePreset?.displayName ?: CustomPresetLabel,
+            options = presetOptions,
+            onOptionSelected = { label ->
+                CardPresentationPreset.entries
+                    .firstOrNull { it.displayName == label }
+                    ?.let(onPresetSelected)
+            },
+        )
+
+        SettingsDropdownRow(
+            label = "Poster size",
+            description = "How large posters render in rows and grids.",
+            value = presentation.posterSize.displayName,
+            options = CardPosterSize.entries.map { it.displayName },
+            onOptionSelected = { label ->
+                CardPosterSize.entries
+                    .firstOrNull { it.displayName == label }
+                    ?.let(onPosterSizeSelected)
+            },
+        )
+
+        SettingsDropdownRow(
+            label = "Captions",
+            description = "What shows beneath each poster.",
+            value = presentation.caption.displayName,
+            options = CardCaption.entries.map { it.displayName },
+            onOptionSelected = { label ->
+                CardCaption.entries
+                    .firstOrNull { it.displayName == label }
+                    ?.let(onCaptionSelected)
+            },
+        )
+
+        val deviceOnly = state.source == CardPresentationSource.DeviceOverride
+        SettingsSwitchRow(
+            label = "Only this device",
+            description = "Keep these choices on this device instead of syncing them.",
+            checked = deviceOnly,
+            onCheckedChange = onDeviceOnlyChanged,
+        )
+
+        if (!deviceOnly && state.source == CardPresentationSource.ClientFamily) {
+            SettingsNavigationRow(
+                label = "Use profile default",
+                description = "Clear this device family's choice and follow the profile.",
+                onClick = onUseProfileDefault,
+                showChevron = false,
+            )
+        }
+
+        SettingsProse(
+            body = "Choices sync with other phones (or tablets) signed into this " +
+                "profile unless 'Only this device' is on.",
+        )
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsScreen.kt
@@ -272,6 +272,17 @@ fun SettingsScreen(
                 }
             }
 
+            item {
+                MediaCardsSettings(
+                    state = state.cardPresentation,
+                    onPresetSelected = viewModel::setCardPreset,
+                    onPosterSizeSelected = viewModel::setCardPosterSize,
+                    onCaptionSelected = viewModel::setCardCaption,
+                    onDeviceOnlyChanged = viewModel::setCardDeviceOnly,
+                    onUseProfileDefault = viewModel::useCardProfileDefault,
+                )
+            }
+
             if (state.notificationsAvailable) {
                 item {
                     SettingsSection(title = "Notifications") {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsViewModel.kt
@@ -2,6 +2,9 @@ package org.siloserver.silo.android.ui.screens.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import org.siloserver.silo.common.settings.CardPresentationSource
+import org.siloserver.silo.common.settings.CardPresentationStore
+import org.siloserver.silo.common.settings.CardPresentationUiState
 import org.siloserver.silo.common.settings.LibraryPlaybackPrefsStore
 import org.siloserver.silo.common.settings.OverlayPrefsStore
 import org.siloserver.silo.common.settings.PlayerSettingsStore
@@ -10,6 +13,10 @@ import org.siloserver.silo.domain.settings.ProfileSettingsController
 import org.siloserver.silo.model.auth.User
 import org.siloserver.silo.model.download.DownloadQuality
 import org.siloserver.silo.model.notifications.NotificationPreferencesUpdate
+import org.siloserver.silo.model.settings.CardCaption
+import org.siloserver.silo.model.settings.CardPosterSize
+import org.siloserver.silo.model.settings.CardPresentation
+import org.siloserver.silo.model.settings.CardPresentationPreset
 import org.siloserver.silo.model.settings.QualityPresets
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.AuthRepository
@@ -97,6 +104,10 @@ data class SettingsUiState(
     val subtitleMode: SubtitleMode = SubtitleMode.AUTO,
     val showForcedSubtitles: Boolean = true,
 
+    // Media cards: the effective `ui.card_presentation` value plus where it
+    // resolved from and whether the server supports the key at all.
+    val cardPresentation: CardPresentationUiState = CardPresentationUiState(),
+
     // Notifications (in-app). Section is hidden entirely unless the server
     // reports in-app notifications are enabled AND preferences load.
     val notificationsAvailable: Boolean = false,
@@ -114,6 +125,7 @@ class SettingsViewModel(
     private val overlayPrefsStore: OverlayPrefsStore,
     private val notificationsRepository: NotificationsRepository,
     private val profileSettings: ProfileSettingsController,
+    private val cardPresentationStore: CardPresentationStore,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
@@ -124,6 +136,7 @@ class SettingsViewModel(
         observePlayerSettings()
         observePlaybackBehaviorSettings()
         observeNotifications()
+        observeCardPresentation()
     }
 
     private fun loadUserInfo() {
@@ -320,6 +333,65 @@ class SettingsViewModel(
         viewModelScope.launch { notificationsRepository.loadPreferences() }
     }
 
+    // -- Media cards --
+
+    private fun observeCardPresentation() {
+        cardPresentationStore.state.onEach { state ->
+            _uiState.update { it.copy(cardPresentation = state) }
+        }.launchIn(viewModelScope)
+        // The provider above the nav graph hydrates too, but this screen can
+        // be reached before any card rendered — make hydration unconditional.
+        viewModelScope.launch { cardPresentationStore.hydrateIfNeeded() }
+    }
+
+    fun setCardPreset(preset: CardPresentationPreset) {
+        setCardPresentation(preset.presentation)
+    }
+
+    fun setCardPosterSize(size: CardPosterSize) {
+        setCardPresentation(
+            _uiState.value.cardPresentation.presentation.copy(posterSize = size),
+        )
+    }
+
+    fun setCardCaption(caption: CardCaption) {
+        setCardPresentation(
+            _uiState.value.cardPresentation.presentation.copy(caption = caption),
+        )
+    }
+
+    /**
+     * Optimistic write through the store — at `profile_device` while the
+     * device override is active, else at `profile_client` so the choice roams
+     * among this profile's like devices (Apple/web parity).
+     */
+    private fun setCardPresentation(presentation: CardPresentation) {
+        val deviceOnly =
+            _uiState.value.cardPresentation.source == CardPresentationSource.DeviceOverride
+        cardPresentationStore.set(presentation, deviceOnly = deviceOnly)
+    }
+
+    /**
+     * "Only this device": ON pins the current presentation at
+     * `profile_device`; OFF deletes that row so resolution falls back to the
+     * client-family value.
+     */
+    fun setCardDeviceOnly(enabled: Boolean) {
+        if (enabled) {
+            cardPresentationStore.set(
+                _uiState.value.cardPresentation.presentation,
+                deviceOnly = true,
+            )
+        } else {
+            viewModelScope.launch { cardPresentationStore.clearDeviceOverride() }
+        }
+    }
+
+    /** Deletes the `profile_client` row so the profile-wide value applies. */
+    fun useCardProfileDefault() {
+        viewModelScope.launch { cardPresentationStore.useProfileDefault() }
+    }
+
     fun setNotificationsEnabled(value: Boolean) {
         updateNotificationPreferences(NotificationPreferencesUpdate(enabled = value))
     }
@@ -357,6 +429,7 @@ class SettingsViewModel(
             // stale rows flash before the fresh fetch lands.
             libraryPlaybackPrefsStore.clear()
             overlayPrefsStore.clear()
+            cardPresentationStore.clear()
             _uiState.update { it.copy(loggedOut = true) }
         }
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -520,6 +520,7 @@ val androidTvModule = module {
             playerSettingsStore = get(),
             libraryPlaybackPrefsStore = get(),
             overlayPrefsStore = get(),
+            cardPresentationStore = get(),
             legacyTvPrefsMigration = get(),
             profileSettings = get(),
             tvLibraryScopeStore = getOrNull(),

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -387,7 +387,7 @@ val androidTvModule = module {
     }
 
     // Content ViewModels
-    viewModel { HomeViewModel(get(), get(), get(), get(), getOrNull(), get()) }
+    viewModel { HomeViewModel(get(), get(), get(), get(), getOrNull(), get(), get()) }
     viewModel { org.siloserver.silo.tv.ui.screens.home.TvUpcomingViewModel(get()) }
     viewModel { RecommendationsViewModel(get()) }
     viewModel { RequestsViewModel(get()) }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvCatalogGrid.kt
@@ -41,6 +41,7 @@ import androidx.tv.material3.Text
 import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.overlays.OverlayDataExtractor
 import org.siloserver.silo.tv.ui.theme.Spacing
+import org.siloserver.silo.tv.ui.theme.cardScaled
 import org.siloserver.silo.tv.ui.theme.rememberTvGridBringIntoViewSpec
 import org.siloserver.silo.tv.ui.util.tvArtworkAspectRatioForMediaType
 
@@ -211,8 +212,12 @@ fun TvCatalogGrid(
     ) {
     LazyVerticalGrid(
         state = resolvedGridState,
+        // Adaptive grids honor the card-presentation poster size by scaling
+        // the min cell width (smaller min → more columns); every caller passes
+        // an unscaled base. Fixed callers shift their column count instead
+        // (tvPresetGridColumns) before passing it in.
         columns = fixedColumnCount?.let { GridCells.Fixed(it) }
-            ?: GridCells.Adaptive(minSize = minCellWidth),
+            ?: GridCells.Adaptive(minSize = minCellWidth.cardScaled()),
         horizontalArrangement = Arrangement.spacedBy(horizontalSpacing),
         verticalArrangement = Arrangement.spacedBy(verticalSpacing),
         contentPadding = contentPadding,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvEpisodeCard.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvEpisodeCard.kt
@@ -37,6 +37,7 @@ import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.overlays.CardOverlayVariant
 import org.siloserver.silo.common.overlays.CardOverlays
 import org.siloserver.silo.common.overlays.LocalCardOverlayUiState
@@ -44,6 +45,7 @@ import org.siloserver.silo.overlays.OverlayData
 import org.siloserver.silo.tv.ui.theme.ProgressFill
 import org.siloserver.silo.tv.ui.theme.ProgressTrack
 import org.siloserver.silo.tv.ui.theme.RowDimens
+import org.siloserver.silo.tv.ui.theme.cardScaled
 import org.siloserver.silo.tv.ui.theme.siloCardDefaults
 
 /**
@@ -67,7 +69,7 @@ fun TvEpisodeCard(
     seasonNumber: Int? = null,
     episodeNumber: Int? = null,
     progress: Float? = null,
-    width: Dp = TvEpisodeCardWidth,
+    width: Dp = tvEpisodeCardWidth(),
     focusRequester: FocusRequester? = null,
     cardModifier: Modifier = Modifier,
     userState: org.siloserver.silo.model.catalog.MediaItemUserState? = null,
@@ -75,6 +77,7 @@ fun TvEpisodeCard(
     actions: TvMediaCardActions = TvMediaCardActions(),
 ) {
     val overlayState = LocalCardOverlayUiState.current
+    val caption = LocalCardPresentation.current.caption
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
 
@@ -178,38 +181,40 @@ fun TvEpisodeCard(
             }
         }
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 7.dp),
-            horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Text(
-                text = seriesTitle ?: title,
-                style = MaterialTheme.typography.titleSmall.copy(
-                    fontSize = 15.5.sp,
-                    lineHeight = 18.5.sp,
-                ),
-                color = if (isFocused) Color.White else Color.White.copy(alpha = 0.78f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            val secondaryLine = if (seriesTitle != null) title else year?.toString()
-            if (secondaryLine != null) {
+        if (caption.showsTitle) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 7.dp),
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
                 Text(
-                    text = secondaryLine,
-                    style = MaterialTheme.typography.bodySmall.copy(
-                        fontSize = 14.sp,
-                        lineHeight = 18.sp,
+                    text = seriesTitle ?: title,
+                    style = MaterialTheme.typography.titleSmall.copy(
+                        fontSize = 15.5.sp,
+                        lineHeight = 18.5.sp,
                     ),
-                    color = Color.White.copy(alpha = 0.75f),
+                    color = if (isFocused) Color.White else Color.White.copy(alpha = 0.78f),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    textAlign = TextAlign.Start,
                     modifier = Modifier.fillMaxWidth(),
                 )
+                val secondaryLine = if (seriesTitle != null) title else year?.toString()
+                if (caption.showsMetadata && secondaryLine != null) {
+                    Text(
+                        text = secondaryLine,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontSize = 14.sp,
+                            lineHeight = 18.sp,
+                        ),
+                        color = Color.White.copy(alpha = 0.75f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Start,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         }
 
@@ -228,6 +233,10 @@ private fun formatEpisodeTag(season: Int?, episode: Int?): String? {
  * that to Android TV as 180×100dp.
  */
 val TvEpisodeCardWidth: Dp = RowDimens.BackdropWidth
+
+/** [TvEpisodeCardWidth] scaled by the active poster-size preference. */
+@Composable
+fun tvEpisodeCardWidth(): Dp = TvEpisodeCardWidth.cardScaled()
 
 /** Hoisted so every card shares one instance instead of allocating a shape per composition. */
 private val TvEpisodeCardShape = RoundedCornerShape(8.dp)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCard.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCard.kt
@@ -40,6 +40,7 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.overlays.CardOverlayVariant
 import org.siloserver.silo.common.overlays.CardOverlays
 import org.siloserver.silo.common.overlays.LocalCardOverlayUiState
@@ -48,6 +49,7 @@ import org.siloserver.silo.overlays.OverlayData
 import org.siloserver.silo.tv.ui.theme.ProgressTrack
 import org.siloserver.silo.tv.ui.theme.ProgressFill
 import org.siloserver.silo.tv.ui.theme.RowDimens
+import org.siloserver.silo.tv.ui.theme.cardScaled
 import org.siloserver.silo.tv.ui.theme.siloCardDefaults
 import org.siloserver.silo.tv.ui.util.tvArtworkAspectRatioForMediaType
 
@@ -75,7 +77,7 @@ fun TvMediaCard(
     userState: MediaItemUserState? = null,
     progress: Float? = null,
     mediaType: String? = null,
-    width: Dp = TvCardWidth,
+    width: Dp = tvCardWidth(),
     fillWidth: Boolean = false,
     artworkAspectRatio: Float? = null,
     focusRequester: FocusRequester? = null,
@@ -84,6 +86,7 @@ fun TvMediaCard(
     actions: TvMediaCardActions = TvMediaCardActions(),
 ) {
     val overlayState = LocalCardOverlayUiState.current
+    val caption = LocalCardPresentation.current.caption
     val effectiveAspectRatio = artworkAspectRatio
         ?: tvArtworkAspectRatioForMediaType(mediaType)
         ?: (2f / 3f)
@@ -194,36 +197,38 @@ fun TvMediaCard(
             }
         }
 
-        Spacer(modifier = Modifier.height(11.dp))
+        if (caption.showsTitle) {
+            Spacer(modifier = Modifier.height(11.dp))
 
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleSmall.copy(
-                fontSize = 15.5.sp,
-                lineHeight = 18.5.sp,
-            ),
-            color = if (isFocused) {
-                Color.White
-            } else {
-                Color.White.copy(alpha = 0.78f)
-            },
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            textAlign = TextAlign.Start,
-            modifier = Modifier.fillMaxWidth(),
-        )
-
-        if (year != null && year > 0) {
             Text(
-                text = year.toString(),
-                style = MaterialTheme.typography.bodySmall.copy(
-                    fontSize = 14.sp,
-                    lineHeight = 18.sp,
+                text = title,
+                style = MaterialTheme.typography.titleSmall.copy(
+                    fontSize = 15.5.sp,
+                    lineHeight = 18.5.sp,
                 ),
-                color = Color.White.copy(alpha = 0.70f),
+                color = if (isFocused) {
+                    Color.White
+                } else {
+                    Color.White.copy(alpha = 0.78f)
+                },
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 textAlign = TextAlign.Start,
                 modifier = Modifier.fillMaxWidth(),
             )
+
+            if (caption.showsMetadata && year != null && year > 0) {
+                Text(
+                    text = year.toString(),
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        fontSize = 14.sp,
+                        lineHeight = 18.sp,
+                    ),
+                    color = Color.White.copy(alpha = 0.70f),
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
 
     }
@@ -234,6 +239,10 @@ fun TvMediaCard(
  * that to Android TV as 130×195dp.
  */
 val TvCardWidth: Dp = RowDimens.PosterWidth
+
+/** [TvCardWidth] scaled by the active poster-size preference. */
+@Composable
+fun tvCardWidth(): Dp = TvCardWidth.cardScaled()
 
 /** Optical scale for wide TV thumbnails; poster cards scale from their actual width. */
 const val TvCardOverlayScale: Float = 0.7f

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.overlays.OverlayData
 import org.siloserver.silo.overlays.OverlayDataExtractor
+import org.siloserver.silo.tv.ui.focus.TvFocusLog
 import org.siloserver.silo.tv.ui.theme.TvRailScrollBehavior
 import org.siloserver.silo.tv.ui.theme.tvRailPinOnFocus
 import org.siloserver.silo.tv.ui.theme.Spacing
@@ -172,12 +173,22 @@ fun TvMediaRow(
     }
 
     LaunchedEffect(restoreFocusRequest, resolvedRestoreFocusIndex, restoreFocusContentId) {
-        prepareTvMediaRowFocusRestore(
+        val scrolled = prepareTvMediaRowFocusRestore(
             requestId = restoreFocusRequest,
             restoreFocusIndex = resolvedRestoreFocusIndex,
             itemCount = rowItems.size,
             scrollToItem = rowState::scrollToItem,
         )
+        // A restore scroll that fires while no caller-driven ladder could be
+        // running is the signature of the rail snapping instead of gliding
+        // (the instant jump cancels the pin's animation) — surface it in the
+        // debug focus log rather than leaving it invisible on screen.
+        if (restoreFocusRequest > 0 || scrolled) {
+            TvFocusLog.d {
+                "rail restore scroll request=$restoreFocusRequest " +
+                    "index=$resolvedRestoreFocusIndex scrolled=$scrolled"
+            }
+        }
     }
 
     LaunchedEffect(firstItemFocusRequest) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -353,7 +353,7 @@ fun TvMediaRow(
                             userState = item.userState,
                             progress = rowItem.progress,
                             mediaType = item.type,
-                            width = posterWidth ?: TvCardWidth,
+                            width = posterWidth ?: tvCardWidth(),
                             onClick = { onItemClick(item.contentId) },
                             focusRequester = itemFocusRequester,
                             cardModifier = appliedCardModifier,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -32,6 +32,9 @@ import org.siloserver.silo.overlays.OverlayDataExtractor
 import org.siloserver.silo.tv.ui.theme.TvRailScrollBehavior
 import org.siloserver.silo.tv.ui.theme.tvRailPinOnFocus
 import org.siloserver.silo.tv.ui.theme.Spacing
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyAnomalyLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyCollection
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
 
 /** Visual style of cards inside a [TvMediaRow]. */
 enum class TvRowStyle { Poster, Backdrop }
@@ -118,6 +121,15 @@ fun TvMediaRow(
     onRowFocusChanged: ((Boolean) -> Unit)? = null,
     cardActions: (SectionItem) -> TvMediaCardActions = { TvMediaCardActions() },
 ) {
+    val diagnosticsKeySnapshot = remember(items) {
+        DiagnosticsListSnapshot.fromKeys(items.map { it.contentId })
+    }
+    LaunchedEffect(diagnosticsKeySnapshot) {
+        DiagnosticsKeyAnomalyLogger.snapshot(
+            DiagnosticsKeyCollection.TV_MEDIA_ROW,
+            diagnosticsKeySnapshot,
+        )
+    }
     if (items.isEmpty()) return
     val rowState = rememberLazyListState()
     val rowItems = remember(items, showProgress, style, cardLayout) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -54,7 +55,9 @@ import org.siloserver.silo.tv.ui.focus.keyedBooleanSaver
 import org.siloserver.silo.tv.ui.focus.keyedIntSaver
 import org.siloserver.silo.tv.ui.focus.resolveTvReturnTarget
 import org.siloserver.silo.tv.ui.focus.toTvReturnSections
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.model.section.SectionItem
+import org.siloserver.silo.model.settings.CardPresentation
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.CatalogRepository
 import org.siloserver.silo.tv.ui.theme.RowDimens
@@ -740,7 +743,9 @@ fun TvSkylineSectionFeed(
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background),
         ) {
-            val bandHeight = maxHeight * TvSkylineRowBandHeightFraction
+            val presentation = LocalCardPresentation.current
+            val bandHeight = tvSkylineRowBandHeight(presentation)
+                .coerceAtMost(maxHeight * TvSkylineRowBandMaxFraction)
             val trailingPreviewPadding = (bandHeight - TvSkylineRowBandBottomInset).coerceAtLeast(0.dp)
 
             // Base content changes drive matching 240 ms backdrop and copy
@@ -811,7 +816,8 @@ fun TvSkylineSectionFeed(
                             itemSpacing = TvSkylineItemSpacing,
                             rowTopPadding = TvSkylineRowCardVerticalPadding,
                             rowBottomPadding = TvSkylineRowCardVerticalPadding,
-                            posterWidth = RowDimens.DensePosterWidth,
+                            posterWidth = RowDimens.DensePosterWidth *
+                                presentation.posterSize.posterScale,
                             firstItemFocusRequester = resolvedFirstRowFocusRequester
                                 .takeIf { isFirstRow },
                             rowContainerFocusRequester = when {
@@ -879,8 +885,33 @@ private val TvSkylineRowCardVerticalPadding = 7.dp
 /** tvOS rowBandBottomInset 20pt maps to 10dp. */
 private val TvSkylineRowBandBottomInset = 10.dp
 
-/** Portion of the screen reserved for the row stack. */
-private const val TvSkylineRowBandHeightFraction = 0.50f
+// The band is sized from what its first row actually needs — section header,
+// card at the scaled dense-poster height, and whichever caption lines the
+// card-presentation preference shows — plus a peek of the next section. The
+// previous fixed 0.50 fraction clipped `large` cards against the marquee and
+// wasted marquee room under artwork-only captions. At the standard preset
+// this derivation reproduces the old 270dp band on a 540dp-tall layout.
+private val TvSkylineRowHeaderHeight = 26.dp // TvSectionHeader: 22sp title line + 4dp bottom pad
+private val TvSkylineRowHeaderGap = 12.dp // TvMediaRow header→rail spacing
+private val TvSkylineCaptionTitleHeight = 30.dp // TvMediaCard: 11dp spacer + 18.5sp title line
+private val TvSkylineCaptionMetadataHeight = 18.dp // TvMediaCard: 18sp year line
+private val TvSkylineRowPreviewPeek = 24.dp // sliver of the next section's header
+
+/** The band never pushes the marquee below ~40% of the screen. */
+private const val TvSkylineRowBandMaxFraction = 0.58f
+
+private fun tvSkylineRowBandHeight(presentation: CardPresentation): Dp {
+    val cardHeight = RowDimens.DensePosterWidth * presentation.posterSize.posterScale * 3f / 2f
+    val captionHeight = when {
+        !presentation.caption.showsTitle -> 0.dp
+        presentation.caption.showsMetadata ->
+            TvSkylineCaptionTitleHeight + TvSkylineCaptionMetadataHeight
+        else -> TvSkylineCaptionTitleHeight
+    }
+    return TvSkylineRowHeaderHeight + TvSkylineRowHeaderGap +
+        TvSkylineRowCardVerticalPadding * 2 + cardHeight + captionHeight +
+        TvSkylineRowPreviewSpacing + TvSkylineRowPreviewPeek
+}
 
 /** Gap between the marquee block and the top of the row band. */
 private val TvSkylineMarqueeBottomGap = 4.dp

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -851,7 +851,20 @@ fun TvSkylineSectionFeed(
                             // moved horizontally can otherwise sit outside the
                             // composed window, leaving the requester unattached
                             // and every retry doomed.
-                            restoreFocusRequest = if (isReturnRow) returnRestoreRequest else 0,
+                            //
+                            // Gated on a ladder being IN FLIGHT, not on the row
+                            // merely being the return row: the pending target is
+                            // re-armed by every focus move and the counter
+                            // outlives its ladder, so an ungated request
+                            // re-fired the row's instant restore scrollToItem on
+                            // every focus move after a detail round trip —
+                            // cancelling the rail pin's animated glide. Ordinary
+                            // row rendering must never move the row.
+                            restoreFocusRequest = if (isReturnRow && restorationsInFlight > 0) {
+                                returnRestoreRequest
+                            } else {
+                                0
+                            },
                             restoreFocusRequester = detailReturnItemFocusRequester
                                 .takeIf { isReturnRow },
                             onItemFocusedAtIndex = { item, itemIndex ->

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -69,6 +69,9 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.siloserver.silo.common.diagnostics.DiagnosticsListLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSurface
 
 /**
  * Android TV port of tvOS `TVSkylineSectionFeed`: shared by Home and library
@@ -126,6 +129,24 @@ fun TvSkylineSectionFeed(
     onContentUpFallbackChanged: ((((Boolean) -> Boolean)?) -> Unit)? = null,
 ) {
     val rows = remember(sections) { sections.filter { it.items.isNotEmpty() } }
+    val diagnosticsSurface = when {
+        surfaceKey == "home" -> DiagnosticsListSurface.TV_HOME
+        surfaceKey == "for_you" -> DiagnosticsListSurface.TV_FOR_YOU
+        surfaceKey.startsWith("library-") -> DiagnosticsListSurface.TV_LIBRARY_RECOMMENDED
+        else -> null
+    }
+    val diagnosticsListSnapshot = remember(rows, sectionsComplete) {
+        DiagnosticsListSnapshot.fromKeys(
+            keys = rows.map { it.id },
+            rowKeys = rows.map { section -> section.items.map { it.contentId } },
+            fullyResolved = sectionsComplete,
+        )
+    }
+    LaunchedEffect(diagnosticsSurface, diagnosticsListSnapshot) {
+        diagnosticsSurface?.let { surface ->
+            DiagnosticsListLogger.snapshot(surface, diagnosticsListSnapshot)
+        }
+    }
     val tintState = rememberAmbientBackdropTintState()
     val context = LocalContext.current
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -56,8 +56,10 @@ import org.siloserver.silo.tv.ui.screens.watchtogether.tvWatchTogetherDestinatio
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.watchtogether.WatchTogetherEntryTarget
 import org.siloserver.silo.watchtogether.watchTogetherEntryTarget
+import org.siloserver.silo.common.cards.ProvideCardPresentation
 import org.siloserver.silo.common.overlays.ProvideCardOverlays
 import org.siloserver.silo.common.diagnostics.DiagnosticsLifecycleLogger
+import org.siloserver.silo.common.settings.CardPresentationStore
 import org.siloserver.silo.common.settings.LibraryPlaybackPrefsStore
 import org.siloserver.silo.common.settings.OverlayPrefsStore
 import org.siloserver.silo.tv.watchnext.WatchNextSeeder
@@ -335,6 +337,7 @@ fun TvAppNavigation(
     val authRepository: AuthRepository = koinInject()
     val profileRepository: ProfileRepository = koinInject()
     val overlayPrefsStore: OverlayPrefsStore = koinInject()
+    val cardPresentationStore: CardPresentationStore = koinInject()
     val libraryPlaybackPrefsStore: LibraryPlaybackPrefsStore = koinInject()
     val watchNextSeeder: WatchNextSeeder = koinInject()
     val siloCastReceiver: TvSiloCastReceiver = koinInject()
@@ -547,6 +550,7 @@ fun TvAppNavigation(
     }
 
     ProvideCardOverlays(store = overlayPrefsStore, sessionKey = overlaySessionKey) {
+    ProvideCardPresentation(store = cardPresentationStore, sessionKey = overlaySessionKey) {
     Box(modifier = Modifier.fillMaxSize()) {
     NavHost(
         navController = navController,
@@ -634,6 +638,7 @@ fun TvAppNavigation(
                     if (destination == TvServerSwitchDestination.Home) {
                         libraryPlaybackPrefsStore.clear()
                         overlayPrefsStore.clear()
+                        cardPresentationStore.clear()
                         watchNextSeeder.clear()
                         watchNextSeeder.seedNow()
                         watchNextSeeder.enqueuePeriodic()
@@ -793,6 +798,7 @@ fun TvAppNavigation(
                         tokenManager.clearTokens()
                         libraryPlaybackPrefsStore.clear()
                         overlayPrefsStore.clear()
+                        cardPresentationStore.clear()
                         // Drop our Watch Next rows + cancel the periodic refresh so
                         // the launcher doesn't keep showing the signed-out user's
                         // progress.
@@ -818,6 +824,7 @@ fun TvAppNavigation(
                         // switch-profile path.
                         libraryPlaybackPrefsStore.clear()
                         overlayPrefsStore.clear()
+                        cardPresentationStore.clear()
                         // Clear the previous profile's Watch Next rows before
                         // landing on the picker; the new profile will re-seed
                         // via [onProfileSelected].
@@ -1302,6 +1309,7 @@ fun TvAppNavigation(
             onDontSend = { diagnosticsViewModel.declinePrompt(prompt) },
             allowAlwaysSend = diagnosticsState.allowsAutomaticUpload,
         )
+    }
     }
     }
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/browse/TvBrowseScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/browse/TvBrowseScreen.kt
@@ -53,6 +53,7 @@ import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvFilterSheet
 import org.siloserver.silo.tv.ui.shell.TvTopMenuLayout
 import org.siloserver.silo.tv.ui.theme.Spacing
+import org.siloserver.silo.tv.ui.theme.tvPresetGridColumns
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
@@ -290,6 +291,7 @@ private fun BrowseGrid(
     // so here isLoading only drives the load-more footer. loadMoreThreshold is
     // expressed in items (rows-from-end * column count) to preserve the prior
     // trigger distance.
+    val browseColumns = tvPresetGridColumns(BrowseGridColumns)
     TvCatalogGrid(
         items = state.items,
         isLoading = state.loadingMore,
@@ -297,8 +299,8 @@ private fun BrowseGrid(
         onItemClick = onItemClick,
         onLoadMore = onLoadMore,
         modifier = Modifier.fillMaxSize(),
-        fixedColumnCount = BrowseGridColumns,
-        loadMoreThreshold = BrowseGridLoadMoreRowsThreshold * BrowseGridColumns,
+        fixedColumnCount = browseColumns,
+        loadMoreThreshold = BrowseGridLoadMoreRowsThreshold * browseColumns,
         contentPadding = PaddingValues(
             start = Spacing.safeArea,
             top = TvTopMenuLayout.contentTopInset,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
@@ -88,6 +88,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.compose.viewmodel.koinViewModel
 import org.siloserver.silo.common.calendar.localDisplayAirTime
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.calendar.CalendarBadge
 import org.siloserver.silo.model.calendar.CalendarFilter
@@ -115,6 +116,7 @@ import org.siloserver.silo.tv.ui.theme.FocusedContainer
 import org.siloserver.silo.tv.ui.theme.FocusedContent
 import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
+import org.siloserver.silo.tv.ui.theme.cardScaled
 import org.siloserver.silo.viewmodel.CalendarViewModel
 
 /**
@@ -1338,8 +1340,8 @@ private val NoVerticalBringIntoViewSpec: BringIntoViewSpec = object : BringIntoV
     override fun calculateScrollDistance(offset: Float, size: Float, containerSize: Float): Float = 0f
 }
 
-private val posterWidth = 124.dp
-private val posterHeight = 186.dp
+private val CalendarPosterWidth = 124.dp
+private val CalendarPosterHeight = 186.dp
 private val CalendarCardSpacing = 18.dp
 private val posterShape = RoundedCornerShape(10.dp)
 
@@ -1353,6 +1355,9 @@ private fun CalendarEventCard(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
+    val posterWidth = CalendarPosterWidth.cardScaled()
+    val posterHeight = CalendarPosterHeight.cardScaled()
+    val caption = LocalCardPresentation.current.caption
 
     // Both edges. Gain alone made the screen's record of "what has focus"
     // sticky, so a card focus passed over on the way somewhere else still
@@ -1451,31 +1456,37 @@ private fun CalendarEventCard(
 
         // Caption below the poster: titles may wrap to two lines, but a
         // one-line title does not reserve an empty second line before detail.
-        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-            Text(
-                text = item.title,
-                style = MaterialTheme.typography.labelLarge.copy(
-                    fontSize = 17.5.sp,
-                    lineHeight = 20.5.sp,
-                ),
-                fontWeight = FontWeight.SemiBold,
-                color = if (isFocused) Color.White else Color.White.copy(alpha = 0.85f),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            cardSubtitle(item)?.let { subtitle ->
+        // Artwork-only drops the whole block; the outer spacedBy only applies
+        // between children, so the poster keeps no trailing gap.
+        if (caption.showsTitle) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.bodySmall.copy(
-                        fontSize = 14.sp,
-                        lineHeight = 18.sp,
+                    text = item.title,
+                    style = MaterialTheme.typography.labelLarge.copy(
+                        fontSize = 17.5.sp,
+                        lineHeight = 20.5.sp,
                     ),
-                    color = Color.White.copy(alpha = 0.75f),
-                    maxLines = 1,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (isFocused) Color.White else Color.White.copy(alpha = 0.85f),
+                    maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.fillMaxWidth(),
                 )
+                if (caption.showsMetadata) {
+                    cardSubtitle(item)?.let { subtitle ->
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodySmall.copy(
+                                fontSize = 14.sp,
+                                lineHeight = 18.sp,
+                            ),
+                            color = Color.White.copy(alpha = 0.75f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
             }
         }
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Icon
 import androidx.tv.material3.Text
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.catalog.EpisodeListItem
 import org.siloserver.silo.tv.ui.components.TvMediaCardActions
@@ -70,6 +71,7 @@ import org.siloserver.silo.tv.ui.theme.DarkSurfaceElevated
 import org.siloserver.silo.tv.ui.theme.ProgressFill
 import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.capsuleCaps
+import org.siloserver.silo.tv.ui.theme.cardScaled
 
 /**
  * Horizontal rail of episode cards for the series/season/episode detail
@@ -192,8 +194,9 @@ private fun TvDetailEpisodeCard(
     onSetFavorite: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val cardWidth = 230.dp
-    val stillHeight = 130.dp
+    val cardWidth = 230.dp.cardScaled()
+    val stillHeight = 130.dp.cardScaled()
+    val caption = LocalCardPresentation.current.caption
     val cornerRadius = 5.dp
     val shape = RoundedCornerShape(cornerRadius)
 
@@ -321,65 +324,71 @@ private fun TvDetailEpisodeCard(
 
         // Keep the hierarchy scannable at TV distance: episode number, title,
         // air date/runtime, then synopsis. Each kind of information owns a
-        // stable line instead of competing in one dense eyebrow.
-        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(5.dp),
-            ) {
-                Text(
-                    text = "EPISODE ${episode.episodeNumber}",
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Bold,
-                    letterSpacing = 1.0.sp,
-                    color = SiloOnSurface.copy(alpha = 0.7f),
-                    maxLines = 1,
-                )
-                if (isCurrent) {
-                    NowViewingTag()
+        // stable line instead of competing in one dense eyebrow. Artwork-only
+        // drops the block entirely (tvOS `TVEpisodeRail`); the card has no
+        // fixed height, so the rail shrinks to the still.
+        if (caption.showsTitle) {
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(5.dp),
+                ) {
+                    Text(
+                        text = "EPISODE ${episode.episodeNumber}",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 1.0.sp,
+                        color = SiloOnSurface.copy(alpha = 0.7f),
+                        maxLines = 1,
+                    )
+                    if (isCurrent) {
+                        NowViewingTag()
+                    }
                 }
-            }
 
-            Text(
-                text = episode.title ?: "Episode ${episode.episodeNumber}",
-                fontSize = 18.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = when {
-                    isCurrent -> SiloOnSurface
-                    isFocused -> SiloOnSurface
-                    else -> SiloOnSurface.copy(alpha = 0.92f)
-                },
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
-
-            episodeMetadataLine(episode)?.let { metadata ->
                 Text(
-                    text = metadata,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium,
-                    color = SiloOnSurface.copy(alpha = 0.75f),
-                    maxLines = 1,
+                    text = episode.title ?: "Episode ${episode.episodeNumber}",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = when {
+                        isCurrent -> SiloOnSurface
+                        isFocused -> SiloOnSurface
+                        else -> SiloOnSurface.copy(alpha = 0.92f)
+                    },
+                    maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
-            }
 
-            // tvOS uses lineLimit(3, reservesSpace: true): always reserve
-            // exactly 3 text lines (minLines/maxLines rather than a fixed dp
-            // clamp so accessibility text scaling can't clip glyphs), and
-            // render even when there is no overview so every card keeps
-            // identical vertical metrics.
-            Text(
-                text = episode.overview?.takeIf { it.isNotBlank() }.orEmpty(),
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Normal,
-                color = SiloSecondaryText,
-                minLines = 3,
-                maxLines = 3,
-                overflow = TextOverflow.Ellipsis,
-                lineHeight = 20.sp,
-                modifier = Modifier.padding(top = 2.dp),
-            )
+                if (caption.showsMetadata) {
+                    episodeMetadataLine(episode)?.let { metadata ->
+                        Text(
+                            text = metadata,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = SiloOnSurface.copy(alpha = 0.75f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+
+                    // tvOS uses lineLimit(3, reservesSpace: true): always reserve
+                    // exactly 3 text lines (minLines/maxLines rather than a fixed dp
+                    // clamp so accessibility text scaling can't clip glyphs), and
+                    // render even when there is no overview so every card keeps
+                    // identical vertical metrics.
+                    Text(
+                        text = episode.overview?.takeIf { it.isNotBlank() }.orEmpty(),
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Normal,
+                        color = SiloSecondaryText,
+                        minLines = 3,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
+                        lineHeight = 20.sp,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
+            }
         }
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryCollectionDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryCollectionDetailScreen.kt
@@ -31,6 +31,7 @@ import org.siloserver.silo.tv.ui.components.TvCatalogEmptyState
 import org.siloserver.silo.tv.ui.components.TvCatalogGrid
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.theme.Spacing
+import org.siloserver.silo.tv.ui.theme.tvPresetGridColumns
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -104,7 +105,7 @@ fun TvLibraryCollectionDetailScreen(
             hasMore = state.hasMore,
             onItemClick = onItemClick,
             onLoadMore = viewModel::loadMore,
-            fixedColumnCount = 6,
+            fixedColumnCount = tvPresetGridColumns(6),
             contentPadding = PaddingValues(
                 start = Spacing.safeArea,
                 top = Spacing.xxl,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/library/TvLibraryDetailScreen.kt
@@ -62,6 +62,7 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.catalog.AudiobookGroup
 import org.siloserver.silo.model.section.LibraryCollection
@@ -77,6 +78,7 @@ import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.SubtleSurface
 import org.siloserver.silo.tv.ui.theme.rememberTvGridBringIntoViewSpec
 import org.siloserver.silo.tv.ui.theme.siloCardDefaults
+import org.siloserver.silo.tv.ui.theme.tvPresetGridColumns
 import org.siloserver.silo.tv.ui.components.TvSectionHeader
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -504,7 +506,7 @@ private fun LibraryGrid(
     ) {
         LazyVerticalGrid(
             state = gridState,
-            columns = GridCells.Fixed(LibraryBrowseGridColumns),
+            columns = GridCells.Fixed(tvPresetGridColumns(LibraryBrowseGridColumns)),
             modifier = Modifier
                 .fillMaxSize()
                 // Entry lands on the return-target card while its requester is
@@ -712,7 +714,7 @@ private fun AudiobookGroupsTab(
     ) {
         LazyVerticalGrid(
             state = gridState,
-            columns = GridCells.Fixed(LibraryGridColumns),
+            columns = GridCells.Fixed(tvPresetGridColumns(LibraryGridColumns)),
             modifier = Modifier
                 .fillMaxSize()
                 .onFocusChanged { groupGridHasFocus = it.hasFocus },
@@ -811,6 +813,8 @@ private fun TvAudiobookGroupCard(
     onClick: () -> Unit,
     focusRequester: FocusRequester? = null,
 ) {
+    val caption = LocalCardPresentation.current.caption
+
     Column(modifier = Modifier.fillMaxWidth()) {
         Card(
             onClick = onClick,
@@ -845,25 +849,29 @@ private fun TvAudiobookGroupCard(
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        if (caption.showsTitle) {
+            Spacer(modifier = Modifier.height(8.dp))
 
-        Text(
-            text = group.name,
-            style = MaterialTheme.typography.titleSmall,
-            color = Color.White.copy(alpha = 0.92f),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        audiobookGroupSubtitle(group)?.let { subtitle ->
             Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodySmall,
-                color = Color.White.copy(alpha = 0.68f),
+                text = group.name,
+                style = MaterialTheme.typography.titleSmall,
+                color = Color.White.copy(alpha = 0.92f),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.fillMaxWidth(),
             )
+            if (caption.showsMetadata) {
+                audiobookGroupSubtitle(group)?.let { subtitle ->
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White.copy(alpha = 0.68f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
         }
     }
 }
@@ -989,7 +997,7 @@ private fun CollectionsTab(
     ) {
         LazyVerticalGrid(
             state = gridState,
-            columns = GridCells.Fixed(LibraryGridColumns),
+            columns = GridCells.Fixed(tvPresetGridColumns(LibraryGridColumns)),
             modifier = Modifier
                 .fillMaxSize()
                 .onFocusChanged { collectionGridHasFocus = it.hasFocus }
@@ -1106,6 +1114,7 @@ private fun TvCollectionCard(
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
     val cardFocus = siloCardDefaults(shape = TvCollectionCardShape)
+    val caption = LocalCardPresentation.current.caption
 
     Column(modifier = Modifier.fillMaxWidth()) {
         Card(
@@ -1144,22 +1153,25 @@ private fun TvCollectionCard(
             }
         }
 
-        Spacer(modifier = Modifier.height(11.dp))
-
         // Title-only caption, start-aligned like every other poster caption in
         // the app. The item count was dropped: it doubled the caption height
-        // and made the rows read differently from Browse.
-        Text(
-            text = collection.name,
-            style = MaterialTheme.typography.titleSmall.copy(
-                fontSize = 15.5.sp,
-                lineHeight = 18.5.sp,
-            ),
-            color = if (isFocused) Color.White else Color.White.copy(alpha = 0.78f),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        // and made the rows read differently from Browse. Gated like
+        // `TvMediaCard` so both card families agree in the same Library tab.
+        if (caption.showsTitle) {
+            Spacer(modifier = Modifier.height(11.dp))
+
+            Text(
+                text = collection.name,
+                style = MaterialTheme.typography.titleSmall.copy(
+                    fontSize = 15.5.sp,
+                    lineHeight = 18.5.sp,
+                ),
+                color = if (isFocused) Color.White else Color.White.copy(alpha = 0.78f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/people/TvPersonDetailScreen.kt
@@ -77,6 +77,7 @@ import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvLoadingScreen
 import org.siloserver.silo.tv.ui.theme.DarkSurfaceElevated
 import org.siloserver.silo.tv.ui.theme.Spacing
+import org.siloserver.silo.tv.ui.theme.tvPresetGridColumns
 import java.time.LocalDate
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -257,7 +258,7 @@ private fun TvPersonDetailContent(
             },
             modifier = Modifier.fillMaxSize(),
             gridState = gridState,
-            fixedColumnCount = PersonGridColumns,
+            fixedColumnCount = tvPresetGridColumns(PersonGridColumns),
             // tvOS `TVPersonDetailContent`: 48pt page top, 72pt bottom, 40pt grid
             // column spacing, 48pt header → filmography gap (all halved to dp).
             contentPadding = PaddingValues(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
@@ -51,6 +51,7 @@ import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.sectionEyebrow
 import org.siloserver.silo.tv.ui.theme.tvPageContentPadding
 import org.siloserver.silo.tv.ui.theme.tvPageStartPadding
+import org.siloserver.silo.tv.ui.theme.tvPresetGridColumns
 import org.siloserver.silo.viewmodel.FavoritesViewModel
 import org.siloserver.silo.viewmodel.HistoryViewModel
 import org.siloserver.silo.tv.ui.shell.TvTopMenuLayout
@@ -404,7 +405,7 @@ private fun PersonalGrid(
                     // Match every other catalog grid (browse/person/collections):
                     // the adaptive default rendered ~5 oversized columns here
                     // (QA 2026-07-08).
-                    fixedColumnCount = 6,
+                    fixedColumnCount = tvPresetGridColumns(6),
                     gridState = gridState,
                     restoreItemIndex = restoration.requesterItemIndex,
                     restoreItemFocusRequester = restoreItemFocusRequester,
@@ -507,7 +508,7 @@ private fun PersonalInlineGrid(
                 top = Spacing.md,
                 bottom = Spacing.xl,
             ),
-            fixedColumnCount = 6,
+            fixedColumnCount = tvPresetGridColumns(6),
             firstItemFocusRequester = firstItemFocusRequester.takeIf { !listIsEmpty },
             header = {
                 PersonalControlHeader(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyAction.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyAction.kt
@@ -25,6 +25,24 @@ internal enum class TvPlayerRemoteKeyAction {
     ConsumeOnly,
 }
 
+/**
+ * Maps one remote key event onto the player's intent vocabulary, or null when
+ * the key is not ours (focus navigation and unhandled keys fall through).
+ *
+ * Media play/pause acts on the first DOWN and consumes UP halves and
+ * auto-repeats so the system media-key fallback cannot act on them twice.
+ * Left/Right quick-skip only while [dpadHorizontalSeek] allows it — with a
+ * focus-owning surface (transport overlay, HUD, Up Next) up, they belong to
+ * Compose focus navigation. The dedicated transport seek keys
+ * (rewind/fast-forward/skip) are never focus navigation, so they skip in
+ * every surface state and deliberately ignore [dpadHorizontalSeek]. Down
+ * focuses the transport, or opens the playback HUD from clean playback when
+ * [dpadDownOpensHud] is set; Menu/Settings open the settings HUD on key UP.
+ *
+ * A null action is what lets the player bridge reveal the controls for an
+ * unknown key from clean playback and swallow the press — so every key that
+ * must act on the FIRST press has to be mapped here.
+ */
 internal fun tvPlayerRemoteKeyAction(
     keyCode: Int,
     action: Int,
@@ -72,6 +90,29 @@ internal fun tvPlayerRemoteKeyAction(
             action == KeyEvent.ACTION_DOWN && repeatCount == 0 -> TvPlayerRemoteKeyAction.SkipForward
             else -> TvPlayerRemoteKeyAction.ConsumeOnly
         }
+
+    // Dedicated transport seek keys (the Shield remote's rewind/fast-forward
+    // buttons, Bluetooth and IR seek keys). Unlike Left/Right these are never
+    // focus navigation, so they skip in every surface state and deliberately
+    // ignore `dpadHorizontalSeek`. Mapping them here is also what makes the
+    // FIRST press seek: left unmapped, the player bridge's null-action branch
+    // only reveals the transport controls and swallows the event, so the user
+    // must press twice. UP halves and auto-repeats are consumed so the system
+    // media-key fallback can't seek a second time (same contract as
+    // PlayPause above).
+    KeyEvent.KEYCODE_MEDIA_REWIND,
+    KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD,
+    -> when {
+        action == KeyEvent.ACTION_DOWN && repeatCount == 0 -> TvPlayerRemoteKeyAction.SkipBack
+        else -> TvPlayerRemoteKeyAction.ConsumeOnly
+    }
+
+    KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
+    KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD,
+    -> when {
+        action == KeyEvent.ACTION_DOWN && repeatCount == 0 -> TvPlayerRemoteKeyAction.SkipForward
+        else -> TvPlayerRemoteKeyAction.ConsumeOnly
+    }
 
     KeyEvent.KEYCODE_MENU,
     KeyEvent.KEYCODE_SETTINGS,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -77,6 +77,7 @@ import androidx.media3.common.Format
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
+import androidx.media3.common.Timeline
 import androidx.media3.common.VideoSize
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
@@ -1544,17 +1545,35 @@ fun TvPlayerScreen(
     // Position polling — lifecycle-bounded so it doesn't outlive the screen.
     LaunchedEffect(mediaController, state.sessionId, lifecycleOwner) {
         val controller = mediaController ?: return@LaunchedEffect
+        val timelineWindow = Timeline.Window()
         lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
             while (isActive && state.sessionId != null) {
                 viewModel.onPositionChanged(
                     controller.currentPosition,
                     controller.duration.coerceAtLeast(0L),
                 )
+                // Mounted-transport extent for the VM's native-first seek
+                // decision (see TvPlayerViewModel.mountedSeekableSourceRange).
+                // A seekable window with a known length can serve any target
+                // it spans without a server reanchor.
+                if (!controller.currentTimeline.isEmpty) {
+                    controller.currentTimeline.getWindow(
+                        controller.currentMediaItemIndex,
+                        timelineWindow,
+                    )
+                    viewModel.onPlayerWindowChanged(
+                        isSeekable = timelineWindow.isSeekable,
+                        windowEndPlayerMs = if (timelineWindow.durationUs != C.TIME_UNSET) {
+                            timelineWindow.durationUs / 1000
+                        } else {
+                            -1L
+                        },
+                    )
+                }
                 delay(500)
             }
         }
     }
-
     LaunchedEffect(
         mediaController,
         state.sessionId,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -931,6 +931,13 @@ class TvPlayerViewModel(
     private var seekSequence = 0L
     private var activeSeekId: Long? = null
     private var hasRenderedFirstFrame = false
+    // Mounted-transport extent reported by the screen's position poll: whether
+    // the current Media3 window is seekable and how far it reaches in
+    // player-local time (-1 = unknown/unset). Feeds
+    // [mountedSeekableSourceRange] so decideSeek can ride the mounted content
+    // for quick skips instead of re-anchoring through the server.
+    private var playerWindowIsSeekable = false
+    private var playerWindowEndPlayerMs = -1L
 
     data class UiState(
         val isLoading: Boolean = true,
@@ -1768,6 +1775,15 @@ class TvPlayerViewModel(
      */
     fun onTransportMountApplied(nonce: Long) {
         if (transportMountGate.applied(nonce)) {
+            // The mounted item was replaced. Facts from the previous
+            // transport's window must not be mapped through the new plan's
+            // timeline offset — that can overstate the new extent and turn a
+            // target the new transport cannot serve into a silent,
+            // wrong-position native seek. The next poll tick (≤500ms)
+            // repopulates from the mounted item; until then the hint is
+            // absent, which at worst costs an unnecessary reanchor.
+            playerWindowIsSeekable = false
+            playerWindowEndPlayerMs = -1L
             pendingNativeSeekAfterMount?.let { targetSeconds ->
                 pendingNativeSeekAfterMount = null
                 // Re-evaluate against the plan that actually won the load;
@@ -2685,6 +2701,28 @@ class TvPlayerViewModel(
         )?.index
     }
 
+    /**
+     * Mounted-transport facts from the screen's 500ms poll (the VM stays free
+     * of MediaController references — the screen owns the player, the same
+     * split as [onPositionChanged]). Read by [mountedSeekableSourceRange] at
+     * seek-commit time. Two staleness rules keep the hint honest:
+     *
+     * - Reports are dropped while [transportMountGate] is suppressing: they
+     *   describe the OLD MediaItem, and mapping them through the new plan's
+     *   timeline offset would overstate the new transport's extent.
+     * - [onTransportMountApplied] clears the facts when a mount wins, so
+     *   until the next poll tick reads the new item the hint is absent and
+     *   ambiguous targets fall back to a server reanchor.
+     *
+     * Within one mounted item a slightly stale window end only ever costs an
+     * unnecessary reanchor, never a wrongly-native seek.
+     */
+    fun onPlayerWindowChanged(isSeekable: Boolean, windowEndPlayerMs: Long) {
+        if (transportMountGate.suppressPositionReports) return
+        playerWindowIsSeekable = isSeekable
+        playerWindowEndPlayerMs = windowEndPlayerMs
+    }
+
     fun onPositionChanged(positionMs: Long, durationMs: Long) {
         if (positionMs < 0) return
         // A new recovery response updates the source/player timeline before Compose can run the
@@ -3109,6 +3147,17 @@ class TvPlayerViewModel(
         if (activeSeekId == null) activeSeekId = ++seekSequence
     }
 
+    /**
+     * Commits a settled seek target (source time) onto the active transport.
+     *
+     * Routing ladder: with no session/plan yet the target parks in
+     * [pendingNativeSeekAfterMount] until the mount wins; with seek recovery
+     * or a mount in flight it queues as a reanchor; otherwise
+     * [decideSeek][org.siloserver.silo.common.player.seek.decideSeek] picks
+     * between a native `Player.seekTo` (fed the mounted transport's proven
+     * extent from [mountedSeekableSourceRange]) and a protocol-V3 server
+     * reanchor. A missing plan timeline falls through to a raw player seek.
+     */
     private fun executeSeekTarget(targetSourceSec: Double) {
         val state = _uiState.value
         if (transportMountGate.suppressPositionReports &&
@@ -3136,7 +3185,13 @@ class TvPlayerViewModel(
             )
             return
         }
-        when (val decision = state.playbackPlan?.timeline?.decideSeek(targetSourceSec)) {
+        val mountedSeekableSourceRange = mountedSeekableSourceRange(state)
+        when (
+            val decision = state.playbackPlan?.timeline?.decideSeek(
+                targetSourceSec,
+                mountedSeekableSourceRange,
+            )
+        ) {
             is PlaybackSeekDecision.ServerReanchor -> {
                 Log.i(
                     TAG,
@@ -3150,12 +3205,33 @@ class TvPlayerViewModel(
                     TAG,
                     "seek_commit seek_id=$activeSeekId action=native " +
                         "target_source_seconds=$targetSourceSec " +
-                        "target_player_seconds=${decision.targetPlayerPositionSeconds}",
+                        "target_player_seconds=${decision.targetPlayerPositionSeconds}" +
+                        (mountedSeekableSourceRange?.let {
+                            " mounted_source_range=${it.start}..${it.endInclusive}"
+                        } ?: ""),
                 )
                 seekRequestChannel.trySend(decision.targetPlayerPositionSeconds)
             }
             null -> seekRequestChannel.trySend(targetSourceSec)
         }
+    }
+
+    /**
+     * Source-time extent the currently mounted transport provably covers, or
+     * null when that cannot be proven. Derived from the Media3 window the
+     * screen polls: a seekable window with a known length can serve any
+     * position it spans as a plain `Player.seekTo`. That covers append-only
+     * (growing) HLS manifests — whose window end is the produced head — and
+     * completed/indexed streams, while a growing progressive copy remux has
+     * no known length and stays excluded. This is what lets quick skips ride
+     * already-mounted content instead of re-anchoring through the server.
+     */
+    private fun mountedSeekableSourceRange(state: UiState): ClosedRange<Double>? {
+        val timeline = state.playbackPlan?.timeline ?: return null
+        if (!playerWindowIsSeekable || playerWindowEndPlayerMs < 0) return null
+        val endSourceSec = timeline.sourcePositionForPlayer(playerWindowEndPlayerMs / 1000.0)
+            ?: return null
+        return timeline.timelineOffsetSeconds..endSourceSec
     }
 
     private fun startSeekReanchor(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestComponents.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestComponents.kt
@@ -35,6 +35,7 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
+import org.siloserver.silo.common.cards.LocalCardPresentation
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.request.MediaRequest
 import org.siloserver.silo.model.request.RequestAvailability
@@ -50,6 +51,7 @@ import org.siloserver.silo.tv.ui.components.TvCardWidth
 import org.siloserver.silo.tv.ui.theme.SiloBlue
 import org.siloserver.silo.tv.ui.theme.DarkOnPrimary
 import org.siloserver.silo.tv.ui.theme.RowDimens
+import org.siloserver.silo.tv.ui.theme.cardScaled
 import org.siloserver.silo.tv.ui.theme.siloCardDefaults
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -63,8 +65,9 @@ fun TvRequestCard(
 ) {
     val cardShape = RoundedCornerShape(8.dp)
     val cardFocus = siloCardDefaults(shape = cardShape)
+    val caption = LocalCardPresentation.current.caption
 
-    Column(modifier = modifier.width(TvCardWidth)) {
+    Column(modifier = modifier.width(TvCardWidth.cardScaled())) {
         Card(
             onClick = onClick,
             shape = CardDefaults.shape(shape = cardShape),
@@ -74,7 +77,7 @@ fun TvRequestCard(
             modifier = Modifier
                 .then(cardModifier)
                 .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
-                .size(RowDimens.PosterWidth, RowDimens.PosterHeight),
+                .size(RowDimens.PosterWidth.cardScaled(), RowDimens.PosterHeight.cardScaled()),
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
                 ThumbhashImage(
@@ -93,16 +96,20 @@ fun TvRequestCard(
                 )
             }
         }
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = result.title,
-            style = MaterialTheme.typography.titleSmall,
-            color = Color.White.copy(alpha = 0.82f),
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        RequestMetaLine(mediaType = result.mediaType, year = result.year)
+        if (caption.showsTitle) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = result.title,
+                style = MaterialTheme.typography.titleSmall,
+                color = Color.White.copy(alpha = 0.82f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            if (caption.showsMetadata) {
+                RequestMetaLine(mediaType = result.mediaType, year = result.year)
+            }
+        }
     }
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/requests/TvRequestDetailScreen.kt
@@ -41,6 +41,7 @@ import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvLoadingScreen
 import org.siloserver.silo.tv.ui.theme.RowDimens
 import org.siloserver.silo.tv.ui.theme.SiloBlue
+import org.siloserver.silo.tv.ui.theme.cardScaled
 import org.siloserver.silo.tv.ui.theme.sectionEyebrow
 import org.siloserver.silo.viewmodel.RequestDetailViewModel
 import org.koin.compose.viewmodel.koinViewModel
@@ -170,7 +171,7 @@ private fun RequestDetailContent(
                     contentDescription = detail.title,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
-                        .size(RowDimens.PosterWidth, RowDimens.PosterHeight)
+                        .size(RowDimens.PosterWidth.cardScaled(), RowDimens.PosterHeight.cardScaled())
                         .clip(RoundedCornerShape(10.dp)),
                 )
             }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
@@ -88,6 +88,12 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 import org.siloserver.silo.common.network.clientVersionLabel
+import org.siloserver.silo.common.settings.CardPresentationSource
+import org.siloserver.silo.common.settings.CardPresentationSupport
+import org.siloserver.silo.model.settings.CardCaption
+import org.siloserver.silo.model.settings.CardPosterSize
+import org.siloserver.silo.model.settings.CardPresentation
+import org.siloserver.silo.model.settings.CardPresentationPreset
 import org.siloserver.silo.model.settings.LanguageOptions
 import org.siloserver.silo.domain.player.IntroSkipMode
 import org.siloserver.silo.domain.settings.ProfileSettingsController
@@ -267,6 +273,9 @@ fun TvSettingsScreen(
         onMetadataLanguageChanged = viewModel::onMetadataLanguageChanged,
         metadataLanguageEnabled = metadataAiStatus.enabled && metadataAiStatus.onView != org.siloserver.silo.model.metadata.MetadataAiOnView.Off,
         onShowForcedSubtitlesChanged = viewModel::onShowForcedSubtitlesChanged,
+        onCardPresentationChanged = viewModel::onCardPresentationSelected,
+        onCardPresentationDeviceOnlyChanged = viewModel::onCardPresentationDeviceOnlyChanged,
+        onUseProfileCardDefault = viewModel::onUseProfileCardDefault,
         onSubtitleFontSizeChanged = viewModel::setSubtitleFontSize,
         onSubtitleFontFamilyChanged = viewModel::setSubtitleFontFamily,
         onSubtitleFontColorChanged = viewModel::setSubtitleFontColor,
@@ -405,6 +414,9 @@ private fun SettingsSplitLayout(
     onMetadataLanguageChanged: (String) -> Unit,
     metadataLanguageEnabled: Boolean,
     onShowForcedSubtitlesChanged: (Boolean) -> Unit,
+    onCardPresentationChanged: (CardPresentation) -> Unit,
+    onCardPresentationDeviceOnlyChanged: (Boolean) -> Unit,
+    onUseProfileCardDefault: () -> Unit,
     onSubtitleFontSizeChanged: (SubtitleFontSizePreset) -> Unit,
     onSubtitleFontFamilyChanged: (String) -> Unit,
     onSubtitleFontColorChanged: (String) -> Unit,
@@ -477,6 +489,9 @@ private fun SettingsSplitLayout(
             onMetadataLanguageChanged = onMetadataLanguageChanged,
             metadataLanguageEnabled = metadataLanguageEnabled,
             onShowForcedSubtitlesChanged = onShowForcedSubtitlesChanged,
+            onCardPresentationChanged = onCardPresentationChanged,
+            onCardPresentationDeviceOnlyChanged = onCardPresentationDeviceOnlyChanged,
+            onUseProfileCardDefault = onUseProfileCardDefault,
             onSubtitleFontSizeChanged = onSubtitleFontSizeChanged,
             onSubtitleFontFamilyChanged = onSubtitleFontFamilyChanged,
             onSubtitleFontColorChanged = onSubtitleFontColorChanged,
@@ -739,6 +754,9 @@ private fun SettingsDetailPane(
     onMetadataLanguageChanged: (String) -> Unit,
     metadataLanguageEnabled: Boolean,
     onShowForcedSubtitlesChanged: (Boolean) -> Unit,
+    onCardPresentationChanged: (CardPresentation) -> Unit,
+    onCardPresentationDeviceOnlyChanged: (Boolean) -> Unit,
+    onUseProfileCardDefault: () -> Unit,
     onSubtitleFontSizeChanged: (SubtitleFontSizePreset) -> Unit,
     onSubtitleFontFamilyChanged: (String) -> Unit,
     onSubtitleFontColorChanged: (String) -> Unit,
@@ -779,6 +797,9 @@ private fun SettingsDetailPane(
                 state = state,
                 firstFocusRequester = detailFocusRequester,
                 onShowAudiobooksTabChanged = onShowAudiobooksTabChanged,
+                onCardPresentationChanged = onCardPresentationChanged,
+                onCardPresentationDeviceOnlyChanged = onCardPresentationDeviceOnlyChanged,
+                onUseProfileCardDefault = onUseProfileCardDefault,
             )
             TvSettingsCategory.Playback -> TvPlaybackSettingsPane(
                 state = state,
@@ -847,7 +868,12 @@ private fun TvGeneralSettingsPane(
     state: TvSettingsViewModel.UiState,
     firstFocusRequester: FocusRequester,
     onShowAudiobooksTabChanged: (Boolean) -> Unit,
+    onCardPresentationChanged: (CardPresentation) -> Unit,
+    onCardPresentationDeviceOnlyChanged: (Boolean) -> Unit,
+    onUseProfileCardDefault: () -> Unit,
 ) {
+    var activeCardPicker by remember { mutableStateOf<CardPresentationPicker?>(null) }
+
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -869,13 +895,115 @@ private fun TvGeneralSettingsPane(
                 )
             }
         }
+        item {
+            // tvOS General → CARDS & POSTERS parity, backed by the
+            // server-driven `ui.card_presentation` setting. Unknown support
+            // (offline probe) keeps the controls up over the cached value;
+            // only a confirmed too-old server hides them.
+            SettingsGroup(title = "Cards & Posters") {
+                if (state.cardPresentationSupport == CardPresentationSupport.Unsupported) {
+                    SettingsFooterText(
+                        text = "Update your Silo server to customize media cards.",
+                    )
+                } else {
+                    SettingsValueRow(
+                        label = "Preset",
+                        value = state.cardPresentation.preset?.displayName ?: "Custom",
+                        onClick = { activeCardPicker = CardPresentationPicker.Preset },
+                    )
+                    SettingsValueRow(
+                        label = "Poster Size",
+                        value = state.cardPresentation.posterSize.displayName,
+                        onClick = { activeCardPicker = CardPresentationPicker.PosterSize },
+                    )
+                    SettingsValueRow(
+                        label = "Captions",
+                        value = state.cardPresentation.caption.displayName,
+                        onClick = { activeCardPicker = CardPresentationPicker.Captions },
+                    )
+                    SettingsToggleRow(
+                        label = "Only This Device",
+                        checked = state.cardPresentationSource ==
+                            CardPresentationSource.DeviceOverride,
+                        onCheckedChange = onCardPresentationDeviceOnlyChanged,
+                    )
+                    if (state.cardPresentationSource == CardPresentationSource.ClientFamily) {
+                        SettingsActionRow(
+                            label = "Use Profile Default",
+                            onClick = onUseProfileCardDefault,
+                        )
+                    }
+                    SettingsFooterText(
+                        text = "Choices sync with other TVs signed into this profile " +
+                            "unless \"Only This Device\" is on.",
+                    )
+                }
+            }
+        }
         // No Library group — tvOS parity: Apple's TVSettingsView has no such
         // section (it is iOS-only). On TV these destinations live in the
         // For You dropdown (Watchlist/Favorites), the profile menu
         // (Watchlist/Favorites/History), Home (Browse), and each library's
         // cascade (Collections). (QA 2026-07-08.)
     }
+
+    when (activeCardPicker) {
+        CardPresentationPicker.Preset -> TvSettingsPickerSheet(
+            title = "Preset",
+            // Synthetic "Custom" appears only while the current pair matches
+            // no preset; it is a label for the state, not a choice.
+            options = buildList {
+                CardPresentationPreset.entries.forEach {
+                    add(PickerOption(it.name, it.displayName))
+                }
+                if (state.cardPresentation.preset == null) {
+                    add(PickerOption(CustomCardPresetId, "Custom"))
+                }
+            },
+            selectedId = state.cardPresentation.preset?.name ?: CustomCardPresetId,
+            onSelect = { id ->
+                CardPresentationPreset.entries.firstOrNull { it.name == id }
+                    ?.let { onCardPresentationChanged(it.presentation) }
+                activeCardPicker = null
+            },
+            onDismiss = { activeCardPicker = null },
+        )
+        CardPresentationPicker.PosterSize -> TvSettingsPickerSheet(
+            title = "Poster Size",
+            options = CardPosterSize.entries.map { PickerOption(it.raw, it.displayName) },
+            selectedId = state.cardPresentation.posterSize.raw,
+            onSelect = { id ->
+                CardPosterSize.fromRaw(id)?.let {
+                    onCardPresentationChanged(state.cardPresentation.copy(posterSize = it))
+                }
+                activeCardPicker = null
+            },
+            onDismiss = { activeCardPicker = null },
+        )
+        CardPresentationPicker.Captions -> TvSettingsPickerSheet(
+            title = "Captions",
+            options = CardCaption.entries.map { PickerOption(it.raw, it.displayName) },
+            selectedId = state.cardPresentation.caption.raw,
+            onSelect = { id ->
+                CardCaption.fromRaw(id)?.let {
+                    onCardPresentationChanged(state.cardPresentation.copy(caption = it))
+                }
+                activeCardPicker = null
+            },
+            onDismiss = { activeCardPicker = null },
+        )
+        null -> Unit
+    }
 }
+
+private enum class CardPresentationPicker {
+    Preset,
+    PosterSize,
+    Captions,
+}
+
+/** Picker id for the synthetic "Custom" preset row (never on the wire). */
+private const val CustomCardPresetId = "custom"
 
 @Composable
 private fun TvPlaybackSettingsPane(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsViewModel.kt
@@ -3,9 +3,13 @@ package org.siloserver.silo.tv.ui.screens.settings
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import org.siloserver.silo.common.settings.CardPresentationSource
+import org.siloserver.silo.common.settings.CardPresentationStore
+import org.siloserver.silo.common.settings.CardPresentationSupport
 import org.siloserver.silo.common.settings.LibraryPlaybackPrefsStore
 import org.siloserver.silo.common.settings.OverlayPrefsStore
 import org.siloserver.silo.common.settings.PlayerSettingsStore
+import org.siloserver.silo.model.settings.CardPresentation
 import org.siloserver.silo.model.auth.User
 import org.siloserver.silo.domain.player.IntroSkipMode
 import org.siloserver.silo.domain.settings.ProfileSettingsController
@@ -52,6 +56,7 @@ class TvSettingsViewModel(
     private val playerSettingsStore: PlayerSettingsStore,
     private val libraryPlaybackPrefsStore: LibraryPlaybackPrefsStore,
     private val overlayPrefsStore: OverlayPrefsStore,
+    private val cardPresentationStore: CardPresentationStore,
     private val legacyTvPrefsMigration: LegacyTvPrefsMigration,
     private val profileSettings: ProfileSettingsController,
     private val tvLibraryScopeStore: org.siloserver.silo.tv.data.preferences.TvLibraryScopeStore? = null,
@@ -109,6 +114,12 @@ class TvSettingsViewModel(
         // Seconds before the end of an episode to surface the Up-Next prompt
         // (0 = at the very end). Mirrors tvOS `nextUpPromptSeconds`.
         val nextUpPromptSeconds: Int = 10,
+        // Cards & Posters (`ui.card_presentation`), mirrored from
+        // CardPresentationStore. Source drives the "Only This Device" toggle
+        // and the "Use Profile Default" action; support gates the whole group.
+        val cardPresentation: CardPresentation = CardPresentation.DEFAULT,
+        val cardPresentationSource: CardPresentationSource = CardPresentationSource.Unknown,
+        val cardPresentationSupport: CardPresentationSupport = CardPresentationSupport.Unknown,
         val navAction: NavAction? = null,
     )
 
@@ -119,6 +130,7 @@ class TvSettingsViewModel(
         loadUser()
         loadSettings()
         observePlayerSettings()
+        observeCardPresentation()
     }
 
     /**
@@ -203,6 +215,10 @@ class TvSettingsViewModel(
             // The store writes them to its DataStore; observePlayerSettings()
             // mirrors them into _uiState.
             playerSettingsStore.refreshFromServer()
+
+            // Idempotent — the nav-level ProvideCardPresentation usually got
+            // here first; this covers a cold open straight into Settings.
+            cardPresentationStore.hydrateIfNeeded()
 
             loadProfileSettings()
         }
@@ -375,6 +391,50 @@ class TvSettingsViewModel(
                 _uiState.update { it.copy(effectiveSubtitleAppearance = appearance) }
             }
         }
+    }
+
+    /** Mirror the card-presentation store into UI state (single source of truth). */
+    private fun observeCardPresentation() {
+        viewModelScope.launch {
+            cardPresentationStore.state.collect { cardState ->
+                _uiState.update {
+                    it.copy(
+                        cardPresentation = cardState.presentation,
+                        cardPresentationSource = cardState.source,
+                        cardPresentationSupport = cardState.support,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Apply a new card presentation. The store is optimistic (cards resize
+     * immediately through LocalCardPresentation) and rolls back on failure.
+     * While the "Only This Device" override is active the edit stays at
+     * `profile_device`; otherwise it roams at `profile_client`.
+     */
+    fun onCardPresentationSelected(presentation: CardPresentation) {
+        val deviceOnly =
+            _uiState.value.cardPresentationSource == CardPresentationSource.DeviceOverride
+        cardPresentationStore.set(presentation, deviceOnly = deviceOnly)
+    }
+
+    /**
+     * "Only This Device": ON copies the current value to `profile_device`;
+     * OFF deletes that row so resolution falls back to the family value.
+     */
+    fun onCardPresentationDeviceOnlyChanged(enabled: Boolean) {
+        if (enabled) {
+            cardPresentationStore.set(_uiState.value.cardPresentation, deviceOnly = true)
+        } else {
+            viewModelScope.launch { cardPresentationStore.clearDeviceOverride() }
+        }
+    }
+
+    /** Drop the `profile_client` value so this TV follows the profile default. */
+    fun onUseProfileCardDefault() {
+        viewModelScope.launch { cardPresentationStore.useProfileDefault() }
     }
 
     /**
@@ -612,6 +672,7 @@ class TvSettingsViewModel(
             // `PlaybackPrefsStore.clear()` in the sign-out path.
             libraryPlaybackPrefsStore.clear()
             overlayPrefsStore.clear()
+            cardPresentationStore.clear()
             _uiState.update { it.copy(navAction = NavAction.SIGNED_OUT) }
         }
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/theme/CardPresentationDimens.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/theme/CardPresentationDimens.kt
@@ -1,0 +1,39 @@
+package org.siloserver.silo.tv.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.unit.Dp
+import org.siloserver.silo.common.cards.LocalCardPresentation
+import org.siloserver.silo.model.settings.CardPosterSize
+
+/**
+ * Sizing helpers for the server-driven "Cards & Posters" preference
+ * ([LocalCardPresentation]). [RowDimens] stays the base token set: rails and
+ * standalone cards scale their widths by the active poster size (height
+ * follows aspect ratio), while fixed-column grids shift their column count
+ * instead so cells keep filling the page width without overlapping focus
+ * frames.
+ */
+@Composable
+@ReadOnlyComposable
+fun tvCardPosterScale(): Float = LocalCardPresentation.current.posterSize.posterScale
+
+/** A base card dimension scaled by the active poster-size preference. */
+@Composable
+@ReadOnlyComposable
+fun Dp.cardScaled(): Dp = this * tvCardPosterScale()
+
+/**
+ * Fixed-column grid count under the active poster size: compact adds a
+ * column, large removes one — floored so a grid never drops below a
+ * browsable width.
+ */
+@Composable
+@ReadOnlyComposable
+fun tvPresetGridColumns(base: Int): Int = when (LocalCardPresentation.current.posterSize) {
+    CardPosterSize.Compact -> base + 1
+    CardPosterSize.Standard -> base
+    CardPosterSize.Large -> (base - 1).coerceAtLeast(TvGridMinColumns)
+}
+
+private const val TvGridMinColumns = 3

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyActionTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyActionTest.kt
@@ -170,6 +170,66 @@ class TvPlayerRemoteKeyActionTest {
         )
     }
 
+    /** Unmapped keys only reveal controls on first press; these must skip, with repeats/UP consumed. */
+    @Test
+    fun mediaSeekKeysSkipOnTheFirstPressAndSwallowTheRest() {
+        // First press must SKIP — unmapped, the player bridge only reveals
+        // the transport for an unknown key and the user has to press twice.
+        listOf(
+            KeyEvent.KEYCODE_MEDIA_REWIND to TvPlayerRemoteKeyAction.SkipBack,
+            KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD to TvPlayerRemoteKeyAction.SkipBack,
+            KeyEvent.KEYCODE_MEDIA_FAST_FORWARD to TvPlayerRemoteKeyAction.SkipForward,
+            KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD to TvPlayerRemoteKeyAction.SkipForward,
+        ).forEach { (keyCode, expectedSkip) ->
+            assertEquals(
+                expectedSkip,
+                tvPlayerRemoteKeyAction(
+                    keyCode = keyCode,
+                    action = KeyEvent.ACTION_DOWN,
+                    repeatCount = 0,
+                ),
+            )
+            // Auto-repeat and the UP half are consumed so the system
+            // media-key fallback can't seek a second time.
+            assertEquals(
+                TvPlayerRemoteKeyAction.ConsumeOnly,
+                tvPlayerRemoteKeyAction(
+                    keyCode = keyCode,
+                    action = KeyEvent.ACTION_DOWN,
+                    repeatCount = 1,
+                ),
+            )
+            assertEquals(
+                TvPlayerRemoteKeyAction.ConsumeOnly,
+                tvPlayerRemoteKeyAction(
+                    keyCode = keyCode,
+                    action = KeyEvent.ACTION_UP,
+                    repeatCount = 0,
+                ),
+            )
+        }
+    }
+
+    /** Media transport keys are never focus navigation, so dpadHorizontalSeek gating must not silence them. */
+    @Test
+    fun mediaSeekKeysSkipEvenWhenTheIdleOverlayOwnsFocus() {
+        // Media transport keys are never focus navigation, so they are not
+        // gated by dpadHorizontalSeek the way Left/Right are.
+        listOf(
+            KeyEvent.KEYCODE_MEDIA_REWIND to TvPlayerRemoteKeyAction.SkipBack,
+            KeyEvent.KEYCODE_MEDIA_FAST_FORWARD to TvPlayerRemoteKeyAction.SkipForward,
+        ).forEach { (keyCode, expectedSkip) ->
+            assertEquals(
+                expectedSkip,
+                tvPlayerIdleOverlayRemoteKeyAction(
+                    keyCode = keyCode,
+                    action = KeyEvent.ACTION_DOWN,
+                    repeatCount = 0,
+                ),
+            )
+        }
+    }
+
     @Test
     fun visibleIdleOverlayLeftAndRightFallThroughToFocusNavigation() {
         // With the transport overlay visible, Left/Right must reach Compose

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerWindowFactInvalidationTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerWindowFactInvalidationTest.kt
@@ -1,0 +1,52 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The mounted-window facts feeding decideSeek's mountedSeekableSourceRange
+ * hint describe exactly one Media3 item. They must be dropped while a
+ * transport handoff suppresses reports and cleared when a mount wins —
+ * otherwise a stale extent maps through the new plan's timeline offset and a
+ * target the new transport cannot serve becomes a silent, wrong-position
+ * native seek.
+ */
+class TvPlayerWindowFactInvalidationTest {
+    private val viewModelSource = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt",
+    ).readText()
+
+    /** Old-item window facts recorded during a handoff would map through the new plan's offset. */
+    @Test
+    fun `window facts are not recorded while a transport handoff suppresses reports`() {
+        val body = viewModelSource
+            .substringAfter("fun onPlayerWindowChanged(")
+            .substringBefore("fun onPositionChanged(")
+
+        assertTrue(
+            "suppressPositionReports" in body,
+            "onPlayerWindowChanged must drop old-item facts during the handoff window",
+        )
+    }
+
+    /** The queued after-mount seek is evaluated at maximal staleness; the reset must precede it. */
+    @Test
+    fun `a won mount clears the window facts before re-evaluating queued seeks`() {
+        val body = viewModelSource
+            .substringAfter("fun onTransportMountApplied(")
+            .substringBefore("private fun resetSeekRecoveryForContentChange")
+        val resetIndex = body.indexOf("playerWindowIsSeekable = false")
+        val queuedSeekIndex = body.indexOf("pendingNativeSeekAfterMount?.let")
+
+        assertTrue(
+            resetIndex >= 0,
+            "onTransportMountApplied must clear playerWindowIsSeekable when a mount wins",
+        )
+        assertTrue(
+            queuedSeekIndex > resetIndex,
+            "the window-fact reset must precede the pendingNativeSeekAfterMount " +
+                "re-evaluation, which runs at the moment of maximal staleness",
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
@@ -20,6 +20,7 @@ const val CLIENT_VIDEO_TRANSFORMATIONS_FEATURE = "client_video_transformations_v
 const val DEVICE_QUIRKS_V3_FEATURE = "device_quirks_v1"
 const val SEEK_REANCHOR_V3_FEATURE = "seek_reanchor_v1"
 const val DIRECT_STREAM_RESUME_V1_FEATURE = "direct_stream_resume_v1"
+const val NATIVE_HLS_PLAYBACK_V1_FEATURE = "native_hls_playback_v1"
 
 /**
  * How a capability list was obtained. The server validates strictly against

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/CardPresentation.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/CardPresentation.kt
@@ -1,0 +1,153 @@
+package org.siloserver.silo.model.settings
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.encodeToJsonElement
+
+/**
+ * Wire models for the canonical `ui.card_presentation` setting — the
+ * cross-client "Cards & Posters" preference (poster size + caption style).
+ * The stored value is ALWAYS the complete two-field object; there is no
+ * partial patch or per-field merging, matching iOS
+ * `CardPresentationPreference` and the server contract exactly.
+ */
+
+@Serializable
+enum class CardPosterSize(val raw: String) {
+    @SerialName("compact") Compact("compact"),
+    @SerialName("standard") Standard("standard"),
+    @SerialName("large") Large("large"),
+    ;
+
+    /**
+     * Artwork scale used by free-scrolling rails and standalone cards.
+     * Grids adjust their column count (or adaptive min width) instead so the
+     * selected size never causes overlapping focus frames.
+     */
+    val posterScale: Float
+        get() = when (this) {
+            Compact -> 0.86f
+            Standard -> 1f
+            Large -> 1.2f
+        }
+
+    val displayName: String
+        get() = when (this) {
+            Compact -> "Compact"
+            Standard -> "Standard"
+            Large -> "Large"
+        }
+
+    companion object {
+        fun fromRaw(value: String?): CardPosterSize? =
+            value?.let { v -> entries.firstOrNull { it.raw == v } }
+    }
+}
+
+@Serializable
+enum class CardCaption(val raw: String) {
+    @SerialName("title_metadata") TitleMetadata("title_metadata"),
+    @SerialName("title") Title("title"),
+    @SerialName("artwork") Artwork("artwork"),
+    ;
+
+    /** Gates the title line under every browse/rail/grid card. */
+    val showsTitle: Boolean get() = this != Artwork
+
+    /** Gates the metadata/year line under every browse/rail/grid card. */
+    val showsMetadata: Boolean get() = this == TitleMetadata
+
+    val displayName: String
+        get() = when (this) {
+            TitleMetadata -> "Title & Metadata"
+            Title -> "Title Only"
+            Artwork -> "Artwork Only"
+        }
+
+    companion object {
+        fun fromRaw(value: String?): CardCaption? =
+            value?.let { v -> entries.firstOrNull { it.raw == v } }
+    }
+}
+
+@Serializable
+data class CardPresentation(
+    @SerialName("poster_size") val posterSize: CardPosterSize = CardPosterSize.Standard,
+    val caption: CardCaption = CardCaption.TitleMetadata,
+) {
+    /** The client-side preset this pair matches, or null when "Custom". */
+    val preset: CardPresentationPreset?
+        get() = CardPresentationPreset.entries.firstOrNull { it.presentation == this }
+
+    fun toJsonElement(): JsonElement = json.encodeToJsonElement(this)
+
+    fun serialize(): String = json.encodeToString(serializer(), this)
+
+    companion object {
+        val DEFAULT = CardPresentation()
+
+        // encodeDefaults: the contract requires the complete two-field object
+        // (additionalProperties:false, both fields required), so default-valued
+        // axes must still be written.
+        private val json = Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+        }
+
+        /**
+         * Defensive wire decode: null/malformed JSON or an unknown enum value
+         * (a newer server's `poster_size`/`caption`) yields null so callers
+         * fall back to [DEFAULT] instead of crashing. A missing field decodes
+         * to its default per the contract's whole-object semantics.
+         */
+        fun decodeOrNull(element: JsonElement?): CardPresentation? {
+            if (element == null || element is JsonNull) return null
+            return runCatching { json.decodeFromJsonElement(serializer(), element) }.getOrNull()
+        }
+
+        fun decodeOrNull(raw: String?): CardPresentation? {
+            if (raw.isNullOrBlank()) return null
+            return runCatching { json.decodeFromString(serializer(), raw) }.getOrNull()
+        }
+
+        fun decodeOrDefault(element: JsonElement?): CardPresentation =
+            decodeOrNull(element) ?: DEFAULT
+
+        fun decodeOrDefault(raw: String?): CardPresentation =
+            decodeOrNull(raw) ?: DEFAULT
+    }
+}
+
+/**
+ * Friendly cross-client recipes over the two contract axes. Never on the
+ * wire — the server only ever stores the normalized size/caption object — so
+ * a user can start from a preset and still fine-tune either control. A pair
+ * matching no preset renders as a synthetic "Custom" in pickers
+ * ([CardPresentation.preset] == null).
+ */
+enum class CardPresentationPreset {
+    Balanced,
+    Compact,
+    Cinema,
+    ArtworkOnly,
+    ;
+
+    val presentation: CardPresentation
+        get() = when (this) {
+            Balanced -> CardPresentation.DEFAULT
+            Compact -> CardPresentation(CardPosterSize.Compact, CardCaption.Title)
+            Cinema -> CardPresentation(CardPosterSize.Large, CardCaption.Title)
+            ArtworkOnly -> CardPresentation(CardPosterSize.Large, CardCaption.Artwork)
+        }
+
+    val displayName: String
+        get() = when (this) {
+            Balanced -> "Balanced"
+            Compact -> "Compact"
+            Cinema -> "Cinema"
+            ArtworkOnly -> "Artwork Only"
+        }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/SettingValueModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/settings/SettingValueModels.kt
@@ -16,13 +16,14 @@ import kotlinx.serialization.json.JsonNull
  */
 
 /**
- * The five scopes an explicit value can live at, in the server's wire
+ * The six scopes an explicit value can live at, in the server's wire
  * spelling. Kept as an enum for request construction only — response fields
  * stay raw strings so a server that adds a scope cannot break deserialization.
  */
 enum class SettingScope(val wire: String) {
     ACCOUNT("account"),
     PROFILE("profile"),
+    PROFILE_CLIENT("profile_client"),
     PROFILE_DEVICE("profile_device"),
     PROFILE_LIBRARY("profile_library"),
     PROFILE_SERIES("profile_series"),
@@ -66,6 +67,15 @@ data class SettingScopeIdentity(
 
         fun profile(): SettingScopeIdentity = SettingScopeIdentity(SettingScope.PROFILE)
 
+        /**
+         * Like-client scope: the value roams among devices of the same client
+         * family. Only `scope` travels in the query — the family half of the
+         * identity comes from the `X-Silo-Client-Family` header the auth
+         * interceptor attaches, never from a query parameter.
+         */
+        fun profileClient(): SettingScopeIdentity =
+            SettingScopeIdentity(SettingScope.PROFILE_CLIENT)
+
         fun profileDevice(): SettingScopeIdentity =
             SettingScopeIdentity(SettingScope.PROFILE_DEVICE)
 
@@ -90,6 +100,7 @@ data class SettingsContractCapabilities(
     @SerialName("contract_etag") val contractEtag: String = "",
     @SerialName("definition_count") val definitionCount: Int = 0,
     val scopes: List<String> = emptyList(),
+    @SerialName("client_families") val clientFamilies: List<String> = emptyList(),
     @SerialName("supports_batched_effective") val supportsBatchedEffective: Boolean = false,
     @SerialName("supports_idempotent_writes") val supportsIdempotentWrites: Boolean = false,
 )

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthInterceptorImpl.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthInterceptorImpl.kt
@@ -786,6 +786,7 @@ private suspend fun HttpRequestBuilder.attachSiloDeviceMetadataHeaders(
     device.clientVersion?.takeIf { it.isNotBlank() }?.let { header("X-Silo-Client-Version", it) }
     device.clientBuild?.takeIf { it.isNotBlank() }?.let { header("X-Silo-Client-Build", it) }
     device.clientChannel?.takeIf { it.isNotBlank() }?.let { header("X-Silo-Client-Channel", it) }
+    device.clientFamily?.takeIf { it.isNotBlank() }?.let { header("X-Silo-Client-Family", it) }
 }
 
 private fun URLBuilder.rebaseRelativeApiUrl(serverUrl: String) {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/DeviceMetadataProvider.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/DeviceMetadataProvider.kt
@@ -17,6 +17,14 @@ data class SiloDeviceMetadata(
      * Opaque to the server, which stores it as reported.
      */
     val clientChannel: String? = null,
+    /**
+     * Closed like-client identity for `profile_client`-scoped settings —
+     * one of "tv", "mobile", "tablet", "desktop", "web" (lower-case exact;
+     * the server never derives it from the platform string). Null skips the
+     * `X-Silo-Client-Family` header, which drops the like-client resolution
+     * layer server-side.
+     */
+    val clientFamily: String? = null,
 )
 
 interface DeviceMetadataProvider {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/SettingsRepository.kt
@@ -105,6 +105,64 @@ class SettingsRepository(
             else -> result
         }
 
+    /**
+     * Write one like-client value (`scope=profile_client`) — the preference
+     * that roams among this profile's devices of the same client family. The
+     * family half of the identity rides the `X-Silo-Client-Family` header the
+     * auth interceptor attaches; see [setProfileValue] for the mutation-id
+     * contract.
+     */
+    suspend fun setProfileClientValue(
+        key: String,
+        value: JsonElement,
+        mutationId: String = newSettingMutationId(),
+    ): ApiResult<StoredSettingValue> =
+        settingsApi.putValue(
+            key = key,
+            scope = SettingScopeIdentity.profileClient(),
+            value = value,
+            mutationId = mutationId,
+        )
+
+    suspend fun clearProfileClientValue(key: String): ApiResult<Unit> =
+        treatMissingAsCleared(
+            settingsApi.deleteValue(key, SettingScopeIdentity.profileClient()),
+        )
+
+    /**
+     * Write one device-override value (`scope=profile_device`) — this profile
+     * on this device only. The device half of the identity rides the
+     * `X-Silo-Device-Id` header.
+     */
+    suspend fun setProfileDeviceValue(
+        key: String,
+        value: JsonElement,
+        mutationId: String = newSettingMutationId(),
+    ): ApiResult<StoredSettingValue> =
+        settingsApi.putValue(
+            key = key,
+            scope = SettingScopeIdentity.profileDevice(),
+            value = value,
+            mutationId = mutationId,
+        )
+
+    suspend fun clearProfileDeviceValue(key: String): ApiResult<Unit> =
+        treatMissingAsCleared(
+            settingsApi.deleteValue(key, SettingScopeIdentity.profileDevice()),
+        )
+
+    /**
+     * 404 on a DELETE means nothing was stored there, which is the state the
+     * caller asked for, so it reports success rather than an error the UI
+     * would have to special-case.
+     */
+    private fun treatMissingAsCleared(result: ApiResult<Unit>): ApiResult<Unit> =
+        when (result) {
+            is ApiResult.Error ->
+                if (result.code == 404) ApiResult.Success(Unit) else result
+            else -> result
+        }
+
     suspend fun getEffectiveSubtitleAppearance(): ApiResult<EffectiveSubtitleAppearance> =
         settingsApi.getEffectiveSubtitleAppearance()
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeDiagnostics.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeDiagnostics.kt
@@ -1,0 +1,48 @@
+package org.siloserver.silo.viewmodel
+
+/**
+ * Privacy-safe semantic result of one Home data-source operation.
+ *
+ * The shared ViewModel reports only fixed enums, aggregate counts, and elapsed
+ * time. Platform observers must not receive section IDs, titles, item IDs, or
+ * error messages.
+ */
+data class HomeLoadObservation(
+    val trigger: HomeLoadTrigger,
+    val source: HomeLoadSource,
+    val outcome: HomeLoadOutcome,
+    val durationMs: Long,
+    val sectionCount: Int,
+    val duplicateSectionKeyCount: Int = 0,
+    val duplicateItemRowCount: Int = 0,
+)
+
+enum class HomeLoadTrigger {
+    INITIAL,
+    MANUAL_REFRESH,
+    REALTIME,
+}
+
+enum class HomeLoadSource {
+    CACHE,
+    NETWORK,
+}
+
+enum class HomeLoadOutcome {
+    HIT,
+    MISS,
+    SUCCESS,
+    PARTIAL,
+    API_ERROR,
+    NETWORK_ERROR,
+    SUPERSEDED,
+    SKIPPED,
+}
+
+fun interface HomeDiagnosticsObserver {
+    fun completed(observation: HomeLoadObservation)
+
+    data object None : HomeDiagnosticsObserver {
+        override fun completed(observation: HomeLoadObservation) = Unit
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.TimeSource
 
 data class HomeUiState(
     val isLoading: Boolean = true,
@@ -59,6 +60,7 @@ class HomeViewModel(
     // commonMain/tests network-only; the apps inject the shared coordinator.
     private val homeRealtime: org.siloserver.silo.repository.HomeRealtimeCoordinator? = null,
     private val identityTransitions: IdentityTransitionBarrier = DefaultIdentityTransitionBarrier(),
+    private val diagnostics: HomeDiagnosticsObserver = HomeDiagnosticsObserver.None,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -94,11 +96,24 @@ class HomeViewModel(
      * sections, so overlapping signals are dropped rather than raced.
      */
     fun refreshFromRealtime() {
-        if (realtimeRefreshInFlight || _uiState.value.isRefreshing) return
+        if (realtimeRefreshInFlight || _uiState.value.isRefreshing) {
+            diagnostics.completed(
+                HomeLoadObservation(
+                    trigger = HomeLoadTrigger.REALTIME,
+                    source = HomeLoadSource.NETWORK,
+                    outcome = HomeLoadOutcome.SKIPPED,
+                    durationMs = 0,
+                    sectionCount = _uiState.value.sections.size,
+                    duplicateSectionKeyCount = _uiState.value.sections.duplicateSectionKeyCount(),
+                    duplicateItemRowCount = _uiState.value.sections.duplicateItemRowCount(),
+                ),
+            )
+            return
+        }
         realtimeRefreshInFlight = true
         viewModelScope.launch {
             try {
-                fetchSections()
+                fetchSections(HomeLoadTrigger.REALTIME)
             } finally {
                 realtimeRefreshInFlight = false
             }
@@ -113,25 +128,52 @@ class HomeViewModel(
             // start and publish fresh sections while we are in there, and
             // overlaying the cache on top would put stale rows back on screen.
             val bootstrapGeneration = fetchGeneration
+            val cacheStarted = TimeSource.Monotonic.markNow()
             val cached = homeCache.getCachedHome()
             if (fetchGeneration != bootstrapGeneration) {
-                fetchSections()
+                diagnostics.completed(
+                    HomeLoadObservation(
+                        trigger = HomeLoadTrigger.INITIAL,
+                        source = HomeLoadSource.CACHE,
+                        outcome = HomeLoadOutcome.SUPERSEDED,
+                        durationMs = cacheStarted.elapsedNow().inWholeMilliseconds,
+                        sectionCount = cached?.sections?.size ?: 0,
+                        duplicateSectionKeyCount = cached?.sections?.duplicateSectionKeyCount() ?: 0,
+                        duplicateItemRowCount = cached?.sections?.duplicateItemRowCount() ?: 0,
+                    ),
+                )
+                fetchSections(HomeLoadTrigger.INITIAL)
                 return@launch
             }
+            diagnostics.completed(
+                HomeLoadObservation(
+                    trigger = HomeLoadTrigger.INITIAL,
+                    source = HomeLoadSource.CACHE,
+                    outcome = if (cached != null && cached.sections.isNotEmpty()) {
+                        HomeLoadOutcome.HIT
+                    } else {
+                        HomeLoadOutcome.MISS
+                    },
+                    durationMs = cacheStarted.elapsedNow().inWholeMilliseconds,
+                    sectionCount = cached?.sections?.size ?: 0,
+                    duplicateSectionKeyCount = cached?.sections?.duplicateSectionKeyCount() ?: 0,
+                    duplicateItemRowCount = cached?.sections?.duplicateItemRowCount() ?: 0,
+                ),
+            )
             if (cached != null && cached.sections.isNotEmpty()) {
                 val overlaid = overlayLocalState(cached.sections)
                 _uiState.update { it.copy(isLoading = false, sections = overlaid, error = null) }
             } else {
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
-            fetchSections()
+            fetchSections(HomeLoadTrigger.INITIAL)
         }
     }
 
     fun refresh() {
         viewModelScope.launch {
             _uiState.update { it.copy(isRefreshing = true, error = null) }
-            val generation = fetchSections()
+            val generation = fetchSections(HomeLoadTrigger.MANUAL_REFRESH)
             // Only the newest fetch may clear the flag. A superseded refresh
             // clearing it hides the spinner while a newer fetch is still
             // running, and re-opens refreshFromRealtime's single-flight gate so
@@ -161,13 +203,30 @@ class HomeViewModel(
      * Runs one home fetch and returns the generation it ran as, so callers can
      * tell whether their own work is still the newest before acting on it.
      */
-    private suspend fun fetchSections(): Int {
+    private suspend fun fetchSections(trigger: HomeLoadTrigger): Int {
         val requestIdentityGeneration = identityTransitions.generation.value
         val cacheWriteLease = HomeCacheWriteLease(requestIdentityGeneration)
         // Whether we already have something to show (cached or prior fetch) — if a
         // refresh fails we keep it rather than replacing it with a blocking error.
         val generation = ++fetchGeneration
         val hadSections = _uiState.value.sections.isNotEmpty()
+        val networkStarted = TimeSource.Monotonic.markNow()
+        var observationReported = false
+        fun report(outcome: HomeLoadOutcome, sections: List<ResolvedSection> = emptyList()) {
+            if (observationReported) return
+            observationReported = true
+            diagnostics.completed(
+                HomeLoadObservation(
+                    trigger = trigger,
+                    source = HomeLoadSource.NETWORK,
+                    outcome = outcome,
+                    durationMs = networkStarted.elapsedNow().inWholeMilliseconds,
+                    sectionCount = sections.size,
+                    duplicateSectionKeyCount = sections.duplicateSectionKeyCount(),
+                    duplicateItemRowCount = sections.duplicateItemRowCount(),
+                ),
+            )
+        }
         when (val result = sectionRepository.getHomeSections()) {
             is ApiResult.Success -> {
                 val sections = result.data.sections
@@ -183,7 +242,10 @@ class HomeViewModel(
                 }
                 // Superseded while in flight: a newer fetch has already
                 // answered, so this reply describes a home nobody is looking at.
-                if (generation != fetchGeneration) return generation
+                if (generation != fetchGeneration) {
+                    report(HomeLoadOutcome.SUPERSEDED, sections)
+                    return generation
+                }
                 val resolved = hydration.sections
                 // Don't persist a partially-resolved home over a good cached one.
                 val fullyResolved = hydration.fullyResolved
@@ -205,7 +267,14 @@ class HomeViewModel(
                 // either — so a check taken before them proves only that this
                 // reply was current when it arrived, not that it still is when
                 // it finally writes.
-                if (generation != fetchGeneration) return generation
+                if (generation != fetchGeneration) {
+                    report(HomeLoadOutcome.SUPERSEDED, resolved)
+                    return generation
+                }
+                report(
+                    outcome = if (fullyResolved) HomeLoadOutcome.SUCCESS else HomeLoadOutcome.PARTIAL,
+                    sections = resolved,
+                )
                 _uiState.update {
                     // Only replace what's shown when the fetch fully resolved (or there
                     // was nothing yet) — a partial refresh must not clobber a good Home.
@@ -226,7 +295,10 @@ class HomeViewModel(
             }
             is ApiResult.Error -> {
                 // A superseded fetch's failure is not this home's failure.
-                if (generation != fetchGeneration) return generation
+                if (generation != fetchGeneration) {
+                    report(HomeLoadOutcome.SUPERSEDED)
+                    return generation
+                }
                 _uiState.update {
                     it.copy(
                         isLoading = false,
@@ -235,15 +307,20 @@ class HomeViewModel(
                         error = if (hadSections) null else result.message.ifBlank { "Failed to load home sections" },
                     )
                 }
+                report(HomeLoadOutcome.API_ERROR)
             }
             is ApiResult.NetworkError -> {
-                if (generation != fetchGeneration) return generation
+                if (generation != fetchGeneration) {
+                    report(HomeLoadOutcome.SUPERSEDED)
+                    return generation
+                }
                 _uiState.update {
                     it.copy(
                         isLoading = false,
                         error = if (hadSections) null else "Network error. Check your connection.",
                     )
                 }
+                report(HomeLoadOutcome.NETWORK_ERROR)
             }
         }
         return generation
@@ -334,6 +411,12 @@ class HomeViewModel(
         }
     }
 }
+
+private fun List<ResolvedSection>.duplicateSectionKeyCount(): Int =
+    size - distinctBy(ResolvedSection::id).size
+
+private fun List<ResolvedSection>.duplicateItemRowCount(): Int =
+    count { section -> section.items.size != section.items.distinctBy(SectionItem::contentId).size }
 
 private fun List<ResolvedSection>.mapItem(
     itemId: String,

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/CardPresentationTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/settings/CardPresentationTest.kt
@@ -1,0 +1,116 @@
+package org.siloserver.silo.model.settings
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CardPresentationTest {
+
+    @Test
+    fun wireRoundTrip() {
+        val presentation = CardPresentation(CardPosterSize.Large, CardCaption.Artwork)
+        val decoded = CardPresentation.decodeOrNull(
+            """{"caption":"artwork","poster_size":"large"}""",
+        )
+        assertEquals(presentation, decoded)
+        assertEquals(presentation, CardPresentation.decodeOrNull(presentation.serialize()))
+
+        val element = Json.parseToJsonElement(presentation.serialize())
+        assertEquals(presentation, CardPresentation.decodeOrNull(element))
+        assertEquals(element, presentation.toJsonElement())
+    }
+
+    @Test
+    fun encodeAlwaysWritesBothFields_evenAtDefaults() {
+        // Contract shape is required:[poster_size,caption]; omitting a
+        // default-valued axis would make the server reject the PUT.
+        assertEquals(
+            Json.parseToJsonElement("""{"poster_size":"standard","caption":"title_metadata"}"""),
+            CardPresentation.DEFAULT.toJsonElement(),
+        )
+        assertEquals(
+            Json.parseToJsonElement("""{"poster_size":"standard","caption":"artwork"}"""),
+            CardPresentation(CardPosterSize.Standard, CardCaption.Artwork).toJsonElement(),
+        )
+    }
+
+    @Test
+    fun decodeUnknownEnumValue_fallsBackToDefault() {
+        assertEquals(
+            CardPresentation.DEFAULT,
+            CardPresentation.decodeOrDefault("""{"poster_size":"gigantic","caption":"title"}"""),
+        )
+        assertEquals(
+            CardPresentation.DEFAULT,
+            CardPresentation.decodeOrDefault("""{"poster_size":"large","caption":"emoji"}"""),
+        )
+    }
+
+    @Test
+    fun decodeMalformed_fallsBackToDefault() {
+        assertEquals(CardPresentation.DEFAULT, CardPresentation.decodeOrDefault(null as String?))
+        assertEquals(CardPresentation.DEFAULT, CardPresentation.decodeOrDefault(""))
+        assertEquals(CardPresentation.DEFAULT, CardPresentation.decodeOrDefault("not json"))
+        assertEquals(CardPresentation.DEFAULT, CardPresentation.decodeOrDefault("[1,2]"))
+    }
+
+    @Test
+    fun decodeIgnoresUnknownKeys_andMissingFieldsUseDefaults() {
+        assertEquals(
+            CardPresentation(CardPosterSize.Compact, CardCaption.TitleMetadata),
+            CardPresentation.decodeOrNull("""{"poster_size":"compact","future_axis":true}"""),
+        )
+        assertEquals(CardPresentation.DEFAULT, CardPresentation.decodeOrNull("{}"))
+    }
+
+    @Test
+    fun presetForwardMapping() {
+        assertEquals(
+            CardPresentation(CardPosterSize.Standard, CardCaption.TitleMetadata),
+            CardPresentationPreset.Balanced.presentation,
+        )
+        assertEquals(
+            CardPresentation(CardPosterSize.Compact, CardCaption.Title),
+            CardPresentationPreset.Compact.presentation,
+        )
+        assertEquals(
+            CardPresentation(CardPosterSize.Large, CardCaption.Title),
+            CardPresentationPreset.Cinema.presentation,
+        )
+        assertEquals(
+            CardPresentation(CardPosterSize.Large, CardCaption.Artwork),
+            CardPresentationPreset.ArtworkOnly.presentation,
+        )
+    }
+
+    @Test
+    fun presetReverseMapping_includingCustom() {
+        for (preset in CardPresentationPreset.entries) {
+            assertEquals(preset, preset.presentation.preset)
+        }
+        assertEquals(CardPresentationPreset.Balanced, CardPresentation.DEFAULT.preset)
+        // A pair matching no preset is the synthetic "Custom" state.
+        assertNull(CardPresentation(CardPosterSize.Compact, CardCaption.Artwork).preset)
+        assertNull(CardPresentation(CardPosterSize.Standard, CardCaption.Title).preset)
+    }
+
+    @Test
+    fun posterScaleMatchesAppleClients() {
+        assertEquals(0.86f, CardPosterSize.Compact.posterScale)
+        assertEquals(1f, CardPosterSize.Standard.posterScale)
+        assertEquals(1.2f, CardPosterSize.Large.posterScale)
+    }
+
+    @Test
+    fun captionFlags() {
+        assertTrue(CardCaption.TitleMetadata.showsTitle)
+        assertTrue(CardCaption.TitleMetadata.showsMetadata)
+        assertTrue(CardCaption.Title.showsTitle)
+        assertFalse(CardCaption.Title.showsMetadata)
+        assertFalse(CardCaption.Artwork.showsTitle)
+        assertFalse(CardCaption.Artwork.showsMetadata)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/HomeViewModelCacheIdentityTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/HomeViewModelCacheIdentityTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModelCacheIdentityTest {
@@ -81,6 +82,39 @@ class HomeViewModelCacheIdentityTest {
         viewModel.uiState.first { !it.isLoading }
 
         assertEquals(null, cache.sections)
+    }
+
+    @Test
+    fun homeReportsCacheAndNetworkProvenanceWithoutContentMetadata() = runTest(dispatcher) {
+        val client = HttpClient(
+            MockEngine {
+                respond(
+                    """{"sections":[{"id":"private-section","section_type":"row","title":"Private Title","items":[]}]}""",
+                    HttpStatusCode.OK,
+                    headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        ) {
+            install(ContentNegotiation) { json(SiloJson) }
+        }
+        val observations = mutableListOf<HomeLoadObservation>()
+        val viewModel = HomeViewModel(
+            sectionRepository = SectionRepository(SectionApi(client)),
+            mediaActions = mediaActions(),
+            diagnostics = HomeDiagnosticsObserver(observations::add),
+        )
+
+        viewModel.uiState.first { !it.isLoading }
+
+        assertEquals(
+            listOf(HomeLoadOutcome.MISS, HomeLoadOutcome.SUCCESS),
+            observations.map(HomeLoadObservation::outcome),
+        )
+        assertEquals(listOf(HomeLoadSource.CACHE, HomeLoadSource.NETWORK), observations.map { it.source })
+        assertTrue(observations.all { it.durationMs >= 0 })
+        // The repository removes empty rows during hydration; diagnostics see
+        // only the aggregate resolved count, never the private row metadata.
+        assertEquals(listOf(0, 0), observations.map { it.sectionCount })
     }
 
     private class RecordingHomeCache : HomeCachePort {


### PR DESCRIPTION
## Summary

Brings the server's card presentation controls to the Android phone and TV apps, porting the "Cards & Posters" feature that already ships on iOS/tvOS. Users pick how large media posters render and how much text sits under them, and the choice follows them across their devices — or stays pinned to one device if they want.

This supersedes #255, which hardcoded a larger TV poster size. The reporter of #163 asked to "increase poster size **or give us the option**"; this is that option, and it covers phone as well as TV.

## What it does

The server exposes one canonical setting, `ui.card_presentation`, holding two axes: `poster_size` (`compact` / `standard` / `large`) and `caption` (`title_metadata` / `title` / `artwork`). Both apps surface the same four presets Apple and the web UI offer — **Balanced**, **Compact**, **Cinema**, **Artwork Only** — plus per-axis pickers for fine-tuning, with a synthetic "Custom" entry shown only while the current pair matches no preset.

**Per-device preferences.** Writes default to `profile_client` scope, so a choice roams between like devices on the profile (all your Android TVs share one; a phone and a tablet are independent). An **"Only this device"** toggle writes at `profile_device` instead, which the server resolves ahead of the family and profile layers; turning it off deletes that row so resolution falls back. A "Use profile default" action clears the family value. This required a new `X-Silo-Client-Family` header — Android TV reports `tv`, phone `mobile`, and tablets `tablet` (`smallestScreenWidthDp >= 600`).

**Rendering** follows the Apple semantics exactly: rails and standalone cards scale by 0.86 / 1.0 / 1.2, fixed-column grids shift one column either way, adaptive grids scale their minimum cell width, and the caption axis gates the title line (`caption != artwork`) and the metadata line (`caption == title_metadata`). Skeletons scale with the real cards so nothing reflows when content lands.

On TV, the Skyline row band height is now derived from the scaled card height plus caption rows instead of a fixed `0.50` fraction, so Large cards get room without clipping against the marquee. At the standard preset it reproduces today's 270dp band exactly, and Artwork Only hands space back to the hero.

## Implementation

State lives in a new `CardPresentationStore` in `android-shared`, following the existing `ui.card_overlays` precedent: capability-gated on the settings contract (revision ≥ 5 plus the batched-effective and idempotent-write flags), cached per server/profile/family/device so a cold start paints at the right size, optimistic writes with latest-wins coalescing and rollback on failure. It refreshes on foreground and reconnect alongside the overlay prefs, and clears on sign-out and on in-app profile/server switch. Cards read it through a `LocalCardPresentation` CompositionLocal mounted next to `ProvideCardOverlays` in both navigation roots.

Servers older than contract revision 5 fail closed: the settings section collapses to a read-only "Update your Silo server to customize media cards." row and the apps render the default presentation.

## Test plan

- [x] `./gradlew :androidApp:assembleDebug :androidTvApp:assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — 4134 tests, 0 failures (includes new `CardPresentationTest` covering wire round-trip, defensive decode of unknown enum values, encoder writing both fields even at defaults, and preset ↔ axes mapping)
- [ ] On a device against a live server: switch presets on phone and TV, confirm cards resize and captions appear/disappear across Home, Libraries, For You, Calendar, Search, Requests, and detail rails
- [ ] Confirm "Only this device" pins the choice to one device and that clearing it falls back to the family value
- [ ] Confirm a second device on the same profile and client family picks the change up
- [ ] TV: check D-pad focus and that Large posters don't clip the marquee on Home / Library Recommended / For You

## Notes for review

Two behaviours worth a look. The phone's `CatalogViewDensity` (Comfortable/Normal/Compact) stays an independent per-session library control and multiplies with the preset scale rather than being folded into it. And the "Only this device" toggle performs an immediate `profile_device` write of the current presentation when switched on, because its checked state is derived from the resolved source — without that pin it would snap straight back off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Media Cards settings on Android and Android TV, including poster sizes, caption styles, presets, device-only overrides, and profile-default reset.
  * Card presentation preferences now sync across supported profiles, devices, and client types.
* **Improvements**
  * Media cards, grids, skeletons, calendars, requests, and TV layouts now adapt to selected poster sizes and caption preferences.
  * TV playback improves native seeking within available content and supports dedicated rewind and fast-forward keys.
  * Settings clear appropriately when signing out or switching profiles and servers.
* **Diagnostics**
  * Expanded privacy-safe diagnostics for home loading, lists, scrolling, images, resources, and crash reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->