### PR TITLE
fix(tv): keep the skyline rail animations after entering detail

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.overlays.OverlayData
 import org.siloserver.silo.overlays.OverlayDataExtractor
+import org.siloserver.silo.tv.ui.focus.TvFocusLog
 import org.siloserver.silo.tv.ui.theme.TvRailScrollBehavior
 import org.siloserver.silo.tv.ui.theme.tvRailPinOnFocus
 import org.siloserver.silo.tv.ui.theme.Spacing
@@ -160,12 +161,22 @@ fun TvMediaRow(
     }
 
     LaunchedEffect(restoreFocusRequest, resolvedRestoreFocusIndex, restoreFocusContentId) {
-        prepareTvMediaRowFocusRestore(
+        val scrolled = prepareTvMediaRowFocusRestore(
             requestId = restoreFocusRequest,
             restoreFocusIndex = resolvedRestoreFocusIndex,
             itemCount = rowItems.size,
             scrollToItem = rowState::scrollToItem,
         )
+        // A restore scroll that fires while no caller-driven ladder could be
+        // running is the signature of the rail snapping instead of gliding
+        // (the instant jump cancels the pin's animation) — surface it in the
+        // debug focus log rather than leaving it invisible on screen.
+        if (restoreFocusRequest > 0 || scrolled) {
+            TvFocusLog.d {
+                "rail restore scroll request=$restoreFocusRequest " +
+                    "index=$resolvedRestoreFocusIndex scrolled=$scrolled"
+            }
+        }
     }
 
     LaunchedEffect(firstItemFocusRequest) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -830,7 +830,20 @@ fun TvSkylineSectionFeed(
                             // moved horizontally can otherwise sit outside the
                             // composed window, leaving the requester unattached
                             // and every retry doomed.
-                            restoreFocusRequest = if (isReturnRow) returnRestoreRequest else 0,
+                            //
+                            // Gated on a ladder being IN FLIGHT, not on the row
+                            // merely being the return row: the pending target is
+                            // re-armed by every focus move and the counter
+                            // outlives its ladder, so an ungated request
+                            // re-fired the row's instant restore scrollToItem on
+                            // every focus move after a detail round trip —
+                            // cancelling the rail pin's animated glide. Ordinary
+                            // row rendering must never move the row.
+                            restoreFocusRequest = if (isReturnRow && restorationsInFlight > 0) {
+                                returnRestoreRequest
+                            } else {
+                                0
+                            },
                             restoreFocusRequester = detailReturnItemFocusRequester
                                 .takeIf { isReturnRow },
                             onItemFocusedAtIndex = { item, itemIndex ->


### PR DESCRIPTION
## Problem

`Home` and `For You` render their card rows through `TvSkylineSectionFeed` → `TvMediaRow`. A focused card pins itself with a 480 ms animated glide (`tvRailPinOnFocus` → `tvRailPinItem`) — the only horizontal scroll a focus change triggers; the row's automatic bring-into-view is deliberately zeroed by `TvRailScrollBehavior` to keep one motion per press.

On first launch, moving between cards in Continue Watching glides as designed. After opening any item from a row into the detail page and backing out, every later left/right press in any row snaps instantly — the glide is gone for the rest of the Home session. It returns only after the feed is disposed again (e.g. a tab switch) and dies on the next detail round trip. For You is affected identically (same component).

## Approach

Three facts combined:

1. `TvSkylineSectionFeed.returnRestoreRequest` is a plain-`remember` counter bumped when a return-restore ladder starts, never reset for the feed's lifetime.
2. The detail round trip runs the recreation/shell-return ladders once, leaving the counter stuck `≥ 1`.
3. `onItemFocused` deliberately re-arms `detailReturnPending = true` on every focus move (the browse-re-arm contract), so the focused row keeps qualifying as the return row.

With the request passed ungated, every post-return focus move re-fired `TvMediaRow`'s restore `LaunchedEffect` (keyed on the resolved index/contentId, which change per move) and ran an instant `rowState.scrollToItem(...)`. A default-priority jump wins the `LazyListState` mutator mutex and cancels the running `animateScrollBy`, so the pin never animates.

The fix narrows one argument: pass `returnRestoreRequest` only while a ladder is actually in flight (`restorationsInFlight > 0`) — the only situation the instant row scroll exists for, composing a ladder's destination card into the horizontal window before focus is requested on it. After the ladder ends, ordinary rendering never moves the row, which is the contract
`TvMediaRow` already documents on that parameter.

Alternatives considered: resetting the counter at ladder end reads the same from the row but adds a second mutation point while the parameter would still mean "pending" and behave "idle"; the in-flight gate keeps the counter's single-writer semantics. `restoreFocusRequester` attachment deliberately stays pending-gated — the shell's content restorer uses that node
as its enter fallback through the whole round trip.

Also added a `TvFocusLog` line in `TvMediaRow` when a restore scroll fires. This failure class is invisible on screen (it reads as "animations gone"); the log makes the signature `request > 0` outside a ladder, per-move lines after a round trip — observable via `adb logcat -s SiloTvFocus`.

## Validation

- `./gradlew :androidTvApp:assembleDebug` (JDK 21 + Android SDK via the repo nix env) → exit 0, APKs emitted.
- Focused test: `./gradlew :androidTvApp:testDebugUnitTest --tests "org.siloserver.silo.tv.ui.components.TvMediaRowFocusRestoreTest"` → exit 0. The scroll executor
`prepareTvMediaRowFocusRestore` is unchanged; its existing tests still pass.
- Device: NVIDIA Shield over network ADB, fixed arm64 debug APK installed, Home driven with D-pad input. The owner reproduced the snap after a detail round trip on the build before this
change; on the fixed build the glide survives the round trip (confirmed on hardware).
- `adb logcat -s SiloTvFocus` on the fixed build across several detail round trips plus ordinary browsing — restore scrolls only at return moments, none during focus moves:

```
08-29 19:26:04.906  7836  7836 D SiloTvFocus: rail restore scroll request=1 index=0 scrolled=true
08-29 19:26:09.660  7836  7836 D SiloTvFocus: rail restore scroll request=1 index=0 scrolled=true
08-29 19:26:22.045  7836  7836 D SiloTvFocus: rail restore scroll request=1 index=0 scrolled=true
08-29 19:26:22.048  7836  7836 D SiloTvFocus: rail restore scroll request=1 index=0 scrolled=true
08-29 19:26:27.215  7836  7836 D SiloTvFocus: rail restore scroll request=1 index=0 scrolled=true
08-29 19:26:32.369  7836  7836 D SiloTvFocus: rail restore scroll request=1 index=0 scrolled=true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus restoration when returning from media details on Android TV.
  * Prevented repeated scrolling during focus movement, preserving smooth animated rail positioning.
  * Added improved diagnostics to help monitor focus and scroll restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->