### PR TITLE
feat(diagnostics): expand Android client evidence

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsCoordinator.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsCoordinator.kt
@@ -443,6 +443,8 @@ class DefaultDiagnosticsCoordinator(
                     // identity mutation either waits and purges this work, or wins first and
                     // prevents this block from running.
                     runtimePublisher.publish(liveCaptureContext)
+                    // Collect the previous process before enabling this process's journal:
+                    // false -> true rotates persistent breadcrumbs and removes the prior run.
                     incidentCollector.collect(liveCaptureContext, consent.mode)
                     capture.setDebugLogging(
                         liveCaptureContext,

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsImageHealth.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsImageHealth.kt
@@ -1,0 +1,195 @@
+package org.siloserver.silo.common.diagnostics
+
+import android.os.SystemClock
+import java.io.IOException
+import java.net.SocketTimeoutException
+import org.siloserver.silo.model.diagnostics.DiagnosticsLogCategory
+
+enum class DiagnosticsImageSource(internal val wireValue: String) {
+    MEMORY("memory"),
+    DISK("disk"),
+    NETWORK("network"),
+}
+
+enum class DiagnosticsImageStage(internal val wireValue: String) {
+    FETCH("fetch"),
+    DECODE("decode"),
+    UNKNOWN("unknown"),
+}
+
+enum class DiagnosticsImageFailureKind(internal val wireValue: String) {
+    HTTP("http"),
+    TIMEOUT("timeout"),
+    OUT_OF_MEMORY("out_of_memory"),
+    DECODE("decode"),
+    IO("io"),
+    OTHER("other"),
+}
+
+internal data class DiagnosticsImageWindow(
+    val completed: Int,
+    val failures: Int,
+    val memorySuccesses: Int,
+    val diskSuccesses: Int,
+    val networkSuccesses: Int,
+)
+
+internal data class DiagnosticsImageFailure(
+    val stage: DiagnosticsImageStage,
+    val kind: DiagnosticsImageFailureKind,
+)
+
+internal data class DiagnosticsImageEvents(
+    val failure: DiagnosticsImageFailure?,
+    val window: DiagnosticsImageWindow?,
+)
+
+internal class DiagnosticsImageHealthAccumulator(
+    private val windowSize: Int = 50,
+    private val failureIntervalMs: Long = 60_000,
+    private val nowMs: () -> Long = SystemClock::elapsedRealtime,
+) {
+    private var completed = 0
+    private var failures = 0
+    private var memorySuccesses = 0
+    private var diskSuccesses = 0
+    private var networkSuccesses = 0
+    private var lastFailureEmissionMs: Long? = null
+
+    init {
+        require(windowSize > 0)
+        require(failureIntervalMs > 0)
+    }
+
+    @Synchronized
+    fun success(source: DiagnosticsImageSource): DiagnosticsImageEvents {
+        completed += 1
+        when (source) {
+            DiagnosticsImageSource.MEMORY -> memorySuccesses += 1
+            DiagnosticsImageSource.DISK -> diskSuccesses += 1
+            DiagnosticsImageSource.NETWORK -> networkSuccesses += 1
+        }
+        return DiagnosticsImageEvents(failure = null, window = completeWindowIfReady())
+    }
+
+    @Synchronized
+    fun failure(
+        stage: DiagnosticsImageStage,
+        kind: DiagnosticsImageFailureKind,
+    ): DiagnosticsImageEvents {
+        completed += 1
+        failures += 1
+        val now = nowMs()
+        val previous = lastFailureEmissionMs
+        val shouldEmit = previous == null || now < previous || now - previous >= failureIntervalMs
+        val emission = if (shouldEmit) {
+            lastFailureEmissionMs = now
+            DiagnosticsImageFailure(stage, kind)
+        } else {
+            null
+        }
+        return DiagnosticsImageEvents(emission, completeWindowIfReady())
+    }
+
+    private fun completeWindowIfReady(): DiagnosticsImageWindow? {
+        if (completed < windowSize) return null
+        val snapshot = DiagnosticsImageWindow(
+            completed = completed,
+            failures = failures,
+            memorySuccesses = memorySuccesses,
+            diskSuccesses = diskSuccesses,
+            networkSuccesses = networkSuccesses,
+        )
+        completed = 0
+        failures = 0
+        memorySuccesses = 0
+        diskSuccesses = 0
+        networkSuccesses = 0
+        return snapshot
+    }
+}
+
+object DiagnosticsImageHealth {
+    private val accumulator = DiagnosticsImageHealthAccumulator()
+
+    fun success(source: DiagnosticsImageSource) = emit(accumulator.success(source))
+
+    fun failure(stage: DiagnosticsImageStage, throwable: Throwable) = emit(
+        accumulator.failure(stage, classifyImageFailure(stage, throwable)),
+    )
+
+    private fun emit(events: DiagnosticsImageEvents) {
+        events.failure?.let(DiagnosticsImageLogger::failure)
+        events.window?.let(DiagnosticsImageLogger::window)
+    }
+}
+
+internal object DiagnosticsImageLogger {
+    fun failure(failure: DiagnosticsImageFailure) = SiloLog.breadcrumb(
+        DiagnosticsLogCategory.LIFECYCLE,
+        "ImagePipeline",
+        "image pipeline failure",
+        mapOf(
+            "phase" to SiloLogAttribute.Text("image_failure"),
+            "outcome" to SiloLogAttribute.Text(failure.stage.wireValue),
+            "reason" to SiloLogAttribute.Text(failure.kind.wireValue),
+        ),
+    )
+
+    fun window(window: DiagnosticsImageWindow) = SiloLog.breadcrumb(
+        DiagnosticsLogCategory.LIFECYCLE,
+        "ImagePipeline",
+        "image pipeline health snapshot",
+        mapOf(
+            "phase" to SiloLogAttribute.Text("image_pipeline"),
+            "outcome" to SiloLogAttribute.Text(failureRateBucket(window.failures, window.completed)),
+            "reason" to SiloLogAttribute.Text(sourceMix(window)),
+        ),
+    )
+}
+
+internal fun classifyImageFailure(
+    stage: DiagnosticsImageStage,
+    throwable: Throwable,
+): DiagnosticsImageFailureKind {
+    val causes = generateSequence(throwable) { it.cause }.take(8).toList()
+    return when {
+        causes.any { it is OutOfMemoryError } -> DiagnosticsImageFailureKind.OUT_OF_MEMORY
+        causes.any { it is SocketTimeoutException } -> DiagnosticsImageFailureKind.TIMEOUT
+        causes.any { cause ->
+            val name = cause.javaClass.name
+            name.contains("HttpException") || name.contains("HttpResponse")
+        } -> DiagnosticsImageFailureKind.HTTP
+        stage == DiagnosticsImageStage.DECODE -> DiagnosticsImageFailureKind.DECODE
+        causes.any { it is IOException } -> DiagnosticsImageFailureKind.IO
+        else -> DiagnosticsImageFailureKind.OTHER
+    }
+}
+
+private fun failureRateBucket(failures: Int, completed: Int): String {
+    if (completed <= 0 || failures <= 0) return "no_failures"
+    val percent = failures * 100 / completed
+    return when (percent) {
+        in 0..9 -> "failure_rate_under_10"
+        in 10..24 -> "failure_rate_10_24"
+        else -> "failure_rate_25_plus"
+    }
+}
+
+private fun sourceMix(window: DiagnosticsImageWindow): String {
+    val successes = (window.completed - window.failures).coerceAtLeast(0)
+    return "memory_${shareBucket(window.memorySuccesses, successes)}_" +
+        "disk_${shareBucket(window.diskSuccesses, successes)}_" +
+        "network_${shareBucket(window.networkSuccesses, successes)}"
+}
+
+private fun shareBucket(count: Int, total: Int): String {
+    if (total <= 0 || count <= 0) return "0"
+    val percent = (count.toLong() * 100 / total).coerceAtLeast(1)
+    return when (percent) {
+        in 1L..24L -> "1_24"
+        in 25L..49L -> "25_49"
+        in 50L..74L -> "50_74"
+        else -> "75_plus"
+    }
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentation.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentation.kt
@@ -2,10 +2,13 @@ package org.siloserver.silo.common.diagnostics
 
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import java.util.Locale
 import org.siloserver.silo.common.player.PlayerStatsSnapshot
 import org.siloserver.silo.common.player.video.PlaybackDiagnosticsCode
 import org.siloserver.silo.model.diagnostics.DiagnosticsLogCategory
 import org.siloserver.silo.network.NetworkDiagnosticsObserver
+import org.siloserver.silo.viewmodel.HomeDiagnosticsObserver
+import org.siloserver.silo.viewmodel.HomeLoadObservation
 
 object DiagnosticsCaptureDetailState {
     private val enabled = AtomicBoolean(false)
@@ -225,6 +228,248 @@ object DiagnosticsLifecycleLogger {
     }
 }
 
+enum class DiagnosticsHomeContentState(internal val wireValue: String) {
+    LOADING("loading"),
+    ERROR("error"),
+    EMPTY("empty"),
+    READY("ready"),
+}
+
+enum class DiagnosticsHomeScrollRegion(internal val wireValue: String) {
+    UNKNOWN("unknown"),
+    TOP("top"),
+    CONTENT("content"),
+    END("end"),
+}
+
+enum class DiagnosticsListSurface(internal val wireValue: String) {
+    PHONE_HOME("phone_home"),
+    PHONE_FOR_YOU("phone_for_you"),
+    PHONE_LIBRARY_RECOMMENDED("phone_lib_rec"),
+    TV_HOME("tv_home"),
+    TV_FOR_YOU("tv_for_you"),
+    TV_LIBRARY_RECOMMENDED("tv_lib_rec"),
+}
+
+enum class DiagnosticsKeyCollection(internal val wireValue: String) {
+    PHONE_MEDIA_ROW("phone_media_row"),
+    PHONE_CATALOG_GRID("phone_catalog_grid"),
+    TV_MEDIA_ROW("tv_media_row"),
+}
+
+/** Only aggregate counts escape this factory; the input keys are never logged. */
+data class DiagnosticsListSnapshot(
+    val itemCount: Int,
+    val duplicateKeyCount: Int,
+    val duplicateItemRowCount: Int,
+    val maxRowItemCount: Int,
+    val fullyResolved: Boolean?,
+) {
+    companion object {
+        fun fromKeys(
+            keys: List<String>,
+            rowKeys: List<List<String>> = emptyList(),
+            fullyResolved: Boolean? = null,
+        ): DiagnosticsListSnapshot = DiagnosticsListSnapshot(
+            itemCount = keys.size,
+            duplicateKeyCount = keys.size - keys.distinct().size,
+            duplicateItemRowCount = rowKeys.count { row -> row.size != row.distinct().size },
+            maxRowItemCount = rowKeys.maxOfOrNull(List<String>::size) ?: 0,
+            fullyResolved = fullyResolved,
+        )
+    }
+}
+
+object DiagnosticsListLogger {
+    fun snapshot(surface: DiagnosticsListSurface, snapshot: DiagnosticsListSnapshot) {
+        SiloLog.breadcrumb(
+            DiagnosticsLogCategory.LIFECYCLE,
+            "UiList",
+            "list integrity snapshot",
+            mapOf(
+                "phase" to SiloLogAttribute.Text("${surface.wireValue}_list"),
+                "outcome" to SiloLogAttribute.Text(
+                    diagnosticsDuplicateOutcome(snapshot.duplicateKeyCount, "keys"),
+                ),
+                "reason" to SiloLogAttribute.Text("items_${diagnosticsCountBucket(snapshot.itemCount)}"),
+            ),
+        )
+        SiloLog.breadcrumb(
+            DiagnosticsLogCategory.LIFECYCLE,
+            "UiList",
+            "row integrity snapshot",
+            mapOf(
+                "phase" to SiloLogAttribute.Text("${surface.wireValue}_rows"),
+                "outcome" to SiloLogAttribute.Text(
+                    diagnosticsDuplicateOutcome(snapshot.duplicateItemRowCount, "rows"),
+                ),
+                "reason" to SiloLogAttribute.Text(
+                    "max_items_${diagnosticsCountBucket(snapshot.maxRowItemCount)}",
+                ),
+            ),
+        )
+        snapshot.fullyResolved?.let { fullyResolved ->
+            SiloLog.breadcrumb(
+                DiagnosticsLogCategory.LIFECYCLE,
+                "UiList",
+                "list resolution snapshot",
+                mapOf(
+                    "phase" to SiloLogAttribute.Text("${surface.wireValue}_resolution"),
+                    "outcome" to SiloLogAttribute.Text(if (fullyResolved) "complete" else "partial"),
+                ),
+            )
+        }
+        DiagnosticsResourceCheckpoints.request(surface)
+    }
+
+}
+
+object DiagnosticsKeyAnomalyLogger {
+    /** Healthy reusable rows/grids stay silent; only a duplicate-key hazard is persisted. */
+    fun snapshot(collection: DiagnosticsKeyCollection, snapshot: DiagnosticsListSnapshot) {
+        val duplicateCount = snapshot.duplicateKeyCount
+        if (duplicateCount <= 0) return
+        SiloLog.breadcrumb(
+            DiagnosticsLogCategory.LIFECYCLE,
+            "UiKeys",
+            "duplicate lazy keys detected",
+            mapOf(
+                "phase" to SiloLogAttribute.Text("${collection.wireValue}_keys"),
+                "outcome" to SiloLogAttribute.Text(
+                    if (duplicateCount == 1) "duplicate_one" else "duplicate_multiple",
+                ),
+                "reason" to SiloLogAttribute.Text("items_${diagnosticsCountBucket(snapshot.itemCount)}"),
+            ),
+        )
+    }
+}
+
+object DiagnosticsHomeLoadObserver : HomeDiagnosticsObserver {
+    override fun completed(observation: HomeLoadObservation) {
+        SiloLog.breadcrumb(
+            DiagnosticsLogCategory.LIFECYCLE,
+            "HomeData",
+            "home data source completed",
+            mapOf(
+                "phase" to SiloLogAttribute.Text(
+                    "home_${observation.source.name.lowercase(Locale.ROOT)}_" +
+                        observation.trigger.name.lowercase(Locale.ROOT),
+                ),
+                "duration_ms" to SiloLogAttribute.Integer(observation.durationMs.coerceAtLeast(0)),
+                "outcome" to SiloLogAttribute.Text(observation.outcome.name.lowercase(Locale.ROOT)),
+                "reason" to SiloLogAttribute.Text(
+                    "sections_${diagnosticsCountBucket(observation.sectionCount)}",
+                ),
+            ),
+        )
+        if (observation.outcome in HOME_CONTENT_OUTCOMES) {
+            SiloLog.breadcrumb(
+                DiagnosticsLogCategory.LIFECYCLE,
+                "HomeData",
+                "home source integrity snapshot",
+                mapOf(
+                    "phase" to SiloLogAttribute.Text("home_source_keys"),
+                    "outcome" to SiloLogAttribute.Text(
+                        diagnosticsDuplicateOutcome(observation.duplicateSectionKeyCount, "section_keys"),
+                    ),
+                    "reason" to SiloLogAttribute.Text(
+                        diagnosticsDuplicateOutcome(observation.duplicateItemRowCount, "item_rows"),
+                    ),
+                ),
+            )
+        }
+    }
+}
+
+/**
+ * Curated, identifier-free context for diagnosing phone-homepage failures.
+ * Scroll evidence records state transitions and broad regions, never offsets,
+ * section names, media titles, or item identifiers.
+ */
+object DiagnosticsHomeLogger {
+    fun content(state: DiagnosticsHomeContentState) = SiloLog.breadcrumb(
+        DiagnosticsLogCategory.LIFECYCLE,
+        "HomeScreen",
+        "home content state changed",
+        mapOf(
+            "phase" to SiloLogAttribute.Text("home_content"),
+            "outcome" to SiloLogAttribute.Text(state.wireValue),
+        ),
+    )
+
+    fun scroll(
+        scrolling: Boolean,
+        region: DiagnosticsHomeScrollRegion,
+        visibleRowOrdinal: Int? = null,
+        rawSectionType: String? = null,
+    ) {
+        SiloLog.breadcrumb(
+            DiagnosticsLogCategory.LIFECYCLE,
+            "HomeScreen",
+            "home scroll state changed",
+            mapOf(
+                "phase" to SiloLogAttribute.Text("home_scroll"),
+                "outcome" to SiloLogAttribute.Text(if (scrolling) "scrolling" else "idle"),
+                "reason" to SiloLogAttribute.Text(
+                    homeScrollReason(region, visibleRowOrdinal, rawSectionType),
+                ),
+            ),
+        )
+        if (scrolling) {
+            DiagnosticsResourceCheckpoints.request(
+                DiagnosticsListSurface.PHONE_HOME,
+                DiagnosticsResourceCheckpointCause.SCROLL_START,
+            )
+        }
+    }
+}
+
+internal fun homeScrollReason(
+    region: DiagnosticsHomeScrollRegion,
+    visibleRowOrdinal: Int?,
+    rawSectionType: String?,
+): String {
+    if (visibleRowOrdinal == null && rawSectionType == null) return region.wireValue
+    val ordinal = visibleRowOrdinal?.let(::diagnosticsOrdinalBucket) ?: "row_unknown"
+    return "${region.wireValue}:$ordinal:${safeHomeSectionType(rawSectionType)}"
+}
+
+private fun safeHomeSectionType(raw: String?): String {
+    val normalized = raw
+        ?.lowercase(Locale.ROOT)
+        ?.replace('-', '_')
+        ?.replace(' ', '_')
+        ?.take(64)
+        ?: return "unknown"
+    return normalized.takeIf(KNOWN_HOME_SECTION_TYPES::contains) ?: "unknown"
+}
+
+private fun diagnosticsOrdinalBucket(value: Int): String = when (value.coerceAtLeast(0)) {
+    0 -> "row_1"
+    1 -> "row_2"
+    in 2..3 -> "row_3_4"
+    in 4..7 -> "row_5_8"
+    in 8..15 -> "row_9_16"
+    else -> "row_17_plus"
+}
+
+internal fun diagnosticsCountBucket(value: Int): String = when (value.coerceAtLeast(0)) {
+    0 -> "0"
+    1 -> "1"
+    in 2..4 -> "2_4"
+    in 5..8 -> "5_8"
+    in 9..16 -> "9_16"
+    in 17..32 -> "17_32"
+    in 33..64 -> "33_64"
+    else -> "65_plus"
+}
+
+private fun diagnosticsDuplicateOutcome(count: Int, unit: String): String = when (count.coerceAtLeast(0)) {
+    0 -> "unique_$unit"
+    1 -> "duplicate_${unit}_one"
+    else -> "duplicate_${unit}_multiple"
+}
+
 private object DiagnosticsPerformanceRoute {
     private val route = AtomicReference("unknown")
 
@@ -339,6 +584,28 @@ private val KNOWN_ROUTE_ROOTS = setOf(
     "silocast",
     "watch_together",
     "watchlist",
+)
+private val KNOWN_HOME_SECTION_TYPES = setOf(
+    "continue_watching",
+    "favorites",
+    "featured",
+    "genre",
+    "history",
+    "in_progress",
+    "latest",
+    "next_up",
+    "popular",
+    "recently_added",
+    "recommendations",
+    "recommended",
+    "trending",
+    "up_next",
+    "watchlist",
+)
+private val HOME_CONTENT_OUTCOMES = setOf(
+    org.siloserver.silo.viewmodel.HomeLoadOutcome.HIT,
+    org.siloserver.silo.viewmodel.HomeLoadOutcome.SUCCESS,
+    org.siloserver.silo.viewmodel.HomeLoadOutcome.PARTIAL,
 )
 private const val DYNAMIC_ROUTE_SEGMENT = "{id}"
 private val API_ROUTE_TEMPLATES: Map<String, List<List<String>>> = mapOf(

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsManualCapture.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsManualCapture.kt
@@ -56,6 +56,7 @@ class FileDiagnosticsCaptureController(
             error("diagnostics capture started concurrently")
         }
         SiloLog.installSink(FanOutDiagnosticsLogSink(logBuffer, fileLogger))
+        breadcrumbJournal?.setEnabled(context.identityKey)
         setDetailedCaptureEnabled(true)
         return capture
     }
@@ -117,6 +118,7 @@ class FileDiagnosticsCaptureController(
             error("diagnostics debug logging started concurrently")
         }
         SiloLog.installSink(FanOutDiagnosticsLogSink(logBuffer, fileLogger))
+        breadcrumbJournal?.setEnabled(context.identityKey)
         setDetailedCaptureEnabled(true)
     }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsModule.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsModule.kt
@@ -30,6 +30,7 @@ private val HOSTED_DIAGNOSTICS_HTTP = named("hosted-diagnostics-http")
 
 val diagnosticsModule = module {
     single<NetworkDiagnosticsObserver> { DiagnosticsNetworkLogger }
+    single<org.siloserver.silo.viewmodel.HomeDiagnosticsObserver> { DiagnosticsHomeLoadObserver }
     single<DataStore<Preferences>>(DIAGNOSTICS_DATA_STORE) {
         PreferenceDataStoreFactory.create(
             produceFile = { androidContext().preferencesDataStoreFile("silo_diagnostics") },

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPerformanceRecorder.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPerformanceRecorder.kt
@@ -17,6 +17,7 @@ import android.view.Window
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 data class PerformanceWindowSnapshot(
     val frameCount: Long,
@@ -108,6 +109,51 @@ interface DiagnosticsPerformanceCapture {
     }
 }
 
+enum class DiagnosticsResourceCheckpointCause(internal val wireValue: String) {
+    LIST_READY("list_ready"),
+    SCROLL_START("scroll_start"),
+}
+
+object DiagnosticsResourceCheckpoints {
+    private val handler = AtomicReference<(DiagnosticsListSurface, DiagnosticsResourceCheckpointCause) -> Unit>(
+        { _, _ -> },
+    )
+
+    internal fun install(value: (DiagnosticsListSurface, DiagnosticsResourceCheckpointCause) -> Unit) {
+        handler.set(value)
+    }
+
+    fun request(
+        surface: DiagnosticsListSurface,
+        cause: DiagnosticsResourceCheckpointCause = DiagnosticsResourceCheckpointCause.LIST_READY,
+    ) {
+        handler.get().invoke(surface, cause)
+    }
+}
+
+internal class DiagnosticsCheckpointCadence(
+    private val intervalMs: Long = 30_000,
+) {
+    private val lastEmissionByKey = mutableMapOf<String, Long>()
+
+    init {
+        require(intervalMs > 0)
+    }
+
+    @Synchronized
+    fun shouldEmit(
+        surface: DiagnosticsListSurface,
+        cause: DiagnosticsResourceCheckpointCause,
+        nowMs: Long,
+    ): Boolean {
+        val key = "${surface.wireValue}:${cause.wireValue}"
+        val previous = lastEmissionByKey[key]
+        if (previous != null && nowMs >= previous && nowMs - previous < intervalMs) return false
+        lastEmissionByKey[key] = nowMs
+        return true
+    }
+}
+
 class AndroidDiagnosticsPerformanceRecorder(
     private val application: Application,
     private val nowElapsedMs: () -> Long = SystemClock::elapsedRealtime,
@@ -124,6 +170,7 @@ class AndroidDiagnosticsPerformanceRecorder(
     private var resumedActivity = WeakReference<Activity>(null)
     private var attachedWindow: Window? = null
     private val startupReported = AtomicBoolean(false)
+    private val checkpointCadence = DiagnosticsCheckpointCadence()
     private var heartbeatExpectedMs = 0L
 
     private val frameListener = Window.OnFrameMetricsAvailableListener { _, metrics, _ ->
@@ -148,7 +195,10 @@ class AndroidDiagnosticsPerformanceRecorder(
     }
 
     fun install() {
-        if (installed.compareAndSet(false, true)) application.registerActivityLifecycleCallbacks(this)
+        if (installed.compareAndSet(false, true)) {
+            application.registerActivityLifecycleCallbacks(this)
+            DiagnosticsResourceCheckpoints.install(::requestResourceCheckpoint)
+        }
     }
 
     override fun setDetailedCaptureEnabled(enabled: Boolean) {
@@ -218,6 +268,17 @@ class AndroidDiagnosticsPerformanceRecorder(
         DiagnosticsPerformanceLogger.snapshot(frameSnapshot, memory, startup)
     }
 
+    private fun requestResourceCheckpoint(
+        surface: DiagnosticsListSurface,
+        cause: DiagnosticsResourceCheckpointCause,
+    ) {
+        val now = nowElapsedMs()
+        if (!checkpointCadence.shouldEmit(surface, cause, now)) return
+        worker.post {
+            DiagnosticsResourceLogger.checkpoint(surface, cause, memorySnapshot())
+        }
+    }
+
     private fun memorySnapshot(): DiagnosticsResourceSnapshot {
         val runtime = Runtime.getRuntime()
         val javaHeapMb = ((runtime.totalMemory() - runtime.freeMemory()) / BYTES_PER_MIB).coerceAtLeast(0)
@@ -254,3 +315,39 @@ data class DiagnosticsResourceSnapshot(
     val lowMemory: Boolean,
     val thermalStatus: Int?,
 )
+
+object DiagnosticsResourceLogger {
+    fun checkpoint(
+        surface: DiagnosticsListSurface,
+        cause: DiagnosticsResourceCheckpointCause,
+        resources: DiagnosticsResourceSnapshot,
+    ) = SiloLog.breadcrumb(
+        org.siloserver.silo.model.diagnostics.DiagnosticsLogCategory.LIFECYCLE,
+        "AppResources",
+        "resource pressure checkpoint",
+        mapOf(
+            "phase" to SiloLogAttribute.Text("resource_pressure"),
+            "outcome" to SiloLogAttribute.Text(resourceOutcome(resources)),
+            "reason" to SiloLogAttribute.Text(
+                "${surface.wireValue}_${cause.wireValue}_" +
+                    "heap_${memoryBucket(resources.javaHeapMb)}_pss_${memoryBucket(resources.processPssMb)}",
+            ),
+        ),
+    )
+}
+
+private fun resourceOutcome(resources: DiagnosticsResourceSnapshot): String = when {
+    resources.lowMemory -> "low_memory"
+    (resources.thermalStatus ?: 0) >= 4 -> "thermal_severe"
+    (resources.thermalStatus ?: 0) >= 2 -> "thermal_elevated"
+    else -> "normal"
+}
+
+internal fun memoryBucket(valueMb: Long): String = when (valueMb.coerceAtLeast(0)) {
+    in 0..63 -> "0_63"
+    in 64..127 -> "64_127"
+    in 128..255 -> "128_255"
+    in 256..511 -> "256_511"
+    in 512..1_023 -> "512_1023"
+    else -> "1024_plus"
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollector.kt
@@ -372,6 +372,7 @@ class ExitInfoCollector(
         run: DiagnosticsRunRecord,
         fingerprint: String,
     ): PendingReport? {
+        val exceptionCode = classifyJvmFailure(marker.throwableType, marker.stack)
         val redactor = DiagnosticsRedactor(
             sensitiveValues = redactionTokens().filter(String::isNotEmpty).toSet(),
         )
@@ -388,18 +389,26 @@ class ExitInfoCollector(
             processName = null,
             pid = null,
             status = null,
+            exceptionCode = exceptionCode.wireValue,
         )
         artifacts[CRASH_STACK_FILE] = safeStack.encodeToByteArray()
         sanitizedLogBytes(marker.logLines, redactor)?.let { artifacts[LOGS_FILE] = it }
+        val captureSessionId = requireNotNull(marker.captureSessionId) {
+            "a matched JVM crash marker must identify its capture session"
+        }
+        runCatching { breadcrumbs.linesForRun(captureSessionId, run.identityKey()) }
+            .getOrDefault(emptyList())
+            .let { lines -> sanitizedLogBytes(lines, redactor) }
+            ?.let { artifacts[BREADCRUMBS_FILE] = it }
         val manifest = manifest(
             reportType = DiagnosticsReportType.CRASH,
             crashSource = DiagnosticsCrashSource.UEH,
             provenance = DiagnosticsCrashProvenance.PRE_FAILURE,
             capturedAtEpochMs = marker.occurredAtEpochMs,
-            captureSessionId = marker.captureSessionId ?: run.captureSessionId,
+            captureSessionId = captureSessionId,
             profileId = run.profileId,
             binding = binding,
-            summary = safeThrowableType,
+            summary = "${safeThrowableType.ifBlank { "Android JVM crash" }} [${exceptionCode.wireValue}]",
             stackExcerpt = safeStack.truncateUtf8ForExit(MAX_STACK_EXCERPT_BYTES),
             thread = safeThreadName,
             foreground = marker.foreground,
@@ -450,6 +459,9 @@ class ExitInfoCollector(
         val classification = classify(exit.reason) ?: return null
         val trace = collected.trace
         val binding = run.pendingBinding()
+        val redactor = DiagnosticsRedactor(
+            sensitiveValues = redactionTokens().filter(String::isNotEmpty).toSet(),
+        )
         val artifacts = linkedMapOf<String, ByteArray>()
         artifacts[DEVICE_FILE] = deviceSnapshotBytes() ?: fallbackDeviceSnapshot(exit.timestampMs)
         artifacts[CRASH_SUMMARY_FILE] = crashSummaryBytes(
@@ -460,17 +472,14 @@ class ExitInfoCollector(
         )
         runCatching { breadcrumbs.linesForRun(run.captureSessionId, run.identityKey()) }
             .getOrDefault(emptyList())
-            .takeIf(List<String>::isNotEmpty)?.let { lines ->
-            artifacts[BREADCRUMBS_FILE] = (lines.joinToString("\n") + "\n").encodeToByteArray()
-        }
+            .let { lines -> sanitizedLogBytes(lines, redactor) }
+            ?.let { artifacts[BREADCRUMBS_FILE] = it }
         var stackExcerpt: String? = null
         when {
             classification.reportType == DiagnosticsReportType.NATIVE_CRASH && trace != null ->
                 artifacts[CRASH_TOMBSTONE_FILE] = trace
             trace != null -> {
-                val text = strictUtf8(trace)?.let {
-                    DiagnosticsRedactor(sensitiveValues = redactionTokens().filter(String::isNotEmpty).toSet()).sanitize(it)
-                } ?: REDACTION_FAILURE_SENTINEL
+                val text = strictUtf8(trace)?.let(redactor::sanitize) ?: REDACTION_FAILURE_SENTINEL
                 val bytes = text.truncateUtf8ForExit(MAX_TEXT_TRACE_BYTES).encodeToByteArray()
                 artifacts[CRASH_STACK_FILE] = bytes
                 stackExcerpt = text.truncateUtf8ForExit(MAX_STACK_EXCERPT_BYTES)
@@ -635,6 +644,53 @@ private fun classify(reason: Int): ExitInfoCollector.ExitClassification? = when 
     else -> null
 }
 
+internal enum class DiagnosticsJvmFailureCode(internal val wireValue: String) {
+    DUPLICATE_LAZY_KEY("duplicate_lazy_key"),
+    INVALID_LAYOUT_CONSTRAINTS("invalid_layout_constraints"),
+    INVALID_SCROLL_POSITION("invalid_scroll_position"),
+    IMAGE_PIPELINE("image_pipeline"),
+    OUT_OF_MEMORY("out_of_memory"),
+    STACK_OVERFLOW("stack_overflow"),
+    ILLEGAL_ARGUMENT_OTHER("illegal_argument_other"),
+    ILLEGAL_STATE_OTHER("illegal_state_other"),
+    NULL_POINTER("null_pointer"),
+    UNKNOWN("unknown"),
+}
+
+/** Classifies raw marker text locally; only the fixed code is persisted or uploaded. */
+internal fun classifyJvmFailure(
+    throwableType: String,
+    rawStack: String,
+): DiagnosticsJvmFailureCode {
+    val type = throwableType.lowercase(Locale.ROOT)
+    val stack = rawStack.take(MAX_CLASSIFICATION_TEXT_CHARS).lowercase(Locale.ROOT)
+    return when {
+        "outofmemoryerror" in type -> DiagnosticsJvmFailureCode.OUT_OF_MEMORY
+        "stackoverflowerror" in type -> DiagnosticsJvmFailureCode.STACK_OVERFLOW
+        ("lazycolumn" in stack || "lazyrow" in stack || "lazygrid" in stack) &&
+            ("was already used" in stack || "duplicate key" in stack) ->
+            DiagnosticsJvmFailureCode.DUPLICATE_LAZY_KEY
+        "constraints" in stack && (
+            "can't represent" in stack ||
+                "cannot represent" in stack ||
+                "must be non-negative" in stack ||
+                "is out of range" in stack
+            ) -> DiagnosticsJvmFailureCode.INVALID_LAYOUT_CONSTRAINTS
+        "scroll" in stack && (
+            "index should be non-negative" in stack ||
+                "index must be non-negative" in stack ||
+                "offset should be non-negative" in stack ||
+                "offset must be non-negative" in stack
+            ) -> DiagnosticsJvmFailureCode.INVALID_SCROLL_POSITION
+        ("coil3." in stack || "coil." in stack) && ("decode" in stack || "image" in stack) ->
+            DiagnosticsJvmFailureCode.IMAGE_PIPELINE
+        "illegalargumentexception" in type -> DiagnosticsJvmFailureCode.ILLEGAL_ARGUMENT_OTHER
+        "illegalstateexception" in type -> DiagnosticsJvmFailureCode.ILLEGAL_STATE_OTHER
+        "nullpointerexception" in type -> DiagnosticsJvmFailureCode.NULL_POINTER
+        else -> DiagnosticsJvmFailureCode.UNKNOWN
+    }
+}
+
 private fun exitFingerprint(exit: ExitInfoCollector.CollectedExit): String {
     val record = exit.record
     val traceHash = exit.trace?.let(::sha256Hex).orEmpty()
@@ -656,15 +712,24 @@ private fun strictUtf8(bytes: ByteArray): String? = runCatching {
         .toString()
 }.getOrNull()
 
-private fun crashSummaryBytes(kind: String, processName: String?, pid: Int?, status: Int?): ByteArray =
+private fun crashSummaryBytes(
+    kind: String,
+    processName: String?,
+    pid: Int?,
+    status: Int?,
+    exceptionCode: String? = null,
+): ByteArray =
     Json.encodeToString(
         buildJsonObject {
             put("kind", kind)
+            exceptionCode?.let { put("exception_code", it) }
             processName?.let { put("process_hash", sha256Hex(it.encodeToByteArray()).take(32)) }
             pid?.let { put("pid", it) }
             status?.let { put("status", it) }
         },
     ).encodeToByteArray()
+
+private const val MAX_CLASSIFICATION_TEXT_CHARS = 64 * 1_024
 
 private fun fallbackDeviceSnapshot(capturedAtEpochMs: Long): ByteArray = Json.encodeToString(
     buildJsonObject {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/images/SiloImageLoader.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/images/SiloImageLoader.kt
@@ -1,12 +1,23 @@
 package org.siloserver.silo.common.images
 
 import coil3.ImageLoader
+import coil3.EventListener
 import coil3.PlatformContext
+import coil3.decode.DataSource
+import coil3.decode.Decoder
 import coil3.disk.DiskCache
+import coil3.fetch.Fetcher
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import coil3.request.ErrorResult
+import coil3.request.ImageRequest
+import coil3.request.Options
+import coil3.request.SuccessResult
 import coil3.request.crossfade
 import okio.Path.Companion.toOkioPath
 import org.siloserver.silo.network.SiloOkHttp
+import org.siloserver.silo.common.diagnostics.DiagnosticsImageHealth
+import org.siloserver.silo.common.diagnostics.DiagnosticsImageSource
+import org.siloserver.silo.common.diagnostics.DiagnosticsImageStage
 import java.io.File
 
 /**
@@ -25,6 +36,7 @@ import java.io.File
 fun buildSiloImageLoader(context: PlatformContext, cacheDir: File): ImageLoader =
     ImageLoader.Builder(context)
         .crossfade(true)
+        .eventListenerFactory { DiagnosticsImageEventListener() }
         .components {
             add(OkHttpNetworkFetcherFactory(callFactory = { SiloOkHttp.imageClient }))
         }
@@ -35,3 +47,28 @@ fun buildSiloImageLoader(context: PlatformContext, cacheDir: File): ImageLoader 
                 .build()
         }
         .build()
+
+private class DiagnosticsImageEventListener : EventListener() {
+    private var stage = DiagnosticsImageStage.UNKNOWN
+
+    override fun fetchStart(request: ImageRequest, fetcher: Fetcher, options: Options) {
+        stage = DiagnosticsImageStage.FETCH
+    }
+
+    override fun decodeStart(request: ImageRequest, decoder: Decoder, options: Options) {
+        stage = DiagnosticsImageStage.DECODE
+    }
+
+    override fun onSuccess(request: ImageRequest, result: SuccessResult) {
+        val source = when (result.dataSource) {
+            DataSource.MEMORY_CACHE, DataSource.MEMORY -> DiagnosticsImageSource.MEMORY
+            DataSource.DISK -> DiagnosticsImageSource.DISK
+            DataSource.NETWORK -> DiagnosticsImageSource.NETWORK
+        }
+        DiagnosticsImageHealth.success(source)
+    }
+
+    override fun onError(request: ImageRequest, result: ErrorResult) {
+        DiagnosticsImageHealth.failure(stage, result.throwable)
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsBundleBuilderTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsBundleBuilderTest.kt
@@ -172,10 +172,12 @@ class DiagnosticsBundleBuilderTest {
         val playbackLine = """{"ts":"2026-08-11T00:00:00Z","run":"run-1","lvl":"I","cat":"playback","tag":"Player","msg":"stats playback_session_id=private-playback-correlation","attrs":{"decoder":"c2.android.avc","buffered_ms":1200,"failure_code":"source-private"}}"""
         val lifecycleLine = """{"ts":"2026-08-11T00:00:01Z","run":"run-1","lvl":"I","cat":"lifecycle","tag":"Lifecycle","msg":"performance","attrs":{"state":"foreground","p95_frame_ms":22,"startup_first_frame_ms":400}}"""
         val focusLine = """{"ts":"2026-08-11T00:00:02Z","run":"run-1","lvl":"I","cat":"focus","tag":"Focus","msg":"moved","attrs":{"target":"send","action":"enter","route":"private-route"}}"""
+        val homeContentLine = """{"ts":"2026-08-11T00:00:03Z","run":"run-1","lvl":"I","cat":"lifecycle","tag":"HomeScreen","msg":"home content state changed","attrs":{"phase":"home_content","outcome":"ready"}}"""
+        val homeScrollLine = """{"ts":"2026-08-11T00:00:04Z","run":"run-1","lvl":"I","cat":"lifecycle","tag":"HomeScreen","msg":"home scroll state changed","attrs":{"phase":"home_scroll","outcome":"scrolling","reason":"content"}}"""
         val artifacts = mapOf(
             "device.json" to "{}".encodeToByteArray(),
             "logs.jsonl" to "$playbackLine\n$lifecycleLine\n".encodeToByteArray(),
-            "breadcrumbs.jsonl" to "$focusLine\n".encodeToByteArray(),
+            "breadcrumbs.jsonl" to "$focusLine\n$homeContentLine\n$homeScrollLine\n".encodeToByteArray(),
             "crash/tombstone.pb" to "opaque-private-native-trace".encodeToByteArray(),
         )
 
@@ -186,9 +188,8 @@ class DiagnosticsBundleBuilderTest {
         val hostedEntries = untar(gunzip(hosted.bytes)).associateBy(TarEntry::name)
         val hostedLogs = hostedEntries.getValue("logs.jsonl").bytes.decodeToString()
             .lineSequence().filter(String::isNotBlank).map { Json.parseToJsonElement(it).jsonObject }.toList()
-        val hostedBreadcrumb = Json.parseToJsonElement(
-            hostedEntries.getValue("breadcrumbs.jsonl").bytes.decodeToString().trim(),
-        ).jsonObject
+        val hostedBreadcrumbs = hostedEntries.getValue("breadcrumbs.jsonl").bytes.decodeToString()
+            .lineSequence().filter(String::isNotBlank).map { Json.parseToJsonElement(it).jsonObject }.toList()
 
         assertEquals(
             "android-c2-platform-decoder",
@@ -199,7 +200,15 @@ class DiagnosticsBundleBuilderTest {
         assertFalse(hostedLogs[0].getValue("msg").jsonPrimitive.content.contains("private-playback-correlation"))
         assertTrue(hostedLogs[0].getValue("msg").jsonPrimitive.content.contains("[redacted_private_id]"))
         assertEquals(setOf("state"), hostedLogs[1].getValue("attrs").jsonObject.keys)
-        assertEquals(setOf("target", "action"), hostedBreadcrumb.getValue("attrs").jsonObject.keys)
+        assertEquals(setOf("target", "action"), hostedBreadcrumbs[0].getValue("attrs").jsonObject.keys)
+        assertEquals(
+            mapOf("phase" to "home_content", "outcome" to "ready"),
+            hostedBreadcrumbs[1].getValue("attrs").jsonObject.mapValues { it.value.jsonPrimitive.content },
+        )
+        assertEquals(
+            mapOf("phase" to "home_scroll", "outcome" to "scrolling", "reason" to "content"),
+            hostedBreadcrumbs[2].getValue("attrs").jsonObject.mapValues { it.value.jsonPrimitive.content },
+        )
         assertFalse(hostedEntries.containsKey("crash/tombstone.pb"))
         assertFalse(hosted.manifest.archive.entries.contains("crash/tombstone.pb"))
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsCoordinatorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsCoordinatorTest.kt
@@ -1356,6 +1356,34 @@ class DiagnosticsCoordinatorTest {
     }
 
     @Test
+    fun priorIncidentCollectionPrecedesEnablingCurrentRunBreadcrumbs() = runTest {
+        val events = mutableListOf<String>()
+        val capture = RecordingCaptureController().apply {
+            onPersistentBreadcrumbsChanged = { enabled ->
+                if (enabled) events += "breadcrumbs-enabled"
+            }
+        }
+        val fixture = fixture(
+            identity = MutableIdentityResolver(ADULT_A),
+            transitions = DefaultIdentityTransitionBarrier(),
+            capture = capture,
+            scope = backgroundScope,
+            actorDispatcher = UnconfinedTestDispatcher(testScheduler),
+            incidentCollectorFactory = {
+                DiagnosticsIncidentCollector { _, _ ->
+                    events += "incidents-collected"
+                    emptyList()
+                }
+            },
+        )
+
+        fixture.coordinator.start()
+        fixture.coordinator.refresh()
+
+        assertTrue(events.indexOf("incidents-collected") in 0 until events.indexOf("breadcrumbs-enabled"), events.toString())
+    }
+
+    @Test
     fun detachedRawGenerationCleanupFailureKeepsActorClosedUntilRetrySucceeds() = runTest {
         val capture = RecordingCaptureController().apply {
             hasPersistentEvidence = true
@@ -1798,6 +1826,7 @@ class DiagnosticsCoordinatorTest {
         var purgeFailuresRemaining = 0
         var reconciliationFailuresRemaining = 0
         var captureNowCalls = 0
+        var onPersistentBreadcrumbsChanged: ((Boolean) -> Unit)? = null
         var captureNowAction: suspend (DiagnosticsCaptureContext) -> PendingReport? = { null }
         private var nextGeneration = 0L
 
@@ -1836,6 +1865,7 @@ class DiagnosticsCoordinatorTest {
 
         override suspend fun setPersistentBreadcrumbs(context: DiagnosticsCaptureContext?, enabled: Boolean) {
             persistentBreadcrumbsEnabled = context != null && enabled
+            onPersistentBreadcrumbsChanged?.invoke(persistentBreadcrumbsEnabled)
             if (persistentBreadcrumbsEnabled) hasPersistentEvidence = true
         }
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsImageHealthTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsImageHealthTest.kt
@@ -1,0 +1,103 @@
+package org.siloserver.silo.common.diagnostics
+
+import java.io.IOException
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DiagnosticsImageHealthTest {
+    @AfterTest
+    fun tearDown() {
+        SiloLog.installSink(null)
+    }
+
+    @Test
+    fun accumulatorEmitsRateLimitedFailuresAndAggregateSourceMix() {
+        var nowMs = 10_000L
+        val accumulator = DiagnosticsImageHealthAccumulator(
+            windowSize = 4,
+            failureIntervalMs = 60_000,
+            nowMs = { nowMs },
+        )
+
+        assertNull(accumulator.success(DiagnosticsImageSource.MEMORY).window)
+        val firstFailure = accumulator.failure(
+            DiagnosticsImageStage.FETCH,
+            DiagnosticsImageFailureKind.HTTP,
+        )
+        assertNotNull(firstFailure.failure)
+        assertNull(firstFailure.window)
+        assertNull(
+            accumulator.failure(
+                DiagnosticsImageStage.DECODE,
+                DiagnosticsImageFailureKind.DECODE,
+            ).failure,
+        )
+        val window = assertNotNull(accumulator.success(DiagnosticsImageSource.NETWORK).window)
+
+        assertEquals(4, window.completed)
+        assertEquals(2, window.failures)
+        assertEquals(1, window.memorySuccesses)
+        assertEquals(1, window.networkSuccesses)
+
+        nowMs += 60_000
+        assertNotNull(
+            accumulator.failure(
+                DiagnosticsImageStage.DECODE,
+                DiagnosticsImageFailureKind.DECODE,
+            ).failure,
+        )
+    }
+
+    @Test
+    fun imageFailureClassificationAndLogsNeverUseThrowableMessages() {
+        val privateMessage = "https://private.example/media/private-title.jpg"
+        val kind = classifyImageFailure(
+            DiagnosticsImageStage.DECODE,
+            IOException(privateMessage),
+        )
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+
+        DiagnosticsImageLogger.failure(
+            DiagnosticsImageFailure(DiagnosticsImageStage.DECODE, kind),
+        )
+        DiagnosticsImageLogger.window(
+            DiagnosticsImageWindow(
+                completed = 50,
+                failures = 5,
+                memorySuccesses = 20,
+                diskSuccesses = 15,
+                networkSuccesses = 10,
+            ),
+        )
+
+        assertEquals(DiagnosticsImageFailureKind.DECODE, kind)
+        assertTrue(lines[0].contains("\"reason\":\"decode\""), lines[0])
+        assertTrue(lines[1].contains("failure_rate_10_24"), lines[1])
+        assertTrue(lines[1].contains("memory_25_49_disk_25_49_network_1_24"), lines[1])
+        assertFalse(lines.any { it.contains(privateMessage) })
+    }
+
+    @Test
+    fun subOnePercentImageShareStaysInTheSmallestNonzeroBucket() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+
+        DiagnosticsImageLogger.window(
+            DiagnosticsImageWindow(
+                completed = 200,
+                failures = 0,
+                memorySuccesses = 1,
+                diskSuccesses = 99,
+                networkSuccesses = 100,
+            ),
+        )
+
+        assertTrue(lines.single().contains("memory_1_24_disk_25_49_network_50_74"), lines.single())
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentationTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentationTest.kt
@@ -5,6 +5,10 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.siloserver.silo.viewmodel.HomeLoadObservation
+import org.siloserver.silo.viewmodel.HomeLoadOutcome
+import org.siloserver.silo.viewmodel.HomeLoadSource
+import org.siloserver.silo.viewmodel.HomeLoadTrigger
 
 class DiagnosticsInstrumentationTest {
     @AfterTest
@@ -144,5 +148,137 @@ class DiagnosticsInstrumentationTest {
         assertTrue(line.contains("slow_frame_count"), line)
         assertTrue(line.contains("process_pss_mb"), line)
         assertFalse(line.contains("view_text"), line)
+    }
+
+    @Test
+    fun homeBreadcrumbsContainOnlyBoundedStateAndRegion() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+
+        DiagnosticsHomeLogger.content(DiagnosticsHomeContentState.READY)
+        DiagnosticsHomeLogger.scroll(scrolling = true, DiagnosticsHomeScrollRegion.CONTENT)
+
+        assertEquals(2, lines.size)
+        assertTrue(lines[0].contains("home content state changed"), lines[0])
+        assertTrue(lines[0].contains("\"outcome\":\"ready\""), lines[0])
+        assertTrue(lines[1].contains("home scroll state changed"), lines[1])
+        assertTrue(lines[1].contains("\"outcome\":\"scrolling\""), lines[1])
+        assertTrue(lines[1].contains("\"reason\":\"content\""), lines[1])
+        assertFalse(lines.any { it.contains("title", ignoreCase = true) })
+        assertFalse(lines.any { it.contains("content_id", ignoreCase = true) })
+    }
+
+    @Test
+    fun listIntegrityBucketsCountsWithoutLoggingKeys() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+        val snapshot = DiagnosticsListSnapshot.fromKeys(
+            keys = listOf("private-section-a", "private-section-a", "private-section-b"),
+            rowKeys = listOf(
+                listOf("private-title-a", "private-title-a"),
+                listOf("private-title-b"),
+            ),
+            fullyResolved = false,
+        )
+
+        DiagnosticsListLogger.snapshot(DiagnosticsListSurface.PHONE_HOME, snapshot)
+
+        assertEquals(3, lines.size)
+        assertTrue(lines[0].contains("duplicate_keys_one"), lines[0])
+        assertTrue(lines[0].contains("items_2_4"), lines[0])
+        assertTrue(lines[1].contains("duplicate_rows_one"), lines[1])
+        assertTrue(lines[2].contains("\"outcome\":\"partial\""), lines[2])
+        assertFalse(lines.any { it.contains("private-section") || it.contains("private-title") })
+    }
+
+    @Test
+    fun librarySurfaceLabelsDoNotResemblePrivateLibraryIdentifiers() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+        val snapshot = DiagnosticsListSnapshot.fromKeys(listOf("private-title"))
+
+        listOf(
+            DiagnosticsListSurface.PHONE_LIBRARY_RECOMMENDED,
+            DiagnosticsListSurface.TV_LIBRARY_RECOMMENDED,
+        ).forEach { surface ->
+            DiagnosticsListLogger.snapshot(surface, snapshot)
+            DiagnosticsResourceLogger.checkpoint(
+                surface = surface,
+                cause = DiagnosticsResourceCheckpointCause.LIST_READY,
+                resources = DiagnosticsResourceSnapshot(82, 140, lowMemory = false, thermalStatus = 1),
+            )
+        }
+
+        assertTrue(lines.any { it.contains("phone_lib_rec_list") }, lines.joinToString("\n"))
+        assertTrue(lines.any { it.contains("tv_lib_rec_list") }, lines.joinToString("\n"))
+        assertFalse(lines.any { it.contains("library_recommended") }, lines.joinToString("\n"))
+        assertFalse(lines.any { it.contains("private-title") }, lines.joinToString("\n"))
+    }
+
+    @Test
+    fun reusableKeyLoggerStaysSilentWhenHealthyAndNeverLogsTheDuplicateKey() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+
+        DiagnosticsKeyAnomalyLogger.snapshot(
+            DiagnosticsKeyCollection.PHONE_MEDIA_ROW,
+            DiagnosticsListSnapshot.fromKeys(listOf("one", "two")),
+        )
+        DiagnosticsKeyAnomalyLogger.snapshot(
+            DiagnosticsKeyCollection.PHONE_MEDIA_ROW,
+            DiagnosticsListSnapshot.fromKeys(listOf("private-title-id", "private-title-id")),
+        )
+
+        assertEquals(1, lines.size)
+        assertTrue(lines.single().contains("duplicate_one"), lines.single())
+        assertFalse(lines.single().contains("private-title-id"), lines.single())
+    }
+
+    @Test
+    fun scrollContextAllowListsSectionTypesAndBucketsTheOrdinal() {
+        assertEquals(
+            "content:row_3_4:recently_added",
+            homeScrollReason(DiagnosticsHomeScrollRegion.CONTENT, 3, "Recently Added"),
+        )
+        assertEquals(
+            "content:row_17_plus:unknown",
+            homeScrollReason(DiagnosticsHomeScrollRegion.CONTENT, 42, "Private Shelf Name"),
+        )
+    }
+
+    @Test
+    fun homeLoadAndResourceCheckpointsContainOnlyAggregateEvidence() {
+        val lines = mutableListOf<String>()
+        SiloLog.installSink { lines += it }
+
+        DiagnosticsHomeLoadObserver.completed(
+            HomeLoadObservation(
+                trigger = HomeLoadTrigger.INITIAL,
+                source = HomeLoadSource.NETWORK,
+                outcome = HomeLoadOutcome.PARTIAL,
+                durationMs = 1_234,
+                sectionCount = 9,
+            ),
+        )
+        DiagnosticsResourceLogger.checkpoint(
+            surface = DiagnosticsListSurface.PHONE_HOME,
+            cause = DiagnosticsResourceCheckpointCause.SCROLL_START,
+            resources = DiagnosticsResourceSnapshot(
+                javaHeapMb = 173,
+                processPssMb = 419,
+                lowMemory = false,
+                thermalStatus = 2,
+            ),
+        )
+
+        assertTrue(lines[0].contains("home_network_initial"), lines[0])
+        assertTrue(lines[0].contains("\"duration_ms\":1234"), lines[0])
+        assertTrue(lines[0].contains("sections_9_16"), lines[0])
+        assertTrue(lines[1].contains("unique_section_keys"), lines[1])
+        assertTrue(lines[1].contains("unique_item_rows"), lines[1])
+        assertTrue(lines[2].contains("thermal_elevated"), lines[2])
+        assertTrue(lines[2].contains("heap_128_255_pss_256_511"), lines[2])
+        assertFalse(lines[2].contains("173"), lines[2])
+        assertFalse(lines[2].contains("419"), lines[2])
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPerformanceRecorderTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPerformanceRecorderTest.kt
@@ -2,6 +2,8 @@ package org.siloserver.silo.common.diagnostics
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class DiagnosticsPerformanceRecorderTest {
     @Test
@@ -37,5 +39,39 @@ class DiagnosticsPerformanceRecorderTest {
 
         assertEquals(60_000, snapshot.worstFrameMs)
         assertEquals(60_000, snapshot.longestMainThreadStallMs)
+    }
+
+    @Test
+    fun resourceCheckpointsAreRateLimitedPerSurfaceAndCause() {
+        val cadence = DiagnosticsCheckpointCadence(intervalMs = 30_000)
+
+        assertTrue(
+            cadence.shouldEmit(
+                DiagnosticsListSurface.PHONE_HOME,
+                DiagnosticsResourceCheckpointCause.LIST_READY,
+                nowMs = 100_000,
+            ),
+        )
+        assertFalse(
+            cadence.shouldEmit(
+                DiagnosticsListSurface.PHONE_HOME,
+                DiagnosticsResourceCheckpointCause.LIST_READY,
+                nowMs = 129_999,
+            ),
+        )
+        assertTrue(
+            cadence.shouldEmit(
+                DiagnosticsListSurface.PHONE_HOME,
+                DiagnosticsResourceCheckpointCause.SCROLL_START,
+                nowMs = 100_001,
+            ),
+        )
+        assertTrue(
+            cadence.shouldEmit(
+                DiagnosticsListSurface.PHONE_HOME,
+                DiagnosticsResourceCheckpointCause.LIST_READY,
+                nowMs = 130_000,
+            ),
+        )
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPrivacyIntegrationTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsPrivacyIntegrationTest.kt
@@ -120,6 +120,41 @@ class DiagnosticsPrivacyIntegrationTest {
     }
 
     @Test
+    fun debugAndTimedCaptureImmediatelyReenablePersistentBreadcrumbs() = runTest {
+        val root = temporaryFolder.newFolder()
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val journal = BreadcrumbJournal(root, writerDispatcher = dispatcher, directorySync = {})
+        val capture = FileDiagnosticsCaptureController(
+            logBuffer = LogRing(),
+            fileLogger = DiagnosticsFileLogger(root, dispatcher, directorySync = {}),
+            breadcrumbJournal = journal,
+            reports = FilePendingReportStore(
+                root,
+                nowMs = { CAPTURED_AT },
+                directorySync = {},
+                atomicRename = ::testAtomicRename,
+            ),
+            deviceSnapshots = DeviceSnapshotCollector(StableProbe, nowRfc3339 = { "2026-07-22T00:00:00Z" }),
+            deviceSnapshotCache = DeviceSnapshotCache(),
+            environment = ENVIRONMENT,
+            nowMs = { CAPTURED_AT },
+        )
+
+        capture.setPersistentBreadcrumbs(ADULT, true)
+        capture.setDebugLogging(ADULT, true)
+        val debugLine = diagnosticsLine("debug-run", "debug capture breadcrumb")
+        journal.offer(debugLine)
+
+        assertEquals(listOf(debugLine), journal.linesForRun("debug-run", ADULT.identityKey))
+
+        capture.start(ADULT)
+        val timedLine = diagnosticsLine("timed-run", "timed capture breadcrumb")
+        journal.offer(timedLine)
+
+        assertEquals(listOf(timedLine), journal.linesForRun("timed-run", ADULT.identityKey))
+    }
+
+    @Test
     fun hostedManualBundleOmitsSourceServerAccountAndProfileIdentity() = runTest {
         val root = temporaryFolder.newFolder()
         val ring = LogRing()
@@ -273,6 +308,7 @@ class DiagnosticsPrivacyIntegrationTest {
         )
         val outerManifest = bundle.manifestBytes.decodeToString()
         val archive = GZIPInputStream(ByteArrayInputStream(bundle.bytes)).use { it.readBytes() }.decodeToString()
+        assertTrue(archive.contains("illegal_state_other"), archive)
         listOf(
             SOURCE_SERVER_ID,
             SOURCE_PROFILE_ID,
@@ -484,6 +520,9 @@ class DiagnosticsPrivacyIntegrationTest {
         override val processStateSummary = RUN_TOKEN.encodeToByteArray()
         override fun trace(maxBytes: Int): ByteArray? = null
     }
+
+    private fun diagnosticsLine(run: String, message: String): String =
+        """{"ts":"2026-07-22T00:00:00Z","run":"$run","lvl":"I","cat":"lifecycle","tag":"Test","msg":"$message"}"""
 
     private class MutableIdentity(var current: DiagnosticsCaptureContext?) : DiagnosticsIdentityResolver {
         override suspend fun resolve(requirePersistentCapture: Boolean): DiagnosticsCaptureContext? = current

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/ExitInfoCollectorTest.kt
@@ -84,7 +84,7 @@ class ExitInfoCollectorTest {
 
     @Test
     fun anrIncludesPersistedBreadcrumbsFromTheExitedRun() = runTest {
-        val breadcrumb = "{\"run\":\"capture-1\",\"msg\":\"foreground\"}"
+        val breadcrumb = """{"ts":"2026-07-22T00:00:01Z","run":"capture-1","lvl":"I","cat":"lifecycle","tag":"AppLifecycle","msg":"foreground secret-token"}"""
         val fixture = fixture(
             records = listOf(exit(reason = AndroidExitReason.ANR, trace = "main blocked".encodeToByteArray())),
             breadcrumbs = DiagnosticsBreadcrumbSource { captureSessionId, _ ->
@@ -94,12 +94,15 @@ class ExitInfoCollectorTest {
 
         val report = fixture.collector.collect().single()
 
-        assertEquals("$breadcrumb\n", report.directory.resolve("breadcrumbs.jsonl").readText())
+        val persisted = report.directory.resolve("breadcrumbs.jsonl").readText()
+        assertFalse(persisted.contains("secret-token"))
+        assertTrue(persisted.contains("foreground [REDACTED]"), persisted)
         assertTrue("breadcrumbs.jsonl" in report.manifest.archive.entries)
     }
 
     @Test
     fun matchingJvmMarkerWinsOverDuplicateExitRecord() = runTest {
+        val breadcrumb = """{"ts":"2026-07-22T00:00:01Z","run":"capture-1","lvl":"I","cat":"lifecycle","tag":"HomeScreen","msg":"home scroll state changed secret-token","attrs":{"phase":"home_scroll","outcome":"scrolling","reason":"content"}}"""
         val marker = JvmCrashMarkerRecord(
             occurredAtEpochMs = EXIT_AT,
             threadName = "main-secret-token",
@@ -124,6 +127,9 @@ class ExitInfoCollectorTest {
         val fixture = fixture(
             records = listOf(exit(reason = AndroidExitReason.JVM_CRASH, timestampMs = EXIT_AT + 100)),
             markers = markers,
+            breadcrumbs = DiagnosticsBreadcrumbSource { captureSessionId, _ ->
+                if (captureSessionId == "capture-1") listOf(breadcrumb) else emptyList()
+            },
         )
 
         val reports = fixture.collector.collect()
@@ -131,14 +137,44 @@ class ExitInfoCollectorTest {
         assertEquals(1, reports.size)
         assertEquals(DiagnosticsCrashSource.UEH, reports.single().manifest.crash?.source)
         assertFalse(reports.single().manifest.crash?.summary.orEmpty().contains("secret-token"))
+        assertTrue(reports.single().manifest.crash?.summary.orEmpty().contains("illegal_state_other"))
         assertFalse(reports.single().manifest.crash?.thread.orEmpty().contains("secret-token"))
         assertFalse(reports.single().directory.resolve("crash/stack.txt").readText().contains("secret-token"))
         assertTrue(reports.single().directory.resolve("crash/stack.txt").readText().contains("[REDACTED]"))
         assertFalse(reports.single().directory.resolve("logs.jsonl").readText().contains("secret-token"))
         assertTrue(reports.single().directory.resolve("logs.jsonl").readText().contains("[REDACTED]"))
+        val breadcrumbs = reports.single().directory.resolve("breadcrumbs.jsonl").readText()
+        assertFalse(breadcrumbs.contains("secret-token"))
+        assertTrue(breadcrumbs.contains("[REDACTED]"))
+        assertTrue(breadcrumbs.contains("home scroll state changed"))
+        assertTrue("breadcrumbs.jsonl" in reports.single().manifest.archive.entries)
+        val crashSummary = reports.single().directory.resolve("crash/summary.json").readText()
+        assertTrue(crashSummary.contains("\"exception_code\":\"illegal_state_other\""), crashSummary)
+        assertFalse(crashSummary.contains("secret-token"), crashSummary)
         assertEquals(listOf(marker), markers.deleted)
         assertTrue(fixture.collector.collect().isEmpty())
         assertEquals(1, fixture.store.list(BINDING).size)
+    }
+
+    @Test
+    fun jvmCrashClassificationUsesRawMessageOnlyToProduceAFixedCode() {
+        val duplicate = classifyJvmFailure(
+            throwableType = "java.lang.IllegalArgumentException",
+            rawStack = """java.lang.IllegalArgumentException: Key \"private-title-123\" was already used. If you are using LazyColumn/Row, use a unique key.""",
+        )
+        val constraints = classifyJvmFailure(
+            throwableType = "java.lang.IllegalArgumentException",
+            rawStack = "java.lang.IllegalArgumentException: Can't represent width in Constraints",
+        )
+        val scroll = classifyJvmFailure(
+            throwableType = "java.lang.IllegalArgumentException",
+            rawStack = "java.lang.IllegalArgumentException: scroll index should be non-negative",
+        )
+
+        assertEquals(DiagnosticsJvmFailureCode.DUPLICATE_LAZY_KEY, duplicate)
+        assertEquals(DiagnosticsJvmFailureCode.INVALID_LAYOUT_CONSTRAINTS, constraints)
+        assertEquals(DiagnosticsJvmFailureCode.INVALID_SCROLL_POSITION, scroll)
+        assertFalse(duplicate.wireValue.contains("private-title-123"))
     }
 
     @Test

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -363,7 +363,7 @@ val androidModule = module {
             castPlaybackPreparer = get(),
         )
     }
-    viewModel { HomeViewModel(get(), get(), get(), get(), getOrNull(), get()) }
+    viewModel { HomeViewModel(get(), get(), get(), get(), getOrNull(), get(), get()) }
     viewModel { MainHeaderViewModel(get()) }
     viewModel {
         LibrariesViewModel(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.runtime.remember
@@ -30,6 +31,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyAnomalyLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyCollection
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
 import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.overlays.OverlayData
 import org.siloserver.silo.overlays.OverlayDataExtractor
@@ -68,6 +72,15 @@ fun MediaRow(
     modifier: Modifier = Modifier,
     cardActions: (SectionItem) -> MediaCardActions = { MediaCardActions() },
 ) {
+    val diagnosticsKeySnapshot = remember(items) {
+        DiagnosticsListSnapshot.fromKeys(items.map { it.contentId })
+    }
+    LaunchedEffect(diagnosticsKeySnapshot) {
+        DiagnosticsKeyAnomalyLogger.snapshot(
+            DiagnosticsKeyCollection.PHONE_MEDIA_ROW,
+            diagnosticsKeySnapshot,
+        )
+    }
     val rowItems = remember(items, showProgress, cardStyle) {
         items.map { item ->
             val pos = item.positionSeconds

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
@@ -64,6 +64,9 @@ import org.siloserver.silo.android.ui.components.MediaCard
 import org.siloserver.silo.android.ui.components.MediaGridDefaults
 import org.siloserver.silo.android.ui.components.rememberBrowseItemCardActions
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyAnomalyLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyCollection
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
 import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.overlays.OverlayDataExtractor
 
@@ -99,6 +102,15 @@ fun CatalogGrid(
 ) {
     val gridState = rememberLazyGridState()
     val cardWidth = viewDensity.minCardWidth
+    val diagnosticsKeySnapshot = remember(items) {
+        DiagnosticsListSnapshot.fromKeys(items.map { it.contentId })
+    }
+    LaunchedEffect(diagnosticsKeySnapshot) {
+        DiagnosticsKeyAnomalyLogger.snapshot(
+            DiagnosticsKeyCollection.PHONE_CATALOG_GRID,
+            diagnosticsKeySnapshot,
+        )
+    }
 
     // Trigger load more when scrolled near bottom. Keyed on the flags: a
     // keyless remember would freeze their first-composition values inside the

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
@@ -40,7 +40,9 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -56,6 +58,7 @@ import org.siloserver.silo.android.ui.components.topBarGlass
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
+import kotlinx.coroutines.flow.distinctUntilChanged
 import org.siloserver.silo.android.ui.components.EmptyStateView
 import org.siloserver.silo.android.ui.components.ErrorView
 import org.siloserver.silo.android.ui.components.MediaRowSkeleton
@@ -64,6 +67,12 @@ import org.siloserver.silo.android.ui.components.rememberShimmerProgress
 import org.siloserver.silo.android.ui.screens.pairing.CompanionPairingViewModel
 import org.siloserver.silo.android.ui.screens.pairing.CompanionPairingBottomOverlay
 import org.siloserver.silo.android.ui.screens.profiles.ProfileAvatar
+import org.siloserver.silo.common.diagnostics.DiagnosticsHomeContentState
+import org.siloserver.silo.common.diagnostics.DiagnosticsHomeLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsHomeScrollRegion
+import org.siloserver.silo.common.diagnostics.DiagnosticsListLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSurface
 import org.siloserver.silo.common.pairing.CompanionPairingStatus
 import org.siloserver.silo.common.pairing.CompanionPairingTarget
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
@@ -122,10 +131,54 @@ fun HomeScreen(
     val regularSections = remember(sections) {
         sections.filter { it.items.isNotEmpty() }
     }
+    val diagnosticsContentState = when {
+        state.isLoading && regularSections.isEmpty() -> DiagnosticsHomeContentState.LOADING
+        state.error != null && regularSections.isEmpty() -> DiagnosticsHomeContentState.ERROR
+        regularSections.isEmpty() -> DiagnosticsHomeContentState.EMPTY
+        else -> DiagnosticsHomeContentState.READY
+    }
+    LaunchedEffect(diagnosticsContentState) {
+        DiagnosticsHomeLogger.content(diagnosticsContentState)
+    }
+    val diagnosticsListSnapshot = remember(regularSections, state.sectionsFullyResolved) {
+        DiagnosticsListSnapshot.fromKeys(
+            keys = regularSections.map { it.id },
+            rowKeys = regularSections.map { section -> section.items.map { it.contentId } },
+            fullyResolved = state.sectionsFullyResolved,
+        )
+    }
+    LaunchedEffect(diagnosticsListSnapshot, diagnosticsContentState) {
+        if (diagnosticsContentState == DiagnosticsHomeContentState.READY) {
+            DiagnosticsListLogger.snapshot(DiagnosticsListSurface.PHONE_HOME, diagnosticsListSnapshot)
+        }
+    }
 
     val listState = rememberLazyListState()
+    val currentDiagnosticsSections by rememberUpdatedState(regularSections)
     LaunchedEffect(scrollToTopTick) {
         if (scrollToTopTick > 0) listState.animateScrollToItem(0)
+    }
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.isScrollInProgress }
+            .distinctUntilChanged()
+            .collect { scrolling ->
+                val currentSections = currentDiagnosticsSections
+                val sectionCount = currentSections.size
+                val firstVisibleItem = listState.firstVisibleItemIndex
+                val visibleRowOrdinal = (firstVisibleItem - 1).takeIf(currentSections.indices::contains)
+                val region = when {
+                    sectionCount == 0 -> DiagnosticsHomeScrollRegion.UNKNOWN
+                    firstVisibleItem <= 1 -> DiagnosticsHomeScrollRegion.TOP
+                    firstVisibleItem >= sectionCount -> DiagnosticsHomeScrollRegion.END
+                    else -> DiagnosticsHomeScrollRegion.CONTENT
+                }
+                DiagnosticsHomeLogger.scroll(
+                    scrolling = scrolling,
+                    region = region,
+                    visibleRowOrdinal = visibleRowOrdinal,
+                    rawSectionType = visibleRowOrdinal?.let { currentSections[it].sectionType },
+                )
+            }
     }
     LaunchedEffect(companionTargets, companionStatus, dismissedPairingSessions) {
         if (companionStatus is CompanionPairingStatus.Idle) {
@@ -435,4 +488,3 @@ private fun HomeFloatingChrome(
 
 /** How far the Home chrome's glass runs past its action row to feather out. */
 private val HomeChromeFeatherExtension = 40.dp
-

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/libraries/LibrariesScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -110,6 +111,9 @@ import org.siloserver.silo.catalog.filter.CatalogFilterQueryBuilder
 import org.siloserver.silo.catalog.filter.CatalogFilterState
 import org.siloserver.silo.common.ui.components.avatarRef
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
+import org.siloserver.silo.common.diagnostics.DiagnosticsListLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSurface
 import org.siloserver.silo.model.catalog.CatalogFiltersResponse
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.android.ui.screens.home.HomeSectionRow
@@ -941,6 +945,20 @@ private fun RecommendedTabContent(
     onItemClick: (String) -> Unit,
     onRetry: () -> Unit,
 ) {
+    val diagnosticsListSnapshot = remember(state.sections) {
+        DiagnosticsListSnapshot.fromKeys(
+            keys = state.sections.map { it.id },
+            rowKeys = state.sections.map { section -> section.items.map { it.contentId } },
+        )
+    }
+    LaunchedEffect(diagnosticsListSnapshot, state.isLoadingSections) {
+        if (!state.isLoadingSections && state.sections.isNotEmpty()) {
+            DiagnosticsListLogger.snapshot(
+                DiagnosticsListSurface.PHONE_LIBRARY_RECOMMENDED,
+                diagnosticsListSnapshot,
+            )
+        }
+    }
     when {
         state.isLoadingSections && state.sections.isEmpty() -> {
             MediaRowsSkeleton(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/recommendations/RecommendationsScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/recommendations/RecommendationsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -60,6 +61,9 @@ import org.siloserver.silo.viewmodel.RecommendationsViewModel
 import org.siloserver.silo.android.ui.components.MediaRowsSkeleton
 import org.siloserver.silo.android.ui.navigation.LocalBottomChromeInset
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
+import org.siloserver.silo.common.diagnostics.DiagnosticsListLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSurface
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
@@ -96,6 +100,20 @@ fun RecommendationsScreen(
     val inFallback = !state.isLoading && state.error == null && state.sections.isEmpty()
     val displayedList = if (inFallback) savedListSelection ?: ForYouList.Watchlist else savedListSelection
     LaunchedEffect(displayedList) { onDisplayedListChange(displayedList) }
+    val diagnosticsListSnapshot = remember(state.sections) {
+        DiagnosticsListSnapshot.fromKeys(
+            keys = state.sections.map { it.id },
+            rowKeys = state.sections.map { section -> section.items.map { it.contentId } },
+        )
+    }
+    LaunchedEffect(diagnosticsListSnapshot, state.isLoading) {
+        if (!state.isLoading && state.sections.isNotEmpty()) {
+            DiagnosticsListLogger.snapshot(
+                DiagnosticsListSurface.PHONE_FOR_YOU,
+                diagnosticsListSnapshot,
+            )
+        }
+    }
 
     // Self-heal the "For You" fallback. The shared VM loads only in init{} and
     // survives tab switches (saveState/restoreState), so an empty server
@@ -395,4 +413,3 @@ private fun SavedShortcutPill(
         )
     }
 }
-

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -387,7 +387,7 @@ val androidTvModule = module {
     }
 
     // Content ViewModels
-    viewModel { HomeViewModel(get(), get(), get(), get(), getOrNull(), get()) }
+    viewModel { HomeViewModel(get(), get(), get(), get(), getOrNull(), get(), get()) }
     viewModel { org.siloserver.silo.tv.ui.screens.home.TvUpcomingViewModel(get()) }
     viewModel { RecommendationsViewModel(get()) }
     viewModel { RequestsViewModel(get()) }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -32,6 +32,9 @@ import org.siloserver.silo.overlays.OverlayDataExtractor
 import org.siloserver.silo.tv.ui.theme.TvRailScrollBehavior
 import org.siloserver.silo.tv.ui.theme.tvRailPinOnFocus
 import org.siloserver.silo.tv.ui.theme.Spacing
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyAnomalyLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsKeyCollection
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
 
 /** Visual style of cards inside a [TvMediaRow]. */
 enum class TvRowStyle { Poster, Backdrop }
@@ -118,6 +121,15 @@ fun TvMediaRow(
     onRowFocusChanged: ((Boolean) -> Unit)? = null,
     cardActions: (SectionItem) -> TvMediaCardActions = { TvMediaCardActions() },
 ) {
+    val diagnosticsKeySnapshot = remember(items) {
+        DiagnosticsListSnapshot.fromKeys(items.map { it.contentId })
+    }
+    LaunchedEffect(diagnosticsKeySnapshot) {
+        DiagnosticsKeyAnomalyLogger.snapshot(
+            DiagnosticsKeyCollection.TV_MEDIA_ROW,
+            diagnosticsKeySnapshot,
+        )
+    }
     if (items.isEmpty()) return
     val rowState = rememberLazyListState()
     val rowItems = remember(items, showProgress, style, cardLayout) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -69,6 +69,9 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.siloserver.silo.common.diagnostics.DiagnosticsListLogger
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
+import org.siloserver.silo.common.diagnostics.DiagnosticsListSurface
 
 /**
  * Android TV port of tvOS `TVSkylineSectionFeed`: shared by Home and library
@@ -126,6 +129,24 @@ fun TvSkylineSectionFeed(
     onContentUpFallbackChanged: ((((Boolean) -> Boolean)?) -> Unit)? = null,
 ) {
     val rows = remember(sections) { sections.filter { it.items.isNotEmpty() } }
+    val diagnosticsSurface = when {
+        surfaceKey == "home" -> DiagnosticsListSurface.TV_HOME
+        surfaceKey == "for_you" -> DiagnosticsListSurface.TV_FOR_YOU
+        surfaceKey.startsWith("library-") -> DiagnosticsListSurface.TV_LIBRARY_RECOMMENDED
+        else -> null
+    }
+    val diagnosticsListSnapshot = remember(rows, sectionsComplete) {
+        DiagnosticsListSnapshot.fromKeys(
+            keys = rows.map { it.id },
+            rowKeys = rows.map { section -> section.items.map { it.contentId } },
+            fullyResolved = sectionsComplete,
+        )
+    }
+    LaunchedEffect(diagnosticsSurface, diagnosticsListSnapshot) {
+        diagnosticsSurface?.let { surface ->
+            DiagnosticsListLogger.snapshot(surface, diagnosticsListSnapshot)
+        }
+    }
     val tintState = rememberAmbientBackdropTintState()
     val context = LocalContext.current
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeDiagnostics.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeDiagnostics.kt
@@ -1,0 +1,48 @@
+package org.siloserver.silo.viewmodel
+
+/**
+ * Privacy-safe semantic result of one Home data-source operation.
+ *
+ * The shared ViewModel reports only fixed enums, aggregate counts, and elapsed
+ * time. Platform observers must not receive section IDs, titles, item IDs, or
+ * error messages.
+ */
+data class HomeLoadObservation(
+    val trigger: HomeLoadTrigger,
+    val source: HomeLoadSource,
+    val outcome: HomeLoadOutcome,
+    val durationMs: Long,
+    val sectionCount: Int,
+    val duplicateSectionKeyCount: Int = 0,
+    val duplicateItemRowCount: Int = 0,
+)
+
+enum class HomeLoadTrigger {
+    INITIAL,
+    MANUAL_REFRESH,
+    REALTIME,
+}
+
+enum class HomeLoadSource {
+    CACHE,
+    NETWORK,
+}
+
+enum class HomeLoadOutcome {
+    HIT,
+    MISS,
+    SUCCESS,
+    PARTIAL,
+    API_ERROR,
+    NETWORK_ERROR,
+    SUPERSEDED,
+    SKIPPED,
+}
+
+fun interface HomeDiagnosticsObserver {
+    fun completed(observation: HomeLoadObservation)
+
+    data object None : HomeDiagnosticsObserver {
+        override fun completed(observation: HomeLoadObservation) = Unit
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/HomeViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.TimeSource
 
 data class HomeUiState(
     val isLoading: Boolean = true,
@@ -59,6 +60,7 @@ class HomeViewModel(
     // commonMain/tests network-only; the apps inject the shared coordinator.
     private val homeRealtime: org.siloserver.silo.repository.HomeRealtimeCoordinator? = null,
     private val identityTransitions: IdentityTransitionBarrier = DefaultIdentityTransitionBarrier(),
+    private val diagnostics: HomeDiagnosticsObserver = HomeDiagnosticsObserver.None,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -94,11 +96,24 @@ class HomeViewModel(
      * sections, so overlapping signals are dropped rather than raced.
      */
     fun refreshFromRealtime() {
-        if (realtimeRefreshInFlight || _uiState.value.isRefreshing) return
+        if (realtimeRefreshInFlight || _uiState.value.isRefreshing) {
+            diagnostics.completed(
+                HomeLoadObservation(
+                    trigger = HomeLoadTrigger.REALTIME,
+                    source = HomeLoadSource.NETWORK,
+                    outcome = HomeLoadOutcome.SKIPPED,
+                    durationMs = 0,
+                    sectionCount = _uiState.value.sections.size,
+                    duplicateSectionKeyCount = _uiState.value.sections.duplicateSectionKeyCount(),
+                    duplicateItemRowCount = _uiState.value.sections.duplicateItemRowCount(),
+                ),
+            )
+            return
+        }
         realtimeRefreshInFlight = true
         viewModelScope.launch {
             try {
-                fetchSections()
+                fetchSections(HomeLoadTrigger.REALTIME)
             } finally {
                 realtimeRefreshInFlight = false
             }
@@ -113,25 +128,52 @@ class HomeViewModel(
             // start and publish fresh sections while we are in there, and
             // overlaying the cache on top would put stale rows back on screen.
             val bootstrapGeneration = fetchGeneration
+            val cacheStarted = TimeSource.Monotonic.markNow()
             val cached = homeCache.getCachedHome()
             if (fetchGeneration != bootstrapGeneration) {
-                fetchSections()
+                diagnostics.completed(
+                    HomeLoadObservation(
+                        trigger = HomeLoadTrigger.INITIAL,
+                        source = HomeLoadSource.CACHE,
+                        outcome = HomeLoadOutcome.SUPERSEDED,
+                        durationMs = cacheStarted.elapsedNow().inWholeMilliseconds,
+                        sectionCount = cached?.sections?.size ?: 0,
+                        duplicateSectionKeyCount = cached?.sections?.duplicateSectionKeyCount() ?: 0,
+                        duplicateItemRowCount = cached?.sections?.duplicateItemRowCount() ?: 0,
+                    ),
+                )
+                fetchSections(HomeLoadTrigger.INITIAL)
                 return@launch
             }
+            diagnostics.completed(
+                HomeLoadObservation(
+                    trigger = HomeLoadTrigger.INITIAL,
+                    source = HomeLoadSource.CACHE,
+                    outcome = if (cached != null && cached.sections.isNotEmpty()) {
+                        HomeLoadOutcome.HIT
+                    } else {
+                        HomeLoadOutcome.MISS
+                    },
+                    durationMs = cacheStarted.elapsedNow().inWholeMilliseconds,
+                    sectionCount = cached?.sections?.size ?: 0,
+                    duplicateSectionKeyCount = cached?.sections?.duplicateSectionKeyCount() ?: 0,
+                    duplicateItemRowCount = cached?.sections?.duplicateItemRowCount() ?: 0,
+                ),
+            )
             if (cached != null && cached.sections.isNotEmpty()) {
                 val overlaid = overlayLocalState(cached.sections)
                 _uiState.update { it.copy(isLoading = false, sections = overlaid, error = null) }
             } else {
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
-            fetchSections()
+            fetchSections(HomeLoadTrigger.INITIAL)
         }
     }
 
     fun refresh() {
         viewModelScope.launch {
             _uiState.update { it.copy(isRefreshing = true, error = null) }
-            val generation = fetchSections()
+            val generation = fetchSections(HomeLoadTrigger.MANUAL_REFRESH)
             // Only the newest fetch may clear the flag. A superseded refresh
             // clearing it hides the spinner while a newer fetch is still
             // running, and re-opens refreshFromRealtime's single-flight gate so
@@ -161,13 +203,30 @@ class HomeViewModel(
      * Runs one home fetch and returns the generation it ran as, so callers can
      * tell whether their own work is still the newest before acting on it.
      */
-    private suspend fun fetchSections(): Int {
+    private suspend fun fetchSections(trigger: HomeLoadTrigger): Int {
         val requestIdentityGeneration = identityTransitions.generation.value
         val cacheWriteLease = HomeCacheWriteLease(requestIdentityGeneration)
         // Whether we already have something to show (cached or prior fetch) — if a
         // refresh fails we keep it rather than replacing it with a blocking error.
         val generation = ++fetchGeneration
         val hadSections = _uiState.value.sections.isNotEmpty()
+        val networkStarted = TimeSource.Monotonic.markNow()
+        var observationReported = false
+        fun report(outcome: HomeLoadOutcome, sections: List<ResolvedSection> = emptyList()) {
+            if (observationReported) return
+            observationReported = true
+            diagnostics.completed(
+                HomeLoadObservation(
+                    trigger = trigger,
+                    source = HomeLoadSource.NETWORK,
+                    outcome = outcome,
+                    durationMs = networkStarted.elapsedNow().inWholeMilliseconds,
+                    sectionCount = sections.size,
+                    duplicateSectionKeyCount = sections.duplicateSectionKeyCount(),
+                    duplicateItemRowCount = sections.duplicateItemRowCount(),
+                ),
+            )
+        }
         when (val result = sectionRepository.getHomeSections()) {
             is ApiResult.Success -> {
                 val sections = result.data.sections
@@ -183,7 +242,10 @@ class HomeViewModel(
                 }
                 // Superseded while in flight: a newer fetch has already
                 // answered, so this reply describes a home nobody is looking at.
-                if (generation != fetchGeneration) return generation
+                if (generation != fetchGeneration) {
+                    report(HomeLoadOutcome.SUPERSEDED, sections)
+                    return generation
+                }
                 val resolved = hydration.sections
                 // Don't persist a partially-resolved home over a good cached one.
                 val fullyResolved = hydration.fullyResolved
@@ -205,7 +267,14 @@ class HomeViewModel(
                 // either — so a check taken before them proves only that this
                 // reply was current when it arrived, not that it still is when
                 // it finally writes.
-                if (generation != fetchGeneration) return generation
+                if (generation != fetchGeneration) {
+                    report(HomeLoadOutcome.SUPERSEDED, resolved)
+                    return generation
+                }
+                report(
+                    outcome = if (fullyResolved) HomeLoadOutcome.SUCCESS else HomeLoadOutcome.PARTIAL,
+                    sections = resolved,
+                )
                 _uiState.update {
                     // Only replace what's shown when the fetch fully resolved (or there
                     // was nothing yet) — a partial refresh must not clobber a good Home.
@@ -226,7 +295,10 @@ class HomeViewModel(
             }
             is ApiResult.Error -> {
                 // A superseded fetch's failure is not this home's failure.
-                if (generation != fetchGeneration) return generation
+                if (generation != fetchGeneration) {
+                    report(HomeLoadOutcome.SUPERSEDED)
+                    return generation
+                }
                 _uiState.update {
                     it.copy(
                         isLoading = false,
@@ -235,15 +307,20 @@ class HomeViewModel(
                         error = if (hadSections) null else result.message.ifBlank { "Failed to load home sections" },
                     )
                 }
+                report(HomeLoadOutcome.API_ERROR)
             }
             is ApiResult.NetworkError -> {
-                if (generation != fetchGeneration) return generation
+                if (generation != fetchGeneration) {
+                    report(HomeLoadOutcome.SUPERSEDED)
+                    return generation
+                }
                 _uiState.update {
                     it.copy(
                         isLoading = false,
                         error = if (hadSections) null else "Network error. Check your connection.",
                     )
                 }
+                report(HomeLoadOutcome.NETWORK_ERROR)
             }
         }
         return generation
@@ -334,6 +411,12 @@ class HomeViewModel(
         }
     }
 }
+
+private fun List<ResolvedSection>.duplicateSectionKeyCount(): Int =
+    size - distinctBy(ResolvedSection::id).size
+
+private fun List<ResolvedSection>.duplicateItemRowCount(): Int =
+    count { section -> section.items.size != section.items.distinctBy(SectionItem::contentId).size }
 
 private fun List<ResolvedSection>.mapItem(
     itemId: String,

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/HomeViewModelCacheIdentityTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/HomeViewModelCacheIdentityTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModelCacheIdentityTest {
@@ -81,6 +82,39 @@ class HomeViewModelCacheIdentityTest {
         viewModel.uiState.first { !it.isLoading }
 
         assertEquals(null, cache.sections)
+    }
+
+    @Test
+    fun homeReportsCacheAndNetworkProvenanceWithoutContentMetadata() = runTest(dispatcher) {
+        val client = HttpClient(
+            MockEngine {
+                respond(
+                    """{"sections":[{"id":"private-section","section_type":"row","title":"Private Title","items":[]}]}""",
+                    HttpStatusCode.OK,
+                    headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        ) {
+            install(ContentNegotiation) { json(SiloJson) }
+        }
+        val observations = mutableListOf<HomeLoadObservation>()
+        val viewModel = HomeViewModel(
+            sectionRepository = SectionRepository(SectionApi(client)),
+            mediaActions = mediaActions(),
+            diagnostics = HomeDiagnosticsObserver(observations::add),
+        )
+
+        viewModel.uiState.first { !it.isLoading }
+
+        assertEquals(
+            listOf(HomeLoadOutcome.MISS, HomeLoadOutcome.SUCCESS),
+            observations.map(HomeLoadObservation::outcome),
+        )
+        assertEquals(listOf(HomeLoadSource.CACHE, HomeLoadSource.NETWORK), observations.map { it.source })
+        assertTrue(observations.all { it.durationMs >= 0 })
+        // The repository removes empty rows during hydration; diagnostics see
+        // only the aggregate resolved count, never the private row metadata.
+        assertEquals(listOf(0, 0), observations.map { it.sectionCount })
     }
 
     private class RecordingHomeCache : HomeCachePort {


### PR DESCRIPTION
## Summary

- capture privacy-safe Home load, integrity, scroll-region, and resource-pressure evidence for homepage crash diagnosis
- extend aggregate list/key and image-pipeline health diagnostics across phone and TV browsing surfaces
- preserve bounded prior-run breadcrumbs and add fixed JVM failure classifications to make crash reports more actionable

## Privacy and reliability

- logs only allowlisted states, types, routes, and bucketed counts; no media titles or content identifiers
- reapplies token-aware redaction and size limits when prior-run breadcrumbs are attached to exit reports
- rate-limits resource and image failure evidence and keeps healthy reusable row diagnostics silent

## Validation

- `./gradlew :android-shared:testDebugUnitTest`
- `./gradlew :shared:test`
- `./gradlew :androidApp:assembleDebug`
- `./gradlew :androidTvApp:assembleDebug`
- Pixel 7 / Android 14 emulator: repeated Home scrolling, Libraries, and For You navigation completed without a crash
- manual hosted diagnostics upload completed with 249 retained lines, zero dropped lines, and all archive/privacy validations passing

The emulator validation confirmed the hosted report retained Home load/scroll, list integrity, resource pressure, lifecycle/network, and image-pipeline evidence. It also caught a diagnostic label that resembled a private library identifier; the final labels and regression coverage now pass the hosted privacy validator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added privacy-safe diagnostics for home-screen loading, scrolling, list integrity, image loading, and resource health.
  - Added aggregate reporting for load outcomes, image sources, failures, and performance checkpoints.
  - Added standardized crash classifications and sanitized breadcrumb information for diagnostic reports.

- **Bug Fixes**
  - Improved diagnostic session transitions so incident data is captured before new breadcrumb recording begins.
  - Ensured debug and timed captures promptly resume breadcrumb collection.
  - Added safeguards against exposing private identifiers, raw error details, or sensitive breadcrumb content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->