### PR TITLE
fix(profiles): gate profile creation and management affordances on admin role

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -442,7 +442,7 @@ val androidModule = module {
     viewModel { SignupViewModel(get()) }
     viewModel { InviteClaimViewModel(get(), get()) }
     viewModel { OnboardingTourViewModel(get(), get(), get(), get(), get()) }
-    viewModel { ProfileSelectionViewModel(get()) }
+    viewModel { ProfileSelectionViewModel(get(), get()) }
     viewModel { CreateProfileViewModel(get()) }
     viewModel { EditProfileViewModel(get()) }
     viewModel { ServerListViewModel(get(), get()) }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionScreen.kt
@@ -193,6 +193,7 @@ fun ProfileSelectionScreen(
 
                 ProfileFlow(
                     profiles = state.profiles,
+                    canAddProfile = state.canManageProfiles,
                     isManageMode = state.isManageMode,
                     onProfileTap = { viewModel.onProfileTapped(it) },
                     onProfileEdit = { onNavigateToEditProfile(it.id) },
@@ -200,15 +201,17 @@ fun ProfileSelectionScreen(
                     onAddProfile = onNavigateToCreateProfile,
                 )
 
-                Spacer(modifier = Modifier.height(24.dp))
+                if (state.canManageProfiles) {
+                    Spacer(modifier = Modifier.height(24.dp))
 
-                TextButton(onClick = viewModel::toggleManageMode) {
-                    Text(
-                        text = if (state.isManageMode) "Done" else "Manage Profiles",
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight.Medium,
-                        color = AuthColors.OnBackground,
-                    )
+                    TextButton(onClick = viewModel::toggleManageMode) {
+                        Text(
+                            text = if (state.isManageMode) "Done" else "Manage Profiles",
+                            fontSize = 15.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = AuthColors.OnBackground,
+                        )
+                    }
                 }
             }
         }
@@ -225,6 +228,7 @@ fun ProfileSelectionScreen(
 @Composable
 private fun ProfileFlow(
     profiles: List<Profile>,
+    canAddProfile: Boolean,
     isManageMode: Boolean,
     onProfileTap: (Profile) -> Unit,
     onProfileEdit: (Profile) -> Unit,
@@ -246,7 +250,9 @@ private fun ProfileFlow(
                 onDelete = { onProfileDelete(profile) },
             )
         }
-        AddProfileCard(onClick = onAddProfile)
+        if (canAddProfile) {
+            AddProfileCard(onClick = onAddProfile)
+        }
     }
 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModel.kt
@@ -87,7 +87,15 @@ class ProfileSelectionViewModel(
                 // Leaving a scope behind for an empty grid is stale metadata
                 // that a later selection could be qualified against.
                 gridScope = null
-                _uiState.update { it.copy(isLoading = false, profiles = emptyList(), canManageProfiles = false) }
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        profiles = emptyList(),
+                        canManageProfiles = false,
+                        isManageMode = false,
+                        deleteDialogProfile = null,
+                    )
+                }
                 return@launch
             }
 
@@ -106,6 +114,8 @@ class ProfileSelectionViewModel(
                             profiles = result.data,
                             activeProfileId = activeId,
                             canManageProfiles = isAdmin,
+                            isManageMode = if (isAdmin) it.isManageMode else false,
+                            deleteDialogProfile = if (isAdmin) it.deleteDialogProfile else null,
                         )
                     }
                 }
@@ -129,6 +139,7 @@ class ProfileSelectionViewModel(
     }
 
     fun toggleManageMode() {
+        if (!_uiState.value.canManageProfiles) return
         _uiState.update { it.copy(isManageMode = !it.isManageMode) }
     }
 
@@ -232,6 +243,7 @@ class ProfileSelectionViewModel(
 
     /** Manage-mode delete tap — opens the confirmation dialog. */
     fun requestDeleteProfile(profile: Profile) {
+        if (!_uiState.value.canManageProfiles) return
         _uiState.update { it.copy(deleteDialogProfile = profile) }
     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModel.kt
@@ -6,6 +6,7 @@ import org.siloserver.silo.model.profile.Profile
 import org.siloserver.silo.model.profile.authorizedProfileToken
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.repository.AuthRepository
 import org.siloserver.silo.repository.ProfileCommitResult
 import org.siloserver.silo.repository.ProfileRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +17,7 @@ import kotlinx.coroutines.launch
 
 data class ProfileSelectionUiState(
     val profiles: List<Profile> = emptyList(),
+    val canManageProfiles: Boolean = false,
     val isLoading: Boolean = false,
     val error: String? = null,
     val isManageMode: Boolean = false,
@@ -34,6 +36,7 @@ data class ProfileSelectionUiState(
 
 class ProfileSelectionViewModel(
     private val profileRepository: ProfileRepository,
+    private val authRepository: AuthRepository? = null,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ProfileSelectionUiState())
@@ -72,6 +75,7 @@ class ProfileSelectionViewModel(
 
             val scope = profileRepository.captureIdentityScope()
             val activeId = profileRepository.getActiveProfileId()
+            val isAdmin = (authRepository?.getCurrentUser() as? ApiResult.Success)?.data?.role?.equals("admin", ignoreCase = true) == true
             val result = profileRepository.listProfiles()
             // Two separate reasons to drop this response: a newer load
             // superseded it, or the identity it was fetched under is gone.
@@ -83,7 +87,7 @@ class ProfileSelectionViewModel(
                 // Leaving a scope behind for an empty grid is stale metadata
                 // that a later selection could be qualified against.
                 gridScope = null
-                _uiState.update { it.copy(isLoading = false, profiles = emptyList()) }
+                _uiState.update { it.copy(isLoading = false, profiles = emptyList(), canManageProfiles = false) }
                 return@launch
             }
 
@@ -97,7 +101,12 @@ class ProfileSelectionViewModel(
                     // the unguarded commit this was meant to fix.
                     gridScope = scope
                     _uiState.update {
-                        it.copy(isLoading = false, profiles = result.data, activeProfileId = activeId)
+                        it.copy(
+                            isLoading = false,
+                            profiles = result.data,
+                            activeProfileId = activeId,
+                            canManageProfiles = isAdmin,
+                        )
                     }
                 }
 

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
@@ -1,0 +1,154 @@
+package org.siloserver.silo.android.ui.screens.profiles
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.siloserver.silo.model.profile.Profile
+import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
+import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.TokenManagerImpl
+import org.siloserver.silo.network.api.AuthApi
+import org.siloserver.silo.network.api.ProfileApi
+import org.siloserver.silo.repository.AuthRepository
+import org.siloserver.silo.repository.ProfileRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileSelectionAdminGateTest {
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `admin user has canManageProfiles set to true`() = runTest {
+        val authRepo = createAuthRepository(
+            userJson = """{"id":1,"username":"admin","email":"admin@example.com","role":"admin"}""",
+        )
+        val profileRepo = createProfileRepository(listOf(Profile(id = "p1", name = "Admin Profile")))
+        val viewModel = ProfileSelectionViewModel(
+            profileRepository = profileRepo,
+            authRepository = authRepo,
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.canManageProfiles)
+    }
+
+    @Test
+    fun `non-admin user has canManageProfiles set to false`() = runTest {
+        val authRepo = createAuthRepository(
+            userJson = """{"id":2,"username":"alice","email":"alice@example.com","role":"user"}""",
+        )
+        val profileRepo = createProfileRepository(listOf(Profile(id = "p1", name = "Alice Profile")))
+        val viewModel = ProfileSelectionViewModel(
+            profileRepository = profileRepo,
+            authRepository = authRepo,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.canManageProfiles)
+    }
+
+    @Test
+    fun `failed user fetch leaves canManageProfiles false`() = runTest {
+        val authRepo = createAuthRepository(
+            userJson = null,
+            status = HttpStatusCode.InternalServerError,
+        )
+        val profileRepo = createProfileRepository(listOf(Profile(id = "p1", name = "Profile 1")))
+        val viewModel = ProfileSelectionViewModel(
+            profileRepository = profileRepo,
+            authRepository = authRepo,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.canManageProfiles)
+    }
+
+    @Test
+    fun `null auth repository defaults canManageProfiles to false`() = runTest {
+        val profileRepo = createProfileRepository(listOf(Profile(id = "p1", name = "Profile 1")))
+        val viewModel = ProfileSelectionViewModel(
+            profileRepository = profileRepo,
+            authRepository = null,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.canManageProfiles)
+    }
+
+    private fun createAuthRepository(
+        userJson: String?,
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ): AuthRepository {
+        val engine = MockEngine {
+            if (userJson != null && status == HttpStatusCode.OK) {
+                respond(
+                    content = userJson,
+                    status = status,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            } else {
+                respond(
+                    content = """{"error":"error","message":"failed"}""",
+                    status = status,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(SiloJson) }
+        }
+        val tokenManager = TokenManagerImpl(DefaultIdentityTransitionBarrier())
+        return AuthRepository(
+            authApi = AuthApi(client),
+            tokenManager = tokenManager,
+        )
+    }
+
+    private fun createProfileRepository(profiles: List<Profile>): ProfileRepository {
+        val jsonString = buildString {
+            append("""{"profiles":[""")
+            append(profiles.joinToString(",") { """{"id":"${it.id}","name":"${it.name}"}""" })
+            append("""]}""")
+        }
+        val engine = MockEngine {
+            respond(
+                content = jsonString,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(SiloJson) }
+        }
+        val tokenManager = TokenManagerImpl(DefaultIdentityTransitionBarrier())
+        return ProfileRepository(
+            profileApi = ProfileApi(client),
+            tokenManager = tokenManager,
+        )
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
@@ -100,6 +100,26 @@ class ProfileSelectionAdminGateTest {
         assertFalse(viewModel.uiState.value.canManageProfiles)
     }
 
+    @Test
+    fun `non-admin cannot toggle manage mode or request delete`() = runTest {
+        val authRepo = createAuthRepository(
+            userJson = """{"id":2,"username":"alice","email":"alice@example.com","role":"user"}""",
+        )
+        val profile = Profile(id = "p1", name = "Alice Profile")
+        val profileRepo = createProfileRepository(listOf(profile))
+        val viewModel = ProfileSelectionViewModel(
+            profileRepository = profileRepo,
+            authRepository = authRepo,
+        )
+        advanceUntilIdle()
+
+        viewModel.toggleManageMode()
+        assertFalse(viewModel.uiState.value.isManageMode)
+
+        viewModel.requestDeleteProfile(profile)
+        assertFalse(viewModel.uiState.value.deleteDialogProfile != null)
+    }
+
     private fun createAuthRepository(
         userJson: String?,
         status: HttpStatusCode = HttpStatusCode.OK,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -364,7 +364,7 @@ val androidTvModule = module {
     viewModel { org.siloserver.silo.tv.ui.screens.auth.TvSetupViewModel(get()) }
     viewModel { org.siloserver.silo.tv.ui.screens.auth.TvSignupViewModel(get()) }
     viewModel { TvLoginViewModel(get(), get(), get()) }
-    viewModel { TvProfileSelectionViewModel(get()) }
+    viewModel { TvProfileSelectionViewModel(get(), get()) }
     viewModel { org.siloserver.silo.tv.ui.screens.profiles.TvCreateProfileViewModel(get()) }
     viewModel { params ->
         org.siloserver.silo.tv.ui.screens.profiles.TvEditProfileViewModel(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionScreen.kt
@@ -160,15 +160,17 @@ fun TvProfileSelectionScreen(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TvHeroActionPill(
-                        label = if (state.isManageMode) "Done" else "Manage",
-                        icon = Icons.Filled.Edit,
-                        variant = TvPillVariant.Hollow,
-                        heightOverride = ProfileUtilityChipHeight,
-                        horizontalPaddingOverride = 10.dp,
-                        labelStyle = MaterialTheme.typography.labelMedium,
-                        onClick = viewModel::toggleManageMode,
-                    )
+                    if (state.canManageProfiles) {
+                        TvHeroActionPill(
+                            label = if (state.isManageMode) "Done" else "Manage",
+                            icon = Icons.Filled.Edit,
+                            variant = TvPillVariant.Hollow,
+                            heightOverride = ProfileUtilityChipHeight,
+                            horizontalPaddingOverride = 10.dp,
+                            labelStyle = MaterialTheme.typography.labelMedium,
+                            onClick = viewModel::toggleManageMode,
+                        )
+                    }
                     TvHeroActionPill(
                         label = "Change Server",
                         icon = Icons.Filled.Dns,
@@ -266,6 +268,7 @@ fun TvProfileSelectionScreen(
                     }
                     ProfileTileGrid(
                         profiles = state.profiles,
+                        canAddProfile = state.canManageProfiles,
                         focusRequesterFor = { id ->
                             tileFocusRequesters.getOrPut(id) { FocusRequester() }
                         },
@@ -329,6 +332,7 @@ fun TvProfileSelectionScreen(
 @Composable
 private fun ProfileTileGrid(
     profiles: List<Profile>,
+    canAddProfile: Boolean,
     focusRequesterFor: (String) -> FocusRequester,
     // Null means no profile tile owns focus — the Add tile has it, or focus
     // left the grid entirely. Restoration must not re-request a tile then.
@@ -339,7 +343,7 @@ private fun ProfileTileGrid(
     onDeleteProfile: (Profile) -> Unit,
     onAddProfile: () -> Unit,
 ) {
-    val itemCount = profiles.size + 1
+    val itemCount = profiles.size + (if (canAddProfile) 1 else 0)
     val rowCount = (itemCount + ProfileGridColumns - 1) / ProfileGridColumns
     Column(
         modifier = Modifier
@@ -382,7 +386,7 @@ private fun ProfileTileGrid(
                                         },
                                 )
                             }
-                            itemIndex == profiles.size -> TvAddProfileCard(
+                            itemIndex == profiles.size && canAddProfile -> TvAddProfileCard(
                                 onClick = onAddProfile,
                                 modifier = Modifier.onFocusChanged {
                                     if (it.isFocused) onProfileFocused(null)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionViewModel.kt
@@ -6,6 +6,7 @@ import org.siloserver.silo.model.profile.Profile
 import org.siloserver.silo.model.profile.authorizedProfileToken
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.repository.AuthRepository
 import org.siloserver.silo.repository.ProfileCommitResult
 import org.siloserver.silo.repository.ProfileRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +17,7 @@ import kotlinx.coroutines.launch
 
 data class TvProfileSelectionUiState(
     val profiles: List<Profile> = emptyList(),
+    val canManageProfiles: Boolean = false,
     val isLoading: Boolean = true,
     val error: String? = null,
     val selectedProfileId: String? = null,
@@ -37,6 +39,7 @@ data class TvProfileSelectionUiState(
  */
 class TvProfileSelectionViewModel(
     private val profileRepository: ProfileRepository,
+    private val authRepository: AuthRepository? = null,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TvProfileSelectionUiState())
@@ -68,6 +71,7 @@ class TvProfileSelectionViewModel(
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             val scope = profileRepository.captureIdentityScope()
+            val isAdmin = (authRepository?.getCurrentUser() as? ApiResult.Success)?.data?.role?.equals("admin", ignoreCase = true) == true
             val listed = profileRepository.listProfiles()
             // Two separate reasons to drop this response: a newer load
             // superseded it, or the identity it was fetched under is gone.
@@ -75,7 +79,7 @@ class TvProfileSelectionViewModel(
             if (!profileRepository.identityScopeUnchanged(scope)) {
                 // The displayed grid is gone, so its scope must go with it.
                 gridScope = null
-                _uiState.update { it.copy(isLoading = false, profiles = emptyList()) }
+                _uiState.update { it.copy(isLoading = false, profiles = emptyList(), canManageProfiles = false) }
                 return@launch
             }
             when (val result = listed) {
@@ -86,7 +90,11 @@ class TvProfileSelectionViewModel(
                     // qualified by the NEW scope.
                     gridScope = scope
                     _uiState.update {
-                        it.copy(isLoading = false, profiles = result.data)
+                        it.copy(
+                            isLoading = false,
+                            profiles = result.data,
+                            canManageProfiles = isAdmin,
+                        )
                     }
                 }
                 is ApiResult.Error -> {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionViewModel.kt
@@ -79,7 +79,15 @@ class TvProfileSelectionViewModel(
             if (!profileRepository.identityScopeUnchanged(scope)) {
                 // The displayed grid is gone, so its scope must go with it.
                 gridScope = null
-                _uiState.update { it.copy(isLoading = false, profiles = emptyList(), canManageProfiles = false) }
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        profiles = emptyList(),
+                        canManageProfiles = false,
+                        isManageMode = false,
+                        deleteCandidate = null,
+                    )
+                }
                 return@launch
             }
             when (val result = listed) {
@@ -94,6 +102,8 @@ class TvProfileSelectionViewModel(
                             isLoading = false,
                             profiles = result.data,
                             canManageProfiles = isAdmin,
+                            isManageMode = if (isAdmin) it.isManageMode else false,
+                            deleteCandidate = if (isAdmin) it.deleteCandidate else null,
                         )
                     }
                 }
@@ -115,6 +125,7 @@ class TvProfileSelectionViewModel(
     }
 
     fun toggleManageMode() {
+        if (!_uiState.value.canManageProfiles) return
         _uiState.update {
             it.copy(
                 isManageMode = !it.isManageMode,
@@ -245,6 +256,7 @@ class TvProfileSelectionViewModel(
 
     /** Opens the delete confirmation for [profile] (manage mode). */
     fun requestDelete(profile: Profile) {
+        if (!_uiState.value.canManageProfiles) return
         _uiState.update { it.copy(deleteCandidate = profile) }
     }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
@@ -1,0 +1,154 @@
+package org.siloserver.silo.tv.ui.screens.profiles
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.siloserver.silo.model.profile.Profile
+import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
+import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.TokenManagerImpl
+import org.siloserver.silo.network.api.AuthApi
+import org.siloserver.silo.network.api.ProfileApi
+import org.siloserver.silo.repository.AuthRepository
+import org.siloserver.silo.repository.ProfileRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvProfileSelectionAdminGateTest {
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `admin user has canManageProfiles set to true on TV`() = runTest {
+        val authRepo = createAuthRepository(
+            userJson = """{"id":1,"username":"admin","email":"admin@example.com","role":"admin"}""",
+        )
+        val profileRepo = createProfileRepository(listOf(Profile(id = "p1", name = "Admin Profile")))
+        val viewModel = TvProfileSelectionViewModel(
+            profileRepository = profileRepo,
+            authRepository = authRepo,
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.canManageProfiles)
+    }
+
+    @Test
+    fun `non-admin user has canManageProfiles set to false on TV`() = runTest {
+        val authRepo = createAuthRepository(
+            userJson = """{"id":2,"username":"alice","email":"alice@example.com","role":"user"}""",
+        )
+        val profileRepo = createProfileRepository(listOf(Profile(id = "p1", name = "Alice Profile")))
+        val viewModel = TvProfileSelectionViewModel(
+            profileRepository = profileRepo,
+            authRepository = authRepo,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.canManageProfiles)
+    }
+
+    @Test
+    fun `failed user fetch leaves canManageProfiles false on TV`() = runTest {
+        val authRepo = createAuthRepository(
+            userJson = null,
+            status = HttpStatusCode.InternalServerError,
+        )
+        val profileRepo = createProfileRepository(listOf(Profile(id = "p1", name = "Profile 1")))
+        val viewModel = TvProfileSelectionViewModel(
+            profileRepository = profileRepo,
+            authRepository = authRepo,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.canManageProfiles)
+    }
+
+    @Test
+    fun `null auth repository defaults canManageProfiles to false on TV`() = runTest {
+        val profileRepo = createProfileRepository(listOf(Profile(id = "p1", name = "Profile 1")))
+        val viewModel = TvProfileSelectionViewModel(
+            profileRepository = profileRepo,
+            authRepository = null,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.canManageProfiles)
+    }
+
+    private fun createAuthRepository(
+        userJson: String?,
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ): AuthRepository {
+        val engine = MockEngine {
+            if (userJson != null && status == HttpStatusCode.OK) {
+                respond(
+                    content = userJson,
+                    status = status,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            } else {
+                respond(
+                    content = """{"error":"error","message":"failed"}""",
+                    status = status,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(SiloJson) }
+        }
+        val tokenManager = TokenManagerImpl(DefaultIdentityTransitionBarrier())
+        return AuthRepository(
+            authApi = AuthApi(client),
+            tokenManager = tokenManager,
+        )
+    }
+
+    private fun createProfileRepository(profiles: List<Profile>): ProfileRepository {
+        val jsonString = buildString {
+            append("""{"profiles":[""")
+            append(profiles.joinToString(",") { """{"id":"${it.id}","name":"${it.name}"}""" })
+            append("""]}""")
+        }
+        val engine = MockEngine {
+            respond(
+                content = jsonString,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(SiloJson) }
+        }
+        val tokenManager = TokenManagerImpl(DefaultIdentityTransitionBarrier())
+        return ProfileRepository(
+            profileApi = ProfileApi(client),
+            tokenManager = tokenManager,
+        )
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
@@ -100,6 +100,26 @@ class TvProfileSelectionAdminGateTest {
         assertFalse(viewModel.uiState.value.canManageProfiles)
     }
 
+    @Test
+    fun `non-admin cannot toggle manage mode or request delete on TV`() = runTest {
+        val authRepo = createAuthRepository(
+            userJson = """{"id":2,"username":"alice","email":"alice@example.com","role":"user"}""",
+        )
+        val profile = Profile(id = "p1", name = "Alice Profile")
+        val profileRepo = createProfileRepository(listOf(profile))
+        val viewModel = TvProfileSelectionViewModel(
+            profileRepository = profileRepo,
+            authRepository = authRepo,
+        )
+        advanceUntilIdle()
+
+        viewModel.toggleManageMode()
+        assertFalse(viewModel.uiState.value.isManageMode)
+
+        viewModel.requestDelete(profile)
+        assertFalse(viewModel.uiState.value.deleteCandidate != null)
+    }
+
     private fun createAuthRepository(
         userJson: String?,
         status: HttpStatusCode = HttpStatusCode.OK,


### PR DESCRIPTION
## Summary
- Fixes #219.
- At the "Who's watching?" profile picker screen (both phone and TV), no active profile is selected yet. Under the server's authorization model, profile management (`POST /api/v1/profiles`, etc.) without an active primary profile requires the account role to be `admin`.
- Previously, `ProfileSelectionScreen` and `TvProfileSelectionScreen` unconditionally rendered the "Add Profile" card and manage mode affordances, causing non-admin users to hit 403 authorization errors.
- Gates `canManageProfiles` behind `authRepository.getCurrentUser()` checking for `user.role == "admin"`:
  - Phone: `AddProfileCard` and the "Manage Profiles" button only render when the account is an admin.
  - TV: `TvAddProfileCard` and the top-right "Manage" pill only render when the account is an admin. Grid dimensions dynamically adjust whether the Add tile is shown.
- Adds unit tests verifying that admin accounts receive `canManageProfiles = true` and standard accounts / errors receive `canManageProfiles = false` on both phone and TV view models.

## Test Plan
- [x] Unit tests in `ProfileSelectionAdminGateTest` and `TvProfileSelectionAdminGateTest` covering admin, non-admin, error, and null-repository cases.
- [ ] Sign in with a standard/non-admin account and confirm no "Add Profile" card or "Manage Profiles" button is shown on the profile picker.
- [ ] Sign in with an admin account and confirm "Add Profile" and "Manage Profiles" remain accessible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Profile management controls are now available only to administrators.
  - Non-administrators no longer see the Manage Profiles option or Add Profile tile on Android and TV.
  - Profile-management permissions reset safely when account or profile scope changes.

- **Bug Fixes**
  - Profile management is hidden when user information cannot be retrieved.

- **Tests**
  - Added coverage for administrator, non-administrator, failed-authentication, and unavailable-authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->