### PR TITLE
docs: standardize contribution guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,12 +33,9 @@ google-services.json
 *.jks
 *.keystore
 
-# Local tooling state — but checked-in project skills under .claude/skills/
-# are shared with the repo. Per-machine skill config (device registries,
-# server endpoints) stays local via the *.local.md convention.
-.claude/*
-!.claude/skills/
-.claude/skills/**/*.local.md
+# Local agent/tooling state
+/.agents/
+/.claude/
 .codex/
 .cursor/
 .worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,42 @@ Use Kotlin 2.1, Java 21 targets, and Compose idioms. The Silo package root is `o
 
 Android tests use Kotlin test/JUnit where present, especially under `android-shared/src/androidUnitTest`. Do not add tests for small changes or UI changes unless requested. For shared logic changes, add focused tests only for critical or high-risk behavior.
 
+## Writing
+
+Run a final readability pass on every human-facing issue, pull request,
+document, or status update.
+
+- Lead with the outcome.
+- Use concrete, plain language and active voice.
+- Cut filler, stock framing, repetition, and promotional claims.
+- Preserve meaning, evidence, citations, uncertainty, and established
+  terminology.
+- Never rewrite exact quotations, commands, logs, identifiers, API names, or
+  contractual language.
+- Match the tone to the audience and use only formatting that improves
+  readability.
+
+## Pull requests
+
+Never create a pull request unless the developer explicitly asks for one.
+
+Use a Conventional Commit title in plain language. Start the body with the
+problem, explain the solution next, and end with the required AI disclosure,
+including the exact model identifier, agent harness, and any other AI tooling.
+Include repository-required issue links, validation evidence, risks, and
+follow-up work.
+
+- Keep one concern per pull request. If an honest description needs the word
+  "also," split the work.
+- Include before-and-after images for UI changes. Include a short video when
+  motion or timing matters.
+- Upload pull request evidence to GitHub. Never commit PR-only assets such as
+  `.github/pr-assets/`.
+- When babysitting a pull request, poll checks and review comments created
+  after the last push. Verify bot findings against the source, fix real issues,
+  and dismiss false positives with a written reason. Remain quiet when nothing
+  new has appeared. Stop when the latest commit is green.
+
 ## Security & Configuration Tips
 
 Do not commit local SDK overrides, signing material, logs, tool state, generated build output, or media fixtures. A running Silo server is required for realistic auth, browsing, and playback validation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to Silo Android
+
+The [Silo contribution guide](https://github.com/Silo-Server/.github/blob/main/CONTRIBUTING.md)
+covers project-wide coordination, focused changes, evidence, AI disclosure, and
+pull request expectations. Those requirements apply here; this guide adds the
+Android-specific workflow.
+
+## Before you start
+
+Open an [issue](https://github.com/Silo-Server/silo-android/issues) before
+implementing a feature, navigation or behavior change, large refactor, or work
+that changes the shared server contract. Documentation, narrow fixes, and
+well-scoped parity corrections can go straight to a pull request.
+
+This repository owns the Android phone and Android TV clients. Server/API work
+belongs in [`silo-server`](https://github.com/Silo-Server/silo-server), and
+shared client behavior should be checked against
+[`silo-apple`](https://github.com/Silo-Server/silo-apple).
+
+## Development setup
+
+Read [README.md](README.md) for prerequisites and build commands, then read
+[AGENTS.md](AGENTS.md) for the current product exposure, module ownership, and
+testing guidance.
+
+Build the two debug applications with JDK 21 and an Android SDK:
+
+```sh
+./gradlew :androidApp:assembleDebug
+./gradlew :androidTvApp:assembleDebug
+```
+
+A running Silo server is required for realistic authentication, browsing, and
+playback validation. Do not commit SDK overrides, signing material, generated
+build output, logs, or media fixtures.
+
+## Validate your change
+
+Run focused module tests while iterating. Before opening a pull request, run the
+same checks as CI:
+
+```sh
+./scripts/test-check-build-supply-chain.sh
+./scripts/check-build-supply-chain.sh
+./gradlew testDebugUnitTest
+./gradlew \
+  :android-shared:lintDebug :androidApp:lintDebug :androidTvApp:lintDebug \
+  :androidApp:lintVitalRelease :androidTvApp:lintVitalRelease
+```
+
+Then build every affected app with `:androidApp:assembleDebug` and/or
+`:androidTvApp:assembleDebug`. Do not regenerate a lint baseline to hide a new
+finding. Exercise visible changes on the affected phone or TV surface and
+include screenshots or a short recording when the result is visual.
+
+## Open the pull request
+
+Use a Conventional Commit title, explain which surfaces are affected, paste the
+actual validation results, and call out any server or Apple coordination. Read
+the [AI-assisted contribution policy](https://github.com/Silo-Server/silo-server/blob/main/docs/ai-contributions.md)
+and include its disclosure block.
+
+## Instructions for coding agents
+
+Coding agents must read [AGENTS.md](AGENTS.md) before changing the repository
+(`CLAUDE.md` points to the same guidance). The organization-wide contribution
+guide and AI-assisted contribution policy apply to agent and human authors
+equally.

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ should start as an issue.
 Active design work lives in `docs/superpowers/specs/` with phased plans in `docs/superpowers/plans/`. Current gaps include:
 
 - **Audiobook polish** — the phone and TV players have chapter-aware UI, speed, bookmarks, and sleep timers. Remaining work includes skip-silence, volume normalization, rich notification polish, Android Auto, and a phone widget.
-- **Ebook reader enhancements** — in-text search and highlights and notes, with coordinated server work where the shared contract changes.
+- **Ebook reader enhancements** — in-text search, highlights, and notes, with coordinated server work where the shared contract changes.
 - **Admin management (users/sessions/logs/scans), Watch Together** — code/design work exists, but these are not currently exposed to users in the Android apps and need product/navigation decisions before being treated as live features.
 
 Known gaps the docs track: TV has no reader/ebooks and no downloads management by design; admin surfaces, session management, and Watch Together are not accessible on either Android surface today.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Android **phone** and **Android TV** clients for the [Silo](https://github.com/S
 
 Built as a Kotlin Multiplatform project: one shared business-logic core, two Jetpack Compose apps (touch + 10-foot TV). This branch uses the full Silo namespace cut: Kotlin packages live under `org.siloserver.silo`, and both apps share a single application ID `org.siloserver.silo` so they publish as one Google Play listing (Play routes each build by manifest feature filtering). Installs under legacy IDs do not upgrade in place; users should expect a fresh app install, sign-in, and offline media download.
 
-> **Status:** WIP (`v0.2.x`). The architecture is solid and the feature surface is broad; some areas are intentionally "bones-level" and under active redesign (see [Roadmap](#roadmap)).
+> **Status:** WIP (`v0.3.x`). Silo Android is pre-1.0 and some areas remain under active development (see [Roadmap](#roadmap)).
 >
-> **Current exposure note:** Requests is live on both Android surfaces, gated by the server's `requests_enabled` flag (`/api/v1/requests/status`), and reached from the profile menu and search — matching the Apple clients. The admin stats dashboard is live for acting admins via Settings (Apple's dashboard design). The richer admin screens (users/sessions/logs/scans) and Watch Together remain inaccessible.
+> **Current exposure note:** Requests is live on both Android surfaces, gated by the server's `requests_enabled` flag (`/api/v1/requests/status`), and reached from the profile menu and search — matching the Apple clients. Admin surfaces, session management, and Watch Together are not exposed in the Android clients.
 
 ---
 
@@ -20,8 +20,9 @@ Built as a Kotlin Multiplatform project: one shared business-logic core, two Jet
 - [Getting started](#getting-started)
 - [Testing](#testing)
 - [Conventions](#conventions)
+- [Contributing](#contributing)
 - [Roadmap](#roadmap)
-- [License](#license)
+- [License & trademarks](#license--trademarks)
 
 ---
 
@@ -78,12 +79,12 @@ WorkManager-backed downloads of video, audiobooks, and books to public device st
 
 ### 📚 Library, browse & discovery (phone + TV)
 - **Phone navigation** — Home, Libraries, For You, Calendar, and Downloads when the active profile has downloads. Video / Audio / Reading are library modes, not bottom-nav tabs.
-- **TV navigation** — Home, visible media-type tabs derived from server libraries (Movies/TV/Music/Audiobooks), and Calendar. Reading/ebooks are intentionally excluded from TV.
+- **TV navigation** — Home, visible media-type tabs derived from server libraries (Movies/TV/Music/Audiobooks), For You, and Calendar. Reading/ebooks are intentionally excluded from TV.
 - **Home** with Continue Watching, Recently Added/Released, and server-curated recommendation rows.
 - **Browse** with genre/rating filters, sorting, and infinite-scroll grids; **collections** are browse-only in the Android clients, while collection authoring/management remains web-only.
 - **Item detail** for movies and series includes seasons → episodes, multi-version files, cast/crew, local download controls, and phone-to-TV playback handoff.
 - **Search** scoped by media type, debounced and paginated.
-- **Requests** — live on phone and TV behind the server's `requests_enabled` flag (profile menu + search). **Admin** — stats dashboard only, role-gated in Settings. **Not exposed** — full admin management and Watch Together are not reachable app surfaces today.
+- **Requests** — live on phone and TV behind the server's `requests_enabled` flag (profile menu + search). **Not exposed** — admin surfaces, session management, and Watch Together are not reachable app surfaces today.
 
 ### 📖 Reading & 🎧 Audio
 - **Ebook reader (phone only)** — EPUB, PDF, CBZ (comics), TXT/Markdown, FB2/FBZ, plus MOBI/AZW/AZW3 when the server can convert to EPUB; CBR and unsupported originals can be downloaded/opened externally. Themes, text size, margins, table of contents, bookmarks, and progress are supported.
@@ -93,7 +94,7 @@ WorkManager-backed downloads of video, audiobooks, and books to public device st
 Android phone can discover SiloCast receivers on the local network, launch movies/episodes on TV with the selected file/track/resume context, and act as a lightweight remote for play/pause, seek, quality, audio, and subtitle changes. TV advertises the local SiloCast receiver only while authenticated and foregrounded. The channel is TLS-PSK and wire-compatible with the Apple clients' SiloControl protocol (same `_silocast._tcp` service, hello/serverId authorization, heartbeat), so Android phones can cast to Apple TVs and iPhones to Android TVs.
 
 ### 🔔 Personalization & engagement (phone + TV)
-Multiple **household profiles** per account (PINs, child profiles, content-rating limits, per-profile language/subtitle prefs), favorites & watchlist, ratings, a release **calendar**, and an in-app **notifications inbox** with realtime updates. Android push has a guarded client-side registration/data-message path, but real FCM delivery requires server provider support plus Firebase configuration in the phone app. TV mirrors continue-watching into the system **Watch Next** row.
+Multiple **household profiles** per account (PINs, child profiles, content-rating limits, per-profile language/subtitle prefs), favorites & watchlist, ratings, a release **calendar**, and an in-app **notifications inbox** with realtime updates. Android push uses Silo's content-free push relay when the server and app are configured for FCM. TV mirrors continue-watching into the system **Watch Next** row.
 
 ### 🌐 Multi-server & accounts (phone + TV)
 Add and switch between multiple Silo servers (encrypted per-server token slots), use username/password or device/QR sign-in, and manage household profiles. Admin screens are not currently exposed in the Android apps.
@@ -148,7 +149,7 @@ Three library layers under two app shells. Dependencies only point downward.
 `sharedModules()` (network + repositories) is combined with the player and Android modules at app startup. The Android apps override the in-memory `TokenManager`/`ServerRegistry` with persistent implementations. ViewModels are resolved with `koinViewModel()`; nav arguments flow in through Koin parameters / `SavedStateHandle`.
 
 ### Navigation & boot
-Each app computes a start destination from registry/token/profile/offline state (`ServerSetup → Login → ProfileSelection → main`), then runs a Compose nav graph. The phone uses an Apple-aligned bottom shell (`Home`, `Libraries`, `For You`, `Calendar`, and conditional `Downloads`). The TV uses a tvOS-aligned top menu (`Home`, available media-type tabs, `Calendar`, plus search/profile actions). Deep links handle device pairing through `silo://device?...` and supported HTTPS `/device` or `/auth/device` URLs.
+Each app computes a start destination from registry/token/profile/offline state (`ServerSetup → Login → ProfileSelection → main`), then runs a Compose nav graph. The phone uses an Apple-aligned bottom shell (`Home`, `Libraries`, `For You`, `Calendar`, and conditional `Downloads`). The TV uses a tvOS-aligned top menu (`Home`, available media-type tabs, `For You`, `Calendar`, plus search/profile actions). Deep links handle device pairing through `silo://device?...` and supported HTTPS `/device` or `/auth/device` URLs.
 
 ### Playback pipeline
 The UI never owns the player directly — a `MediaController` drives the shared `SiloPlaybackService` (a Media3 `MediaSessionService`), so there is exactly one player and system session. For video, `PlaybackSessionManager` sends protocol-v3 capabilities and executes the server's direct/remux/transcode plan; classified failures and track/output changes use the v3 replan endpoint. `PlaybackSessionLifecycle` owns progress and outage handling. Offline playback bypasses the server through a local `file://` URI. The normative contract is in [`docs/playback`](docs/playback/README.md).
@@ -217,24 +218,29 @@ On first launch, point the app at your Silo server URL, sign in, and pick a prof
 
 ## Conventions
 
-- **Kotlin** with `gofmt`-equivalent cleanliness via the project's lint/format setup; keep packages lowercase and focused.
+- **Kotlin** formatted consistently with the surrounding source; keep packages lowercase and focused, and keep Android lint clean.
 - **Shared first** — put platform-agnostic logic (models, networking, view-model logic, pure algorithms) in `shared`; keep Android-only concerns in `android-shared`; keep each app's module to its UI. New non-UI behavior that both apps need belongs in a shared module, not duplicated per app.
 - **Compose** screens are thin; logic lives in ViewModels (testable in `commonTest` where possible).
 - Design specs and implementation plans for larger efforts live under `docs/superpowers/{specs,plans}/`.
 - This is part of a multi-repo Silo workspace — client-visible API/auth/playback changes often need coordinated work in `silo-server` (and the sibling `silo-apple` clients).
 
+## Contributing
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Features,
+navigation or behavior changes, large refactors, and shared contract changes
+should start as an issue.
+
 ---
 
 ## Roadmap
 
-Active design work lives in `docs/superpowers/specs/` with phased plans in `docs/superpowers/plans/`. Notable in-flight items:
+Active design work lives in `docs/superpowers/specs/` with phased plans in `docs/superpowers/plans/`. Current gaps include:
 
 - **Audiobook polish** — the phone and TV players have chapter-aware UI, speed, bookmarks, and sleep timers. Remaining work includes skip-silence, volume normalization, rich notification polish, Android Auto, and a phone widget.
-- **Ebook reader enhancements** — real paginated EPUB (page turns), in-text search, highlights & notes (with a coordinated server change), font/brightness controls, and reading-time estimates across all server formats.
-- **Picture-in-Picture** — not yet implemented on phone.
+- **Ebook reader enhancements** — in-text search and highlights and notes, with coordinated server work where the shared contract changes.
 - **Admin management (users/sessions/logs/scans), Watch Together** — code/design work exists, but these are not currently exposed to users in the Android apps and need product/navigation decisions before being treated as live features.
 
-Known gaps the docs track: TV has no reader/ebooks and no downloads management by design; Requests/Admin/Watch Together are not accessible on either Android surface today.
+Known gaps the docs track: TV has no reader/ebooks and no downloads management by design; admin surfaces, session management, and Watch Together are not accessible on either Android surface today.
 
 ---
 


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Android did not have a repository-specific contribution guide, and its README contained stale version, navigation, admin-surface, push, tooling, and roadmap claims.

## Approach

Add Android-specific setup and CI validation guidance, correct the README against current phone/TV source and product exposure, embed the shared writing and pull-request policy in `AGENTS.md`, simplify stale local-skill ignore rules, and retain the existing `CLAUDE.md -> AGENTS.md` link.

## Validation

- Android CI, Gradle tasks, scripts, navigation, and product-exposure claims were checked against the workflow and source tree.
- All changed relative documentation links — passed.
- `git diff --check` — passed.
- Existing `CLAUDE.md -> AGENTS.md` target and resolved contents — verified.
- Gradle builds and device tests — not run; this PR changes documentation and agent guidance only.

## Risks

Documentation and contributor-workflow changes only. No Kotlin, Compose, Gradle, manifest, signing, or application behavior changed.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Codex desktop with Codex subagents
- Tool(s): Codex
- Model(s): GPT-5; the exact backend identifier was not exposed by the harness
- Involvement: AI-assisted
- Adversarial review: An independent subagent compared the README and contribution commands with Android CI, Gradle modules, scripts, navigation, and shipped feature exposure. Fresh ponytail-reviews of the staged diff and exact commit both found no unnecessary complexity: “Lean already. Ship.”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project status and roadmap information for the v0.3.x work-in-progress release.
  - Added contribution guidance covering setup, validation, visual testing, pull requests, and AI disclosure.
  - Added writing and pull request standards for maintainers and contributors.
  - Documented TV navigation updates, including the For You section.
  - Clarified that admin surfaces, session management, and Watch Together are currently unavailable.
  - Updated push notification behavior and revised known gaps and conventions.

- **Chores**
  - Refined local tooling ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->