### PR TITLE
chore(android): give phone debug builds their own applicationId

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -233,6 +233,8 @@ android {
     buildTypes {
         debug {
             buildConfigField("String", "RELEASE_CHANNEL", "\"dev\"")
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
         }
         release {
             buildConfigField("String", "RELEASE_CHANNEL", "\"${siloReleaseChannel.get()}\"")


### PR DESCRIPTION
## Problem

Debug builds of the phone app shared `org.siloserver.silo` with the Play release. Installing a locally built debug APK onto a device that already has the store build fails:

```
INSTALL_FAILED_VERSION_DOWNGRADE: Update version code 14 is older than current 220000030
```

The signatures differ too, so the only way through is to uninstall the release build first — which wipes its login, server configuration, and downloaded media. That is a bad trade for wanting to test a branch on a real device.

## Change

Suffix the **debug** applicationId with `.debug` and the version name with `-debug`:

```kotlin
debug {
    buildConfigField("String", "RELEASE_CHANNEL", "\"dev\"")
    applicationIdSuffix = ".debug"
    versionNameSuffix = "-debug"
}
```

A development build now installs side by side with the release instead of colliding with it.

## Why this is safe

Nothing in the phone app hardcodes the package name:

- Both `<provider>` authorities already interpolate `${applicationId}` (`.androidx-startup`, `.fileprovider`), so they follow the suffix automatically.
- Deep links are scheme-based (`silo://device`, `silo://item`, `silo://play`, …), not package-scoped.
- There is no `google-services.json` pinning a client package.
- `HostedDiagnosticsInstallationManager.appId` stays the canonical `org.siloserver.silo` by design — it identifies the product to the diagnostics service, not the installed package.

Release builds are untouched, so the single Play listing and the phone/TV versionCode split (`base*2` / `base*2+1`) are unaffected.

## Test plan

- [x] `./gradlew :androidApp:assembleDebug` succeeds
- [x] Merged debug manifest reports `package="org.siloserver.silo.debug"`
- [x] Debug APK installs onto a Pixel that already has the Play release, both present afterwards
- [ ] Release build still resolves to `org.siloserver.silo` in CI

## Note for reviewers

`androidTvApp` deliberately does **not** get the same suffix in this PR — the change is scoped to what was actually needed and verified. Worth deciding separately whether TV should match for symmetry; the same "don't fight a Play-installed release" argument applies there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Debug Android builds now use a distinct application identifier and include a `-debug` suffix in the version name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->