### PR TITLE
fix(tv): prefer native mounted transport for quick skips instead of re-anchoring + map seek input + fix second press for seek

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/seek/PlaybackTimelineSeekPolicy.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/seek/PlaybackTimelineSeekPolicy.kt
@@ -143,9 +143,19 @@ fun PlaybackTimeline.seekRestorationMode(): PlaybackSeekRestoration = when (seek
  * [PlaybackTimeline.canSeekAnywhere] is false. With no complete window, the
  * server's explicit `can_seek_anywhere` claim is required; a false claim plus
  * an absent or partial window is deliberately treated as unknown and reanchored.
- * Known bounds remain authoritative even when `can_seek_anywhere` is true.
+ * Known bounds remain authoritative even when `canSeekAnywhere` is true.
+ *
+ * Exception: the caller may prove local seekability itself by passing
+ * [mountedSeekableSourceRange] — the source-time extent the currently mounted
+ * transport provably covers (e.g. an append-only HLS manifest's produced head,
+ * or a stream the player reports as seekable with a known length). A target
+ * inside that extent is a plain `Player.seekTo` even when the published window
+ * is open-ended; only targets the mounted transport cannot serve reanchor.
  */
-fun PlaybackTimeline.decideSeek(targetSourcePositionSeconds: Double): PlaybackSeekDecision {
+fun PlaybackTimeline.decideSeek(
+    targetSourcePositionSeconds: Double,
+    mountedSeekableSourceRange: ClosedRange<Double>? = null,
+): PlaybackSeekDecision {
     require(targetSourcePositionSeconds.isFinite() && targetSourcePositionSeconds >= 0.0) {
         "Seek target must be a finite, non-negative source position."
     }
@@ -175,11 +185,13 @@ fun PlaybackTimeline.decideSeek(targetSourcePositionSeconds: Double): PlaybackSe
         )
     }
     if (!window.complete && !canSeekAnywhere) {
-        return PlaybackSeekDecision.ServerReanchor(
-            targetSourcePositionSeconds = targetSourcePositionSeconds,
-            restoration = restoration,
-            reason = ServerReanchorReason.UnknownSeekWindow,
-        )
+        if (mountedSeekableSourceRange?.contains(targetSourcePositionSeconds) != true) {
+            return PlaybackSeekDecision.ServerReanchor(
+                targetSourcePositionSeconds = targetSourcePositionSeconds,
+                restoration = restoration,
+                reason = ServerReanchorReason.UnknownSeekWindow,
+            )
+        }
     }
 
     val playerPosition = playerPositionForSource(targetSourcePositionSeconds)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/seek/PlaybackTimelineSeekPolicyTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/seek/PlaybackTimelineSeekPolicyTest.kt
@@ -161,6 +161,7 @@ class PlaybackTimelineSeekPolicyTest {
         assertEquals(ServerReanchorReason.InvalidTimelineMapping, reanchor.reason)
     }
 
+    /** An open server window cannot override a proven mounted extent: targets inside it seek natively. */
     @Test
     fun mountedExtentHintAllowsNativeSeekInsideAnOpenWindow() {
         val decision = PlaybackTimeline(
@@ -175,6 +176,7 @@ class PlaybackTimelineSeekPolicyTest {
         assertEquals(PlaybackSeekRestoration.SourcePosition, native.restoration)
     }
 
+    /** Beyond the mounted extent the hint proves nothing, so the conservative server reanchor applies. */
     @Test
     fun mountedExtentHintDoesNotCoverTargetsBeyondTheProvedExtent() {
         val decision = PlaybackTimeline(
@@ -188,6 +190,7 @@ class PlaybackTimelineSeekPolicyTest {
         assertEquals(ServerReanchorReason.UnknownSeekWindow, reanchor.reason)
     }
 
+    /** The hint never overrides published window bounds: below the window start still reanchors. */
     @Test
     fun mountedExtentHintCannotRescueTargetsOutsideThePublishedWindow() {
         val decision = PlaybackTimeline(

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/seek/PlaybackTimelineSeekPolicyTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/seek/PlaybackTimelineSeekPolicyTest.kt
@@ -160,4 +160,44 @@ class PlaybackTimelineSeekPolicyTest {
         val reanchor = assertIs<PlaybackSeekDecision.ServerReanchor>(decision)
         assertEquals(ServerReanchorReason.InvalidTimelineMapping, reanchor.reason)
     }
+
+    @Test
+    fun mountedExtentHintAllowsNativeSeekInsideAnOpenWindow() {
+        val decision = PlaybackTimeline(
+            timelineOffsetSeconds = 120.0,
+            canSeekAnywhere = false,
+            seekWindowStartSeconds = 120.0,
+            seekRestoration = "source_position",
+        ).decideSeek(150.0, mountedSeekableSourceRange = 120.0..240.0)
+
+        val native = assertIs<PlaybackSeekDecision.NativeSeek>(decision)
+        assertEquals(30.0, native.targetPlayerPositionSeconds)
+        assertEquals(PlaybackSeekRestoration.SourcePosition, native.restoration)
+    }
+
+    @Test
+    fun mountedExtentHintDoesNotCoverTargetsBeyondTheProvedExtent() {
+        val decision = PlaybackTimeline(
+            timelineOffsetSeconds = 120.0,
+            canSeekAnywhere = false,
+            seekWindowStartSeconds = 120.0,
+            seekRestoration = "source_position",
+        ).decideSeek(300.0, mountedSeekableSourceRange = 120.0..240.0)
+
+        val reanchor = assertIs<PlaybackSeekDecision.ServerReanchor>(decision)
+        assertEquals(ServerReanchorReason.UnknownSeekWindow, reanchor.reason)
+    }
+
+    @Test
+    fun mountedExtentHintCannotRescueTargetsOutsideThePublishedWindow() {
+        val decision = PlaybackTimeline(
+            timelineOffsetSeconds = 120.0,
+            canSeekAnywhere = false,
+            seekWindowStartSeconds = 120.0,
+            seekRestoration = "source_position",
+        ).decideSeek(60.0, mountedSeekableSourceRange = 0.0..240.0)
+
+        val reanchor = assertIs<PlaybackSeekDecision.ServerReanchor>(decision)
+        assertEquals(ServerReanchorReason.OutsideSeekWindow, reanchor.reason)
+    }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyAction.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyAction.kt
@@ -73,6 +73,29 @@ internal fun tvPlayerRemoteKeyAction(
             else -> TvPlayerRemoteKeyAction.ConsumeOnly
         }
 
+    // Dedicated transport seek keys (the Shield remote's rewind/fast-forward
+    // buttons, Bluetooth and IR seek keys). Unlike Left/Right these are never
+    // focus navigation, so they skip in every surface state and deliberately
+    // ignore `dpadHorizontalSeek`. Mapping them here is also what makes the
+    // FIRST press seek: left unmapped, the player bridge's null-action branch
+    // only reveals the transport controls and swallows the event, so the user
+    // must press twice. UP halves and auto-repeats are consumed so the system
+    // media-key fallback can't seek a second time (same contract as
+    // PlayPause above).
+    KeyEvent.KEYCODE_MEDIA_REWIND,
+    KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD,
+    -> when {
+        action == KeyEvent.ACTION_DOWN && repeatCount == 0 -> TvPlayerRemoteKeyAction.SkipBack
+        else -> TvPlayerRemoteKeyAction.ConsumeOnly
+    }
+
+    KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
+    KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD,
+    -> when {
+        action == KeyEvent.ACTION_DOWN && repeatCount == 0 -> TvPlayerRemoteKeyAction.SkipForward
+        else -> TvPlayerRemoteKeyAction.ConsumeOnly
+    }
+
     KeyEvent.KEYCODE_MENU,
     KeyEvent.KEYCODE_SETTINGS,
     -> if (action == KeyEvent.ACTION_UP) TvPlayerRemoteKeyAction.OpenSettingsHud else null

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyAction.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyAction.kt
@@ -25,6 +25,24 @@ internal enum class TvPlayerRemoteKeyAction {
     ConsumeOnly,
 }
 
+/**
+ * Maps one remote key event onto the player's intent vocabulary, or null when
+ * the key is not ours (focus navigation and unhandled keys fall through).
+ *
+ * Media play/pause acts on the first DOWN and consumes UP halves and
+ * auto-repeats so the system media-key fallback cannot act on them twice.
+ * Left/Right quick-skip only while [dpadHorizontalSeek] allows it — with a
+ * focus-owning surface (transport overlay, HUD, Up Next) up, they belong to
+ * Compose focus navigation. The dedicated transport seek keys
+ * (rewind/fast-forward/skip) are never focus navigation, so they skip in
+ * every surface state and deliberately ignore [dpadHorizontalSeek]. Down
+ * focuses the transport, or opens the playback HUD from clean playback when
+ * [dpadDownOpensHud] is set; Menu/Settings open the settings HUD on key UP.
+ *
+ * A null action is what lets the player bridge reveal the controls for an
+ * unknown key from clean playback and swallow the press — so every key that
+ * must act on the FIRST press has to be mapped here.
+ */
 internal fun tvPlayerRemoteKeyAction(
     keyCode: Int,
     action: Int,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -77,6 +77,7 @@ import androidx.media3.common.Format
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
+import androidx.media3.common.Timeline
 import androidx.media3.common.VideoSize
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
@@ -1544,17 +1545,35 @@ fun TvPlayerScreen(
     // Position polling — lifecycle-bounded so it doesn't outlive the screen.
     LaunchedEffect(mediaController, state.sessionId, lifecycleOwner) {
         val controller = mediaController ?: return@LaunchedEffect
+        val timelineWindow = Timeline.Window()
         lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
             while (isActive && state.sessionId != null) {
                 viewModel.onPositionChanged(
                     controller.currentPosition,
                     controller.duration.coerceAtLeast(0L),
                 )
+                // Mounted-transport extent for the VM's native-first seek
+                // decision (see TvPlayerViewModel.mountedSeekableSourceRange).
+                // A seekable window with a known length can serve any target
+                // it spans without a server reanchor.
+                if (!controller.currentTimeline.isEmpty) {
+                    controller.currentTimeline.getWindow(
+                        controller.currentMediaItemIndex,
+                        timelineWindow,
+                    )
+                    viewModel.onPlayerWindowChanged(
+                        isSeekable = timelineWindow.isSeekable,
+                        windowEndPlayerMs = if (timelineWindow.durationUs != C.TIME_UNSET) {
+                            timelineWindow.durationUs / 1000
+                        } else {
+                            -1L
+                        },
+                    )
+                }
                 delay(500)
             }
         }
     }
-
     LaunchedEffect(
         mediaController,
         state.sessionId,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -931,6 +931,13 @@ class TvPlayerViewModel(
     private var seekSequence = 0L
     private var activeSeekId: Long? = null
     private var hasRenderedFirstFrame = false
+    // Mounted-transport extent reported by the screen's position poll: whether
+    // the current Media3 window is seekable and how far it reaches in
+    // player-local time (-1 = unknown/unset). Feeds
+    // [mountedSeekableSourceRange] so decideSeek can ride the mounted content
+    // for quick skips instead of re-anchoring through the server.
+    private var playerWindowIsSeekable = false
+    private var playerWindowEndPlayerMs = -1L
 
     data class UiState(
         val isLoading: Boolean = true,
@@ -2685,6 +2692,18 @@ class TvPlayerViewModel(
         )?.index
     }
 
+    /**
+     * Mounted-transport facts from the screen's 500ms poll (the VM stays free
+     * of MediaController references — the screen owns the player, the same
+     * split as [onPositionChanged]). Read by [mountedSeekableSourceRange] at
+     * seek-commit time; a slightly stale window end only ever costs an
+     * unnecessary reanchor, never a wrongly-native seek.
+     */
+    fun onPlayerWindowChanged(isSeekable: Boolean, windowEndPlayerMs: Long) {
+        playerWindowIsSeekable = isSeekable
+        playerWindowEndPlayerMs = windowEndPlayerMs
+    }
+
     fun onPositionChanged(positionMs: Long, durationMs: Long) {
         if (positionMs < 0) return
         // A new recovery response updates the source/player timeline before Compose can run the
@@ -3136,7 +3155,13 @@ class TvPlayerViewModel(
             )
             return
         }
-        when (val decision = state.playbackPlan?.timeline?.decideSeek(targetSourceSec)) {
+        val mountedSeekableSourceRange = mountedSeekableSourceRange(state)
+        when (
+            val decision = state.playbackPlan?.timeline?.decideSeek(
+                targetSourceSec,
+                mountedSeekableSourceRange,
+            )
+        ) {
             is PlaybackSeekDecision.ServerReanchor -> {
                 Log.i(
                     TAG,
@@ -3150,12 +3175,33 @@ class TvPlayerViewModel(
                     TAG,
                     "seek_commit seek_id=$activeSeekId action=native " +
                         "target_source_seconds=$targetSourceSec " +
-                        "target_player_seconds=${decision.targetPlayerPositionSeconds}",
+                        "target_player_seconds=${decision.targetPlayerPositionSeconds}" +
+                        (mountedSeekableSourceRange?.let {
+                            " mounted_source_range=${it.start}..${it.endInclusive}"
+                        } ?: ""),
                 )
                 seekRequestChannel.trySend(decision.targetPlayerPositionSeconds)
             }
             null -> seekRequestChannel.trySend(targetSourceSec)
         }
+    }
+
+    /**
+     * Source-time extent the currently mounted transport provably covers, or
+     * null when that cannot be proven. Derived from the Media3 window the
+     * screen polls: a seekable window with a known length can serve any
+     * position it spans as a plain `Player.seekTo`. That covers append-only
+     * (growing) HLS manifests — whose window end is the produced head — and
+     * completed/indexed streams, while a growing progressive copy remux has
+     * no known length and stays excluded. This is what lets quick skips ride
+     * already-mounted content instead of re-anchoring through the server.
+     */
+    private fun mountedSeekableSourceRange(state: UiState): ClosedRange<Double>? {
+        val timeline = state.playbackPlan?.timeline ?: return null
+        if (!playerWindowIsSeekable || playerWindowEndPlayerMs < 0) return null
+        val endSourceSec = timeline.sourcePositionForPlayer(playerWindowEndPlayerMs / 1000.0)
+            ?: return null
+        return timeline.timelineOffsetSeconds..endSourceSec
     }
 
     private fun startSeekReanchor(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -3147,6 +3147,17 @@ class TvPlayerViewModel(
         if (activeSeekId == null) activeSeekId = ++seekSequence
     }
 
+    /**
+     * Commits a settled seek target (source time) onto the active transport.
+     *
+     * Routing ladder: with no session/plan yet the target parks in
+     * [pendingNativeSeekAfterMount] until the mount wins; with seek recovery
+     * or a mount in flight it queues as a reanchor; otherwise
+     * [decideSeek][org.siloserver.silo.common.player.seek.decideSeek] picks
+     * between a native `Player.seekTo` (fed the mounted transport's proven
+     * extent from [mountedSeekableSourceRange]) and a protocol-V3 server
+     * reanchor. A missing plan timeline falls through to a raw player seek.
+     */
     private fun executeSeekTarget(targetSourceSec: Double) {
         val state = _uiState.value
         if (transportMountGate.suppressPositionReports &&

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -1775,6 +1775,15 @@ class TvPlayerViewModel(
      */
     fun onTransportMountApplied(nonce: Long) {
         if (transportMountGate.applied(nonce)) {
+            // The mounted item was replaced. Facts from the previous
+            // transport's window must not be mapped through the new plan's
+            // timeline offset — that can overstate the new extent and turn a
+            // target the new transport cannot serve into a silent,
+            // wrong-position native seek. The next poll tick (≤500ms)
+            // repopulates from the mounted item; until then the hint is
+            // absent, which at worst costs an unnecessary reanchor.
+            playerWindowIsSeekable = false
+            playerWindowEndPlayerMs = -1L
             pendingNativeSeekAfterMount?.let { targetSeconds ->
                 pendingNativeSeekAfterMount = null
                 // Re-evaluate against the plan that actually won the load;
@@ -2696,10 +2705,20 @@ class TvPlayerViewModel(
      * Mounted-transport facts from the screen's 500ms poll (the VM stays free
      * of MediaController references — the screen owns the player, the same
      * split as [onPositionChanged]). Read by [mountedSeekableSourceRange] at
-     * seek-commit time; a slightly stale window end only ever costs an
+     * seek-commit time. Two staleness rules keep the hint honest:
+     *
+     * - Reports are dropped while [transportMountGate] is suppressing: they
+     *   describe the OLD MediaItem, and mapping them through the new plan's
+     *   timeline offset would overstate the new transport's extent.
+     * - [onTransportMountApplied] clears the facts when a mount wins, so
+     *   until the next poll tick reads the new item the hint is absent and
+     *   ambiguous targets fall back to a server reanchor.
+     *
+     * Within one mounted item a slightly stale window end only ever costs an
      * unnecessary reanchor, never a wrongly-native seek.
      */
     fun onPlayerWindowChanged(isSeekable: Boolean, windowEndPlayerMs: Long) {
+        if (transportMountGate.suppressPositionReports) return
         playerWindowIsSeekable = isSeekable
         playerWindowEndPlayerMs = windowEndPlayerMs
     }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyActionTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyActionTest.kt
@@ -170,6 +170,7 @@ class TvPlayerRemoteKeyActionTest {
         )
     }
 
+    /** Unmapped keys only reveal controls on first press; these must skip, with repeats/UP consumed. */
     @Test
     fun mediaSeekKeysSkipOnTheFirstPressAndSwallowTheRest() {
         // First press must SKIP — unmapped, the player bridge only reveals
@@ -209,6 +210,7 @@ class TvPlayerRemoteKeyActionTest {
         }
     }
 
+    /** Media transport keys are never focus navigation, so dpadHorizontalSeek gating must not silence them. */
     @Test
     fun mediaSeekKeysSkipEvenWhenTheIdleOverlayOwnsFocus() {
         // Media transport keys are never focus navigation, so they are not

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyActionTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerRemoteKeyActionTest.kt
@@ -171,6 +171,64 @@ class TvPlayerRemoteKeyActionTest {
     }
 
     @Test
+    fun mediaSeekKeysSkipOnTheFirstPressAndSwallowTheRest() {
+        // First press must SKIP — unmapped, the player bridge only reveals
+        // the transport for an unknown key and the user has to press twice.
+        listOf(
+            KeyEvent.KEYCODE_MEDIA_REWIND to TvPlayerRemoteKeyAction.SkipBack,
+            KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD to TvPlayerRemoteKeyAction.SkipBack,
+            KeyEvent.KEYCODE_MEDIA_FAST_FORWARD to TvPlayerRemoteKeyAction.SkipForward,
+            KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD to TvPlayerRemoteKeyAction.SkipForward,
+        ).forEach { (keyCode, expectedSkip) ->
+            assertEquals(
+                expectedSkip,
+                tvPlayerRemoteKeyAction(
+                    keyCode = keyCode,
+                    action = KeyEvent.ACTION_DOWN,
+                    repeatCount = 0,
+                ),
+            )
+            // Auto-repeat and the UP half are consumed so the system
+            // media-key fallback can't seek a second time.
+            assertEquals(
+                TvPlayerRemoteKeyAction.ConsumeOnly,
+                tvPlayerRemoteKeyAction(
+                    keyCode = keyCode,
+                    action = KeyEvent.ACTION_DOWN,
+                    repeatCount = 1,
+                ),
+            )
+            assertEquals(
+                TvPlayerRemoteKeyAction.ConsumeOnly,
+                tvPlayerRemoteKeyAction(
+                    keyCode = keyCode,
+                    action = KeyEvent.ACTION_UP,
+                    repeatCount = 0,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun mediaSeekKeysSkipEvenWhenTheIdleOverlayOwnsFocus() {
+        // Media transport keys are never focus navigation, so they are not
+        // gated by dpadHorizontalSeek the way Left/Right are.
+        listOf(
+            KeyEvent.KEYCODE_MEDIA_REWIND to TvPlayerRemoteKeyAction.SkipBack,
+            KeyEvent.KEYCODE_MEDIA_FAST_FORWARD to TvPlayerRemoteKeyAction.SkipForward,
+        ).forEach { (keyCode, expectedSkip) ->
+            assertEquals(
+                expectedSkip,
+                tvPlayerIdleOverlayRemoteKeyAction(
+                    keyCode = keyCode,
+                    action = KeyEvent.ACTION_DOWN,
+                    repeatCount = 0,
+                ),
+            )
+        }
+    }
+
+    @Test
     fun visibleIdleOverlayLeftAndRightFallThroughToFocusNavigation() {
         // With the transport overlay visible, Left/Right must reach Compose
         // focus navigation (scrubber ticks, transport-cluster movement) —

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerWindowFactInvalidationTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerWindowFactInvalidationTest.kt
@@ -1,0 +1,50 @@
+package org.siloserver.silo.tv.ui.screens.player
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The mounted-window facts feeding decideSeek's mountedSeekableSourceRange
+ * hint describe exactly one Media3 item. They must be dropped while a
+ * transport handoff suppresses reports and cleared when a mount wins —
+ * otherwise a stale extent maps through the new plan's timeline offset and a
+ * target the new transport cannot serve becomes a silent, wrong-position
+ * native seek.
+ */
+class TvPlayerWindowFactInvalidationTest {
+    private val viewModelSource = File(
+        "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt",
+    ).readText()
+
+    @Test
+    fun `window facts are not recorded while a transport handoff suppresses reports`() {
+        val body = viewModelSource
+            .substringAfter("fun onPlayerWindowChanged(")
+            .substringBefore("fun onPositionChanged(")
+
+        assertTrue(
+            "suppressPositionReports" in body,
+            "onPlayerWindowChanged must drop old-item facts during the handoff window",
+        )
+    }
+
+    @Test
+    fun `a won mount clears the window facts before re-evaluating queued seeks`() {
+        val body = viewModelSource
+            .substringAfter("fun onTransportMountApplied(")
+            .substringBefore("private fun resetSeekRecoveryForContentChange")
+        val resetIndex = body.indexOf("playerWindowIsSeekable = false")
+        val queuedSeekIndex = body.indexOf("pendingNativeSeekAfterMount?.let")
+
+        assertTrue(
+            resetIndex >= 0,
+            "onTransportMountApplied must clear playerWindowIsSeekable when a mount wins",
+        )
+        assertTrue(
+            queuedSeekIndex > resetIndex,
+            "the window-fact reset must precede the pendingNativeSeekAfterMount " +
+                "re-evaluation, which runs at the moment of maximal staleness",
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerWindowFactInvalidationTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerWindowFactInvalidationTest.kt
@@ -17,6 +17,7 @@ class TvPlayerWindowFactInvalidationTest {
         "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt",
     ).readText()
 
+    /** Old-item window facts recorded during a handoff would map through the new plan's offset. */
     @Test
     fun `window facts are not recorded while a transport handoff suppresses reports`() {
         val body = viewModelSource
@@ -29,6 +30,7 @@ class TvPlayerWindowFactInvalidationTest {
         )
     }
 
+    /** The queued after-mount seek is evaluated at maximal staleness; the reset must precede it. */
     @Test
     fun `a won mount clears the window facts before re-evaluating queued seeks`() {
         val body = viewModelSource


### PR DESCRIPTION
## Problem

Android TV: pressing D-pad left/right during playback shows the
buffering spinner and forces a server round trip that restreams the content,
while the remote's rewind/fast-forward buttons jump instantly using locally
mounted content.

### TL;DR and what you'll notice as a user:

 - D-pad left/right skips are instant. Within the content the player already has, skips no longer show the buffer screen or hit the server — they're plain local seeks (usually measured @ ~0.1–0.5 s).
   Previously every skip re-requested the stream from the server.
 - The rewind/fast-forward buttons work on the first press. Previously the first press just pulled up the controls and you had to press again.
 - Those buttons now skip the same amounts as the on-screen buttons (−10 s / +30 s) instead of Media3's ±5/±15 s defaults.
 - In Watch Together rooms, the rewind/FF buttons no longer desync the room and they now respect the same gating as everything else.

Two cooperating causes:

1. For growing-HLS transcodes and copy-remux transports, the server publishes
   an open-ended seek window with `can_seek_anywhere=false` (it cannot keep the
   produced head current, and web clients would 404 past it — see the growing-
   manifest branch and `configureCopyRemuxTimelineV3` in `playback_v3.go`).
   The client's `decideSeek` therefore returned `ServerReanchor` for every
   seek on those transports: buffering UI, a protocol-V3 `seek_reanchor` round
   trip, and a remount — even when the target sat inside content the player
   already had mounted.
2. `KEYCODE_MEDIA_REWIND` / `KEYCODE_MEDIA_FAST_FORWARD` were unmapped, so the
   player bridge's null-action branch only revealed the transport controls and
   swallowed the first press (users had to press twice to seek), and the
   second press fell through to Media3's session-level `seekBack`/
   `seekForward`, bypassing the route-aware seek path and the Watch Together
   room transport gate.

## Approach

Three commits; the second and third are separable if you prefer them
standalone.

1. `33feccdf` — `decideSeek` gains an optional `mountedSeekableSourceRange`:
   the source-time extent the currently mounted transport provably covers.
   The TV screen reports the Media3 window's seekability and length alongside
   its existing 500 ms position poll; a target inside that range is a plain
   `Player.seekTo`. The hint is only claimed when the window is seekable with
   a known length, which covers append-only HLS manifests (window end =
   produced head), completed transcodes, and indexed streams; a growing
   progressive copy remux has no known length and stays excluded. Targets the
   mounted transport cannot serve — before the stream origin, past the
   produced head — still reanchor, and the existing same-route reanchor
   recovery (404/410/416) remains the fallback for native seeks that fail.
   The parameter is optional, so the audiobook and Cast call sites are
   unchanged.
2. `dc234833` — map REWIND/FAST_FORWARD/SKIP_BACKWARD/SKIP_FORWARD to
   `SkipBack`/`SkipForward`. They ignore `dpadHorizontalSeek` because they
   are never focus navigation, and UP halves plus auto-repeats are consumed
   so the system media-key fallback cannot seek a second time.
3. `328d12b3` — invalidate the mounted-window facts when the transport is
   replaced. The facts describe exactly one Media3 item: reports are dropped
   while the transport mount gate suppresses position reports (the same guard
   `onPositionChanged` applies), and a won mount clears them before the
   queued after-mount seek is re-evaluated. Without this, the previous
   transport's window end maps through the new plan's timeline offset and can
   overstate the new extent — a target the new transport cannot serve becomes
   a silent, wrong-position native seek with no error and no self-heal. Until
   the next poll tick (≤500 ms) the hint is simply absent, which at worst
   costs an unnecessary reanchor.

Behavioral changes, end to end:

- Quick skips within the mounted transport's proven extent no longer hit the
  server: no buffering screen, no `seek_reanchor` call, no remount. Skips the
  mounted transport cannot serve reanchor exactly as before.
- The remote's rewind/fast-forward keys seek on the first press, take the
  same route-aware path as D-pad, and skip −10 s/+30 s matching the on-screen
  transport labels instead of Media3's default ±5/±15 s session increments.
- In Watch Together rooms, media-key seeks now pass the room transport gate
  instead of forking playback.
- After a remount (reanchor, subtitle/audio replan, content switch), seeks
  commit only once the new transport's window is known; the handoff window
  degrades to a reanchor rather than a guess.

Alternatives considered and rejected: flipping `can_seek_anywhere` server-side
for event playlists (web clients seek past the produced head and 404); waiting
for the manifest head to grow on short overshoots (stall/latency risk for
marginal gain — reanchor already settles in about a second).

## Validation

- `./gradlew :android-shared:testDebugUnitTest --tests "org.siloserver.silo.common.player.seek.PlaybackTimelineSeekPolicyTest" :androidTvApp:testDebugUnitTest --tests
"org.siloserver.silo.tv.ui.screens.player.TvPlayerRemoteKeyActionTest" --tests "org.siloserver.silo.tv.ui.screens.player.TvPlayerWindowFactInvalidationTest"`
  → BUILD SUCCESSFUL. Adds 3 policy tests (hint allows native inside an open
  window; hint does not cover targets beyond the proved extent; hint cannot
  rescue targets outside the published window), 2 key-mapping tests (first
  press skips, repeat/UP consumed; media keys skip even when the idle overlay
  owns focus), and 2 invariant tests locking the mounted-window-fact
  invalidation (handoff suppression; won-mount reset ordered before the
  queued-seek re-evaluation).
- `./gradlew :androidTvApp:compileDebugKotlin :android-shared:compileDebugUnitTestKotlin`
  → success.
- `./gradlew :androidTvApp:assembleDebug`, installed on a Shield over ADB and
  exercised by hand on a growing-HLS episode (build at
  `33feccdf`+`dc234833`). 48 seeks in the logcat trace: 32 committed
  `action=native` with a non-null `mounted_source_range` (settle 85–500 ms,
  no server interaction); 16 reanchor-class commits, only for targets before
  the stream origin (`OutsideSeekWindow`) or past the produced head
  (`UnknownSeekWindow`), each settling in ~0.8–1.3 s; 0 `PlaybackException`s.
  The final build (`328d12b3`) additionally invalidates the window facts
  across remounts — that path degrades to the reanchor behavior this trace
  already exercises. Representative excerpt (raw):

  ```
  I/TvPlayerViewModel: seek_commit seek_id=23 action=native target_source_seconds=415.921 target_player_seconds=38.044 mounted_source_range=377.877..435.935
  I/TvPlayerViewModel: seek_settled seek_id=23 target_source_seconds=415.921 actual_source_seconds=416.117
  I/TvPlayerViewModel: seek_commit seek_id=32 action=server_reanchor target_source_seconds=370.427 reason=OutsideSeekWindow
  I/TvPlayerViewModel: seek_settled seek_id=32 target_source_seconds=370.427 actual_source_seconds=370.426
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - TV media rewind, skip, and fast-forward keys now support single-press seeking across player states.
  - Seeking within already loaded, seekable content now responds more quickly without unnecessary server re-anchoring.

- **Bug Fixes**
  - Prevented stale playback-window information from affecting seeks during transport changes.
  - Improved handling of seek targets outside the currently available playback range.
  - Auto-repeat and key-release events no longer trigger duplicate seek actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->