### PR TITLE
fix(playback): advertise native Media3 HLS

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -28,6 +28,7 @@ import org.siloserver.silo.model.playback.CLIENT_SURFACE_RECOVERY
 import org.siloserver.silo.model.playback.CLIENT_DV7_TO_DV81
 import org.siloserver.silo.model.playback.CLIENT_DV7_TO_HDR10
 import org.siloserver.silo.model.playback.CLIENT_DV_TRANSFORM_RECIPE_VERSION
+import org.siloserver.silo.model.playback.NATIVE_HLS_PLAYBACK_V1_FEATURE
 import org.siloserver.silo.model.playback.PlaybackDeviceContext
 import org.siloserver.silo.model.playback.PlaybackTransformationExecutor
 import org.siloserver.silo.model.playback.PlaybackTransformationV3
@@ -411,6 +412,11 @@ class PlaybackCapabilityDetector(
                     ),
                     features = buildList {
                         addAll(listOf("hls", "track_switching", "buffer_reporting"))
+                        // This delivery is consumed by Media3's native HLS
+                        // pipeline, not a MediaSource implementation such as
+                        // hls.js. The server can therefore use the hvc1/dvh1
+                        // sample-entry recipes that Media3 accepts.
+                        add(NATIVE_HLS_PLAYBACK_V1_FEATURE)
                         add(CLIENT_DV8_HDR10_PLUS_SANITIZER)
                         add(CLIENT_POST_RESUME_VIDEO_RECOVERY)
                         add(CLIENT_SURFACE_RECOVERY)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -1,14 +1,58 @@
 package org.siloserver.silo.common.player
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.siloserver.silo.common.network.SiloClientBuildIdentity
+import org.siloserver.silo.libass.LibassBridge
 import org.siloserver.silo.model.playback.HdrCapabilities
 import org.siloserver.silo.model.playback.CLIENT_DV7_TO_DV81
 import org.siloserver.silo.model.playback.CLIENT_DV7_TO_HDR10
+import org.siloserver.silo.model.playback.ClientCodecCapabilities
+import org.siloserver.silo.model.playback.DELIVERY_CLASS_HLS
+import org.siloserver.silo.model.playback.DELIVERY_CLASS_ORIGINAL_HTTP
+import org.siloserver.silo.model.playback.DELIVERY_CLASS_PROGRESSIVE
+import org.siloserver.silo.model.playback.NATIVE_HLS_PLAYBACK_V1_FEATURE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@RunWith(RobolectricTestRunner::class)
 class PlaybackCapabilityDetectorDolbyVisionTest {
+
+    @Test
+    fun phoneAndTvAdvertiseNativeHlsOnlyOnMedia3HlsDelivery() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val detector = PlaybackCapabilityDetector(
+            context = context,
+            audioCapabilityManager = AudioCapabilityManager(context),
+            libassBridge = LibassBridge(false),
+            buildIdentity = SiloClientBuildIdentity(buildNumber = "test", channel = "test"),
+        )
+
+        listOf("mobile", "tv").forEach { formFactor ->
+            val playbackContext = detector.detectPlaybackContext(
+                formFactor = formFactor,
+                appVersion = "test",
+                capabilities = ClientCodecCapabilities(),
+            )
+
+            assertTrue(
+                NATIVE_HLS_PLAYBACK_V1_FEATURE in playbackContext.deliveries.getValue(DELIVERY_CLASS_HLS).features,
+                "$formFactor must identify its local Media3 HLS pipeline",
+            )
+            assertFalse(
+                NATIVE_HLS_PLAYBACK_V1_FEATURE in playbackContext.deliveries.getValue(DELIVERY_CLASS_ORIGINAL_HTTP).features,
+                "$formFactor must not apply the HLS sample-entry contract to original HTTP",
+            )
+            assertFalse(
+                NATIVE_HLS_PLAYBACK_V1_FEATURE in playbackContext.deliveries.getValue(DELIVERY_CLASS_PROGRESSIVE).features,
+                "$formFactor must not apply the HLS sample-entry contract to progressive delivery",
+            )
+        }
+    }
 
     @Test
     fun profile8DirectPlayRequiresAValidatedNativeOutputRoute() {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
@@ -20,6 +20,7 @@ const val CLIENT_VIDEO_TRANSFORMATIONS_FEATURE = "client_video_transformations_v
 const val DEVICE_QUIRKS_V3_FEATURE = "device_quirks_v1"
 const val SEEK_REANCHOR_V3_FEATURE = "seek_reanchor_v1"
 const val DIRECT_STREAM_RESUME_V1_FEATURE = "direct_stream_resume_v1"
+const val NATIVE_HLS_PLAYBACK_V1_FEATURE = "native_hls_playback_v1"
 
 /**
  * How a capability list was obtained. The server validates strictly against


### PR DESCRIPTION
## What happened

Two users on the current Android build could not reliably start HEVC/Dolby Vision playback. The matching server logs showed the native Media3 HLS path being treated like a web MediaSource/hls.js client, so the server could not choose the correct HLS sample-entry recipe for Android.

The server-side compatibility fallback already makes unchanged build 15 clients work, but the durable fix is for Android to say explicitly that its local HLS delivery is handled by native Media3.

## What I changed

- Add the `native_hls_playback_v1` capability name to the shared playback contract.
- Advertise it on local Media3 HLS for both phone and TV.
- Do not advertise it for Original HTTP, progressive playback, or Cast.
- Cover both form factors and all of those delivery boundaries with a Robolectric test.

This is intentionally delivery-scoped. It gives the server enough evidence to choose `hvc1` for regular HEVC/DV7-to-HDR10 output and `dvh1` for preserved DV5/DV8 without changing unrelated playback routes.

## Live validation

I deployed the equivalent server behavior as build 122 and tested it with the two affected users on the unchanged Android build 15:

- User 1's first Auto DV8 2160p route was ready in 102 ms. The manifest, init data, subtitles, and media requests were all HTTP 200, and progress reached 204 seconds.
- User 1 then ran seven DV7 2160p sessions at roughly 68–89 Mbps, including seeks and resumes. Those sessions delivered 174/174 media segments successfully with no playback 4xx/5xx responses.
- User 2 ran five HLS remux sessions plus a separate direct-play session of about ten minutes. The HLS runs delivered 106/107 initial segment requests; the one early 404 was a seek race, rebuilt immediately, and did not recur. The direct-play run produced 46 successful progress updates with clean 200/206 responses.
- Across the post-deploy window there were no playback 5xx responses and none of the previous `unsupported video sample-entry`, `transcode_start_failed`, or `spawn_failed` signatures. There were no genuine FFmpeg crashes.

Both users confirmed playback now works, and User 2 continued watching multiple titles without another issue. This covers Auto and 2160p/4K, DV7 and DV8, audio-copy/AAC adaptation, seeking, HLS remux, and direct play. The server regression tests also cover Auto, Original, and 2160p planning.

## Validation

```text
./gradlew :android-shared:testDebugUnitTest \
  --tests org.siloserver.silo.common.player.PlaybackCapabilityDetectorDolbyVisionTest \
  --no-daemon --max-workers=2
BUILD SUCCESSFUL

./gradlew :android-shared:lintDebug --no-daemon --max-workers=2
BUILD SUCCESSFUL

git diff --check upstream/main...HEAD
<no output>
```

## Coordination and related work

- Companion server PR: [Silo-Server/silo-server#841](https://github.com/Silo-Server/silo-server/pull/841)
- Production source and validation trail: [blurbery/silo-android#5](https://github.com/blurbery/silo-android/pull/5) and [blurbery/silo-server#79](https://github.com/blurbery/silo-server/pull/79)
- Related server fixes: [Silo-Server/silo-server#657](https://github.com/Silo-Server/silo-server/pull/657) corrects DV7 fallback bytes, and [Silo-Server/silo-server#790](https://github.com/Silo-Server/silo-server/pull/790) keeps Android E-AC-3 fallback from needlessly re-encoding video.

Together with the companion server change, this closes out the remaining Android Media3 sample-entry/startup failure. It is a better boundary than globally allowing `hev1`, which only moved the failure to the next Profile 8 validation and risked changing web playback behavior.

## Risk

Low and bounded. This adds one capability token to one delivery class. Existing build 15 clients remain supported by the server compatibility path, while upgraded clients provide explicit evidence. Original, progressive, Cast, Apple, and web behavior are unchanged.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): Codex Sol (`gpt-5.6-sol`), Ultra reasoning
- Involvement: AI-assisted. I directed the investigation and fix, supplied the affected-user reports, made the scope decisions, and helped reproduce and validate it on my live server.
- Adversarial review: We checked the Android phone/TV boundary, confirmed the token is HLS-only, kept Original/progressive/Cast out of scope, traced the matching server recipe through final FFmpeg validation, and tested the previously failing Auto/Original/2160p and DV7/DV8 cases. The live build 15 sessions above were the final acceptance test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for advertising native HLS playback capabilities on compatible HLS deliveries.
  * Enables improved handling of Dolby Vision and HEVC video formats through the native playback pipeline.

* **Tests**
  * Added coverage verifying native HLS support is advertised for mobile and TV HLS playback, but not other delivery types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

