### PR TITLE
Modernize Android TV

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/TrackSelectionPresets.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/TrackSelectionPresets.kt
@@ -6,8 +6,12 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import org.siloserver.silo.common.player.video.canonicalAudioCodecFamily
+import org.siloserver.silo.model.catalog.AudioTrack
 import org.siloserver.silo.model.playback.AudioPassthroughCapabilities
+import org.siloserver.silo.model.playback.ClientCodecCapabilities
 import org.siloserver.silo.model.playback.HdrCapabilities
+import org.siloserver.silo.playback.canonicalSubtitleLanguage
 
 /**
  * Client-side track-selection presets. Without these, the default selector
@@ -28,6 +32,11 @@ import org.siloserver.silo.model.playback.HdrCapabilities
  */
 @UnstableApi
 object TrackSelectionPresets {
+    fun effectivePreferredAudioLanguage(
+        settingsLanguage: String?,
+        profileLanguage: String?,
+    ): String? = settingsLanguage?.trim()?.takeIf { it.isNotEmpty() }
+        ?: profileLanguage?.trim()?.takeIf { it.isNotEmpty() }
 
     /**
      * TV: prioritize passthrough and let Media3 use the platform's native
@@ -88,8 +97,8 @@ object TrackSelectionPresets {
             .setPreferredVideoMimeTypes(*videoMimes.toTypedArray())
             .setPreferredAudioMimeTypes(*audioMimes.toTypedArray())
 
-        preferredAudioLanguage?.takeIf { it.isNotBlank() }
-            ?.let { builder.setPreferredAudioLanguage(it) }
+        preferredAudioLanguages(preferredAudioLanguage).takeIf { it.isNotEmpty() }
+            ?.let { builder.setPreferredAudioLanguages(*it.toTypedArray()) }
 
         return builder.build()
     }
@@ -126,8 +135,8 @@ object TrackSelectionPresets {
             )
             .setPreferredAudioMimeTypes(*audioMimes.toTypedArray())
 
-        preferredAudioLanguage?.takeIf { it.isNotBlank() }
-            ?.let { builder.setPreferredAudioLanguage(it) }
+        explicitPreferredAudioLanguages(preferredAudioLanguage).takeIf { it.isNotEmpty() }
+            ?.let { builder.setPreferredAudioLanguages(*it.toTypedArray()) }
 
         preferredTextLanguage?.takeIf { it.isNotBlank() }
             ?.let { builder.setPreferredTextLanguage(it) }
@@ -211,6 +220,177 @@ object TrackSelectionPresets {
     }
 
     /**
+     * Media3 language preference order. The viewer's explicit language wins;
+     * English is the deterministic fallback instead of whatever track happens
+     * to be first in the container. ISO-639 aliases are deduplicated, so
+     * `eng` and `en` do not become two artificial tiers.
+     */
+    internal fun preferredAudioLanguages(preferred: String?): List<String> {
+        val result = mutableListOf<String>()
+        val seen = mutableSetOf<String>()
+        listOfNotNull(preferred?.trim()?.takeIf { it.isNotEmpty() }, "en").forEach { language ->
+            val canonical = canonicalSubtitleLanguage(language) ?: language.lowercase()
+            if (seen.add(canonical)) result += language
+        }
+        return result
+    }
+
+    /**
+     * Phone keeps the container/server default when no preference is set. Once
+     * the viewer explicitly chooses a language, English remains its fallback.
+     * TV intentionally calls [preferredAudioLanguages] directly so its Auto
+     * policy is deterministic even without an explicit setting.
+     */
+    internal fun explicitPreferredAudioLanguages(preferred: String?): List<String> =
+        preferred?.trim()?.takeIf { it.isNotEmpty() }
+            ?.let(::preferredAudioLanguages)
+            .orEmpty()
+
+    /**
+     * Resolve the catalog audio ordinal before the server creates a playback
+     * plan. Explicit per-play choices are handled by the caller; this is the
+     * automatic policy used when no override exists.
+     *
+     * Selection is language-first (preferred, then English), then quality. A
+     * track only enters the first pass when the current device/output can
+     * decode it or carry it as passthrough at that channel count. If the file
+     * has no directly compatible track, a second pass still chooses the best
+     * source track so the server can adapt it rather than failing playback.
+     */
+    fun selectBestCompatibleAudioTrackOrdinal(
+        tracks: List<AudioTrack>,
+        preferredAudioLanguage: String?,
+        capabilities: ClientCodecCapabilities,
+    ): Int? {
+        if (tracks.isEmpty()) return null
+        val candidates = tracks.mapIndexed(::RankedAudioTrack)
+        val languageTiers = preferredAudioLanguages(preferredAudioLanguage)
+            .mapNotNull(::canonicalSubtitleLanguage)
+        languageTiers.forEach { language ->
+            val tier = candidates.filter {
+                canonicalSubtitleLanguage(it.track.language) == language
+            }
+            if (tier.isNotEmpty()) {
+                return bestCompatibleOrAdaptableAudioCandidate(tier, capabilities)?.ordinal
+            }
+        }
+
+        val mainMixes = withoutCommentaryWhenMainMixExists(candidates)
+        val directlyCompatible = mainMixes.filter {
+            isDirectlyCompatibleAudioTrack(it.track, capabilities)
+        }
+        return bestAudioCandidate(directlyCompatible.filter { it.track.isDefault })?.ordinal
+            ?: bestAudioCandidate(directlyCompatible)?.ordinal
+            ?: bestAudioCandidate(mainMixes.filter { it.track.isDefault })?.ordinal
+            ?: bestAudioCandidate(mainMixes)?.ordinal
+    }
+
+    /**
+     * Compatibility is ranked only *inside* a language tier. An available
+     * preferred-language source that needs server adaptation must not lose to
+     * directly playable English, and a compatible commentary track must not
+     * beat an adaptable main mix in that same language.
+     */
+    private fun bestCompatibleOrAdaptableAudioCandidate(
+        candidates: List<RankedAudioTrack>,
+        capabilities: ClientCodecCapabilities,
+    ): RankedAudioTrack? {
+        val mainMixes = withoutCommentaryWhenMainMixExists(candidates)
+        val directlyCompatible = mainMixes.filter {
+            isDirectlyCompatibleAudioTrack(it.track, capabilities)
+        }
+        return bestAudioCandidate(directlyCompatible) ?: bestAudioCandidate(mainMixes)
+    }
+
+    private fun withoutCommentaryWhenMainMixExists(
+        candidates: List<RankedAudioTrack>,
+    ): List<RankedAudioTrack> = candidates.filterNot { looksLikeCommentary(it.track.title) }
+        .ifEmpty { candidates }
+
+    private fun bestAudioCandidate(candidates: List<RankedAudioTrack>): RankedAudioTrack? {
+        if (candidates.isEmpty()) return null
+        val mainMixes = candidates.filterNot { looksLikeCommentary(it.track.title) }
+            .ifEmpty { candidates }
+        return mainMixes.maxWithOrNull(
+            compareBy<RankedAudioTrack> { audioQualityRank(it.track.codec) }
+                .thenBy { it.track.channels ?: 0 }
+                .thenBy { it.track.bitrate ?: 0 }
+                .thenBy { if (it.track.isDefault) 1 else 0 }
+                // Stable tie-break: the earlier catalog ordinal wins.
+                .thenBy { -it.ordinal },
+        )
+    }
+
+    private fun isDirectlyCompatibleAudioTrack(
+        track: AudioTrack,
+        capabilities: ClientCodecCapabilities,
+    ): Boolean {
+        val codec = audioPreferenceCodec(track.codec) ?: return false
+        if (codec == "aac") return true
+        val decodeCodecs = capabilities.codecsAudio
+            .mapNotNull(::audioPreferenceCodec)
+            .toSet()
+        if (codec in decodeCodecs) return true
+
+        val passthrough = capabilities.audioPassthrough ?: return false
+        val channelCount = track.channels ?: 0
+        val passthroughCandidates = when (codec) {
+            "eac3_joc" -> listOf("eac3_joc", "eac3")
+            "dts_hd" -> listOf("dts_hd", "dts")
+            else -> listOf(codec)
+        }
+        return passthroughCandidates.any { candidate ->
+            sinkCanPassthrough(candidate, channelCount, passthrough)
+        }
+    }
+
+    private fun audioPreferenceCodec(raw: String?): String? {
+        val token = raw
+            ?.substringAfterLast('/')
+            ?.lowercase()
+            ?.filter { it.isLetterOrDigit() }
+            ?.takeIf { it.isNotBlank() }
+            ?: return null
+        return when {
+            token.contains("truehd") || token == "mlp" -> "truehd"
+            token.contains("eac3joc") || token.contains("ec3joc") -> "eac3_joc"
+            token.contains("dtshd") || token.contains("dtsma") || token.contains("dtshra") -> "dts_hd"
+            token.startsWith("ec3") || token == "eac3" || token == "ddp" -> "eac3"
+            token.startsWith("ac3") -> "ac3"
+            token.startsWith("ac4") -> "ac4"
+            else -> canonicalAudioCodecFamily(raw)
+        }
+    }
+
+    private fun audioQualityRank(raw: String?): Int = when (audioPreferenceCodec(raw)) {
+        "truehd" -> 1_000
+        "eac3_joc" -> 950
+        "eac3" -> 900
+        "dts_hd" -> 850
+        "flac" -> 825
+        "ac4" -> 800
+        "dts" -> 700
+        "ac3" -> 650
+        "aac" -> 500
+        "opus" -> 450
+        "vorbis" -> 400
+        "mp3" -> 300
+        "pcm" -> 250
+        else -> 0
+    }
+
+    private fun looksLikeCommentary(title: String?): Boolean {
+        val value = title?.lowercase().orEmpty()
+        return listOf("commentary", "description", "descriptive", "director", "isolated score")
+            .any(value::contains)
+    }
+
+    private data class RankedAudioTrack(
+        val ordinal: Int,
+        val track: AudioTrack,
+    )
+
+    /**
      * MIMEs playable on this device — union of passthrough-reachable codecs
      * and, when the FFmpeg audio extension is on the classpath, the
      * FFmpeg-decodable codecs. AAC is always included (every Android
@@ -245,11 +425,11 @@ object TrackSelectionPresets {
      * guarantees it's still in the output because AAC is always reachable.
      */
     private val TV_DESIRED_ORDER = listOf(
-        MimeTypes.AUDIO_E_AC3_JOC,
         MimeTypes.AUDIO_TRUEHD,
-        MimeTypes.AUDIO_AC4,
+        MimeTypes.AUDIO_E_AC3_JOC,
         MimeTypes.AUDIO_E_AC3,
         MimeTypes.AUDIO_DTS_HD,
+        MimeTypes.AUDIO_AC4,
         MimeTypes.AUDIO_DTS,
         MimeTypes.AUDIO_AC3,
         MimeTypes.AUDIO_AAC,

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsCoordinatorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsCoordinatorTest.kt
@@ -373,6 +373,7 @@ class DiagnosticsCoordinatorTest {
         fixture.reports.saveHostedEnvelope(report.id, bundle)
 
         assertTrue(fixture.coordinator.delete(report.id))
+        runCurrent()
 
         assertEquals(null, fixture.reports.load(report.id))
         assertEquals(listOf(report.id), fixture.reports.hostedDeletionIntents())
@@ -382,6 +383,7 @@ class DiagnosticsCoordinatorTest {
 
         deleter.result = true
         fixture.coordinator.refresh()
+        runCurrent()
 
         assertTrue(fixture.reports.hostedDeletionIntents().isEmpty())
         assertEquals(listOf(report.id, report.id), deleter.reportIds)
@@ -434,6 +436,7 @@ class DiagnosticsCoordinatorTest {
         fixture.reports.saveHostedEnvelope(report.id, bundle)
 
         fixture.coordinator.setConsent(DiagnosticsConsentMode.NEVER)
+        runCurrent()
 
         assertEquals(null, fixture.reports.load(report.id))
         assertEquals(listOf(report.id), fixture.reports.hostedDeletionIntents())
@@ -680,6 +683,7 @@ class DiagnosticsCoordinatorTest {
 
         assertEquals(DiagnosticsUploadDecision.Uploaded("ABC123"), upload.await())
         assertTrue(deletion.await())
+        runCurrent()
         assertNull(fixture.reports.load(report.id))
         assertEquals(hosted.binding, fixture.reports.hostedReadyBinding(report.id))
         assertEquals(listOf(report.id), fixture.reports.hostedDeletionIntents())
@@ -687,6 +691,7 @@ class DiagnosticsCoordinatorTest {
 
         deleter.result = true
         fixture.coordinator.refresh()
+        runCurrent()
 
         assertTrue(fixture.reports.hostedDeletionIntents().isEmpty())
         assertNull(fixture.reports.hostedReadyBinding(report.id))
@@ -729,6 +734,7 @@ class DiagnosticsCoordinatorTest {
 
         assertEquals(DiagnosticsUploadDecision.Uploaded("ABC123"), upload.await())
         turnOff.await()
+        runCurrent()
         assertEquals(DiagnosticsConsentMode.NEVER, fixture.coordinator.state.value.consent)
         assertNull(fixture.reports.load(report.id))
         assertEquals(hosted.binding, fixture.reports.hostedReadyBinding(report.id))
@@ -738,6 +744,7 @@ class DiagnosticsCoordinatorTest {
 
         deleter.result = true
         fixture.coordinator.refresh()
+        runCurrent()
 
         assertTrue(fixture.reports.hostedDeletionIntents().isEmpty())
         assertNull(fixture.reports.hostedReadyBinding(report.id))

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentationTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/diagnostics/DiagnosticsInstrumentationTest.kt
@@ -278,7 +278,7 @@ class DiagnosticsInstrumentationTest {
         assertTrue(lines[1].contains("unique_item_rows"), lines[1])
         assertTrue(lines[2].contains("thermal_elevated"), lines[2])
         assertTrue(lines[2].contains("heap_128_255_pss_256_511"), lines[2])
-        assertFalse(lines[2].contains("173"), lines[2])
-        assertFalse(lines[2].contains("419"), lines[2])
+        assertFalse(lines[2].contains("\"java_heap_mb\""), lines[2])
+        assertFalse(lines[2].contains("\"process_pss_mb\""), lines[2])
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionManagerStagedReplanTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionManagerStagedReplanTest.kt
@@ -117,7 +117,7 @@ class PlaybackSessionManagerStagedReplanTest {
             // asynchronous cleanup still owns its first network attempt.
             harness.manager.stopSession("s2")
             releaseFirstCleanup.complete(Unit)
-            withTimeout(AWAIT_POLL_TIMEOUT_MS) {
+            withWallClockAwaitTimeout {
                 while (harness.manager.orphanedSessionIdsForTest().isNotEmpty()) {
                     yield()
                 }
@@ -596,9 +596,7 @@ class PlaybackSessionManagerStagedReplanTest {
         firstStopStarted.await()
         val secondDiscard = launch { harness.manager.discardStagedVideoReplan(second) }
         try {
-            withContext(Dispatchers.Default) {
-                withTimeout(AWAIT_POLL_TIMEOUT_MS) { secondStopStarted.await() }
-            }
+            withWallClockAwaitTimeout { secondStopStarted.await() }
             assertFalse(firstDiscard.isCompleted)
             assertTrue("s3" in harness.stopAttempts)
         } finally {
@@ -1631,12 +1629,12 @@ class PlaybackSessionManagerStagedReplanTest {
         }
 
         suspend fun awaitRouteEvent(event: String, planId: String): JsonObject =
-            withTimeout(AWAIT_POLL_TIMEOUT_MS) {
+            withWallClockAwaitTimeout {
                 while (true) {
                     routeEvents.firstOrNull { body ->
                         body["event"]?.jsonPrimitive?.content == event &&
                             body["plan_id"]?.jsonPrimitive?.content == planId
-                    }?.let { return@withTimeout it }
+                    }?.let { return@withWallClockAwaitTimeout it }
                     routeEventSignals.receive()
                 }
                 error("unreachable")
@@ -1777,4 +1775,10 @@ private object StagedReplanNoOpTokenManager : TokenManager {
  * a merely-slow test failed as if it had raced. The deadline exists to turn a
  * hang into a failure, not to police latency.
  */
+private suspend fun <T> withWallClockAwaitTimeout(
+    block: suspend CoroutineScope.() -> T,
+): T = withContext(Dispatchers.IO) {
+    withTimeout(AWAIT_POLL_TIMEOUT_MS, block)
+}
+
 private const val AWAIT_POLL_TIMEOUT_MS = 30_000L

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/TrackSelectionPresetsFfmpegTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/TrackSelectionPresetsFfmpegTest.kt
@@ -1,7 +1,9 @@
 package org.siloserver.silo.common.player
 
 import androidx.media3.common.MimeTypes
+import org.siloserver.silo.model.catalog.AudioTrack
 import org.siloserver.silo.model.playback.AudioPassthroughCapabilities
+import org.siloserver.silo.model.playback.ClientCodecCapabilities
 import org.siloserver.silo.model.playback.HdrCapabilities
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -85,7 +87,7 @@ class TrackSelectionPresetsFfmpegTest {
     }
 
     @Test
-    fun `TV desired order — E-AC-3 JOC beats TrueHD beats AC-3 beats AAC`() {
+    fun `TV desired order — TrueHD beats E-AC-3 JOC beats AC-3 beats AAC`() {
         val mimes = TrackSelectionPresets.buildTvAudioMimePreferences(
             caps = atmosAvrSink,
             ffmpegAvailable = false,
@@ -94,9 +96,134 @@ class TrackSelectionPresetsFfmpegTest {
         val truehdIdx = mimes.indexOf(MimeTypes.AUDIO_TRUEHD)
         val ac3Idx = mimes.indexOf(MimeTypes.AUDIO_AC3)
         val aacIdx = mimes.indexOf(MimeTypes.AUDIO_AAC)
-        assertTrue(jocIdx in 0 until truehdIdx, "JOC should precede TrueHD")
-        assertTrue(truehdIdx < ac3Idx, "TrueHD should precede AC-3")
+        assertTrue(truehdIdx in 0 until jocIdx, "TrueHD should precede JOC")
+        assertTrue(jocIdx < ac3Idx, "JOC should precede AC-3")
         assertTrue(ac3Idx < aacIdx, "AC-3 should precede AAC")
+    }
+
+    @Test
+    fun `automatic audio keeps preferred language and falls from unsupported TrueHD to E-AC-3`() {
+        val tracks = listOf(
+            AudioTrack(codec = "truehd", channels = 8, language = "ja"),
+            AudioTrack(codec = "eac3", channels = 6, language = "jpn"),
+            AudioTrack(codec = "aac", channels = 2, language = "en", isDefault = true),
+        )
+        val capabilities = ClientCodecCapabilities(codecsAudio = listOf("eac3", "aac"))
+
+        assertEquals(
+            1,
+            TrackSelectionPresets.selectBestCompatibleAudioTrackOrdinal(
+                tracks = tracks,
+                preferredAudioLanguage = "ja",
+                capabilities = capabilities,
+            ),
+        )
+    }
+
+    @Test
+    fun `automatic audio uses English when preferred language is unavailable`() {
+        val tracks = listOf(
+            AudioTrack(codec = "aac", channels = 2, language = "de", isDefault = true),
+            AudioTrack(codec = "eac3", channels = 6, language = "eng"),
+        )
+
+        assertEquals(
+            1,
+            TrackSelectionPresets.selectBestCompatibleAudioTrackOrdinal(
+                tracks = tracks,
+                preferredAudioLanguage = "fr",
+                capabilities = ClientCodecCapabilities(codecsAudio = listOf("eac3", "aac")),
+            ),
+        )
+    }
+
+    @Test
+    fun `automatic audio keeps available preferred language even when English is directly compatible`() {
+        val tracks = listOf(
+            AudioTrack(codec = "truehd", channels = 8, language = "fr", title = "Main"),
+            AudioTrack(codec = "aac", channels = 2, language = "en", isDefault = true),
+        )
+
+        assertEquals(
+            0,
+            TrackSelectionPresets.selectBestCompatibleAudioTrackOrdinal(
+                tracks = tracks,
+                preferredAudioLanguage = "fr",
+                capabilities = ClientCodecCapabilities(codecsAudio = listOf("aac")),
+            ),
+        )
+    }
+
+    @Test
+    fun `automatic audio keeps adaptable preferred main mix over compatible commentary`() {
+        val tracks = listOf(
+            AudioTrack(codec = "truehd", channels = 8, language = "fr", title = "Main"),
+            AudioTrack(codec = "aac", channels = 2, language = "fra", title = "Director Commentary"),
+        )
+
+        assertEquals(
+            0,
+            TrackSelectionPresets.selectBestCompatibleAudioTrackOrdinal(
+                tracks = tracks,
+                preferredAudioLanguage = "fr",
+                capabilities = ClientCodecCapabilities(codecsAudio = listOf("aac")),
+            ),
+        )
+    }
+
+    @Test
+    fun `automatic audio chooses TrueHD 7 point 1 when the output supports it`() {
+        val tracks = listOf(
+            AudioTrack(codec = "eac3", channels = 6, language = "en"),
+            AudioTrack(codec = "truehd", channels = 8, language = "en"),
+        )
+        val capabilities = ClientCodecCapabilities(
+            codecsAudio = listOf("eac3", "aac"),
+            audioPassthrough = AudioPassthroughCapabilities(
+                passthroughCodecs = listOf("truehd", "eac3"),
+                maxChannels = 8,
+            ),
+        )
+
+        assertEquals(
+            1,
+            TrackSelectionPresets.selectBestCompatibleAudioTrackOrdinal(
+                tracks = tracks,
+                preferredAudioLanguage = "en",
+                capabilities = capabilities,
+            ),
+        )
+    }
+
+    @Test
+    fun `automatic audio does not promote a commentary mix over the main track`() {
+        val tracks = listOf(
+            AudioTrack(codec = "truehd", channels = 8, language = "en", title = "Director Commentary"),
+            AudioTrack(codec = "eac3", channels = 6, language = "en", title = "Main"),
+        )
+
+        assertEquals(
+            1,
+            TrackSelectionPresets.selectBestCompatibleAudioTrackOrdinal(
+                tracks = tracks,
+                preferredAudioLanguage = "en",
+                capabilities = ClientCodecCapabilities(codecsAudio = listOf("truehd", "eac3")),
+            ),
+        )
+    }
+
+    @Test
+    fun `preferred audio languages always include English exactly once`() {
+        assertEquals(listOf("fr", "en"), TrackSelectionPresets.preferredAudioLanguages("fr"))
+        assertEquals(listOf("eng"), TrackSelectionPresets.preferredAudioLanguages("eng"))
+        assertEquals(listOf("en"), TrackSelectionPresets.preferredAudioLanguages(null))
+    }
+
+    @Test
+    fun `phone only applies English fallback after an explicit language preference`() {
+        assertEquals(emptyList(), TrackSelectionPresets.explicitPreferredAudioLanguages(null))
+        assertEquals(emptyList(), TrackSelectionPresets.explicitPreferredAudioLanguages("  "))
+        assertEquals(listOf("fr", "en"), TrackSelectionPresets.explicitPreferredAudioLanguages("fr"))
     }
 
     // -----------------------------------------------------------------------

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/MainTvActivity.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/MainTvActivity.kt
@@ -233,8 +233,28 @@ class MainTvActivity : ComponentActivity() {
 
     @SuppressLint("RestrictedApi")
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (TvPlayerRemoteKeyBridge.dispatch(event)) return true
-        return super.dispatchKeyEvent(event)
+        // Desktop TV emulators deliver the host keyboard's Escape key as
+        // KEYCODE_ESCAPE, not always as Android's KEYCODE_BACK. Translate it
+        // before normal window dispatch so a focused popup/menu gets first
+        // refusal, exactly as it does for a physical remote's Back button.
+        val translatedEvent = if (event.keyCode == KeyEvent.KEYCODE_ESCAPE) {
+            KeyEvent(
+                event.downTime,
+                event.eventTime,
+                event.action,
+                KeyEvent.KEYCODE_BACK,
+                event.repeatCount,
+                event.metaState,
+                event.deviceId,
+                event.scanCode,
+                event.flags,
+                event.source,
+            )
+        } else {
+            event
+        }
+        if (TvPlayerRemoteKeyBridge.dispatch(translatedEvent)) return true
+        return super.dispatchKeyEvent(translatedEvent)
     }
 
     /**

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/data/preferences/TvHomeSectionPreferences.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/data/preferences/TvHomeSectionPreferences.kt
@@ -1,0 +1,238 @@
+package org.siloserver.silo.tv.data.preferences
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStoreFile
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.siloserver.silo.model.section.ResolvedSection
+import org.siloserver.silo.network.TokenManager
+
+/** Device-local Home row order and visibility for one server/profile. */
+data class TvHomeSectionLayout(
+    val orderedSectionIds: List<String> = emptyList(),
+    val hiddenSectionIds: Set<String> = emptySet(),
+)
+
+data class TvHomeSectionPreferenceState(
+    val authority: String? = null,
+    val layout: TvHomeSectionLayout = TvHomeSectionLayout(),
+    /** Changes only when the active authority or its saved layout changes. */
+    val layoutRevision: Long = 0,
+)
+
+/**
+ * Android TV counterpart to tvOS `HomeSectionPreferences`.
+ *
+ * The server remains authoritative for which populated rows exist. This store
+ * only projects those rows into a device-local order/visibility layout, scoped
+ * to the active server and profile. Newly-added server rows therefore append
+ * in server order and remain visible until explicitly hidden.
+ */
+class TvHomeSectionPreferences(
+    private val context: Context,
+    private val tokenManager: TokenManager,
+    private val dataStoreFactory: (profileId: String) -> DataStore<Preferences> = { profileId ->
+        PreferenceDataStoreFactory.create(
+            produceFile = { context.preferencesDataStoreFile(fileNameFor(profileId)) },
+        )
+    },
+) {
+    private data class Authority(val profileId: String, val serverId: String) {
+        val identity: String = "$serverId\u001f$profileId"
+    }
+
+    private val mutex = Mutex()
+    private val storeCache = mutableMapOf<String, DataStore<Preferences>>()
+    private val _state = MutableStateFlow(TvHomeSectionPreferenceState())
+    val state: StateFlow<TvHomeSectionPreferenceState> = _state.asStateFlow()
+
+    private fun storeFor(profileId: String): DataStore<Preferences> =
+        synchronized(storeCache) {
+            storeCache.getOrPut(profileId) { dataStoreFactory(profileId) }
+        }
+
+    /** Load the active server/profile layout, if it is not already current. */
+    suspend fun refresh() {
+        val authority = activeAuthority()
+        mutex.withLock {
+            if (authority == null) {
+                publishIfChanged(authority = null, layout = TvHomeSectionLayout())
+                return
+            }
+            if (_state.value.authority == authority.identity) return
+            publishIfChanged(authority.identity, readLayout(authority))
+        }
+    }
+
+    suspend fun setVisible(sectionId: String, visible: Boolean) {
+        val authority = activeAuthority() ?: return
+        mutex.withLock {
+            val current = currentLayout(authority)
+            val wasVisible = sectionId !in current.hiddenSectionIds
+            if (wasVisible == visible) return
+
+            val hidden = current.hiddenSectionIds.toMutableSet().apply {
+                if (visible) remove(sectionId) else add(sectionId)
+            }
+            val updated = current.copy(hiddenSectionIds = hidden)
+            persist(authority, updated)
+            publish(authority.identity, updated)
+        }
+    }
+
+    /**
+     * Replace the order of currently-known rows while retaining remembered
+     * rows that are temporarily absent (for example empty Continue Watching).
+     */
+    suspend fun setOrder(sectionIds: List<String>) {
+        val authority = activeAuthority() ?: return
+        mutex.withLock {
+            val current = currentLayout(authority)
+            val updatedOrder = retainedOrder(sectionIds, current.orderedSectionIds)
+            if (updatedOrder == current.orderedSectionIds) return
+
+            val updated = current.copy(orderedSectionIds = updatedOrder)
+            persist(authority, updated)
+            publish(authority.identity, updated)
+        }
+    }
+
+    private suspend fun activeAuthority(): Authority? {
+        val profileId = tokenManager.getProfileId()?.takeIf(String::isNotBlank) ?: return null
+        val serverId = tokenManager.getCurrentServerId()?.takeIf(String::isNotBlank)
+            ?: DEFAULT_SERVER_ID
+        return Authority(profileId = profileId, serverId = serverId)
+    }
+
+    private suspend fun currentLayout(authority: Authority): TvHomeSectionLayout =
+        if (_state.value.authority == authority.identity) {
+            _state.value.layout
+        } else {
+            readLayout(authority)
+        }
+
+    private suspend fun readLayout(authority: Authority): TvHomeSectionLayout {
+        val preferences = storeFor(authority.profileId).data.first()
+        return TvHomeSectionLayout(
+            orderedSectionIds = unique(decodeIds(preferences[orderKey(authority.serverId)])),
+            hiddenSectionIds = preferences[hiddenKey(authority.serverId)].orEmpty(),
+        )
+    }
+
+    private suspend fun persist(authority: Authority, layout: TvHomeSectionLayout) {
+        storeFor(authority.profileId).edit { preferences ->
+            preferences[orderKey(authority.serverId)] = encodeIds(layout.orderedSectionIds)
+            preferences[hiddenKey(authority.serverId)] = layout.hiddenSectionIds
+        }
+    }
+
+    private fun publishIfChanged(authority: String?, layout: TvHomeSectionLayout) {
+        val current = _state.value
+        if (current.authority == authority && current.layout == layout) return
+        publish(authority, layout)
+    }
+
+    private fun publish(authority: String?, layout: TvHomeSectionLayout) {
+        _state.value = TvHomeSectionPreferenceState(
+            authority = authority,
+            layout = layout,
+            layoutRevision = _state.value.layoutRevision + 1,
+        )
+    }
+
+    companion object {
+        private const val DEFAULT_SERVER_ID = "default"
+
+        /** Apply saved order, then visibility, without introducing row gaps. */
+        fun arrange(
+            sections: List<ResolvedSection>,
+            layout: TvHomeSectionLayout,
+            includingHidden: Boolean = false,
+        ): List<ResolvedSection> {
+            val rank = layout.orderedSectionIds.withIndex().associate { it.value to it.index }
+            val arranged = sections
+                .filter { it.items.isNotEmpty() }
+                .withIndex()
+                .sortedWith { left, right ->
+                    val leftRank = rank[left.value.id]
+                    val rightRank = rank[right.value.id]
+                    when {
+                        leftRank != null && rightRank != null -> leftRank.compareTo(rightRank)
+                        leftRank != null -> -1
+                        rightRank != null -> 1
+                        else -> left.index.compareTo(right.index)
+                    }
+                }
+                .map { it.value }
+
+            return if (includingHidden) {
+                arranged
+            } else {
+                arranged.filterNot { it.id in layout.hiddenSectionIds }
+            }
+        }
+
+        internal fun retainedOrder(
+            sectionIds: List<String>,
+            rememberedSectionIds: List<String>,
+        ): List<String> {
+            val knownOrder = unique(sectionIds)
+            val knownIds = knownOrder.toSet()
+            return knownOrder + unique(rememberedSectionIds).filterNot(knownIds::contains)
+        }
+
+        private fun orderKey(serverId: String) =
+            stringPreferencesKey("home_section_order_${serverHash(serverId)}")
+
+        private fun hiddenKey(serverId: String) =
+            stringSetPreferencesKey("home_section_hidden_${serverHash(serverId)}")
+
+        /** Length-prefixing keeps arbitrary server section ids reversible. */
+        private fun encodeIds(ids: List<String>): String =
+            unique(ids).joinToString(separator = "") { "${it.length}:$it" }
+
+        private fun decodeIds(encoded: String?): List<String> {
+            if (encoded.isNullOrEmpty()) return emptyList()
+            val result = mutableListOf<String>()
+            var cursor = 0
+            while (cursor < encoded.length) {
+                val separator = encoded.indexOf(':', startIndex = cursor)
+                if (separator < 0) return emptyList()
+                val length = encoded.substring(cursor, separator).toIntOrNull() ?: return emptyList()
+                val start = separator + 1
+                val end = start + length
+                if (length < 0 || end > encoded.length) return emptyList()
+                result += encoded.substring(start, end)
+                cursor = end
+            }
+            return result
+        }
+
+        private fun unique(ids: List<String>): List<String> {
+            val seen = mutableSetOf<String>()
+            return ids.filter { it.isNotBlank() && seen.add(it) }
+        }
+
+        private fun fileNameFor(profileId: String): String =
+            "tv_home_sections_${profileHash(profileId)}"
+
+        private fun profileHash(profileId: String): String = hash(profileId).take(16)
+
+        private fun serverHash(serverId: String): String = hash(serverId).take(16)
+
+        private fun hash(value: String): String =
+            java.security.MessageDigest.getInstance("SHA-256")
+                .digest(value.toByteArray(Charsets.UTF_8))
+                .joinToString(separator = "") { "%02x".format(it) }
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/data/preferences/TvHomeSectionPreferences.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/data/preferences/TvHomeSectionPreferences.kt
@@ -108,8 +108,12 @@ class TvHomeSectionPreferences(
     }
 
     private suspend fun activeAuthority(): Authority? {
-        val profileId = tokenManager.getProfileId()?.takeIf(String::isNotBlank) ?: return null
-        val serverId = tokenManager.getCurrentServerId()?.takeIf(String::isNotBlank)
+        val scope = tokenManager.snapshotCurrentScope()
+        val profileId = (if (scope != null) scope.profileId else tokenManager.getProfileId())
+            ?.takeIf(String::isNotBlank)
+            ?: return null
+        val serverId = (if (scope != null) scope.serverId else tokenManager.getCurrentServerId())
+            ?.takeIf(String::isNotBlank)
             ?: DEFAULT_SERVER_ID
         return Authority(profileId = profileId, serverId = serverId)
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -6,6 +6,7 @@ import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.SettingsRepository
 import org.siloserver.silo.tv.BuildConfig
 import org.siloserver.silo.tv.data.preferences.LegacyTvPrefsMigration
+import org.siloserver.silo.tv.data.preferences.TvHomeSectionPreferences
 import org.siloserver.silo.tv.data.preferences.TvLibrarySelectionStore
 import org.siloserver.silo.common.network.AndroidDeviceMetadataProvider
 import org.siloserver.silo.common.network.SiloClientBuildIdentity
@@ -262,6 +263,10 @@ val androidTvModule = module {
         org.siloserver.silo.tv.data.preferences.TvLibraryScopeStore(androidContext(), get())
     }
 
+    // tvOS-parity Home row visibility/order, local to this TV and partitioned
+    // by active server + profile.
+    single { TvHomeSectionPreferences(androidContext(), get()) }
+
     // One-shot legacy `tv_prefs` import (playback settings → server device
     // overrides; selected-library id → active profile's selection store).
     // Sentinel-gated; invoked from TvSettingsViewModel.loadSettings and
@@ -448,6 +453,7 @@ val androidTvModule = module {
             recommendationRepository = getOrNull(),
             tokenManager = get(),
             identityTransitions = get(),
+            capabilityDetector = get(),
         )
     }
     // Watch Together entry (create/join orchestration) — backs the entry +

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
@@ -1,6 +1,10 @@
 package org.siloserver.silo.tv.ui.components
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -12,6 +16,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -20,6 +25,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -55,6 +61,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -93,6 +100,13 @@ data class TvSelectorOption(
     val onSelect: () -> Unit,
     val enabled: Boolean = true,
 )
+
+/** Trigger chrome used by the selector without changing its anchored menu. */
+internal enum class TvSelectorTriggerStyle {
+    SquaredPill,
+    ConnectedSegment,
+    CircularAction,
+}
 
 internal fun selectorExpansionAfterInteractivityChange(
     expanded: Boolean,
@@ -173,7 +187,7 @@ internal fun initialSelectorMenuIndex(options: List<TvSelectorOption>): Int {
  */
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-fun TvAnchoredSelectorMenu(
+internal fun TvAnchoredSelectorMenu(
     icon: ImageVector,
     label: String,
     value: String,
@@ -181,6 +195,13 @@ fun TvAnchoredSelectorMenu(
     modifier: Modifier = Modifier,
     triggerFocusRequester: FocusRequester? = null,
     interactive: Boolean = true,
+    triggerStyle: TvSelectorTriggerStyle = TvSelectorTriggerStyle.SquaredPill,
+    compactValue: String = value,
+    groupExpanded: Boolean = false,
+    /** Fixed selector bands make the connected trigger occupy its equal share. */
+    connectedFillWidth: Boolean = false,
+    /** Compact fixed bands keep their value stable instead of growing on focus. */
+    connectedExpandValue: Boolean = true,
 ) {
     var expansionRequested by remember { mutableStateOf(false) }
     // Derived, not deferred: a LaunchedEffect would leave the dropdown drawn
@@ -201,71 +222,83 @@ fun TvAnchoredSelectorMenu(
     // popup at the trigger's layout position (the menu inherits the anchor's
     // top-start), so it opens at/under the pill rather than as a centered modal.
     Box(modifier = modifier) {
-        SquaredPillSurface(
-            kind = PillKind.Secondary,
-            onClick = { if (interactive) expansionRequested = true },
-            modifier = Modifier,
-            focusRequester = triggerFr,
-            // Deliberately NOT `enabled = interactive`. A single-choice pill is
-            // not a disabled control — it is Apple's `TVSelectorValue`, a value
-            // display that stays focusable and simply does nothing on Select.
-            // `SquaredPillSurface` routes `enabled` into `Modifier.clickable`,
-            // and a disabled clickable is also unfocusable, so handing it
-            // `interactive` would drop the pill out of D-pad traversal. Most
-            // titles have one version and one audio track, so that would strand
-            // the row: three pills drawn, none reachable, and Down from the
-            // action row skipping the whole cluster. The chevron below is
-            // hidden instead, which is what tells the viewer it will not open.
-            // Secondary .compact pill body padding, tvOS 40×22pt → 20×11dp,
-            // +2/+1 per design review.
-            contentPadding = PaddingValues(horizontal = 22.dp, vertical = 12.dp),
-        ) { fg ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = fg,
-                    modifier = Modifier.size(13.dp),
-                )
-                Spacer(Modifier.width(7.dp))
-                // tvOS `TVSelectorButton`: label 18pt bold tracking 1.0 @0.6,
-                // value 22pt semibold — floored at 14sp for 10-ft legibility
-                // (audit 2026-07-20).
-                Text(
-                    text = label.uppercase(),
-                    style = MaterialTheme.typography.labelLarge.copy(
-                        fontSize = 14.sp,
-                        lineHeight = 18.sp,
-                        fontWeight = FontWeight.Bold,
-                        letterSpacing = 0.5.sp,
-                    ),
-                    color = fg.copy(alpha = 0.75f),
-                    maxLines = 1,
-                )
-                Spacer(Modifier.width(7.dp))
-                Text(
-                    text = value,
-                    style = MaterialTheme.typography.titleMedium.copy(
-                        fontSize = 14.sp,
-                        lineHeight = 18.sp,
-                        fontWeight = FontWeight.SemiBold,
-                    ),
-                    color = fg,
-                    modifier = Modifier.weight(1f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                if (interactive) {
-                    Spacer(Modifier.width(7.dp))
+        when (triggerStyle) {
+            TvSelectorTriggerStyle.CircularAction -> TvSquareToggleButton(
+                icon = icon,
+                iconActive = icon,
+                isActive = false,
+                contentDescription = buildString {
+                    append(label)
+                    value.takeIf { it.isNotBlank() }?.let { append(", ").append(it) }
+                },
+                onClick = { if (interactive) expansionRequested = true },
+                focusRequester = triggerFr,
+            )
+            TvSelectorTriggerStyle.ConnectedSegment -> ConnectedSelectorTrigger(
+                icon = icon,
+                label = label,
+                value = value,
+                compactValue = compactValue,
+                expanded = groupExpanded || expanded,
+                interactive = interactive,
+                focusRequester = triggerFr,
+                fillWidth = connectedFillWidth,
+                expandValue = connectedExpandValue,
+                onClick = { if (interactive) expansionRequested = true },
+            )
+            TvSelectorTriggerStyle.SquaredPill -> SquaredPillSurface(
+                kind = PillKind.Secondary,
+                onClick = { if (interactive) expansionRequested = true },
+                modifier = Modifier,
+                focusRequester = triggerFr,
+                // Deliberately NOT `enabled = interactive`. A single-choice
+                // value remains focusable and simply does nothing on Select.
+                contentPadding = PaddingValues(horizontal = 22.dp, vertical = 12.dp),
+            ) { fg ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     Icon(
-                        imageVector = Icons.Filled.KeyboardArrowDown,
+                        imageVector = icon,
                         contentDescription = null,
-                        tint = fg.copy(alpha = 0.6f),
-                        modifier = Modifier.size(9.5.dp),
+                        tint = fg,
+                        modifier = Modifier.size(13.dp),
                     )
+                    Spacer(Modifier.width(7.dp))
+                    Text(
+                        text = label.uppercase(),
+                        style = MaterialTheme.typography.labelLarge.copy(
+                            fontSize = 14.sp,
+                            lineHeight = 18.sp,
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 0.5.sp,
+                        ),
+                        color = fg.copy(alpha = 0.75f),
+                        maxLines = 1,
+                    )
+                    Spacer(Modifier.width(7.dp))
+                    Text(
+                        text = value,
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontSize = 14.sp,
+                            lineHeight = 18.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        ),
+                        color = fg,
+                        modifier = Modifier.weight(1f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (interactive) {
+                        Spacer(Modifier.width(7.dp))
+                        Icon(
+                            imageVector = Icons.Filled.KeyboardArrowDown,
+                            contentDescription = null,
+                            tint = fg.copy(alpha = 0.6f),
+                            modifier = Modifier.size(9.5.dp),
+                        )
+                    }
                 }
             }
         }
@@ -401,6 +434,86 @@ fun TvAnchoredSelectorMenu(
                 }
                 CascadePanelFooter(caption = "Press selects · Back closes")
             }
+        }
+    }
+}
+
+/** One focusable segment inside the approved connected selector capsule. */
+@Composable
+private fun ConnectedSelectorTrigger(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    compactValue: String,
+    expanded: Boolean,
+    interactive: Boolean,
+    focusRequester: FocusRequester,
+    fillWidth: Boolean,
+    expandValue: Boolean,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val focused by interactionSource.collectIsFocusedAsState()
+    val foreground by animateColorAsState(
+        targetValue = if (focused) Color.Black else Color.White,
+        animationSpec = tween(120),
+        label = "selectorSegmentForeground",
+    )
+    val fill by animateColorAsState(
+        targetValue = if (focused) Color.White else Color.Transparent,
+        animationSpec = tween(120),
+        label = "selectorSegmentFill",
+    )
+    val showsFullValue = expandValue && (expanded || focused)
+
+    Row(
+        modifier = (if (fillWidth) {
+            Modifier.fillMaxWidth()
+        } else {
+            Modifier.animateContentSize(animationSpec = tween(durationMillis = 280))
+        })
+            .height(23.dp)
+            .clip(CircleShape)
+            .background(fill)
+            .border(
+                width = if (focused) 1.25.dp else 0.dp,
+                color = if (focused) Color.White.copy(alpha = 0.95f) else Color.Transparent,
+                shape = CircleShape,
+            )
+            .focusRequester(focusRequester)
+            .semantics { contentDescription = "$label, $value" }
+            // Keep single-choice values focusable, matching tvOS
+            // TVSelectorValue; interactivity only controls menu expansion.
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .padding(horizontal = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = foreground,
+            modifier = Modifier.size(15.dp),
+        )
+        Text(
+            text = if (showsFullValue) value else compactValue,
+            color = foreground,
+            fontWeight = FontWeight.Medium,
+            fontSize = 14.sp,
+            lineHeight = 17.sp,
+            maxLines = 1,
+        )
+        if (interactive && showsFullValue) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowDown,
+                contentDescription = null,
+                tint = foreground.copy(alpha = 0.78f),
+                modifier = Modifier.size(8.dp),
+            )
         }
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvEpisodeCard.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvEpisodeCard.kt
@@ -75,6 +75,7 @@ fun TvEpisodeCard(
     userState: org.siloserver.silo.model.catalog.MediaItemUserState? = null,
     overlay: OverlayData? = null,
     actions: TvMediaCardActions = TvMediaCardActions(),
+    onLongClick: (() -> Unit)? = null,
 ) {
     val overlayState = LocalCardOverlayUiState.current
     val caption = LocalCardPresentation.current.caption
@@ -101,7 +102,7 @@ fun TvEpisodeCard(
 
         Card(
             onClick = onClick,
-            onLongClick = if (actions.isEmpty) null else { { menuExpanded = true } },
+            onLongClick = onLongClick ?: if (actions.isEmpty) null else { { menuExpanded = true } },
             interactionSource = interactionSource,
             shape = CardDefaults.shape(shape = cardShape),
             scale = cardFocus.scale,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarquee.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarquee.kt
@@ -25,12 +25,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -251,50 +249,52 @@ private fun TvMarqueeBlock(
             }
         }
 
-        // Format spec line: the resolution / dynamic-range / audio trio, kept
-        // as quiet text under the credits so the rating stays the only chip.
-        content.specLine?.let { spec ->
-            Text(
-                text = spec,
-                color = SiloOnSurface.copy(alpha = 0.55f),
-                fontSize = MarqueeSpecSize,
-                fontFamily = FontFamily.Monospace,
-                fontWeight = FontWeight.Medium,
-                letterSpacing = MarqueeSpecSize * 0.04f,
-                lineHeight = MarqueeSpecSize * 1.2f,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.offset(y = (-6).dp),
-            )
-        }
+        // tvOS keeps resolution, dynamic range and audio as separate outlined
+        // badges below the aired/cast line, rather than a dot-joined spec line.
+        content.specLine
+            ?.split(" · ")
+            ?.filter { it.isNotBlank() }
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { badges ->
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(7.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.offset(y = (-6).dp),
+                ) {
+                    badges.forEach { badge -> MarqueeBadge(badge.uppercase()) }
+                }
+            }
     }
 }
 
 @Composable
 private fun MarqueeBadge(label: String) {
-    val shape = RoundedCornerShape(5.dp)
-    // Solid, not outlined: the content rating is the one chip on the hero
-    // and has to read before the meta text next to it.
+    val shape = RoundedCornerShape(3.dp)
     Box(
         modifier = Modifier
-            .clip(shape)
-            .background(Color.White.copy(alpha = 0.92f))
-            .padding(horizontal = 9.dp, vertical = 3.dp),
+            .background(Color.White.copy(alpha = 0.08f), shape)
+            .border(
+                width = 0.5.dp,
+                color = Color.White.copy(alpha = 0.24f),
+                shape = shape,
+            )
+            .padding(horizontal = 6.dp, vertical = 2.5.dp),
     ) {
         Text(
             text = label,
-            color = Color.Black.copy(alpha = 0.92f),
+            color = Color.White.copy(alpha = 0.92f),
             fontSize = MarqueeBadgeSize,
             lineHeight = MarqueeBadgeSize * 1.25f,
-            letterSpacing = MarqueeBadgeSize * 0.08f,
+            letterSpacing = 0.55.sp,
             fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
         )
     }
 }
 
 // Skyline marquee metrics. Geometry stays ~0.5x of the tvOS 1920×1080 tokens;
-// text sizes are floored at 14sp (16sp for the synopsis body) for 10-ft
-// legibility — audit 2026-07-20.
+// body text stays at the 10-ft legibility floor; the compact outlined badges
+// intentionally follow the smaller tvOS metadata treatment.
 private val MarqueeContentWidth = 440.dp
 private val MarqueeSynopsisMaxWidth = 390.dp
 private val MarqueeLogoMaxWidth = 440.dp
@@ -304,5 +304,4 @@ private val MarqueeTitleSize = 44.sp
 private val MarqueeMetaSize = 14.sp
 private val MarqueeDetailSize = 14.sp
 private val MarqueeSynopsisSize = 16.sp
-private val MarqueeBadgeSize = 14.sp
-private val MarqueeSpecSize = 13.sp
+private val MarqueeBadgeSize = 10.5.sp

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarqueeModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarqueeModel.kt
@@ -28,7 +28,7 @@ data class TvMarqueeContent(
     val id: String,
     val title: String,
     val logoUrl: String?,
-    /** Optional uppercase content-classification chip. */
+    /** Optional uppercase content-classification badge before the editorial metadata. */
     val badges: List<String>,
     /** Dot-joined editorial metadata after the badge. */
     val metaParts: List<String>,
@@ -37,9 +37,8 @@ data class TvMarqueeContent(
     val detailLine: String?,
     /**
      * Playback format, `4K · Dolby Vision · EAC3 5.1`, from the section
-     * payload's overlay summary. Rendered as a muted spec line under the
-     * detail line rather than as chips, so the content rating stays the only
-     * badge on the hero and the format is there when the viewer looks for it.
+     * payload's overlay summary. The view splits this stable representation
+     * into the three tvOS-style badges beneath the detail line.
      */
     val specLine: String?,
     val backdropUrl: String?,
@@ -93,15 +92,11 @@ data class TvMarqueeContent(
             if (isEpisode) {
                 episodeToken(item.seasonNumber, item.episodeNumber)?.let(meta::add)
                 if (item.title.isNotBlank()) meta.add(item.title)
-                lengthText(item.runtime, item.durationSeconds)?.let(meta::add)
-                timeLeftText(item.positionSeconds, item.durationSeconds)?.let(meta::add)
-                ratingToken(item.ratingImdb)?.let(meta::add)
             } else {
                 if (item.year > 0) meta.add(item.year.toString())
                 lengthText(item.runtime, item.durationSeconds)?.let(meta::add)
                 ratingToken(item.ratingImdb)?.let(meta::add)
                 item.genres.firstOrNull { it.isNotBlank() }?.let(meta::add)
-                timeLeftText(item.positionSeconds, item.durationSeconds)?.let(meta::add)
             }
 
             val badges = item.contentRating
@@ -144,18 +139,10 @@ data class TvMarqueeContent(
             else -> null
         }
 
-        private fun timeLeftText(position: Double?, duration: Double?): String? {
-            if (position == null || duration == null || duration <= 0) return null
-            if (position <= 60 || position / duration >= 0.95) return null
-            val remaining = (((duration - position) / 60.0)).let { kotlin.math.ceil(it).toInt() }.coerceAtLeast(1)
-            return "$remaining min left"
-        }
-
         /**
          * `4K · Dolby Vision · EAC3 5.1` from the payload's overlay summary —
-         * the same resolution / dynamic-range / audio trio the tvOS marquee
-         * shows, spelled out rather than uppercased since it is a text line
-         * here, not a chip row.
+         * a stable delimiter representation that the view turns into separate,
+         * uppercased tvOS-style badges.
          */
         internal fun specLine(summary: OverlaySummary?): String? {
             if (summary == null) return null

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCard.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCard.kt
@@ -84,6 +84,7 @@ fun TvMediaCard(
     cardModifier: Modifier = Modifier,
     overlay: OverlayData? = null,
     actions: TvMediaCardActions = TvMediaCardActions(),
+    onLongClick: (() -> Unit)? = null,
 ) {
     val overlayState = LocalCardOverlayUiState.current
     val caption = LocalCardPresentation.current.caption
@@ -122,7 +123,7 @@ fun TvMediaCard(
 
         Card(
             onClick = onClick,
-            onLongClick = if (actions.isEmpty) null else { { menuExpanded = true } },
+            onLongClick = onLongClick ?: if (actions.isEmpty) null else { { menuExpanded = true } },
             interactionSource = interactionSource,
             shape = CardDefaults.shape(shape = cardShape),
             scale = cardFocus.scale,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCardActions.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCardActions.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -69,13 +70,16 @@ import org.siloserver.silo.tv.ui.theme.FocusedContent
  * app — kept separate to avoid pulling phone components into the TV module.
  */
 data class TvMediaCardActions(
+    val onPlay: (() -> Unit)? = null,
+    val playLabel: String = "Play",
     val onSetWatched: ((watched: Boolean) -> Unit)? = null,
     val onToggleFavorite: ((favorite: Boolean) -> Unit)? = null,
     val onToggleWatchlist: ((inWatchlist: Boolean) -> Unit)? = null,
     val onRemoveFromContinueWatching: (() -> Unit)? = null,
 ) {
     val isEmpty: Boolean
-        get() = onSetWatched == null &&
+        get() = onPlay == null &&
+            onSetWatched == null &&
             onToggleFavorite == null &&
             onToggleWatchlist == null &&
             onRemoveFromContinueWatching == null
@@ -110,6 +114,7 @@ fun TvMediaCardContextMenu(
         AboveAnchorPopupPositionProvider(popupMarginPx)
     }
     val firstAction = when {
+        actions.onPlay != null -> TvMenuAction.Play
         actions.onSetWatched != null -> TvMenuAction.Watched
         actions.onToggleFavorite != null -> TvMenuAction.Favorite
         actions.onToggleWatchlist != null -> TvMenuAction.Watchlist
@@ -174,6 +179,21 @@ private fun TvMediaCardMenuRows(
     firstRowFocus: FocusRequester,
     onDismiss: () -> Unit,
 ) {
+    actions.onPlay?.let { play ->
+        TvMenuRow(
+            text = actions.playLabel,
+            icon = Icons.Default.PlayArrow,
+            onClick = {
+                onDismiss()
+                play()
+            },
+            modifier = if (firstAction == TvMenuAction.Play) {
+                Modifier.focusRequester(firstRowFocus)
+            } else {
+                Modifier
+            },
+        )
+    }
     actions.onSetWatched?.let { setWatched ->
         TvMenuRow(
             text = if (isPlayed) "Mark as Unwatched" else "Mark as Watched",
@@ -261,6 +281,7 @@ private class AboveAnchorPopupPositionProvider(
 }
 
 private enum class TvMenuAction {
+    Play,
     Watched,
     Favorite,
     Watchlist,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaRow.kt
@@ -121,6 +121,8 @@ fun TvMediaRow(
     /** Reports whether this row or any descendant card currently owns focus. */
     onRowFocusChanged: ((Boolean) -> Unit)? = null,
     cardActions: (SectionItem) -> TvMediaCardActions = { TvMediaCardActions() },
+    /** Optional direct long-press action. Null keeps the card's context menu. */
+    longClickAction: (SectionItem) -> (() -> Unit)? = { null },
 ) {
     val diagnosticsKeySnapshot = remember(items) {
         DiagnosticsListSnapshot.fromKeys(items.map { it.contentId })
@@ -337,6 +339,7 @@ fun TvMediaRow(
                 // owners) after a refresh that reclassifies the section while
                 // leaving the item equal (Codex).
                 val itemActions = remember(item, cardActions) { cardActions(item) }
+                val itemLongClick = remember(item, longClickAction) { longClickAction(item) }
                 when (cardLayout) {
                     TvRowCardLayout.ReferenceShelf -> TvReferenceShelfCard(
                         title = rowItem.shelfTitle,
@@ -350,6 +353,7 @@ fun TvMediaRow(
                         cardModifier = appliedCardModifier,
                         userState = item.userState,
                         actions = itemActions,
+                        onLongClick = itemLongClick,
                     )
                     TvRowCardLayout.Default -> when (style) {
                         TvRowStyle.Backdrop -> TvEpisodeCard(
@@ -367,6 +371,7 @@ fun TvMediaRow(
                             userState = item.userState,
                             overlay = rowItem.overlay,
                             actions = itemActions,
+                            onLongClick = itemLongClick,
                         )
                         TvRowStyle.Poster -> TvMediaCard(
                             title = item.title,
@@ -382,6 +387,7 @@ fun TvMediaRow(
                             cardModifier = appliedCardModifier,
                             overlay = rowItem.overlay,
                             actions = itemActions,
+                            onLongClick = itemLongClick,
                         )
                     }
                 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvReferenceShelfCard.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvReferenceShelfCard.kt
@@ -53,6 +53,7 @@ fun TvReferenceShelfCard(
     cardModifier: Modifier = Modifier,
     userState: org.siloserver.silo.model.catalog.MediaItemUserState? = null,
     actions: TvMediaCardActions = TvMediaCardActions(),
+    onLongClick: (() -> Unit)? = null,
 ) {
     val shape = RoundedCornerShape(12.dp)
     val focus = siloCardDefaults(shape = shape, focusedScale = 1f)
@@ -66,7 +67,7 @@ fun TvReferenceShelfCard(
     ) {
         Card(
             onClick = onClick,
-            onLongClick = if (actions.isEmpty) null else { { menuExpanded = true } },
+            onLongClick = onLongClick ?: if (actions.isEmpty) null else { { menuExpanded = true } },
             shape = CardDefaults.shape(shape = shape),
             scale = focus.scale,
             border = focus.border,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvRootHeroBackdrop.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvRootHeroBackdrop.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -30,7 +28,6 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.section.SectionItem
@@ -42,8 +39,8 @@ import org.siloserver.silo.model.section.SectionItem
  * the leading edge and the bottom by a two-axis corner mask into a color
  * sampled from the art itself, which is carried (dimmed) diagonally
  * topEnd → bottomStart across the page so the metadata and rows sit on the same
- * tint. A ~95dp top scrim maps the tvOS 190pt ramp into the half-scale Android
- * TV layout and keeps the menu bar legible over bright art.
+ * tint. The shell owns the single shared top-navigation shadow so this artwork
+ * does not double-darken Home relative to other root pages.
  *
  * Driven by whichever row card holds focus — pass that item's marquee
  * [content]; when null the page renders flat on the app background.
@@ -163,18 +160,6 @@ fun TvRootHeroBackdrop(
             )
         }
 
-        // Full-width top scrim so the menu bar stays legible over bright art.
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(TopScrimHeight)
-                .background(
-                    Brush.verticalGradient(
-                        0f to Color.Black.copy(alpha = 0.5f),
-                        1f to Color.Transparent,
-                    ),
-                ),
-        )
     }
 }
 
@@ -268,7 +253,6 @@ fun TvRootHeroBackdrop(
 
 private const val ArtWidthFraction = 0.64f
 private const val ArtHeightFraction = 0.70f
-private val TopScrimHeight = 95.dp
 private const val TintOnlyDitherAlpha = 0.28f
 private const val EmptyWashDitherAlpha = 0.34f
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSkylineSectionFeed.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -77,6 +78,24 @@ import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
 import org.siloserver.silo.common.diagnostics.DiagnosticsListSurface
 
 /**
+ * Data worth warming while a card is focused because Select opens a different
+ * detail identity than the card itself (Continue Watching episodes open their
+ * combined Series page). All fields are cache-only inputs; no navigation or
+ * presentation state is changed by this request.
+ */
+data class TvSkylineDetailPrefetchTarget(
+    val detailContentId: String,
+    val seriesId: String? = null,
+    val seasonNumber: Int? = null,
+    val episodeContentId: String? = null,
+)
+
+private data class TvSkylinePriorityPrefetchRequest(
+    val sourceContentId: String,
+    val target: TvSkylineDetailPrefetchTarget,
+)
+
+/**
  * Android TV port of tvOS `TVSkylineSectionFeed`: shared by Home and library
  * Recommended so their lower row band, focus marquee, and ambient backdrop
  * stay pixel-aligned.
@@ -101,6 +120,8 @@ fun TvSkylineSectionFeed(
      */
     surfaceKey: String,
     modifier: Modifier = Modifier,
+    /** Home-only foreground drop; backdrop and fixed top navigation do not move. */
+    contentVerticalOffset: Dp = 0.dp,
     /**
      * False while rows are still being hydrated.
      *
@@ -129,6 +150,20 @@ fun TvSkylineSectionFeed(
         if (it.isTvProgressRow()) TvRowStyle.Backdrop else TvRowStyle.Poster
     },
     cardActions: (ResolvedSection, SectionItem) -> TvMediaCardActions = { _, _ -> TvMediaCardActions() },
+    /** A non-null action replaces [onItemClick] while preserving detail-return tracking. */
+    clickActionForSection: (ResolvedSection, SectionItem) -> (() -> Unit)? = { _, _ -> null },
+    /**
+     * Optional high-priority cache warmer for cards whose Select target needs
+     * more than the card's own marquee detail. It starts on raw focus (and for
+     * the initial card) so an immediate Select does not wait for the marquee's
+     * focus-rest interval before useful work begins.
+     */
+    priorityDetailPrefetchTargetForSection: (
+        ResolvedSection,
+        SectionItem,
+    ) -> TvSkylineDetailPrefetchTarget? = { _, _ -> null },
+    /** A non-null action replaces the card context menu for that long press. */
+    longClickActionForSection: (ResolvedSection, SectionItem) -> (() -> Unit)? = { _, _ -> null },
     onContentUpFallbackChanged: ((((Boolean) -> Boolean)?) -> Unit)? = null,
 ) {
     val rows = remember(sections) { sections.filter { it.items.isNotEmpty() } }
@@ -192,6 +227,78 @@ fun TvSkylineSectionFeed(
     var focusedItemIndex by remember { mutableIntStateOf(-1) }
     var focusedContentId by remember { mutableStateOf<String?>(null) }
     var removalFocusRequest by remember { mutableIntStateOf(0) }
+
+    val priorityPrefetchRequest = remember(
+        rows,
+        focusedRowIndex,
+        focusedContentId,
+        initialMarqueeSeed,
+    ) {
+        val focused = rows.getOrNull(focusedRowIndex)?.let { section ->
+            section.items.firstOrNull { it.contentId == focusedContentId }?.let { item ->
+                priorityDetailPrefetchTargetForSection(section, item)?.let { target ->
+                    TvSkylinePriorityPrefetchRequest(item.contentId, target)
+                }
+            }
+        }
+        focused ?: rows.firstOrNull()?.let { section ->
+            section.items.firstOrNull()?.let { item ->
+                priorityDetailPrefetchTargetForSection(section, item)?.let { target ->
+                    TvSkylinePriorityPrefetchRequest(item.contentId, target)
+                }
+            }
+        }
+    }
+
+    // Continue Watching is a latency-sensitive handoff: a movie opens its own
+    // detail, while an episode opens Series + season + episode state. Warm the
+    // exact navigation target immediately, independently of the 150 ms marquee
+    // rest used to avoid noisy visual enrichment requests during fast D-pad
+    // travel. The cache-first repository calls make revisits local-only.
+    LaunchedEffect(priorityPrefetchRequest, fetchDetail) {
+        val request = priorityPrefetchRequest ?: return@LaunchedEffect
+        val target = request.target
+        if (target.detailContentId.isBlank()) return@LaunchedEffect
+
+        suspend fun warmDetail(contentId: String) {
+            if (contentId.isBlank() || !marquee.beginEnrichmentRequest(contentId)) return
+            try {
+                val detail = runCatching { fetchDetail(contentId) }.getOrNull() ?: return
+                // Only the card's own detail may enrich its hero. A Continue
+                // Watching episode also warms its Series target, but Series
+                // copy must never replace episode copy in the Home marquee.
+                if (contentId == request.sourceContentId) {
+                    marquee.applyEnrichment(contentId, TvMarqueeEnrichment.from(detail))
+                }
+            } finally {
+                marquee.finishEnrichmentRequest(contentId)
+            }
+        }
+
+        coroutineScope {
+            val jobs = linkedSetOf(target.detailContentId, target.episodeContentId)
+                .filterNotNull()
+                .map { contentId -> async { warmDetail(contentId) } }
+                .toMutableList()
+
+            val seriesId = target.seriesId?.takeIf { it.isNotBlank() }
+            if (seriesId != null) {
+                jobs += async {
+                    runCatching { catalogRepository.getSeasonsForPrefetch(seriesId) }
+                    Unit
+                }
+                target.seasonNumber?.let { seasonNumber ->
+                    jobs += async {
+                        runCatching {
+                            catalogRepository.getEpisodesForPrefetch(seriesId, seasonNumber)
+                        }
+                        Unit
+                    }
+                }
+            }
+            jobs.awaitAll()
+        }
+    }
     // Disposal drops the shell restorer's saved child NODE, so its default
     // enter can land on the wrong card; this target is what lets the recreation
     // ladder re-target the launch card exactly. Updated continuously from card
@@ -786,7 +893,9 @@ fun TvSkylineSectionFeed(
                 // floors made it tall enough to collide with the bar.
                 topPadding = TvSkyline.barTopInset + TvSkyline.barHeight,
                 bottomPadding = bandHeight + TvSkylineMarqueeBottomGap,
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .offset(y = contentVerticalOffset),
             )
 
             Box(
@@ -794,6 +903,7 @@ fun TvSkylineSectionFeed(
                     .fillMaxWidth()
                     .height(bandHeight)
                     .align(Alignment.BottomStart)
+                    .offset(y = contentVerticalOffset)
                     .clipToBounds(),
             ) {
                 LazyColumn(
@@ -817,6 +927,7 @@ fun TvSkylineSectionFeed(
                             title = section.title,
                             items = section.items,
                             onItemClick = { contentId ->
+                                val item = section.items.firstOrNull { it.contentId == contentId }
                                 returnTarget = TvReturnTarget(
                                     sectionId = section.id,
                                     itemId = contentId,
@@ -826,7 +937,8 @@ fun TvSkylineSectionFeed(
                                 )
                                 returnGeneration++
                                 detailReturnPending = true
-                                onItemClick(contentId)
+                                item?.let { clickActionForSection(section, it) }?.invoke()
+                                    ?: onItemClick(contentId)
                             },
                             icon = iconForSection(section),
                             onSeeAllClick = onSeeAllClickForSection(section),
@@ -877,6 +989,9 @@ fun TvSkylineSectionFeed(
                                 onItemFocused(item, section.title, section.id, rowIndex, itemIndex)
                             },
                             cardActions = { item -> cardActions(section, item) },
+                            longClickAction = { item ->
+                                longClickActionForSection(section, item)
+                            },
                         )
                     }
                 }
@@ -892,6 +1007,12 @@ fun ResolvedSection.isTvProgressRow(): Boolean {
         type.contains("in_progress") ||
         type.contains("next_up") ||
         type.contains("up_next")
+}
+
+/** Rows whose Select action resumes immediately instead of opening details. */
+fun ResolvedSection.isTvContinueWatchingRow(): Boolean {
+    val type = sectionType.lowercase()
+    return type.contains("continue") || type.contains("in_progress")
 }
 
 private data class TvSkylineMarqueeSeed(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSquaredButtons.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSquaredButtons.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -171,6 +172,7 @@ private fun SquaredPill(
         onClick = onClick,
         modifier = modifier,
         focusRequester = focusRequester,
+        capsule = true,
         contentPadding = PaddingValues(
             horizontal = if (primary) 27.dp else 20.dp,
             vertical = if (primary) 13.dp else 11.dp,
@@ -226,6 +228,8 @@ internal fun SquaredPillSurface(
     modifier: Modifier,
     focusRequester: FocusRequester?,
     enabled: Boolean = true,
+    /** Hero Play/Start Over use tvOS Capsule; selector triggers keep their approved squared shape. */
+    capsule: Boolean = false,
     contentPadding: PaddingValues,
     content: @Composable (foreground: Color) -> Unit,
 ) {
@@ -233,12 +237,16 @@ internal fun SquaredPillSurface(
     val isPressed by interactionSource.collectIsPressedAsState()
     var isFocused by remember { mutableStateOf(false) }
 
-    val shape = RoundedCornerShape(TvControlCorner)
+    val shape = if (capsule) RoundedCornerShape(percent = 50) else RoundedCornerShape(TvControlCorner)
     val primary = kind == PillKind.Primary
 
     // --- Body visuals (per kind) ---
     val foreground by animateColorAsState(
         targetValue = when (kind) {
+            // The Play pill remains the bright primary action at rest. Making
+            // it use the same translucent treatment as the circular utility
+            // buttons erased the hierarchy and made the whole action cluster
+            // look malformed whenever focus moved down to the selector.
             PillKind.Primary -> Color.Black
             PillKind.Secondary -> if (isFocused) Color.Black else Color.White
         },
@@ -276,7 +284,7 @@ internal fun SquaredPillSurface(
 
     // --- Compact focus treatment (shared by both pills) ---
     val focusOutlineColor = if (primary) Color.White.copy(alpha = 0.94f) else Color.White.copy(alpha = 0.98f)
-    val focusOutlineShape = RoundedCornerShape(TvControlCorner + 2.dp)
+    val focusOutlineShape = if (capsule) RoundedCornerShape(percent = 50) else RoundedCornerShape(TvControlCorner + 2.dp)
     val shadowOpacity by animateFloatAsState(
         targetValue = if (isFocused) 0.24f else 0.14f,
         animationSpec = focusSpring(),
@@ -333,7 +341,7 @@ internal fun SquaredPillSurface(
                 color = focusOutlineColor,
                 width = 1.25.dp,
                 inset = 1.5.dp,
-                corner = TvControlCorner + 2.dp,
+                corner = if (capsule) 50.dp else TvControlCorner + 2.dp,
             )
             .background(fill, shape)
             .border(innerBorderWidth, innerBorderColor, shape)
@@ -353,7 +361,7 @@ internal fun SquaredPillSurface(
 }
 
 /**
- * 72×72 squared icon toggle (Favorite / Watchlist / Watched). Mirrors
+ * 72×72 circular icon toggle (Favorite / Watchlist / Watched). Mirrors
  * `TVCircleActionButton` + `TVCircleButtonStyle`.
  *
  * Fill white@0.10 → focus white; icon white → focus black; swaps [icon] /
@@ -375,7 +383,7 @@ fun TvSquareToggleButton(
     val isPressed by interactionSource.collectIsPressedAsState()
     var isFocused by remember { mutableStateOf(false) }
 
-    val shape = RoundedCornerShape(TvControlCorner)
+    val shape = CircleShape
 
     val fill by animateColorAsState(
         targetValue = if (isFocused) Color.White else Color.White.copy(alpha = 0.10f),
@@ -410,7 +418,7 @@ fun TvSquareToggleButton(
     )
     val scale = focusScale * pressScale
 
-    val focusOutlineShape = RoundedCornerShape(TvControlCorner + 2.dp)
+    val focusOutlineShape = CircleShape
 
     Box(
         modifier = modifier
@@ -442,7 +450,7 @@ fun TvSquareToggleButton(
                 color = Color.White.copy(alpha = 0.96f),
                 width = 1.5.dp,
                 inset = 2.5.dp,
-                corner = TvControlCorner + 2.dp,
+                corner = 22.dp,
             )
             .background(fill, shape)
             .border(innerBorderWidth, innerBorderColor, shape)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -114,10 +114,13 @@ internal fun tvIsAlreadyShowingItemDetail(
     currentSeasonNumber: Int?,
     contentId: String,
     seasonNumber: Int?,
+    currentEpisodeContentId: String? = null,
+    episodeContentId: String? = null,
 ): Boolean =
     currentRoute == TvRoute.ItemDetail.ROUTE &&
         currentContentId == contentId &&
-        currentSeasonNumber == seasonNumber
+        currentSeasonNumber == seasonNumber &&
+        currentEpisodeContentId == episodeContentId
 
 /** Destinations that own an active playback session. */
 private val tvPlayerRoutes = setOf(TvRoute.Player.ROUTE, TvRoute.AudiobookPlayer.ROUTE)
@@ -273,6 +276,7 @@ private fun NavHostController.navigateToTvWatchTogether(
 private fun NavHostController.navigateToTvItemDetail(
     contentId: String,
     seasonNumber: Int? = null,
+    episodeContentId: String? = null,
 ) {
     val top = currentBackStackEntry
     if (
@@ -282,13 +286,16 @@ private fun NavHostController.navigateToTvItemDetail(
             currentSeasonNumber = top?.arguments
                 ?.getString(TvRoute.ItemDetail.ARG_SEASON_NUMBER)
                 ?.toIntOrNull(),
+            currentEpisodeContentId = top?.arguments
+                ?.getString(TvRoute.ItemDetail.ARG_EPISODE_CONTENT_ID),
             contentId = contentId,
             seasonNumber = seasonNumber,
+            episodeContentId = episodeContentId,
         )
     ) {
         return
     }
-    navigate(TvRoute.ItemDetail(contentId, seasonNumber).route)
+    navigate(TvRoute.ItemDetail(contentId, seasonNumber, episodeContentId).route)
 }
 
 /**
@@ -765,6 +772,13 @@ fun TvAppNavigation(
                 onOpenItemDetail = { contentId ->
                     navController.navigateToTvItemDetail(contentId)
                 },
+                onOpenItemDetailSelection = { contentId, seasonNumber, episodeContentId ->
+                    navController.navigateToTvItemDetail(
+                        contentId = contentId,
+                        seasonNumber = seasonNumber,
+                        episodeContentId = episodeContentId,
+                    )
+                },
                 onOpenWatchTogether = { room ->
                     navController.navigateToTvWatchTogether(room, lastPlaybackNavigation)
                 },
@@ -903,6 +917,11 @@ fun TvAppNavigation(
                     nullable = true
                     defaultValue = null
                 },
+                navArgument(TvRoute.ItemDetail.ARG_EPISODE_CONTENT_ID) {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
             ),
         ) { backStack ->
             val contentId = backStack.arguments
@@ -911,9 +930,12 @@ fun TvAppNavigation(
             val seasonNumber = backStack.arguments
                 ?.getString(TvRoute.ItemDetail.ARG_SEASON_NUMBER)
                 ?.toIntOrNull()
+            val episodeContentId = backStack.arguments
+                ?.getString(TvRoute.ItemDetail.ARG_EPISODE_CONTENT_ID)
             TvItemDetailScreen(
                 contentId = contentId,
                 seasonNumber = seasonNumber,
+                initialEpisodeContentId = episodeContentId,
                 // The detail screen's playback selector row writes the chosen
                 // version's fileId into [TvItemDetailViewModel.selectedFileId];
                 // we forward it through the route so the player session

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvRoute.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvRoute.kt
@@ -62,18 +62,26 @@ sealed class TvRoute(val route: String) {
     }
 
     // --- Detail & player (no drawer, immersive) ---
-    data class ItemDetail(val contentId: String, val seasonNumber: Int? = null) :
-        TvRoute(
-            if (seasonNumber != null) {
-                "item/${contentId.routeEncode()}?seasonNumber=$seasonNumber"
-            } else {
-                "item/${contentId.routeEncode()}"
-            },
-        ) {
+    data class ItemDetail(
+        val contentId: String,
+        val seasonNumber: Int? = null,
+        val episodeContentId: String? = null,
+    ) : TvRoute(
+        buildString {
+            append("item/${contentId.routeEncode()}")
+            val query = buildList {
+                seasonNumber?.let { add("seasonNumber=$it") }
+                episodeContentId?.let { add("episodeContentId=${it.routeEncode()}") }
+            }
+            if (query.isNotEmpty()) append("?${query.joinToString("&")}")
+        },
+    ) {
         companion object {
-            const val ROUTE = "item/{contentId}?seasonNumber={seasonNumber}"
+            const val ROUTE =
+                "item/{contentId}?seasonNumber={seasonNumber}&episodeContentId={episodeContentId}"
             const val ARG_CONTENT_ID = "contentId"
             const val ARG_SEASON_NUMBER = "seasonNumber"
+            const val ARG_EPISODE_CONTENT_ID = "episodeContentId"
         }
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -69,7 +70,6 @@ import org.siloserver.silo.tv.ui.theme.SiloOnSurface
 import org.siloserver.silo.tv.ui.theme.SiloSecondaryText
 import org.siloserver.silo.tv.ui.theme.DarkSurfaceElevated
 import org.siloserver.silo.tv.ui.theme.ProgressFill
-import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.capsuleCaps
 import org.siloserver.silo.tv.ui.theme.cardScaled
 
@@ -77,8 +77,9 @@ import org.siloserver.silo.tv.ui.theme.cardScaled
  * Horizontal rail of episode cards for the series/season/episode detail
  * screens — a direct port of tvOS `TVEpisodeRail`. Pressing OK on a card
  * navigates to that episode's own detail page (where the user picks a
- * version, marks watched and starts playback); the rail is a browsing
- * surface, NOT a direct play launcher.
+ * version, marks watched and starts playback). Container detail pages may use
+ * the rail as a browser; the combined Series page uses OK as direct playback,
+ * matching tvOS without pushing a second episode-detail page.
  *
  * When `currentContentId` is non-null the matching card is highlighted
  * (white 2dp ring + full-color title), scrolled to the horizontal center
@@ -95,7 +96,10 @@ internal fun TvDetailEpisodeRail(
     onSetFavorite: (contentId: String, favorite: Boolean) -> Unit,
     modifier: Modifier = Modifier,
     currentContentId: String? = null,
+    onEpisodeFocused: ((EpisodeListItem) -> Unit)? = null,
     onDirectionUp: (() -> Boolean)? = null,
+    hidesEpisodeTitle: Boolean = false,
+    usesSeriesGeometry: Boolean = false,
 ) {
     if (episodes.isEmpty()) return
 
@@ -103,16 +107,29 @@ internal fun TvDetailEpisodeRail(
     val currentIndex = remember(currentContentId, episodes) {
         episodes.indexOfFirst { it.contentId == currentContentId }.takeIf { it >= 0 }
     }
-    // Default focus target: the current episode if present. Mirrors tvOS
-    // `defaultFocus(..., priority: .userInitiated)` so d-pad entry into the
-    // rail lands on the current episode rather than the first card.
+    // The first entry uses next-up/current. Once the viewer browses sideways,
+    // retain that exact episode for every Up/Down round-trip through the
+    // selector and supporting rails. Keying by the first episode resets this
+    // memory when a different season's rail replaces the current one.
+    val episodeSetKey = episodes.first().contentId
+    var rememberedFocusedContentId by remember(episodeSetKey) { mutableStateOf<String?>(null) }
+    val entryIndex = remember(rememberedFocusedContentId, currentContentId, episodes) {
+        val targetId = rememberedFocusedContentId
+            ?.takeIf { remembered -> episodes.any { it.contentId == remembered } }
+            ?: currentContentId
+        episodes.indexOfFirst { it.contentId == targetId }.takeIf { it >= 0 }
+    }
+    // Default focus target: the remembered episode, falling back to current.
+    // Mirrors tvOS's focusedEpisodeContentId plus its suggestedEpisode entry.
     val defaultFocusRequester = remember { FocusRequester() }
 
-    // Auto-center the current episode on first appearance (parity with the
-    // tvOS `proxy.scrollTo(id, anchor: .center)` on appear). Same true-center
-    // approach as TvSeasonPicker: bring the item into view, then nudge by the
-    // delta between the item center and the viewport center.
-    LaunchedEffect(currentContentId, episodes.size) {
+    // Auto-center the suggested episode ONCE when this season's rail appears
+    // (parity with tvOS `scrollTo(..., anchor: .center)`). Do not key this on
+    // currentContentId: Series focus intentionally updates that id for every
+    // Left/Right step. Re-running this centering animation would race the
+    // one-shot tvRailPinOnFocus glide and make Right visually travel backward
+    // even though focus reached the correct episode.
+    LaunchedEffect(episodeSetKey) {
         val target = currentIndex ?: return@LaunchedEffect
         listState.scrollToItem(target)
         val info = listState.layoutInfo
@@ -142,7 +159,7 @@ internal fun TvDetailEpisodeRail(
             )
             .focusGroup()
             .then(
-                if (currentIndex != null) {
+                if (entryIndex != null) {
                     Modifier.focusProperties { enter = { defaultFocusRequester } }
                 } else {
                     Modifier
@@ -150,10 +167,12 @@ internal fun TvDetailEpisodeRail(
             ),
         state = listState,
         contentPadding = PaddingValues(
-            horizontal = Spacing.safeArea,
-            vertical = 16.dp,
+            horizontal = TvDetailHorizontalInset,
+            // Compact Series padding keeps the lowered episode band within the
+            // fixed primary viewport beneath the selector and season controls.
+            vertical = if (usesSeriesGeometry) 6.dp else 16.dp,
         ),
-        horizontalArrangement = Arrangement.spacedBy(18.dp),
+        horizontalArrangement = Arrangement.spacedBy(if (usesSeriesGeometry) 16.dp else 18.dp),
     ) {
         itemsIndexed(
             episodes,
@@ -161,6 +180,7 @@ internal fun TvDetailEpisodeRail(
             contentType = { _, _ -> "episode-card" },
         ) { index, episode ->
             val isCurrent = episode.contentId == currentContentId
+            val isEntryTarget = index == entryIndex
             TvDetailEpisodeCard(
                 episode = episode,
                 isCurrent = isCurrent,
@@ -168,10 +188,18 @@ internal fun TvDetailEpisodeRail(
                 onClick = { onEpisodeSelected(episode) },
                 onSetWatched = { watched -> onSetWatched(episode.contentId, watched) },
                 onSetFavorite = { favorite -> onSetFavorite(episode.contentId, favorite) },
+                hidesEpisodeTitle = hidesEpisodeTitle,
+                usesSeriesGeometry = usesSeriesGeometry,
                 modifier = Modifier
-                    .tvRailPinOnFocus(listState, index, Spacing.safeArea)
+                    .tvRailPinOnFocus(listState, index, TvDetailHorizontalInset)
+                    .onFocusChanged { focusState ->
+                        if (focusState.isFocused) {
+                            rememberedFocusedContentId = episode.contentId
+                            onEpisodeFocused?.invoke(episode)
+                        }
+                    }
                     .then(
-                        if (isCurrent) {
+                        if (isEntryTarget) {
                             Modifier.focusRequester(defaultFocusRequester)
                         } else {
                             Modifier
@@ -192,10 +220,12 @@ private fun TvDetailEpisodeCard(
     onClick: () -> Unit,
     onSetWatched: (Boolean) -> Unit,
     onSetFavorite: (Boolean) -> Unit,
+    hidesEpisodeTitle: Boolean,
+    usesSeriesGeometry: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val cardWidth = 230.dp.cardScaled()
-    val stillHeight = 130.dp.cardScaled()
+    val cardWidth = (if (usesSeriesGeometry) 240.dp else 230.dp).cardScaled()
+    val stillHeight = (if (usesSeriesGeometry) 135.dp else 130.dp).cardScaled()
     val caption = LocalCardPresentation.current.caption
     val cornerRadius = 5.dp
     val shape = RoundedCornerShape(cornerRadius)
@@ -336,8 +366,9 @@ private fun TvDetailEpisodeCard(
                     Text(
                         text = "EPISODE ${episode.episodeNumber}",
                         fontSize = 14.sp,
+                        lineHeight = 17.sp,
                         fontWeight = FontWeight.Bold,
-                        letterSpacing = 1.0.sp,
+                        letterSpacing = 0.75.sp,
                         color = SiloOnSurface.copy(alpha = 0.7f),
                         maxLines = 1,
                     )
@@ -346,20 +377,22 @@ private fun TvDetailEpisodeCard(
                     }
                 }
 
-                Text(
-                    text = episode.title ?: "Episode ${episode.episodeNumber}",
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    color = when {
-                        isCurrent -> SiloOnSurface
-                        isFocused -> SiloOnSurface
-                        else -> SiloOnSurface.copy(alpha = 0.92f)
-                    },
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                if (!hidesEpisodeTitle) {
+                    Text(
+                        text = episode.title ?: "Episode ${episode.episodeNumber}",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = when {
+                            isCurrent -> SiloOnSurface
+                            isFocused -> SiloOnSurface
+                            else -> SiloOnSurface.copy(alpha = 0.92f)
+                        },
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
 
-                if (caption.showsMetadata) {
+                if (!hidesEpisodeTitle && caption.showsMetadata) {
                     episodeMetadataLine(episode)?.let { metadata ->
                         Text(
                             text = metadata,
@@ -399,14 +432,14 @@ private fun NowViewingTag() {
         modifier = Modifier
             .clip(RoundedCornerShape(50.dp))
             .background(Color.White)
-            .padding(horizontal = 9.dp, vertical = 3.dp),
+            .padding(horizontal = 7.dp, vertical = 2.dp),
     ) {
         Text(
             text = "NOW VIEWING",
             style = capsuleCaps.copy(
                 fontSize = 14.sp,
-                lineHeight = 18.sp,
-                letterSpacing = 0.7.sp,
+                lineHeight = 17.sp,
+                letterSpacing = 0.55.sp,
             ),
             color = Color.Black,
         )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt
@@ -64,6 +64,7 @@ import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.catalog.EpisodeListItem
 import org.siloserver.silo.tv.ui.components.TvMediaCardActions
 import org.siloserver.silo.tv.ui.components.TvMediaCardContextMenu
+import org.siloserver.silo.tv.ui.components.tvEpisodeCardWidth
 import org.siloserver.silo.tv.ui.theme.TvRailScrollBehavior
 import org.siloserver.silo.tv.ui.theme.tvRailPinOnFocus
 import org.siloserver.silo.tv.ui.theme.SiloOnSurface
@@ -224,10 +225,15 @@ private fun TvDetailEpisodeCard(
     usesSeriesGeometry: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val cardWidth = (if (usesSeriesGeometry) 240.dp else 230.dp).cardScaled()
-    val stillHeight = (if (usesSeriesGeometry) 135.dp else 130.dp).cardScaled()
+    // The combined Series page uses the exact same card footprint as Home's
+    // Continue Watching rail. Legacy season/episode routes keep their existing
+    // geometry so this targeted parity change cannot disturb those layouts.
+    val cardWidth = if (usesSeriesGeometry) tvEpisodeCardWidth() else 230.dp.cardScaled()
+    val stillHeight = if (usesSeriesGeometry) cardWidth * (9f / 16f) else 130.dp.cardScaled()
+    val eyebrowFontSize = if (usesSeriesGeometry) 11.sp else 14.sp
+    val eyebrowLineHeight = if (usesSeriesGeometry) 14.sp else 17.sp
     val caption = LocalCardPresentation.current.caption
-    val cornerRadius = 5.dp
+    val cornerRadius = if (usesSeriesGeometry) 8.dp else 5.dp
     val shape = RoundedCornerShape(cornerRadius)
 
     val interactionSource = remember { MutableInteractionSource() }
@@ -252,14 +258,16 @@ private fun TvDetailEpisodeCard(
     Column(
         modifier = modifier
             .width(cardWidth)
-            .scale(scale)
+            // Continue Watching lifts only its artwork; keep the inline label
+            // locked while the focused still hovers above it.
+            .then(if (usesSeriesGeometry) Modifier else Modifier.scale(scale))
             .combinedClickable(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onClick,
                 onLongClick = { menuExpanded = true },
             ),
-        verticalArrangement = Arrangement.spacedBy(9.dp),
+        verticalArrangement = Arrangement.spacedBy(if (usesSeriesGeometry) 7.dp else 9.dp),
     ) {
         TvMediaCardContextMenu(
             expanded = menuExpanded,
@@ -275,8 +283,9 @@ private fun TvDetailEpisodeCard(
             modifier = Modifier
                 .width(cardWidth)
                 .height(stillHeight)
+                .then(if (usesSeriesGeometry) Modifier.scale(scale) else Modifier)
                 .shadow(
-                    elevation = if (isFocused) 18.dp else 8.dp,
+                    elevation = if (isFocused && usesSeriesGeometry) 12.dp else if (isFocused) 18.dp else 8.dp,
                     shape = shape,
                     ambientColor = Color.Black,
                     spotColor = Color.Black,
@@ -352,11 +361,9 @@ private fun TvDetailEpisodeCard(
             }
         }
 
-        // Keep the hierarchy scannable at TV distance: episode number, title,
-        // air date/runtime, then synopsis. Each kind of information owns a
-        // stable line instead of competing in one dense eyebrow. Artwork-only
-        // drops the block entirely (tvOS `TVEpisodeRail`); the card has no
-        // fixed height, so the rail shrinks to the still.
+        // Series keeps the compact tvOS-style single caption line:
+        // "EPISODE 1 · Episode name". Other episode rails retain their richer
+        // title/metadata/synopsis hierarchy.
         if (caption.showsTitle) {
             Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 Row(
@@ -365,14 +372,35 @@ private fun TvDetailEpisodeCard(
                 ) {
                     Text(
                         text = "EPISODE ${episode.episodeNumber}",
-                        fontSize = 14.sp,
-                        lineHeight = 17.sp,
+                        fontSize = eyebrowFontSize,
+                        lineHeight = eyebrowLineHeight,
                         fontWeight = FontWeight.Bold,
-                        letterSpacing = 0.75.sp,
+                        letterSpacing = if (usesSeriesGeometry) 0.55.sp else 0.75.sp,
                         color = SiloOnSurface.copy(alpha = 0.7f),
                         maxLines = 1,
                     )
-                    if (isCurrent) {
+                    if (hidesEpisodeTitle) {
+                        episode.title?.takeIf { it.isNotBlank() }?.let { inlineTitle ->
+                            Text(
+                                text = "·",
+                                fontSize = eyebrowFontSize,
+                                lineHeight = eyebrowLineHeight,
+                                fontWeight = FontWeight.Bold,
+                                color = SiloOnSurface.copy(alpha = 0.7f),
+                                maxLines = 1,
+                            )
+                            Text(
+                                text = inlineTitle,
+                                modifier = Modifier.weight(1f),
+                                fontSize = 11.5.sp,
+                                lineHeight = eyebrowLineHeight,
+                                fontWeight = FontWeight.SemiBold,
+                                color = SiloOnSurface.copy(alpha = 0.86f),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    } else if (isCurrent) {
                         NowViewingTag()
                     }
                 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt
@@ -97,7 +97,7 @@ internal fun TvDetailHero(
     actions: @Composable () -> Unit,
     playbackSummary: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
-    /** Compact 520pt Series header while the standard 690pt artwork fade continues behind its mode row. */
+    /** Compact 580pt Series header while the standard 690pt artwork fade continues behind its mode row. */
     compactSeries: Boolean = false,
     // Optional description-translation affordance (Apple tvOS parity),
     // rendered as its own focus stop directly under the synopsis.

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt
@@ -1,13 +1,12 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -16,17 +15,26 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -43,9 +51,6 @@ import androidx.compose.material.icons.filled.CheckCircle
 import coil3.compose.AsyncImage
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.tv.R
-import org.siloserver.silo.tv.ui.theme.DarkBackground
-import org.siloserver.silo.tv.ui.theme.DarkSurface
-import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.SuccessGreen
 
 /**
@@ -54,7 +59,9 @@ import org.siloserver.silo.tv.ui.theme.SuccessGreen
  * - [TextToken] plain text (year / runtime / ★rating); consecutive text
  *   tokens get a "·" divider between them.
  * - [Rating] a maturity/check token: green check icon + label.
- * - [Chip] an outlined squared pill (4K / HDR / DOLBY VISION / ATMOS / CC).
+ * - [Chip] a playback-format value (4K / HDR / DOLBY VISION / ATMOS / CC).
+ *   Detail renders these with the same quiet monospaced treatment as Home's
+ *   format line rather than promoting every value to an outlined badge.
  */
 internal sealed class TvHeroFactToken {
     data class TextToken(val value: String) : TvHeroFactToken()
@@ -63,22 +70,16 @@ internal sealed class TvHeroFactToken {
 }
 
 /**
- * Full-bleed cinematic hero for the Android TV detail screen. Structurally
- * mirrors tvOS `TVDetailHero`.
+ * Approved tvOS detail hero, mapped onto Android TV's half-scale layout
+ * canvas. The page owns the sampled opaque tint; this composable draws only
+ * the crisp top-trailing artwork and its alpha masks, so the image naturally
+ * scrolls away with the hero instead of behaving like a fixed backdrop.
  *
- * Layout = a `ZStack(bottomLeading)`: a near-full-viewport backdrop, a
- * 4-stop horizontal darkening on the left, a soft vertical fade into the
- * rail body at the bottom, then the bottom-anchored editorial + action
- * column on the left.
- *
- * Apple sizes the hero relative to the viewport (`heroHeight = 980` of a
- * 1080-pt canvas ≈ 0.907×), so we compute the height as a fraction of the
- * screen height rather than a fixed dp — see [HERO_HEIGHT_FRACTION].
- *
- * The action cluster is given the full hero width (leading-aligned) and
- * wrapped in its own focus group so the selector row inside can stretch
- * its own focus section full-width for Down navigation, and lower rails can
- * move "up" into the cluster from a far-right card.
+ * The editorial and action stack is top-leading (50dp / 44dp = tvOS
+ * 100pt / 88pt), while the artwork occupies the trailing 64 percent and
+ * dissolves into the page surface at its leading and lower edges. The action
+ * cluster remains full-width and focus-grouped; Version and Subtitles live in
+ * that same row as circular actions.
  */
 @Composable
 internal fun TvDetailHero(
@@ -94,35 +95,38 @@ internal fun TvDetailHero(
     factsLine: List<TvHeroFactToken>,
     directorText: String?,
     actions: @Composable () -> Unit,
+    playbackSummary: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
+    /** Compact 520pt Series header while the standard 690pt artwork fade continues behind its mode row. */
+    compactSeries: Boolean = false,
     // Optional description-translation affordance (Apple tvOS parity),
     // rendered as its own focus stop directly under the synopsis.
     translation: (@Composable () -> Unit)? = null,
-    /**
-     * How far (px) the page has scrolled past the hero's top. Read inside the
-     * draw phase only, so scrolling never recomposes the hero. The backdrop
-     * recedes with it — dims toward the page background and drifts at a
-     * fraction of the scroll — so moving into the body reads as the hero
-     * giving way rather than being chopped off by the next section.
-     */
-    scrollOffsetPx: () -> Float = { 0f },
 ) {
-    // heroHeight = 980 of a 1080-pt tvOS canvas ≈ 0.907 × viewport height.
-    // The TV theme keeps dp geometry at device density, so screenHeightDp maps
-    // directly to the Android TV layout canvas.
-    val heroHeight = LocalConfiguration.current.screenHeightDp.dp * HERO_HEIGHT_FRACTION
-    val contentMaxWidth = 600.dp
-    val usesConstrainedEditorial = heroHeight < DetailHeroComfortableHeight
-    val editorialSpacing = if (usesConstrainedEditorial) 8.dp else 12.dp
-    val collapsedSynopsisLines = if (usesConstrainedEditorial) 2 else 3
+    // tvOS 690pt on a 1080pt canvas. Android TV's 1920×1080 emulator reports
+    // a 960×540dp layout canvas, so the same fraction produces 345dp.
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    val backdropHeight = screenHeight * HERO_HEIGHT_FRACTION
+    val heroHeight = if (compactSeries) {
+        screenHeight * SERIES_HERO_HEIGHT_FRACTION
+    } else {
+        backdropHeight
+    }
+    val heroTopInset = if (compactSeries) SERIES_HERO_TOP_INSET else HERO_TOP_INSET
+    val density = LocalDensity.current
+    var seriesOverviewEditorialHeightPx by remember { mutableIntStateOf(0) }
 
-    Box(
+    BoxWithConstraints(
         modifier = modifier
             .fillMaxWidth()
             .height(heroHeight)
-            .clipToBounds(),
+            .then(if (compactSeries) Modifier else Modifier.clipToBounds()),
     ) {
-        // Backdrop (fill; else siloSurface).
+        val artworkWidth = maxWidth * ARTWORK_WIDTH_FRACTION
+        val artworkHeight = minOf(backdropHeight * ARTWORK_HEIGHT_FRACTION, artworkWidth * 9f / 16f)
+
+        // Crisp artwork in the top-right. DstIn multiplies the horizontal and
+        // vertical alpha ramps without painting black over the sampled page.
         if (!backdropUrl.isNullOrEmpty() || !backdropThumbhash.isNullOrEmpty()) {
             ThumbhashImage(
                 url = backdropUrl,
@@ -130,57 +134,67 @@ internal fun TvDetailHero(
                 contentDescription = title,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
-                    .matchParentSize()
-                    .graphicsLayer {
-                        val offset = scrollOffsetPx().coerceAtLeast(0f)
-                        val fadeDistance = size.height * BackdropFadeHeightFraction
-                        val progress = if (fadeDistance > 0f) (offset / fadeDistance).coerceIn(0f, 1f) else 0f
-                        alpha = 1f - progress * (1f - BackdropMinAlpha)
-                        translationY = minOf(offset, size.height) * BackdropParallaxFactor
+                    .align(Alignment.TopEnd)
+                    // Movie and Series artwork share the same top edge. A
+                    // layout offset here exposed the sampled page tint as a
+                    // grey strip above only the Series image.
+                    .width(artworkWidth)
+                    .height(artworkHeight)
+                    .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+                    .drawWithContent {
+                        drawContent()
+                        drawRect(
+                            brush = Brush.horizontalGradient(
+                                0.00f to Color.Transparent,
+                                0.54f to Color.Black,
+                                1.00f to Color.Black,
+                            ),
+                            blendMode = BlendMode.DstIn,
+                        )
+                        drawRect(
+                            brush = Brush.verticalGradient(
+                                0.00f to Color.Black,
+                                0.70f to Color.Black,
+                                1.00f to Color.Transparent,
+                            ),
+                            size = Size(size.width, size.height),
+                            blendMode = BlendMode.DstIn,
+                        )
                     },
             )
-        } else {
-            Box(modifier = Modifier.matchParentSize().background(DarkSurface))
         }
 
-        // Heavy left-side darkening — clears toward the right so the imagery
-        // breathes while text stays legible. (leading → trailing)
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-                .background(
-                    Brush.horizontalGradient(
-                        0.00f to Color.Black.copy(alpha = 0.92f),
-                        0.22f to Color.Black.copy(alpha = 0.70f),
-                        0.55f to Color.Black.copy(alpha = 0.35f),
-                        0.88f to Color.Transparent,
-                    ),
-                ),
-        )
-
-        // Soft bottom fade that hands off into the rail body underneath, so a
-        // hint of the next rail peeks through the seam. (top → bottom)
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-                .background(
-                    Brush.verticalGradient(
-                        0.00f to Color.Transparent,
-                        0.55f to Color.Transparent,
-                        0.85f to DarkBackground.copy(alpha = 0.55f),
-                        1.00f to DarkBackground,
-                    ),
-                ),
-        )
-
-        // Reserve and pin the action cluster before measuring the editorial
-        // column. The hero can therefore keep the fixed tvOS viewport framing
-        // without letting tall copy collapse visible-but-focusable controls.
-        TvDetailHeroContentLayout(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(start = Spacing.safeArea, end = Spacing.safeArea, bottom = TvDetailHeroBottomInset),
-            editorial = {
+                .padding(top = heroTopInset, start = TvDetailHorizontalInset, end = TvDetailHorizontalInset),
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.spacedBy(HERO_CONTENT_SPACING),
+        ) {
+            Box(
+                modifier = Modifier
+                    .then(
+                        if (compactSeries && seriesOverviewEditorialHeightPx > 0) {
+                            Modifier.height(with(density) { seriesOverviewEditorialHeightPx.toDp() })
+                        } else {
+                            Modifier
+                        },
+                    )
+                    .then(if (compactSeries) Modifier.clipToBounds() else Modifier)
+                    .onSizeChanged { size ->
+                        // The Show overview is the approved reference shown in
+                        // the design. Capture it once, then give every focused
+                        // episode that exact editorial footprint so changing
+                        // title/overview text cannot move the action row.
+                        if (
+                            compactSeries &&
+                            seriesTitle == null &&
+                            seriesOverviewEditorialHeightPx == 0
+                        ) {
+                            seriesOverviewEditorialHeightPx = size.height
+                        }
+                    },
+            ) {
                 EditorialColumn(
                     title = title,
                     seriesTitle = seriesTitle,
@@ -191,34 +205,27 @@ internal fun TvDetailHero(
                     tagline = tagline,
                     factsLine = factsLine,
                     directorText = directorText,
-                    contentMaxWidth = contentMaxWidth,
-                    verticalSpacing = editorialSpacing,
-                    collapsedSynopsisLines = collapsedSynopsisLines,
+                    contentMaxWidth = HERO_CONTENT_MAX_WIDTH,
+                    verticalSpacing = EDITORIAL_SPACING,
+                    collapsedSynopsisLines = 2,
+                    compactSeries = compactSeries,
                     translation = translation,
+                    playbackSummary = playbackSummary,
                 )
-            },
-            actions = {
-                // Full-width, leading-aligned focus container for the action +
-                // selector cluster (own focus section).
-                Box(
-                    modifier = Modifier
-                        .padding(top = 8.dp)
-                        .fillMaxWidth()
-                        .focusGroup(),
-                    contentAlignment = Alignment.CenterStart,
-                ) {
-                    actions()
-                }
-            },
-        )
+            }
+
+            Box(
+                modifier = Modifier
+                    .padding(top = 1.dp)
+                    .fillMaxWidth()
+                    .focusGroup(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                actions()
+            }
+        }
     }
 }
-
-/** Scrolling ~40% of the hero height fades the backdrop to [BackdropMinAlpha]. */
-private const val BackdropFadeHeightFraction = 0.4f
-private const val BackdropMinAlpha = 0.35f
-/** Backdrop drifts down at this fraction of the scroll — a light parallax. */
-private const val BackdropParallaxFactor = 0.4f
 
 @Composable
 private fun EditorialColumn(
@@ -234,32 +241,81 @@ private fun EditorialColumn(
     contentMaxWidth: androidx.compose.ui.unit.Dp,
     verticalSpacing: androidx.compose.ui.unit.Dp,
     collapsedSynopsisLines: Int,
+    compactSeries: Boolean,
     translation: (@Composable () -> Unit)? = null,
+    playbackSummary: (@Composable () -> Unit)? = null,
 ) {
+    val isCombinedSeriesEpisode = compactSeries && !seriesTitle.isNullOrBlank()
     Column(
         modifier = Modifier.widthIn(max = contentMaxWidth),
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(verticalSpacing),
     ) {
         TitleBlock(
-            title = title,
-            seriesTitle = seriesTitle,
+            // A focused episode must not shrink or move the Show identity.
+            // Its name belongs to the bounded synopsis slot below instead.
+            title = if (isCombinedSeriesEpisode) seriesTitle!! else title,
+            seriesTitle = seriesTitle.takeUnless { isCombinedSeriesEpisode },
             logoUrl = logoUrl,
         )
 
-        if (sourceTokens.isNotEmpty() || !ratingChip.isNullOrBlank()) {
-            SourceRow(tokens = sourceTokens, ratingChip = ratingChip)
+        // Editorial identity gets its own line: "Movie · Horror · Thriller"
+        // (or Season/Episode context) must read before year/runtime/playback
+        // information rather than trailing after it on one overlong row.
+        if (sourceTokens.isNotEmpty()) SourceRow(tokens = sourceTokens)
+        val hasMetadata = factsLine.isNotEmpty() || !ratingChip.isNullOrBlank()
+        if (compactSeries) {
+            // Episode focus may swap a full Show facts row for a shorter date /
+            // runtime row. Keep the approved facts baseline and the margin
+            // below it fixed so the synopsis and action row cannot follow the
+            // newly measured text up or down.
+            Box(
+                modifier = Modifier
+                    .height(SERIES_METADATA_SLOT_HEIGHT)
+                    .clipToBounds(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                if (hasMetadata) {
+                    MetadataRow(tokens = factsLine, sourceTokens = emptyList(), ratingChip = ratingChip)
+                }
+            }
+        } else if (hasMetadata) {
+            MetadataRow(tokens = factsLine, sourceTokens = emptyList(), ratingChip = ratingChip)
         }
+        playbackSummary?.invoke()
 
         // Synopsis slot — the hero's only text focus stop. A focusable leaf
         // that clamps the overview to the current height budget and, on
         // OK/Select, expands with the tagline revealed above it.
-        overview?.takeIf { it.isNotBlank() }?.let { line ->
-            TvExpandableSynopsis(
-                overview = line,
-                tagline = tagline,
-                collapsedMaxLines = collapsedSynopsisLines,
-            )
+        if (compactSeries) {
+            // Reserve the exact two-line Show synopsis footprint even when an
+            // episode has no description yet. This also covers direct entry
+            // from Continue Watching, where the Show overview was never
+            // composed first and therefore cannot be used as a measured lock.
+            Box(
+                modifier = Modifier
+                    .height(SERIES_EPISODE_SYNOPSIS_HEIGHT)
+                    .clipToBounds(),
+            ) {
+                overview?.takeIf { it.isNotBlank() }?.let { line ->
+                    TvExpandableSynopsis(
+                        overview = line,
+                        tagline = tagline.takeUnless { isCombinedSeriesEpisode },
+                        collapsedMaxLines = 2,
+                        dialogTitle = title,
+                        previewText = if (isCombinedSeriesEpisode) "$title · $line" else line,
+                    )
+                }
+            }
+        } else {
+            overview?.takeIf { it.isNotBlank() }?.let { line ->
+                TvExpandableSynopsis(
+                    overview = line,
+                    tagline = tagline,
+                    collapsedMaxLines = collapsedSynopsisLines,
+                    dialogTitle = title,
+                )
+            }
         }
         translation?.invoke()
 
@@ -276,10 +332,6 @@ private fun EditorialColumn(
                 overflow = TextOverflow.Ellipsis,
             )
         }
-
-        if (factsLine.isNotEmpty()) {
-            FactsRow(tokens = factsLine)
-        }
     }
 }
 
@@ -292,18 +344,22 @@ private fun TitleBlock(
     val seriesContext = seriesTitle?.trim()?.takeIf { it.isNotEmpty() }
 
     when {
-        seriesContext != null -> EpisodeHierarchyTitle(seriesTitle = seriesContext, episodeTitle = title)
+        seriesContext != null -> EpisodeHierarchyTitle(
+            seriesTitle = seriesContext,
+            episodeTitle = title,
+            logoUrl = logoUrl,
+        )
         !logoUrl.isNullOrBlank() -> AsyncImage(
             model = logoUrl,
             contentDescription = title,
             contentScale = ContentScale.Fit,
             alignment = Alignment.BottomStart,
-            // Reserve the framed logo area (Apple frames it maxHeight 220) so a
+            // Reserve the framed logo area (approved tvOS maxHeight 160pt) so a
             // loading/failed logo can't measure as 0 and collapse the editorial
             // stack. Fixed height + Fit keeps the logo's aspect within it.
             modifier = Modifier
-                .height(110.dp)
-                .widthIn(max = 310.dp),
+                .height(80.dp)
+                .widthIn(max = 325.dp),
         )
         else -> HeroTextTitle(title = title)
     }
@@ -342,50 +398,54 @@ private fun HeroTextTitle(title: String) {
 }
 
 @Composable
-private fun EpisodeHierarchyTitle(seriesTitle: String, episodeTitle: String) {
-    val parts = remember(episodeTitle) { splitDisplayTitle(episodeTitle) }
+private fun EpisodeHierarchyTitle(
+    seriesTitle: String,
+    episodeTitle: String,
+    logoUrl: String?,
+) {
     Column(
         horizontalAlignment = Alignment.Start,
-        verticalArrangement = Arrangement.spacedBy(5.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
+        if (!logoUrl.isNullOrBlank()) {
+            AsyncImage(
+                model = logoUrl,
+                contentDescription = seriesTitle,
+                contentScale = ContentScale.Fit,
+                alignment = Alignment.BottomStart,
+                modifier = Modifier
+                    .height(64.dp)
+                    .widthIn(max = 325.dp),
+            )
+        } else {
+            Text(
+                text = seriesTitle.uppercase(),
+                style = heroDisplayHero,
+                color = Color.White,
+                textAlign = TextAlign.Start,
+                maxLines = 2,
+            )
+        }
         Text(
-            text = seriesTitle.uppercase(),
-            style = heroDisplayHero,
-            color = Color.White,
-            textAlign = TextAlign.Start,
-            maxLines = 2,
-        )
-        Text(
-            text = parts.first,
+            text = episodeTitle,
             style = heroDisplayHero.copy(
                 fontWeight = FontWeight.ExtraBold,
-                fontSize = 23.sp,
-                lineHeight = 25.sp,
+                // The episode hierarchy shares the compact Series hero with
+                // its persistent actions. A slightly smaller two-line title
+                // keeps long episode names readable without colliding with
+                // Play or the selector below.
+                fontSize = 20.sp,
+                lineHeight = 22.sp,
             ),
             color = Color.White.copy(alpha = 0.94f),
             textAlign = TextAlign.Start,
             maxLines = 2,
         )
-        parts.second?.let { sub ->
-            Text(
-                text = sub.uppercase(),
-                style = heroDisplayHero.copy(
-                    fontWeight = FontWeight.ExtraBold,
-                    fontSize = 16.sp,
-                    lineHeight = 18.sp,
-                    // tvOS `.tracking(1.2)` → 0.6sp at half scale.
-                    letterSpacing = 0.6.sp,
-                ),
-                color = Color.White.copy(alpha = 0.82f),
-                textAlign = TextAlign.Start,
-                maxLines = 2,
-            )
-        }
     }
 }
 
 @Composable
-private fun SourceRow(tokens: List<String>, ratingChip: String?) {
+private fun SourceRow(tokens: List<String>) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(7.dp),
@@ -407,29 +467,21 @@ private fun SourceRow(tokens: List<String>, ratingChip: String?) {
                 maxLines = 1,
             )
         }
-        if (!ratingChip.isNullOrBlank()) {
-            Spacer(modifier = Modifier.width(2.dp))
-            RatingChip(text = ratingChip)
-        }
     }
 }
 
 @Composable
-private fun FactsRow(tokens: List<TvHeroFactToken>) {
+private fun MetadataRow(
+    tokens: List<TvHeroFactToken>,
+    sourceTokens: List<String>,
+    ratingChip: String?,
+) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(7.dp),
     ) {
         tokens.forEachIndexed { index, token ->
-            val previous = tokens.getOrNull(index - 1)
-            if (index > 0 && token is TvHeroFactToken.TextToken && previous is TvHeroFactToken.TextToken) {
-                Text(
-                    text = "·",
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 14.sp,
-                    color = Color.White.copy(alpha = 0.7f),
-                )
-            }
+            if (index > 0) MetadataDivider()
             when (token) {
                 is TvHeroFactToken.TextToken -> Text(
                     text = token.value,
@@ -456,10 +508,42 @@ private fun FactsRow(tokens: List<TvHeroFactToken>) {
                         maxLines = 1,
                     )
                 }
-                is TvHeroFactToken.Chip -> QualityChip(text = token.value)
+                is TvHeroFactToken.Chip -> Text(
+                    text = homeStyleFormatLabel(token.value),
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 14.sp,
+                    fontFamily = FontFamily.Monospace,
+                    letterSpacing = 0.52.sp,
+                    color = Color.White.copy(alpha = 0.55f),
+                    maxLines = 1,
+                )
             }
         }
+        sourceTokens.forEachIndexed { index, token ->
+            if (tokens.isNotEmpty() || index > 0) MetadataDivider()
+            Text(
+                text = token,
+                fontWeight = FontWeight.Medium,
+                fontSize = 14.sp,
+                color = Color.White.copy(alpha = 0.90f),
+                maxLines = 1,
+            )
+        }
+        ratingChip?.takeIf { it.isNotBlank() }?.let { rating ->
+            if (tokens.isNotEmpty() || sourceTokens.isNotEmpty()) MetadataDivider()
+            RatingChip(text = rating)
+        }
     }
+}
+
+@Composable
+private fun MetadataDivider() {
+    Text(
+        text = "·",
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 14.sp,
+        color = Color.White.copy(alpha = 0.45f),
+    )
 }
 
 @Composable
@@ -485,27 +569,10 @@ private fun RatingChip(text: String) {
     }
 }
 
-@Composable
-private fun QualityChip(text: String) {
-    Box(
-        modifier = Modifier
-            .border(
-                width = 0.6.dp,
-                color = Color.White.copy(alpha = 0.65f),
-                shape = RoundedCornerShape(2.dp),
-            )
-            .padding(horizontal = 7.dp, vertical = 3.dp),
-    ) {
-        // 14sp floor for 10-ft legibility (tvOS 16pt heavy, tracking 1.0) — audit 2026-07-20.
-        Text(
-            text = text,
-            fontWeight = FontWeight.Black,
-            fontSize = 14.sp,
-            letterSpacing = 0.5.sp,
-            color = Color.White,
-            maxLines = 1,
-        )
-    }
+private fun homeStyleFormatLabel(value: String): String = when (value.uppercase()) {
+    "DOLBY VISION" -> "Dolby Vision"
+    "ATMOS" -> "Atmos"
+    else -> value
 }
 
 private fun splitDisplayTitle(raw: String): Pair<String, String?> {
@@ -521,9 +588,22 @@ private fun splitDisplayTitle(raw: String): Pair<String, String?> {
     return raw to null
 }
 
-/** heroHeight = 980 of a 1080-pt tvOS canvas ≈ 0.907. */
-private const val HERO_HEIGHT_FRACTION = 0.907f
-private val DetailHeroComfortableHeight = 500.dp
+/** Approved tvOS detail geometry mapped onto Android TV's half-scale canvas. */
+private const val HERO_HEIGHT_FRACTION = 690f / 1080f
+// The action row now remains visible while browsing seasons/episodes. The old
+// 520pt compact height was sized for a header that hid those controls and let
+// the episode hierarchy overlap the selector. 580pt keeps the full hierarchy
+// inside the hero while preserving the 690pt artwork fade behind it.
+private const val SERIES_HERO_HEIGHT_FRACTION = 580f / 1080f
+private const val ARTWORK_WIDTH_FRACTION = 0.64f
+private const val ARTWORK_HEIGHT_FRACTION = 0.94f
+private val HERO_TOP_INSET = 44.dp
+private val SERIES_HERO_TOP_INSET = 23.dp
+private val HERO_CONTENT_MAX_WIDTH = 540.dp
+private val HERO_CONTENT_SPACING = 9.dp
+private val EDITORIAL_SPACING = 7.dp
+private val SERIES_METADATA_SLOT_HEIGHT = 24.dp
+private val SERIES_EPISODE_SYNOPSIS_HEIGHT = 52.dp
 
 /**
  * Condensed family for the hero display title. tvOS renders the title in SF

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt
@@ -259,11 +259,13 @@ private fun EditorialColumn(
             logoUrl = logoUrl,
         )
 
-        // Editorial identity gets its own line: "Movie · Horror · Thriller"
-        // (or Season/Episode context) must read before year/runtime/playback
-        // information rather than trailing after it on one overlong row.
-        if (sourceTokens.isNotEmpty()) SourceRow(tokens = sourceTokens)
-        val hasMetadata = factsLine.isNotEmpty() || !ratingChip.isNullOrBlank()
+        // Movies keep their separate editorial identity line. The combined
+        // Series page follows tvOS's single metadata line instead: episode date
+        // and runtime, then Season / Episode context, then the rating chip.
+        if (!compactSeries && sourceTokens.isNotEmpty()) SourceRow(tokens = sourceTokens)
+        val hasMetadata = factsLine.isNotEmpty() ||
+            !ratingChip.isNullOrBlank() ||
+            (compactSeries && sourceTokens.isNotEmpty())
         if (compactSeries) {
             // Episode focus may swap a full Show facts row for a shorter date /
             // runtime row. Keep the approved facts baseline and the margin
@@ -276,13 +278,31 @@ private fun EditorialColumn(
                 contentAlignment = Alignment.CenterStart,
             ) {
                 if (hasMetadata) {
-                    MetadataRow(tokens = factsLine, sourceTokens = emptyList(), ratingChip = ratingChip)
+                    MetadataRow(
+                        tokens = factsLine,
+                        sourceTokens = sourceTokens,
+                        ratingChip = ratingChip,
+                        compactRating = true,
+                    )
                 }
             }
         } else if (hasMetadata) {
-            MetadataRow(tokens = factsLine, sourceTokens = emptyList(), ratingChip = ratingChip)
+            // Keep the standard hero's established metadata footprint while
+            // giving movie ratings the same compact tvOS badge used by Series.
+            Box(
+                modifier = Modifier
+                    .height(SERIES_METADATA_SLOT_HEIGHT)
+                    .clipToBounds(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                MetadataRow(
+                    tokens = factsLine,
+                    sourceTokens = emptyList(),
+                    ratingChip = ratingChip,
+                    compactRating = true,
+                )
+            }
         }
-        playbackSummary?.invoke()
 
         // Synopsis slot — the hero's only text focus stop. A focusable leaf
         // that clamps the overview to the current height budget and, on
@@ -319,20 +339,44 @@ private fun EditorialColumn(
         }
         translation?.invoke()
 
-        // Quiet "Directed by …" credit between the synopsis and the facts row.
-        // 14sp = the ten-foot metadata floor; the 0.62 alpha keeps it reading
-        // as a credit rather than another synopsis line.
-        directorText?.takeIf { it.isNotBlank() }?.let { line ->
-            Text(
-                text = line,
-                fontWeight = FontWeight.Medium,
-                fontSize = 14.sp,
-                color = Color.White.copy(alpha = 0.62f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+        if (compactSeries) {
+            // Keep this slot mounted even while episode data changes so the
+            // playback readout and action row remain completely locked.
+            Box(
+                modifier = Modifier
+                    .height(SERIES_CREDIT_SLOT_HEIGHT)
+                    .clipToBounds(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                directorText?.takeIf { it.isNotBlank() }?.let { line ->
+                    HeroCreditLine(line)
+                }
+            }
+        } else {
+            directorText?.takeIf { it.isNotBlank() }?.let { line ->
+                HeroCreditLine(line)
+            }
         }
+        // Both movie and Series heroes now share the same footer hierarchy:
+        // synopsis, credit, then Version / Audio / Subtitles directly above
+        // the action row. Reordering these existing children does not change
+        // the standard hero's total measured height.
+        playbackSummary?.invoke()
     }
+}
+
+@Composable
+private fun HeroCreditLine(line: String) {
+    // 14sp = the ten-foot metadata floor; the quieter alpha lets a Starring or
+    // Directed-by line read as supporting credit rather than another synopsis.
+    Text(
+        text = line,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        color = Color.White.copy(alpha = 0.62f),
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
 }
 
 @Composable
@@ -475,6 +519,7 @@ private fun MetadataRow(
     tokens: List<TvHeroFactToken>,
     sourceTokens: List<String>,
     ratingChip: String?,
+    compactRating: Boolean = false,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -531,7 +576,7 @@ private fun MetadataRow(
         }
         ratingChip?.takeIf { it.isNotBlank() }?.let { rating ->
             if (tokens.isNotEmpty() || sourceTokens.isNotEmpty()) MetadataDivider()
-            RatingChip(text = rating)
+            RatingChip(text = rating, compact = compactRating)
         }
     }
 }
@@ -547,7 +592,7 @@ private fun MetadataDivider() {
 }
 
 @Composable
-private fun RatingChip(text: String) {
+private fun RatingChip(text: String, compact: Boolean) {
     Box(
         modifier = Modifier
             .border(
@@ -555,14 +600,18 @@ private fun RatingChip(text: String) {
                 color = Color.White.copy(alpha = 0.7f),
                 shape = RoundedCornerShape(2.5.dp),
             )
-            .padding(horizontal = 8.dp, vertical = 3.dp),
+            .padding(
+                horizontal = if (compact) 6.dp else 8.dp,
+                vertical = if (compact) 2.dp else 3.dp,
+            ),
     ) {
-        // 14sp floor for 10-ft legibility (tvOS 20pt heavy, tracking 1.0) — audit 2026-07-20.
+        // Compact detail ratings use the tvOS 20pt badge mapped to Android's
+        // half-scale canvas.
         Text(
             text = text,
             fontWeight = FontWeight.Black,
-            fontSize = 14.sp,
-            letterSpacing = 0.5.sp,
+            fontSize = if (compact) 10.5.sp else 14.sp,
+            letterSpacing = if (compact) 0.35.sp else 0.5.sp,
             color = Color.White,
             maxLines = 1,
         )
@@ -590,11 +639,11 @@ private fun splitDisplayTitle(raw: String): Pair<String, String?> {
 
 /** Approved tvOS detail geometry mapped onto Android TV's half-scale canvas. */
 private const val HERO_HEIGHT_FRACTION = 690f / 1080f
-// The action row now remains visible while browsing seasons/episodes. The old
-// 520pt compact height was sized for a header that hid those controls and let
-// the episode hierarchy overlap the selector. 580pt keeps the full hierarchy
-// inside the hero while preserving the 690pt artwork fade behind it.
-private const val SERIES_HERO_HEIGHT_FRACTION = 580f / 1080f
+// The full Series hierarchy (single metadata row, synopsis, fixed Starring and
+// playback readout, then 72pt controls) needs 610pt. This remains compact next
+// to the 690pt movie artwork while keeping the body from painting over the
+// controls or their focus treatment.
+private const val SERIES_HERO_HEIGHT_FRACTION = 610f / 1080f
 private const val ARTWORK_WIDTH_FRACTION = 0.64f
 private const val ARTWORK_HEIGHT_FRACTION = 0.94f
 private val HERO_TOP_INSET = 44.dp
@@ -604,6 +653,7 @@ private val HERO_CONTENT_SPACING = 9.dp
 private val EDITORIAL_SPACING = 7.dp
 private val SERIES_METADATA_SLOT_HEIGHT = 24.dp
 private val SERIES_EPISODE_SYNOPSIS_HEIGHT = 52.dp
+private val SERIES_CREDIT_SLOT_HEIGHT = 18.dp
 
 /**
  * Condensed family for the hero display title. tvOS renders the title in SF

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadata.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadata.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
 import org.siloserver.silo.model.catalog.FileVersion
+import org.siloserver.silo.model.catalog.EpisodeListItem
 import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import java.time.Instant
@@ -48,10 +49,29 @@ internal object TvDetailMetadata {
     fun ratingChip(detail: ItemDetail): String? =
         detail.contentRating?.trim()?.takeIf { it.isNotEmpty() }
 
+    fun seriesEpisodeSourceTokens(episode: EpisodeListItem): List<String> = listOf(
+        if (episode.seasonNumber == 0) "Specials" else "Season ${episode.seasonNumber}",
+        "Episode ${episode.episodeNumber}",
+    )
+
+    /** Episode editorial facts used by the combined Series page. These mirror
+     * tvOS: the episode's air date and runtime replace the Show facts, while
+     * version choices remain directly beneath the episode carousel. */
+    fun seriesEpisodeFactsLine(
+        episode: EpisodeListItem,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): List<TvHeroFactToken> = buildList {
+        abbreviatedDate(episode.airDate, zone)?.let {
+            add(TvHeroFactToken.TextToken(it))
+        }
+        runtimeLabel(episode.runtime)?.let { add(TvHeroFactToken.TextToken(it)) }
+    }
+
     fun factsLine(
         detail: ItemDetail,
         preferredQuality: String? = null,
         selectedFileId: Int? = null,
+        includePlaybackFormats: Boolean = true,
         zone: ZoneId = ZoneId.systemDefault(),
     ): List<TvHeroFactToken> {
         val tokens = mutableListOf<TvHeroFactToken>()
@@ -73,7 +93,9 @@ internal object TvDetailMetadata {
         detail.ratingImdb?.let {
             tokens += TvHeroFactToken.TextToken("★ ${formatOneDecimal(it)}")
         }
-        tokens += qualityTokens(detail, preferredQuality, selectedFileId)
+        if (includePlaybackFormats) {
+            tokens += qualityTokens(detail, preferredQuality, selectedFileId)
+        }
         return tokens
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadata.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadata.kt
@@ -49,9 +49,9 @@ internal object TvDetailMetadata {
     fun ratingChip(detail: ItemDetail): String? =
         detail.contentRating?.trim()?.takeIf { it.isNotEmpty() }
 
-    fun seriesEpisodeSourceTokens(episode: EpisodeListItem): List<String> = listOf(
+    fun seriesEpisodeSourceTokens(episode: EpisodeListItem): List<String> = listOfNotNull(
         if (episode.seasonNumber == 0) "Specials" else "Season ${episode.seasonNumber}",
-        "Episode ${episode.episodeNumber}",
+        "Episode ${episode.episodeNumber}".takeIf { episode.episodeNumber > 0 },
     )
 
     /** Episode editorial facts used by the combined Series page. These mirror

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailTrailersSection.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailTrailersSection.kt
@@ -82,7 +82,7 @@ internal fun tvDetailTrailerEntries(detail: ItemDetail): List<TvDetailTrailerEnt
         .filter { it.site.equals("youtube", ignoreCase = true) && it.siteKey.isNotBlank() }
         .forEach { add(TvDetailTrailerEntry.Remote(it)) }
     detail.extras.orEmpty().forEach { add(TvDetailTrailerEntry.Local(it)) }
-}
+}.distinctBy(TvDetailTrailerEntry::key)
 
 @Composable
 internal fun TvDetailTrailersSection(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailTrailersSection.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailTrailersSection.kt
@@ -1,0 +1,273 @@
+package org.siloserver.silo.tv.ui.screens.detail
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Icon
+import androidx.tv.material3.Text
+import coil3.compose.AsyncImage
+import org.siloserver.silo.model.catalog.ItemDetail
+import org.siloserver.silo.model.catalog.ItemExtra
+import org.siloserver.silo.model.catalog.ItemVideo
+import org.siloserver.silo.tv.ui.theme.DarkSurfaceElevated
+import org.siloserver.silo.tv.ui.theme.SiloOnSurface
+import org.siloserver.silo.tv.ui.theme.SiloSecondaryText
+import org.siloserver.silo.tv.ui.theme.TvRailScrollBehavior
+import org.siloserver.silo.tv.ui.theme.tvRailPinOnFocus
+
+internal sealed interface TvDetailTrailerEntry {
+    val key: String
+    val title: String
+    val kind: String
+
+    data class Remote(val video: ItemVideo) : TvDetailTrailerEntry {
+        override val key = "remote:${video.site}:${video.siteKey}"
+        override val title = video.name?.trim()?.takeIf { it.isNotEmpty() }
+            ?: trailerKindLabel(video.kind)
+        override val kind = video.kind
+    }
+
+    data class Local(val extra: ItemExtra) : TvDetailTrailerEntry {
+        override val key = "local:${extra.contentId}"
+        override val title = extra.title?.trim()?.takeIf { it.isNotEmpty() }
+            ?: trailerKindLabel(extra.kind)
+        override val kind = extra.kind
+    }
+}
+
+internal fun tvDetailTrailerEntries(detail: ItemDetail): List<TvDetailTrailerEntry> = buildList {
+    detail.videos.orEmpty()
+        .filter { it.site.equals("youtube", ignoreCase = true) && it.siteKey.isNotBlank() }
+        .forEach { add(TvDetailTrailerEntry.Remote(it)) }
+    detail.extras.orEmpty().forEach { add(TvDetailTrailerEntry.Local(it)) }
+}
+
+@Composable
+internal fun TvDetailTrailersSection(
+    entries: List<TvDetailTrailerEntry>,
+    onSelectRemote: (ItemVideo) -> Unit,
+    onSelectLocal: (ItemExtra) -> Unit,
+    modifier: Modifier = Modifier,
+    onDirectionUp: (() -> Boolean)? = null,
+) {
+    if (entries.isEmpty()) return
+
+    val listState = rememberLazyListState()
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(7.dp),
+    ) {
+        TvDetailSectionHeader(
+            title = "Trailers & More",
+            modifier = Modifier.padding(horizontal = TvDetailHorizontalInset),
+        )
+        TvRailScrollBehavior {
+            LazyRow(
+                state = listState,
+                modifier = Modifier
+                    .then(
+                        if (onDirectionUp != null) {
+                            Modifier.onPreviewKeyEvent { event ->
+                                if (event.type == KeyEventType.KeyDown && event.key == Key.DirectionUp) {
+                                    onDirectionUp()
+                                } else {
+                                    false
+                                }
+                            }
+                        } else {
+                            Modifier
+                        },
+                    )
+                    .focusGroup(),
+                contentPadding = PaddingValues(
+                    horizontal = TvDetailHorizontalInset,
+                    vertical = 6.dp,
+                ),
+                horizontalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                itemsIndexed(
+                    items = entries,
+                    key = { _, entry -> entry.key },
+                    contentType = { _, entry -> if (entry is TvDetailTrailerEntry.Remote) "remote-trailer" else "local-extra" },
+                ) { index, entry ->
+                    TvDetailTrailerCard(
+                        entry = entry,
+                        onClick = {
+                            when (entry) {
+                                is TvDetailTrailerEntry.Remote -> onSelectRemote(entry.video)
+                                is TvDetailTrailerEntry.Local -> onSelectLocal(entry.extra)
+                            }
+                        },
+                        modifier = Modifier.tvRailPinOnFocus(listState, index, TvDetailHorizontalInset),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvDetailTrailerCard(
+    entry: TvDetailTrailerEntry,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isFocused) 1.05f else 1f,
+        animationSpec = tween(180),
+        label = "trailerCardScale",
+    )
+    val cardShape = RoundedCornerShape(9.dp)
+
+    Column(
+        modifier = modifier
+            .width(235.dp)
+            .scale(scale)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(7.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .width(235.dp)
+                .height(132.dp)
+                .shadow(if (isFocused) 16.dp else 7.dp, cardShape, clip = false)
+                .clip(cardShape)
+                .background(DarkSurfaceElevated)
+                .then(
+                    if (isFocused) Modifier.border(2.dp, Color.White.copy(alpha = 0.94f), cardShape)
+                    else Modifier,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            when (entry) {
+                is TvDetailTrailerEntry.Remote -> AsyncImage(
+                    model = "https://i.ytimg.com/vi/${entry.video.siteKey}/hqdefault.jpg",
+                    contentDescription = entry.title,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+                is TvDetailTrailerEntry.Local -> Icon(
+                    imageVector = Icons.Filled.Movie,
+                    contentDescription = null,
+                    tint = SiloSecondaryText,
+                    modifier = Modifier.size(30.dp),
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .size(30.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = if (isFocused) 0.72f else 0.55f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.PlayArrow,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+
+        Text(
+            text = entry.title,
+            color = if (isFocused) SiloOnSurface else SiloOnSurface.copy(alpha = 0.92f),
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        trailerSecondaryLine(entry)?.let { secondary ->
+            Text(
+                text = secondary,
+                color = SiloSecondaryText,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+private fun trailerSecondaryLine(entry: TvDetailTrailerEntry): String? = when (entry) {
+    is TvDetailTrailerEntry.Remote -> "YouTube"
+    is TvDetailTrailerEntry.Local -> entry.extra.durationSeconds
+        ?.takeIf { it > 0 }
+        ?.let(::formatTrailerDuration)
+}
+
+private fun formatTrailerDuration(totalSeconds: Int): String {
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        "$hours:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
+    } else {
+        "$minutes:${seconds.toString().padStart(2, '0')}"
+    }
+}
+
+private fun trailerKindLabel(kind: String): String = when (kind.lowercase()) {
+    "trailer" -> "Trailer"
+    "teaser" -> "Teaser"
+    "featurette" -> "Featurette"
+    "behind_the_scenes", "behind-the-scenes" -> "Behind the Scenes"
+    "deleted_scene", "deleted-scene" -> "Deleted Scene"
+    "interview" -> "Interview"
+    else -> kind.replace('_', ' ').replace('-', ' ').trim()
+        .split(' ')
+        .filter { it.isNotBlank() }
+        .joinToString(" ") { word -> word.replaceFirstChar { it.uppercase() } }
+        .ifBlank { "Extra" }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvExpandableSynopsis.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvExpandableSynopsis.kt
@@ -1,44 +1,67 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
-import android.provider.Settings
-import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import kotlinx.coroutines.launch
+import org.siloserver.silo.tv.ui.focus.TvContentInitialFocusMaxAttempts
+import org.siloserver.silo.tv.ui.focus.claimFocusOrReport
+import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
 import org.siloserver.silo.tv.ui.theme.DarkSurfaceElevated
 
 /**
- * The hero's overview as an expand-in-place control. Mirrors tvOS
- * `TVExpandableSynopsis` 1:1.
+ * The hero's clamped overview and entry point to its full-description popup.
  *
  * The overview defaults to a 3-line clamp at tvOS÷2 sizing (26pt regular →
  * 13sp); constrained hero layouts can supply a smaller [collapsedMaxLines].
- * Pressing OK/Select toggles [expanded]: when expanded the line clamp is removed
- * AND the [tagline] is shown above the overview (only when non-blank).
+ * Pressing OK/Select opens a window-level, scrollable popup instead of
+ * expanding the page and moving the detail controls beneath it.
  *
  * This is a **focusable leaf** — the hero's only text focus stop, reachable by
  * pressing Up from the action row, and actionable so it never feels "stuck".
@@ -47,9 +70,8 @@ import org.siloserver.silo.tv.ui.theme.DarkSurfaceElevated
  * white text stays readable. The system halo
  * is suppressed (`indication = null`), matching the squared-control idiom.
  *
- * `animateContentSize` (≈120ms easeOut) animates the expand/collapse; the
- * animation is disabled when the device has motion reduced (animator duration
- * scale 0).
+ * [previewText] can include compact context (for example the focused episode
+ * name) while [overview] remains the clean full text displayed in the popup.
  */
 @Composable
 internal fun TvExpandableSynopsis(
@@ -57,30 +79,16 @@ internal fun TvExpandableSynopsis(
     tagline: String?,
     modifier: Modifier = Modifier,
     collapsedMaxLines: Int = 3,
+    dialogTitle: String? = null,
+    previewText: String = overview,
 ) {
     require(collapsedMaxLines > 0) { "collapsedMaxLines must be positive" }
 
-    var expanded by remember(overview) { mutableStateOf(false) }
+    var showFullSynopsis by remember(overview, dialogTitle) { mutableStateOf(false) }
+    val synopsisFocus = remember { FocusRequester() }
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
     val shape = RoundedCornerShape(4.dp)
-
-    // Best-effort reduce-motion: animator duration scale of 0 means the user
-    // (or the OS) has disabled animations.
-    val context = LocalContext.current
-    val reduceMotion = remember(context) {
-        Settings.Global.getFloat(
-            context.contentResolver,
-            Settings.Global.ANIMATOR_DURATION_SCALE,
-            1f,
-        ) == 0f
-    }
-
-    val sizeModifier = if (reduceMotion) {
-        Modifier
-    } else {
-        Modifier.animateContentSize(animationSpec = tween(durationMillis = 160))
-    }
 
     Column(
         modifier = modifier
@@ -95,41 +103,163 @@ internal fun TvExpandableSynopsis(
                     Modifier
                 },
             )
+            .focusRequester(synopsisFocus)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
-            ) { expanded = !expanded }
+            ) { showFullSynopsis = true }
             // Keep the synopsis text on the same leading edge as the title,
             // episode hierarchy, and metadata rows. The old 10dp horizontal
             // inset made the description visibly drift right.
-            .padding(vertical = 7.dp)
-            .then(sizeModifier),
+            .padding(vertical = 7.dp),
         horizontalAlignment = Alignment.Start,
-        verticalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.Top,
     ) {
-        if (expanded && !tagline.isNullOrBlank()) {
-            // tvOS: 28pt serif italic → 14sp, +2 per design review.
-            Text(
-                text = tagline,
-                fontFamily = FontFamily.Serif,
-                fontStyle = FontStyle.Italic,
-                fontWeight = FontWeight.Normal,
-                fontSize = 16.sp,
-                lineHeight = 19.sp,
-                color = Color.White.copy(alpha = 0.85f),
-                textAlign = TextAlign.Start,
-            )
-        }
         // tvOS: 26pt regular → 13sp, +2 per design review (2026-07-11).
         Text(
-            text = overview,
+            text = previewText,
             fontWeight = FontWeight.Normal,
             fontSize = 15.sp,
             lineHeight = 19.sp,
             color = Color.White.copy(alpha = 0.82f),
             textAlign = TextAlign.Start,
-            maxLines = if (expanded) Int.MAX_VALUE else collapsedMaxLines,
+            maxLines = collapsedMaxLines,
             overflow = TextOverflow.Ellipsis,
         )
+    }
+
+    if (showFullSynopsis) {
+        TvSynopsisDialog(
+            title = dialogTitle,
+            overview = overview,
+            tagline = tagline,
+            onDismiss = { showFullSynopsis = false },
+        )
+        DisposableEffect(Unit) {
+            onDispose {
+                synopsisFocus.claimFocusOrReport(
+                    target = "detail_synopsis",
+                    action = "popup_dismissed",
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvSynopsisDialog(
+    title: String?,
+    overview: String,
+    tagline: String?,
+    onDismiss: () -> Unit,
+) {
+    val focus = remember { FocusRequester() }
+    var popupHasFocus by remember { mutableStateOf(false) }
+    val scrollState = rememberScrollState()
+    val scrollScope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        kotlinx.coroutines.delay(50)
+        requestFocusUntilObserved(
+            maxAttempts = TvContentInitialFocusMaxAttempts,
+            awaitAttempt = { withFrameNanos { } },
+            requestFocus = focus::requestFocus,
+            isFocused = { popupHasFocus },
+        )
+    }
+
+    Popup(
+        alignment = Alignment.Center,
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true, dismissOnBackPress = true),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.66f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.62f)
+                    .fillMaxHeight(0.72f)
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.98f))
+                    .border(
+                        0.6.dp,
+                        Color.White.copy(alpha = 0.14f),
+                        RoundedCornerShape(18.dp),
+                    )
+                    .onPreviewKeyEvent { event ->
+                        when {
+                            event.type == KeyEventType.KeyUp &&
+                                (event.key == Key.Back || event.key == Key.Escape ||
+                                    event.key == Key.DirectionCenter || event.key == Key.Enter) -> {
+                                onDismiss()
+                                true
+                            }
+                            event.type == KeyEventType.KeyDown && event.key == Key.DirectionDown -> {
+                                scrollScope.launch {
+                                    scrollState.animateScrollTo(
+                                        (scrollState.value + 180).coerceAtMost(scrollState.maxValue),
+                                    )
+                                }
+                                true
+                            }
+                            event.type == KeyEventType.KeyDown && event.key == Key.DirectionUp -> {
+                                scrollScope.launch {
+                                    scrollState.animateScrollTo(
+                                        (scrollState.value - 180).coerceAtLeast(0),
+                                    )
+                                }
+                                true
+                            }
+                            else -> false
+                        }
+                    },
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(scrollState)
+                        .focusRequester(focus)
+                        .onFocusChanged { popupHasFocus = it.hasFocus }
+                        .focusable()
+                        .padding(horizontal = 32.dp, vertical = 28.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    title?.trim()?.takeIf { it.isNotEmpty() }?.let { heading ->
+                        Text(
+                            text = heading,
+                            style = MaterialTheme.typography.headlineSmall.copy(
+                                fontSize = 24.sp,
+                                lineHeight = 28.sp,
+                                fontWeight = FontWeight.Bold,
+                            ),
+                            color = Color.White,
+                        )
+                    }
+                    tagline?.trim()?.takeIf { it.isNotEmpty() }?.let { line ->
+                        Text(
+                            text = line,
+                            fontFamily = FontFamily.Serif,
+                            fontStyle = FontStyle.Italic,
+                            fontWeight = FontWeight.Normal,
+                            fontSize = 16.sp,
+                            lineHeight = 21.sp,
+                            color = Color.White.copy(alpha = 0.82f),
+                        )
+                    }
+                    Text(
+                        text = overview,
+                        style = MaterialTheme.typography.bodyLarge.copy(
+                            fontSize = 17.sp,
+                            lineHeight = 25.sp,
+                        ),
+                        color = Color.White.copy(alpha = 0.86f),
+                    )
+                }
+            }
+        }
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -4,6 +4,11 @@ import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
@@ -104,6 +109,7 @@ import org.siloserver.silo.model.catalog.EpisodeListItem
 import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.catalog.ItemVideo
+import org.siloserver.silo.model.catalog.Season
 import org.siloserver.silo.model.catalog.VersionChapter
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.catalog.isSpecialsForDisplay
@@ -156,6 +162,9 @@ fun TvItemDetailScreen(
     ),
 ) {
     val state by viewModel.uiState.collectAsState()
+    var pendingEntrySeasonNumber by rememberSaveable(contentId, seasonNumber) {
+        mutableStateOf(seasonNumber)
+    }
 
     BackHandler(enabled = true) { onBack() }
 
@@ -177,12 +186,24 @@ fun TvItemDetailScreen(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    LaunchedEffect(state.detail?.contentId, seasonNumber, state.seasons, state.selectedSeason) {
+    LaunchedEffect(state.detail?.contentId, pendingEntrySeasonNumber, state.seasons) {
         val detail = state.detail ?: return@LaunchedEffect
-        if (detail.type != "series" || seasonNumber == null) return@LaunchedEffect
-        if (state.selectedSeason == seasonNumber) return@LaunchedEffect
-        if (state.seasons.any { it.seasonNumber == seasonNumber }) {
-            viewModel.onSeasonSelected(seasonNumber)
+        val entrySeason = pendingEntrySeasonNumber ?: return@LaunchedEffect
+        if (detail.type != "series") {
+            pendingEntrySeasonNumber = null
+            return@LaunchedEffect
+        }
+        if (state.selectedSeason == entrySeason) {
+            pendingEntrySeasonNumber = null
+            return@LaunchedEffect
+        }
+        // Wait only until the season list resolves, then consume the route hint
+        // exactly once. Later focus-driven season changes must never bounce back
+        // to the season that originally opened this page.
+        if (state.seasons.isEmpty()) return@LaunchedEffect
+        pendingEntrySeasonNumber = null
+        if (state.seasons.any { it.seasonNumber == entrySeason }) {
+            viewModel.onSeasonSelected(entrySeason)
         }
     }
 
@@ -507,6 +528,14 @@ private fun TvDetailContent(
     val heroOverview = activeSeriesEpisode?.let { episode ->
         activeSeriesPlaybackDetail?.overview ?: episode.overview
     } ?: detail.overview
+    // Always derive the Series credit from the Show itself. Episode focus can
+    // replace the synopsis and playback target, but must never make Starring or
+    // the controls underneath it jump to a different position.
+    val heroCreditText = if (isSeriesDetail) {
+        seriesStarringCredit(detail)
+    } else {
+        movieDirectorCredit(detail).takeIf { activeSeriesEpisode == null }
+    }
     val heroSourceTokens = activeSeriesEpisode?.let(TvDetailMetadata::seriesEpisodeSourceTokens)
         ?: TvDetailMetadata.sourceTokens(detail)
     val heroFactsLine = activeSeriesEpisode?.let { episode ->
@@ -684,7 +713,7 @@ private fun TvDetailContent(
                             overview = heroOverview,
                             tagline = detail.tagline.takeIf { activeSeriesEpisode == null },
                             factsLine = heroFactsLine,
-                            directorText = movieDirectorCredit(detail).takeIf { activeSeriesEpisode == null },
+                            directorText = heroCreditText,
                             translation = translationSlot.takeIf { activeSeriesEpisode == null },
                             compactSeries = isSeriesDetail,
                             playbackSummary = {
@@ -1143,7 +1172,7 @@ private fun TvDetailContent(
 }
 
 /**
- * Quiet, non-pill playback readout directly under the date/runtime facts.
+ * Quiet, non-pill playback readout directly under the fixed credit line.
  * It follows the same selected file and next-up episode state as Play, so a
  * Series episode focus change updates this line and the circular menus together.
  */
@@ -1226,22 +1255,22 @@ private fun TvDetailPlaybackSelectionSummary(
     Row(
         modifier = Modifier.height(TV_PLAYBACK_SUMMARY_HEIGHT),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         TvPlaybackSummaryItem(
             label = "VERSION",
             value = versionValue,
-            valueWidth = TV_PLAYBACK_VERSION_VALUE_WIDTH,
+            itemWidth = TV_PLAYBACK_VERSION_ITEM_WIDTH,
         )
         TvPlaybackSummaryItem(
             label = "AUDIO",
             value = audioValue,
-            valueWidth = TV_PLAYBACK_AUDIO_VALUE_WIDTH,
+            itemWidth = TV_PLAYBACK_AUDIO_ITEM_WIDTH,
         )
         TvPlaybackSummaryItem(
             label = "SUBTITLES",
             value = subtitleValue,
-            valueWidth = TV_PLAYBACK_SUBTITLE_VALUE_WIDTH,
+            itemWidth = TV_PLAYBACK_SUBTITLE_ITEM_WIDTH,
         )
     }
 }
@@ -1250,28 +1279,29 @@ private fun TvDetailPlaybackSelectionSummary(
 private fun TvPlaybackSummaryItem(
     label: String,
     value: String?,
-    valueWidth: androidx.compose.ui.unit.Dp,
+    itemWidth: androidx.compose.ui.unit.Dp,
 ) {
     Row(
+        modifier = Modifier.width(itemWidth),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Text(
             text = label,
             fontWeight = FontWeight.Bold,
-            fontSize = 14.sp,
-            letterSpacing = 0.65.sp,
+            fontSize = 11.sp,
+            letterSpacing = 0.5.sp,
             color = Color.White.copy(alpha = 0.48f),
             maxLines = 1,
         )
         if (value == null) {
-            TvPlaybackSummarySkeleton(valueWidth)
+            TvPlaybackSummarySkeleton(modifier = Modifier.weight(1f))
         } else {
             Text(
                 text = value,
-                modifier = Modifier.width(valueWidth),
+                modifier = Modifier.weight(1f),
                 fontWeight = FontWeight.Medium,
-                fontSize = 14.sp,
+                fontSize = 11.5.sp,
                 color = Color.White.copy(alpha = 0.82f),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -1281,10 +1311,9 @@ private fun TvPlaybackSummaryItem(
 }
 
 @Composable
-private fun TvPlaybackSummarySkeleton(width: androidx.compose.ui.unit.Dp) {
+private fun TvPlaybackSummarySkeleton(modifier: Modifier = Modifier) {
     Box(
-        modifier = Modifier
-            .width(width)
+        modifier = modifier
             .height(7.dp)
             .background(
                 color = Color.White.copy(alpha = 0.14f),
@@ -1293,10 +1322,22 @@ private fun TvPlaybackSummarySkeleton(width: androidx.compose.ui.unit.Dp) {
     )
 }
 
-private val TV_PLAYBACK_SUMMARY_HEIGHT = 18.dp
-private val TV_PLAYBACK_VERSION_VALUE_WIDTH = 72.dp
-private val TV_PLAYBACK_AUDIO_VALUE_WIDTH = 104.dp
-private val TV_PLAYBACK_SUBTITLE_VALUE_WIDTH = 116.dp
+private val TV_PLAYBACK_SUMMARY_HEIGHT = 20.dp
+private val TV_PLAYBACK_VERSION_ITEM_WIDTH = 120.dp
+private val TV_PLAYBACK_AUDIO_ITEM_WIDTH = 160.dp
+private val TV_PLAYBACK_SUBTITLE_ITEM_WIDTH = 130.dp
+
+internal fun seriesStarringCredit(detail: ItemDetail): String? {
+    val names = detail.cast
+        .asSequence()
+        .filter { it.name.isNotBlank() }
+        .sortedBy { it.order }
+        .map { it.name.trim() }
+        .distinct()
+        .take(3)
+        .toList()
+    return names.takeIf { it.isNotEmpty() }?.joinToString(", ", prefix = "Starring ")
+}
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -1484,6 +1525,11 @@ private fun HeroActionRow(
                             )
                         }
                     },
+                    // tvOS reserves 340pt for the Series Play/Resume label.
+                    // Android's half-scale canvas maps that to 170dp, keeping
+                    // every circular action on a fixed x-position as episode
+                    // titles and progress state change.
+                    modifier = if (detail.type == "series") Modifier.width(170.dp) else Modifier,
                     focusRequester = playFocus,
                 )
 
@@ -1799,6 +1845,28 @@ private fun watchedUnmarkLabel(detail: ItemDetail): String = when (detail.type) 
 /** Tiny breathing room between the fixed hero controls and the series modes. */
 private val SeriesSeasonPickerTopPadding = 3.dp
 
+private data class SeriesEpisodeRailPage(
+    val seasonNumber: Int,
+    val episodes: List<EpisodeListItem>,
+)
+
+private const val SERIES_EPISODE_CAROUSEL_DURATION_MS = 360
+
+internal fun seriesEpisodeCarouselDirection(
+    fromSeasonNumber: Int,
+    toSeasonNumber: Int,
+    seasons: List<Season>,
+): Int {
+    if (fromSeasonNumber == toSeasonNumber) return 0
+    val fromIndex = seasons.indexOfFirst { it.seasonNumber == fromSeasonNumber }
+    val toIndex = seasons.indexOfFirst { it.seasonNumber == toSeasonNumber }
+    return if (fromIndex >= 0 && toIndex >= 0) {
+        if (toIndex > fromIndex) 1 else -1
+    } else {
+        if (toSeasonNumber > fromSeasonNumber) 1 else -1
+    }
+}
+
 @Composable
 private fun EpisodesSection(
     detail: ItemDetail,
@@ -1883,11 +1951,11 @@ private fun EpisodesSection(
                 .padding(top = if (isSeries && showsSeasonChips) 10.dp else 0.dp),
         ) {
             when {
-                // Spinner while a newly-selected season loads, instead of leaving the
-                // previous season's episodes under the new season header (T15b). The
-                // quiet refreshOnReturn reload does not set episodesLoading, so this
-                // never flashes on returning to the page.
-                state.episodesLoading -> {
+                // The first season still gets a loading indicator. Once a Series rail
+                // exists, retain it until the requested season is ready so the two
+                // complete rails can perform the directional carousel hand-off below.
+                // Non-Series detail routes retain their established spinner behavior.
+                state.episodesLoading && (!isSeries || state.episodes.isEmpty()) -> {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -1910,25 +1978,70 @@ private fun EpisodesSection(
                     )
                 }
                 else -> {
-                    TvDetailEpisodeRail(
-                        episodes = state.episodes,
-                        currentContentId = currentEpisodeRailContentId(
-                            detail = detail,
-                            state = state,
-                            entryEpisodeContentId = entryEpisodeContentId,
-                        ),
-                        favoriteStates = state.episodeFavoriteStates,
-                        onEpisodeSelected = onEpisodeSelected,
-                        onEpisodeFocused = onEpisodeFocused.takeIf { isSeries },
-                        onSetWatched = onSetEpisodeWatched,
-                        onSetFavorite = onSetEpisodeFavorite,
-                        // Up returns to the hero only when the season chips aren't above
-                        // the rail (the chips own the Up traversal when present).
-                        onDirectionUp = if (showsSeasonChips) null else onReturnToHero,
-                        hidesEpisodeTitle = isSeries,
-                        usesSeriesGeometry = isSeries,
-                        modifier = Modifier.onSizeChanged { railHeightPx = it.height },
-                    )
+                    val renderEpisodeRail: @Composable (List<EpisodeListItem>) -> Unit = { episodes ->
+                        TvDetailEpisodeRail(
+                            episodes = episodes,
+                            currentContentId = currentEpisodeRailContentId(
+                                detail = detail,
+                                state = state,
+                                entryEpisodeContentId = entryEpisodeContentId,
+                            ),
+                            favoriteStates = state.episodeFavoriteStates,
+                            onEpisodeSelected = onEpisodeSelected,
+                            onEpisodeFocused = onEpisodeFocused.takeIf { isSeries },
+                            onSetWatched = onSetEpisodeWatched,
+                            onSetFavorite = onSetEpisodeFavorite,
+                            // Up returns to the hero only when the season chips aren't above
+                            // the rail (the chips own the Up traversal when present).
+                            onDirectionUp = if (showsSeasonChips) null else onReturnToHero,
+                            hidesEpisodeTitle = isSeries,
+                            usesSeriesGeometry = isSeries,
+                            modifier = Modifier.onSizeChanged { railHeightPx = it.height },
+                        )
+                    }
+
+                    if (isSeries) {
+                        // Retain the outgoing season while the next one loads,
+                        // then move both complete rails as one viewport-wide
+                        // carousel page. Card geometry and each rail's own
+                        // focus/scroll state remain entirely unchanged.
+                        val railPage = SeriesEpisodeRailPage(
+                            seasonNumber = state.episodes.first().seasonNumber,
+                            episodes = state.episodes,
+                        )
+                        AnimatedContent(
+                            targetState = railPage,
+                            contentKey = { it.seasonNumber },
+                            transitionSpec = {
+                                val direction = seriesEpisodeCarouselDirection(
+                                    fromSeasonNumber = initialState.seasonNumber,
+                                    toSeasonNumber = targetState.seasonNumber,
+                                    seasons = state.seasons,
+                                )
+                                (
+                                    slideInHorizontally(
+                                        animationSpec = tween(
+                                            durationMillis = SERIES_EPISODE_CAROUSEL_DURATION_MS,
+                                            easing = FastOutSlowInEasing,
+                                        ),
+                                        initialOffsetX = { width -> width * direction },
+                                    ) togetherWith slideOutHorizontally(
+                                        animationSpec = tween(
+                                            durationMillis = SERIES_EPISODE_CAROUSEL_DURATION_MS,
+                                            easing = FastOutSlowInEasing,
+                                        ),
+                                        targetOffsetX = { width -> -width * direction },
+                                    )
+                                ).using(SizeTransform(clip = false))
+                            },
+                            label = "seriesEpisodeCarousel",
+                            modifier = Modifier.fillMaxWidth(),
+                        ) { page ->
+                            renderEpisodeRail(page.episodes)
+                        }
+                    } else {
+                        renderEpisodeRail(state.episodes)
+                    }
                 }
             }
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -1153,7 +1153,11 @@ private fun TvDetailPlaybackSelectionSummary(
     state: TvItemDetailUiState,
 ) {
     val usesNextUp = detail.type == "series" || detail.type == "season"
-    val playbackDetail = if (usesNextUp) state.nextUpPlaybackDetail else detail
+    val playbackDetail = if (usesNextUp) {
+        state.nextUpPlaybackDetail.takeIf { state.nextUpTargetReady }
+    } else {
+        detail
+    }
     val versions = playbackDetail?.versions.orEmpty()
     val selectedFileId = (if (usesNextUp) state.selectedNextUpFileId else state.selectedFileId)
         ?.takeIf { fileId -> versions.any { it.fileId == fileId } }
@@ -1769,12 +1773,8 @@ private fun openTvYoutubeTrailer(context: android.content.Context, video: ItemVi
         Intent.ACTION_VIEW,
         Uri.parse("https://www.youtube.com/watch?v=${video.siteKey}"),
     )
-    val intent = if (appIntent.resolveActivity(context.packageManager) != null) {
-        appIntent
-    } else {
-        webIntent
-    }
-    runCatching { context.startActivity(intent) }
+    runCatching { context.startActivity(appIntent) }
+        .recoverCatching { context.startActivity(webIntent) }
         .onFailure {
             Toast.makeText(context, "No app is available to open this trailer", Toast.LENGTH_SHORT).show()
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -1,5 +1,7 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
+import android.content.Intent
+import android.net.Uri
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.AnimationSpec
@@ -24,27 +26,22 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.BookmarkAdded
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.SkipPrevious
-import androidx.compose.material.icons.filled.Tv
-import androidx.compose.material.icons.outlined.BookmarkBorder
-import androidx.compose.material.icons.outlined.CheckCircle
-import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -68,7 +65,6 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -86,7 +82,6 @@ import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Border
 import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
-import androidx.tv.material3.Glow
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
@@ -108,6 +103,7 @@ import org.siloserver.silo.model.audiobook.AudiobookNarration
 import org.siloserver.silo.model.catalog.EpisodeListItem
 import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.catalog.ItemDetail
+import org.siloserver.silo.model.catalog.ItemVideo
 import org.siloserver.silo.model.catalog.VersionChapter
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.catalog.isSpecialsForDisplay
@@ -128,8 +124,8 @@ import org.siloserver.silo.tv.ui.components.TvOptionDialog
 import org.siloserver.silo.tv.ui.components.TvPillVariant
 import org.siloserver.silo.tv.ui.components.TvPrimaryPillButton
 import org.siloserver.silo.tv.ui.components.TvRowStyle
-import org.siloserver.silo.tv.ui.components.TvSecondaryPillButton
 import org.siloserver.silo.tv.ui.components.TvSquareToggleButton
+import org.siloserver.silo.tv.ui.components.rememberAmbientBackdropTintState
 import org.siloserver.silo.tv.ui.focus.TvObservedFocusResult
 import org.siloserver.silo.tv.ui.focus.claimFocusOrReport
 import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
@@ -139,13 +135,13 @@ import org.siloserver.silo.tv.ui.screens.watchtogether.TvSuggestToRoomViewModel
 import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherEntryDialog
 import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherViewModel
 import org.siloserver.silo.tv.ui.theme.Spacing
-import org.siloserver.silo.tv.ui.theme.TvControlCorner
 import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
 
 @Composable
 fun TvItemDetailScreen(
     contentId: String,
     seasonNumber: Int? = null,
+    initialEpisodeContentId: String? = null,
     onPlay: (contentId: String, fileId: Int?, audioTrackIndex: Int?, audioPickedThisSession: Boolean, subtitleSelection: TvSubtitleLaunchSelection?, itemType: String?, resumePositionSeconds: Double?) -> Unit,
     onItemDetail: (contentId: String) -> Unit,
     onItemDetailReplace: (contentId: String) -> Unit = onItemDetail,
@@ -155,7 +151,7 @@ fun TvItemDetailScreen(
     onOpenPerson: (personId: Long) -> Unit,
     onBack: () -> Unit,
     viewModel: TvItemDetailViewModel = koinViewModel(
-        key = "item-detail-$contentId-${seasonNumber ?: "default"}",
+        key = "item-detail-$contentId-${seasonNumber ?: "default"}-${initialEpisodeContentId ?: "default"}",
         parameters = { parametersOf(contentId) },
     ),
 ) {
@@ -190,6 +186,23 @@ fun TvItemDetailScreen(
         }
     }
 
+    LaunchedEffect(
+        state.detail?.contentId,
+        seasonNumber,
+        initialEpisodeContentId,
+        state.selectedSeason,
+        state.episodes,
+        state.episodesLoading,
+        state.entryEpisodeSelectionApplied,
+    ) {
+        val detail = state.detail ?: return@LaunchedEffect
+        val episodeContentId = initialEpisodeContentId ?: return@LaunchedEffect
+        if (detail.type != "series" || state.entryEpisodeSelectionApplied) return@LaunchedEffect
+        if (seasonNumber != null && state.selectedSeason != seasonNumber) return@LaunchedEffect
+        if (state.episodesLoading || state.episodes.isEmpty()) return@LaunchedEffect
+        viewModel.onEntrySeriesEpisodeRequested(episodeContentId)
+    }
+
     when {
         state.isLoading && state.detail == null -> TvLoadingScreen(
             modifier = Modifier.background(MaterialTheme.colorScheme.background),
@@ -202,6 +215,7 @@ fun TvItemDetailScreen(
         state.detail != null -> TvDetailContent(
             detail = state.detail!!,
             state = state,
+            initialEpisodeContentId = initialEpisodeContentId,
             viewModel = viewModel,
             onPlay = onPlay,
             onItemDetail = onItemDetail,
@@ -219,6 +233,7 @@ fun TvItemDetailScreen(
 private fun TvDetailContent(
     detail: ItemDetail,
     state: TvItemDetailUiState,
+    initialEpisodeContentId: String?,
     viewModel: TvItemDetailViewModel,
     onPlay: (contentId: String, fileId: Int?, audioTrackIndex: Int?, audioPickedThisSession: Boolean, subtitleSelection: TvSubtitleLaunchSelection?, itemType: String?, resumePositionSeconds: Double?) -> Unit,
     onItemDetail: (contentId: String) -> Unit,
@@ -229,10 +244,9 @@ private fun TvDetailContent(
     onOpenPerson: (personId: Long) -> Unit,
 ) {
     val playFocus = remember { FocusRequester() }
-    // The playback selector row inside the hero action cluster. Hoisted here so
-    // an Up press from the body (episodes/season chips) can land on the
-    // selectors — the hero's bottom-most focus stop — instead of skipping
-    // straight to Play.
+    // The circular Version control in the hero action cluster. Hoisted here so
+    // an Up press from the body can return to the bottom-most playback control
+    // without skipping straight to Play.
     val selectorFocus = remember { FocusRequester() }
     val firstCastFocus = remember { FocusRequester() }
     // Focus restore for the cast rail: remembers which cast card pushed the
@@ -277,6 +291,31 @@ private fun TvDetailContent(
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
     val isAudiobook = isAudiobookItemType(detail.type)
+    val isSeriesDetail = detail.type == "series"
+    var isShowingSeriesOverview by rememberSaveable(detail.contentId) { mutableStateOf(true) }
+    LaunchedEffect(
+        initialEpisodeContentId,
+        state.entryEpisodeSelectionApplied,
+        state.nextUpEpisode?.contentId,
+    ) {
+        if (
+            initialEpisodeContentId != null &&
+            state.entryEpisodeSelectionApplied &&
+            state.nextUpEpisode?.contentId == initialEpisodeContentId
+        ) {
+            isShowingSeriesOverview = false
+        }
+    }
+    // tvOS treats Show / Season tabs, Episodes and the playback selector as a
+    // single fixed first viewport. Supporting rails only begin vertical page
+    // movement after focus leaves that complete primary region.
+    val seriesPrimaryViewportActive = remember(detail.contentId) { mutableStateOf(false) }
+    var seriesPrimaryFocusGeneration by remember(detail.contentId) { mutableStateOf(0) }
+    var seriesHeroHeightPx by remember(detail.contentId) { mutableStateOf(0) }
+    val trailerEntries = remember(detail.videos, detail.extras) {
+        tvDetailTrailerEntries(detail)
+    }
+    val detailContext = LocalContext.current
 
     // Default focus → Play (user-initiated), mirroring Apple's
     // `defaultFocus($playFocused, true, priority: .userInitiated)`. This
@@ -329,6 +368,12 @@ private fun TvDetailContent(
         if (pendingSimilarContentId != null) return@LaunchedEffect
         listState.scrollToItem(0)
         playFocus.claimFocusOrReport(target = "detail_play", action = "entry_fallback")
+        // Play's initial focus claim can enqueue its own bring-into-view before
+        // heroHasFocus observes the node. Let that request settle, then restore
+        // the approved top framing (most visible on the compact Series hero).
+        withFrameNanos { }
+        withFrameNanos { }
+        listState.scrollToItem(0)
     }
 
     // Returning from a related item: land back on the card that opened it
@@ -399,7 +444,11 @@ private fun TvDetailContent(
 
     val isEpisodicType = detail.type in setOf("series", "season", "episode")
     val showsEpisodeRail = isEpisodicType && state.episodes.isNotEmpty()
-    val showsSeasonChips = isEpisodicType && state.seasons.size > 1
+    val showsSeasonChips = isEpisodicType && if (isSeriesDetail) {
+        state.seasons.isNotEmpty()
+    } else {
+        state.seasons.size > 1
+    }
     // Keep the whole Episodes section — and, crucially, the season chips —
     // mounted whenever the series has seasons, so selecting an empty or failed
     // season can't unmount the chips and strand the user (T15). The rail itself
@@ -411,6 +460,7 @@ private fun TvDetailContent(
     // Up-return-to-hero fallback.
     val hasEpisodeNavAbove = showsEpisodeRail || showsSeasonChips
     val showsCastSection = !isAudiobook && detail.cast.isNotEmpty()
+    val showsTrailersSection = !isAudiobook && trailerEntries.isNotEmpty()
     val showsSimilarRail = !isAudiobook && detail.type != "episode" && state.moreLikeThis.isNotEmpty()
     val showsDetailsSection = !isAudiobook && remember(detail) { detail.hasTvDetailFacts() }
     // Whole-book timeline stitched from the item's audiobook-part files — the
@@ -443,7 +493,36 @@ private fun TvDetailContent(
     } else {
         state.selectedFileId
     }
+    val activeSeriesEpisode = state.nextUpEpisode.takeIf {
+        isSeriesDetail && !isShowingSeriesOverview
+    }
+    val activeSeriesPlaybackDetail = state.nextUpPlaybackDetail.takeIf { playbackDetail ->
+        activeSeriesEpisode?.contentId == playbackDetail?.contentId
+    }
+    val heroTitle = activeSeriesEpisode?.let { episode ->
+        activeSeriesPlaybackDetail?.title
+            ?: episode.title
+            ?: "Episode ${episode.episodeNumber}"
+    } ?: detail.title
+    val heroOverview = activeSeriesEpisode?.let { episode ->
+        activeSeriesPlaybackDetail?.overview ?: episode.overview
+    } ?: detail.overview
+    val heroSourceTokens = activeSeriesEpisode?.let(TvDetailMetadata::seriesEpisodeSourceTokens)
+        ?: TvDetailMetadata.sourceTokens(detail)
+    val heroFactsLine = activeSeriesEpisode?.let { episode ->
+        TvDetailMetadata.seriesEpisodeFactsLine(episode)
+    } ?: TvDetailMetadata.factsLine(
+        detail = detail,
+        preferredQuality = state.preferredQuality,
+        selectedFileId = heroSelectedFileId,
+        includePlaybackFormats = false,
+    )
     val heroArtwork = resolveTvDetailHeroArtwork(detail, state.nextUpEpisode)
+    val detailPageTint = rememberAmbientBackdropTintState()
+    LaunchedEffect(heroArtwork.url) {
+        detailPageTint.set(item = null, url = heroArtwork.url)
+    }
+    val pageSurfaceColor = tvDetailPageSurfaceColor(detailPageTint.accent)
     var chaptersDialogOpen by remember(detail.contentId) { mutableStateOf(false) }
 
     // The first focusable body rail (episode rail, else cast). An Up press from
@@ -452,8 +531,8 @@ private fun TvDetailContent(
     // actions section.
     val returnToHero: () -> Boolean = {
         coroutineScope.launch {
-            // Land on the selector row (the hero element directly above the
-            // body) when it is composed; otherwise fall back to Play
+            // Land on the selector row (the bottom-most primary control) when
+            // it is composed; otherwise fall back to Play
             // (audiobooks, or the next-up placeholder pill). Focus moves
             // BEFORE the scroll so the highlight travels with the window
             // instead of appearing only after it settles; when the hero has
@@ -528,7 +607,7 @@ private fun TvDetailContent(
     // hopping Play ↔ selector row. Suppress it for hero-origin requests and
     // keep the smooth spec for body rails.
     val heroHasFocus = remember { mutableStateOf(false) }
-    val detailBringIntoViewSpec = remember(heroHasFocus) {
+    val detailBringIntoViewSpec = remember(heroHasFocus, seriesPrimaryViewportActive, isSeriesDetail) {
         object : BringIntoViewSpec {
             override val scrollAnimationSpec: AnimationSpec<Float> = DetailAnchorScrollSpec
 
@@ -536,7 +615,10 @@ private fun TvDetailContent(
                 offset: Float,
                 size: Float,
                 containerSize: Float,
-            ): Float = if (heroHasFocus.value) {
+            ): Float = if (
+                heroHasFocus.value ||
+                (isSeriesDetail && seriesPrimaryViewportActive.value)
+            ) {
                 0f
             } else {
                 TvSmoothBringIntoViewSpec.calculateScrollDistance(offset, size, containerSize)
@@ -562,19 +644,21 @@ private fun TvDetailContent(
                 }
                 false
             }
-            .background(MaterialTheme.colorScheme.background),
+            .background(pageSurfaceColor),
     ) {
         CompositionLocalProvider(LocalBringIntoViewSpec provides detailBringIntoViewSpec) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 state = listState,
-                contentPadding = PaddingValues(bottom = 160.dp),
+                contentPadding = PaddingValues(bottom = if (isAudiobook) 160.dp else TvDetailPageBottomPadding),
             ) {
                 item(key = "hero", contentType = "detail-hero") {
                     Box(
-                        modifier = Modifier.onFocusChanged { focusState ->
-                            heroHasFocus.value = focusState.hasFocus
-                        },
+                        modifier = Modifier
+                            .onSizeChanged { seriesHeroHeightPx = it.height }
+                            .onFocusChanged { focusState ->
+                                heroHasFocus.value = focusState.hasFocus
+                            },
                     ) {
                     if (isAudiobook) {
                         TvAudiobookDetailHero(
@@ -586,30 +670,35 @@ private fun TvDetailContent(
                         )
                     } else {
                         TvDetailHero(
-                            scrollOffsetPx = {
-                                if (listState.firstVisibleItemIndex == 0) {
-                                    listState.firstVisibleItemScrollOffset.toFloat()
-                                } else {
-                                    Float.MAX_VALUE
-                                }
+                            title = heroTitle,
+                            seriesTitle = when {
+                                activeSeriesEpisode != null -> detail.title
+                                detail.type == "episode" -> detail.seriesTitle
+                                else -> null
                             },
-                            title = detail.title,
-                            seriesTitle = if (detail.type == "episode") detail.seriesTitle else null,
                             logoUrl = detail.logoUrl,
                             backdropUrl = heroArtwork.url,
                             backdropThumbhash = heroArtwork.thumbhash,
-                            sourceTokens = TvDetailMetadata.sourceTokens(detail),
+                            sourceTokens = heroSourceTokens,
                             ratingChip = TvDetailMetadata.ratingChip(detail),
-                            overview = detail.overview,
-                            tagline = detail.tagline,
-                            factsLine = TvDetailMetadata.factsLine(
-                                detail = detail,
-                                preferredQuality = state.preferredQuality,
-                                selectedFileId = heroSelectedFileId,
-                            ),
-                            directorText = movieDirectorCredit(detail),
-                            translation = translationSlot,
+                            overview = heroOverview,
+                            tagline = detail.tagline.takeIf { activeSeriesEpisode == null },
+                            factsLine = heroFactsLine,
+                            directorText = movieDirectorCredit(detail).takeIf { activeSeriesEpisode == null },
+                            translation = translationSlot.takeIf { activeSeriesEpisode == null },
+                            compactSeries = isSeriesDetail,
+                            playbackSummary = {
+                                TvDetailPlaybackSelectionSummary(
+                                    detail = detail,
+                                    state = state,
+                                )
+                            },
                             actions = {
+                                // Series keeps the full action row in both Show
+                                // and Season browsing modes. Because episode
+                                // focus updates state.nextUpEpisode, Play/Resume
+                                // always follows the focused episode while the
+                                // other Show-level actions stay available.
                                 HeroActionRow(
                                     detail = detail,
                                     state = state,
@@ -627,14 +716,13 @@ private fun TvDetailContent(
                     }
                 }
 
-                // Keep a short hero→body handoff so the next section header
-                // peeks below the selectors and signals that more is available.
-                // Every gap derives from TvDetailSectionGap (the hero handoff
-                // adds only the remainder above its internal bottom inset), so
-                // the whole page's vertical rhythm changes with one value.
+                // Approved hero→body rhythm: the artwork ends with the hero;
+                // the first section begins one standard body gap below it.
                 item(key = "body", contentType = "detail-body") {
                     Column(
-                        modifier = Modifier.padding(top = TvDetailSectionGap - TvDetailHeroBottomInset),
+                        // tvOS starts the first body section immediately after
+                        // the hero; the 64pt token is only BETWEEN sections.
+                        modifier = Modifier,
                         verticalArrangement = Arrangement.spacedBy(TvDetailSectionGap),
                     ) {
                         if (isAudiobook && audiobookParts.size > 1) {
@@ -715,24 +803,72 @@ private fun TvDetailContent(
                         }
 
                         if (showsEpisodesSection) {
-                            // Anchor the window when focus ENTERS the episodes
-                            // section (chips or cards): both center the section
-                            // in the viewport (tvOS scrolls the episode section
-                            // with `anchor: .center`), so focusing "Season N"
-                            // sits where an episode focus sits, and coming back
-                            // up from Cast & Crew restores the same position.
+                            // Series owns a fixed first viewport through the
+                            // selector. Entering it from Cast (or another
+                            // supporting rail) restores the hero top with one
+                            // smooth curve; internal mode/episode/selector
+                            // moves then suppress native reveal entirely.
                             Box(
-                                modifier = Modifier.detailSectionAnchor(listState, coroutineScope) { height, viewport ->
-                                    (viewport - height) / 2f
+                                modifier = if (isSeriesDetail) {
+                                    Modifier.onFocusChanged { focusState ->
+                                        seriesPrimaryFocusGeneration += 1
+                                        val generation = seriesPrimaryFocusGeneration
+                                        if (focusState.hasFocus) {
+                                            val needsRestore = !seriesPrimaryViewportActive.value
+                                            seriesPrimaryViewportActive.value = true
+                                            if (needsRestore) {
+                                                coroutineScope.launch {
+                                                    withFrameNanos { }
+                                                    if (
+                                                        seriesPrimaryViewportActive.value &&
+                                                        seriesPrimaryFocusGeneration == generation
+                                                    ) {
+                                                        listState.animateSeriesPrimaryViewport(seriesHeroHeightPx)
+                                                    }
+                                                }
+                                            }
+                                        } else {
+                                            // Preserve the lock across the tiny
+                                            // hand-off gap between descendants.
+                                            coroutineScope.launch {
+                                                delay(180)
+                                                if (seriesPrimaryFocusGeneration == generation) {
+                                                    seriesPrimaryViewportActive.value = false
+                                                }
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    Modifier.detailSectionAnchor(listState, coroutineScope) { height, viewport ->
+                                        (viewport - height) / 2f
+                                    }
                                 },
                             ) {
                             EpisodesSection(
                                 detail = detail,
                                 state = state,
+                                entryEpisodeContentId = initialEpisodeContentId
+                                    ?.takeUnless { state.entryEpisodeSelectionApplied },
                                 showsSeasonChips = showsSeasonChips,
+                                isShowingSeriesOverview = isShowingSeriesOverview,
+                                onShowSelected = {
+                                    isShowingSeriesOverview = true
+                                    viewModel.onSeriesEpisodeActivated(null)
+                                },
                                 onReturnToHero = returnToHero,
+                                onReturnToSeriesSelector = if (isSeriesDetail) {
+                                    {
+                                        selectorFocus.claimFocusOrReport(
+                                            target = "detail_series_selector",
+                                            action = "season_up",
+                                        ) || returnToHero()
+                                    }
+                                } else {
+                                    null
+                                },
                                 onSeasonSelected = { season ->
                                     if (detail.type == "series") {
+                                        isShowingSeriesOverview = false
                                         viewModel.onSeasonSelected(season.seasonNumber)
                                     } else if (season.contentId != detail.contentId) {
                                         // Season/episode pages own their hero and
@@ -743,12 +879,48 @@ private fun TvDetailContent(
                                         onItemDetailReplace(season.contentId)
                                     }
                                 },
-                                // Match tvOS browse semantics: OK opens the
-                                // episode detail. Playback remains an explicit
-                                // Play/Resume action so its version and track
-                                // selectors are honored.
                                 onEpisodeSelected = { episode ->
-                                    onItemDetail(episode.contentId)
+                                    if (isSeriesDetail) {
+                                        // The combined tvOS Series page never
+                                        // pushes an episode-detail route. OK on
+                                        // the focused card quick-plays it.
+                                        isShowingSeriesOverview = false
+                                        viewModel.onSeriesEpisodeActivated(episode.contentId)
+                                        val launch = seriesEpisodePlaybackLaunch(state, episode)
+                                        onPlay(
+                                            episode.contentId,
+                                            launch.fileId,
+                                            launch.audioTrackIndex,
+                                            launch.audioPickedThisSession,
+                                            launch.subtitleSelection,
+                                            "episode",
+                                            launch.resumePositionSeconds,
+                                        )
+                                    } else {
+                                        // Season/episode routes use the same
+                                        // direct-play contract: no legacy
+                                        // episode-detail page is pushed.
+                                        val launch = seriesEpisodePlaybackLaunch(state, episode)
+                                        onPlay(
+                                            episode.contentId,
+                                            launch.fileId,
+                                            launch.audioTrackIndex,
+                                            launch.audioPickedThisSession,
+                                            launch.subtitleSelection,
+                                            "episode",
+                                            launch.resumePositionSeconds,
+                                        )
+                                    }
+                                },
+                                onEpisodeFocused = { episode ->
+                                    if (isSeriesDetail) {
+                                        // Entering the rail swaps the hero's
+                                        // editorial and Play target to the
+                                        // focused episode without hiding the
+                                        // action row.
+                                        isShowingSeriesOverview = false
+                                        viewModel.onSeriesEpisodeActivated(episode.contentId)
+                                    }
                                 },
                                 onSetEpisodeWatched = viewModel::onSetEpisodeWatched,
                                 onSetEpisodeFavorite = viewModel::onSetEpisodeFavorite,
@@ -757,10 +929,19 @@ private fun TvDetailContent(
                         }
 
                         if (showsCastSection) {
-                            Box(modifier = Modifier.detailBodySectionAnchor(listState, coroutineScope)) {
+                            Box(
+                                modifier = Modifier
+                                    .onFocusChanged { focusState ->
+                                        if (focusState.hasFocus && isSeriesDetail) {
+                                            seriesPrimaryFocusGeneration += 1
+                                            seriesPrimaryViewportActive.value = false
+                                        }
+                                    }
+                                    .detailBodySectionAnchor(listState, coroutineScope),
+                            ) {
                             TvCastCrewSection(
                                 cast = detail.cast,
-                                horizontalContentPadding = Spacing.safeArea,
+                                horizontalContentPadding = TvDetailHorizontalInset,
                                 firstItemFocusRequester = firstCastFocus,
                                 // Cast is the first body rail only when there is no
                                 // episode rail or season chips above it; Up then
@@ -788,15 +969,36 @@ private fun TvDetailContent(
                             }
                         }
 
-                        if (showsDetailsSection) {
-                            DetailsSection(
-                                detail = detail,
+                        if (showsTrailersSection) {
+                            TvDetailTrailersSection(
+                                entries = trailerEntries,
+                                onSelectRemote = { video ->
+                                    openTvYoutubeTrailer(detailContext, video)
+                                },
+                                onSelectLocal = { extra ->
+                                    onPlay(
+                                        extra.contentId,
+                                        extra.fileId,
+                                        null,
+                                        false,
+                                        null,
+                                        "extra",
+                                        0.0,
+                                    )
+                                },
+                                onDirectionUp = if (!hasEpisodeNavAbove && !showsCastSection) {
+                                    returnToHero
+                                } else {
+                                    null
+                                },
                                 modifier = Modifier
-                                    .detailBodySectionAnchor(listState, coroutineScope)
-                                    // The section pads its own inner inset so the
-                                    // focus highlight box extends past the text
-                                    // instead of starting flush at its left edge.
-                                    .padding(horizontal = Spacing.safeArea - TvDetailsFocusInset),
+                                    .onFocusChanged { focusState ->
+                                        if (focusState.hasFocus && isSeriesDetail) {
+                                            seriesPrimaryFocusGeneration += 1
+                                            seriesPrimaryViewportActive.value = false
+                                        }
+                                    }
+                                    .detailBodySectionAnchor(listState, coroutineScope),
                             )
                         }
 
@@ -805,15 +1007,23 @@ private fun TvDetailContent(
                             // header (Recommended / More Like This) over a bare
                             // poster rail — no See-all on the detail page.
                             Column(
-                                modifier = Modifier.detailBodySectionAnchor(listState, coroutineScope),
+                                modifier = Modifier
+                                    .onFocusChanged { focusState ->
+                                        if (focusState.hasFocus && isSeriesDetail) {
+                                            seriesPrimaryFocusGeneration += 1
+                                            seriesPrimaryViewportActive.value = false
+                                        }
+                                    }
+                                    .detailBodySectionAnchor(listState, coroutineScope),
                                 verticalArrangement = Arrangement.spacedBy(20.dp),
                             ) {
+                                val similarTitle = if (isSeriesDetail) "Recommended Series" else "Related Movies"
                                 TvDetailSectionHeader(
-                                    title = "More Like This",
-                                    modifier = Modifier.padding(horizontal = Spacing.safeArea),
+                                    title = similarTitle,
+                                    modifier = Modifier.padding(horizontal = TvDetailHorizontalInset),
                                 )
                                 TvMediaRow(
-                                    title = "More Like This",
+                                    title = similarTitle,
                                     showHeader = false,
                                     items = state.moreLikeThis,
                                     onItemClick = { clickedContentId ->
@@ -855,10 +1065,10 @@ private fun TvDetailContent(
                                         null
                                     },
                                     style = TvRowStyle.Poster,
-                                    horizontalPadding = Spacing.safeArea,
+                                    horizontalPadding = TvDetailHorizontalInset,
                                     rowTopPadding = 0.dp,
                                     firstItemFocusRequester = firstSimilarFocus,
-                                    onDirectionUp = if (!hasEpisodeNavAbove && !showsCastSection) {
+                                    onDirectionUp = if (!hasEpisodeNavAbove && !showsCastSection && !showsTrailersSection) {
                                         returnToHero
                                     } else {
                                         null
@@ -866,13 +1076,31 @@ private fun TvDetailContent(
                                     // When Similar is the first body rail (movie with no
                                     // episode rail and no cast), Up returns to the hero
                                     // Play button instead of relying on geometry.
-                                    upFocusRequester = if (!hasEpisodeNavAbove && !showsCastSection) {
+                                    upFocusRequester = if (!hasEpisodeNavAbove && !showsCastSection && !showsTrailersSection) {
                                         playFocus
                                     } else {
                                         null
                                     },
                                 )
                             }
+                        }
+
+                        if (showsDetailsSection) {
+                            DetailsSection(
+                                detail = detail,
+                                modifier = Modifier
+                                    .onFocusChanged { focusState ->
+                                        if (focusState.hasFocus && isSeriesDetail) {
+                                            seriesPrimaryFocusGeneration += 1
+                                            seriesPrimaryViewportActive.value = false
+                                        }
+                                    }
+                                    .detailBodySectionAnchor(listState, coroutineScope)
+                                    // The section pads its own inner inset so the
+                                    // focus highlight box extends past the text
+                                    // instead of starting flush at its left edge.
+                                    .padding(horizontal = TvDetailHorizontalInset - TvDetailsFocusInset),
+                            )
                         }
                     }
                 }
@@ -913,6 +1141,158 @@ private fun TvDetailContent(
         }
     }
 }
+
+/**
+ * Quiet, non-pill playback readout directly under the date/runtime facts.
+ * It follows the same selected file and next-up episode state as Play, so a
+ * Series episode focus change updates this line and the circular menus together.
+ */
+@Composable
+private fun TvDetailPlaybackSelectionSummary(
+    detail: ItemDetail,
+    state: TvItemDetailUiState,
+) {
+    val usesNextUp = detail.type == "series" || detail.type == "season"
+    val playbackDetail = if (usesNextUp) state.nextUpPlaybackDetail else detail
+    val versions = playbackDetail?.versions.orEmpty()
+    val selectedFileId = (if (usesNextUp) state.selectedNextUpFileId else state.selectedFileId)
+        ?.takeIf { fileId -> versions.any { it.fileId == fileId } }
+    val selectedAudioIndex = if (usesNextUp) state.selectedNextUpAudioIndex else state.selectedAudioIndex
+    val selectedSubtitleIndex =
+        if (usesNextUp) state.selectedNextUpSubtitleIndex else state.selectedSubtitleIndex
+    val selectedVersion = remember(
+        versions,
+        selectedFileId,
+        playbackDetail?.userData?.lastFileId,
+        state.preferredQuality,
+    ) {
+        selectTvDetailDisplayVersion(
+            versions = versions,
+            selectedFileId = selectedFileId,
+            lastFileId = playbackDetail?.userData?.lastFileId,
+            preferredQuality = state.preferredQuality,
+        )
+    }
+    val compactVersion = selectedVersion?.let(TvPlaybackFormatting::versionCompactLabel)
+    val versionValue = if (selectedVersion == null) {
+        null
+    } else if (selectedFileId == null && compactVersion != "Auto") {
+        "Auto · $compactVersion"
+    } else {
+        compactVersion
+    }
+    val automaticAudioTrackOrdinal = resolveTvAutomaticAudioTrackOrdinal(
+        version = selectedVersion,
+        preferredAudioLanguage = state.preferredAudioLanguage,
+        capabilities = state.audioSelectionCapabilities,
+    )
+    val automaticAudioResolutionKnown = state.audioSelectionCapabilities != null
+    val audioValue = selectedVersion?.let { version ->
+        if (selectedAudioIndex == null && !automaticAudioResolutionKnown) {
+            "Auto"
+        } else {
+            TvPlaybackFormatting.audioValueLabel(
+                version = version,
+                selectedAudioTrackIndex = selectedAudioIndex,
+                automaticAudioTrackOrdinal = automaticAudioTrackOrdinal,
+            ).replace("Auto: ", "Auto · ")
+        }
+    }
+    val subtitleValue = selectedVersion?.let { version ->
+        TvPlaybackFormatting.subtitleValueLabel(
+            version = version,
+            selectedSubtitleTrackIndex = selectedSubtitleIndex,
+            autoContext = if (selectedAudioIndex != null || automaticAudioResolutionKnown) {
+                TvPlaybackFormatting.SubtitleAutoContext(
+                    preferredLanguage = state.preferredSubtitleLanguage,
+                    mode = state.subtitleMode,
+                    showForced = state.showForcedSubtitles,
+                    audioLanguage = TvPlaybackFormatting.resolvedAudioLanguage(
+                        version,
+                        selectedAudioIndex,
+                        automaticAudioTrackOrdinal,
+                    ),
+                )
+            } else {
+                null
+            },
+        ).replace("Auto - ", "Auto · ")
+    }
+
+    Row(
+        modifier = Modifier.height(TV_PLAYBACK_SUMMARY_HEIGHT),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        TvPlaybackSummaryItem(
+            label = "VERSION",
+            value = versionValue,
+            valueWidth = TV_PLAYBACK_VERSION_VALUE_WIDTH,
+        )
+        TvPlaybackSummaryItem(
+            label = "AUDIO",
+            value = audioValue,
+            valueWidth = TV_PLAYBACK_AUDIO_VALUE_WIDTH,
+        )
+        TvPlaybackSummaryItem(
+            label = "SUBTITLES",
+            value = subtitleValue,
+            valueWidth = TV_PLAYBACK_SUBTITLE_VALUE_WIDTH,
+        )
+    }
+}
+
+@Composable
+private fun TvPlaybackSummaryItem(
+    label: String,
+    value: String?,
+    valueWidth: androidx.compose.ui.unit.Dp,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = label,
+            fontWeight = FontWeight.Bold,
+            fontSize = 14.sp,
+            letterSpacing = 0.65.sp,
+            color = Color.White.copy(alpha = 0.48f),
+            maxLines = 1,
+        )
+        if (value == null) {
+            TvPlaybackSummarySkeleton(valueWidth)
+        } else {
+            Text(
+                text = value,
+                modifier = Modifier.width(valueWidth),
+                fontWeight = FontWeight.Medium,
+                fontSize = 14.sp,
+                color = Color.White.copy(alpha = 0.82f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TvPlaybackSummarySkeleton(width: androidx.compose.ui.unit.Dp) {
+    Box(
+        modifier = Modifier
+            .width(width)
+            .height(7.dp)
+            .background(
+                color = Color.White.copy(alpha = 0.14f),
+                shape = RoundedCornerShape(2.dp),
+            ),
+    )
+}
+
+private val TV_PLAYBACK_SUMMARY_HEIGHT = 18.dp
+private val TV_PLAYBACK_VERSION_VALUE_WIDTH = 72.dp
+private val TV_PLAYBACK_AUDIO_VALUE_WIDTH = 104.dp
+private val TV_PLAYBACK_SUBTITLE_VALUE_WIDTH = 116.dp
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -955,11 +1335,11 @@ private fun HeroActionRow(
     // Series / season detail target the *next-up episode* rather than the
     // container itself (mirrors silo-apple's TVSeriesDetailView /
     // TVSeasonDetailView). For those types the hero Play button, the resume
-    // position, and the inline selector row all bind to the next-up episode's
+    // position, and the circular selectors all bind to the next-up episode's
     // own playback detail; movie / episode detail keep the container behavior.
     val isSeriesOrSeason = detail.type == "series" || detail.type == "season"
     val nextUp = state.nextUpEpisode.takeIf { isSeriesOrSeason }
-    val nextUpDetail = state.nextUpPlaybackDetail
+    val nextUpDetail = state.nextUpPlaybackDetail.takeIf { state.nextUpTargetReady }
 
     // The contentId / type / versions / resume the Play action actually uses.
     val playContentId = nextUp?.contentId ?: detail.contentId
@@ -967,15 +1347,14 @@ private fun HeroActionRow(
     // For series/season we must NOT fall back to playing the container — Play is
     // a no-op until the next-up episode resolves (episodes still loading, or an
     // empty/error season). Movie/episode are always ready.
-    val playReady = !isSeriesOrSeason || nextUp != null
+    val playReady = !isSeriesOrSeason || (nextUp != null && state.nextUpTargetReady)
     val containerResume = remember(detail.userData) { detail.resumePositionSeconds() }
     val nextUpResume = remember(nextUp?.userData) { nextUp?.userData?.resumePositionSeconds() }
     val resumePosition = if (isSeriesOrSeason) nextUpResume else containerResume
     val hasResume = resumePosition != null
 
-    // tvOS overflow: episode Go-to-Series / Go-to-Season navigation and season
-    // Go-to-Series (mirrors `TVMovieDetailView.moreMenu` /
-    // `TVSeasonDetailView.moreMenu`). Movies do not show an overflow button.
+    // Every video detail owns a More menu. Favorite now lives there while the
+    // higher-frequency Watchlist toggle is visible in the stable action row.
     val hasSeriesNavigation = detail.type in setOf("episode", "season") && detail.seriesId != null
     val hasOverflowNavigation = hasSeriesNavigation
     val hasWatchTogether =
@@ -983,7 +1362,6 @@ private fun HeroActionRow(
     val hasSuggestionTarget = detail.type in setOf("movie", "episode") || nextUp != null
     val canSuggestToRoom =
         CLIENT_WATCH_TOGETHER_SURFACE_ENABLED && activeRoom != null && hasSuggestionTarget
-    val hasOverflowMenu = hasOverflowNavigation || hasWatchTogether || canSuggestToRoom
 
     // Version set + selection state driving the selector row / Play file id.
     // Series/season use the next-up episode's versions + the next-up selection;
@@ -1023,6 +1401,12 @@ private fun HeroActionRow(
         )
     }
     val selectedFileId = selectedVersion?.fileId
+    val automaticAudioTrackOrdinal = resolveTvAutomaticAudioTrackOrdinal(
+        version = selectedVersion,
+        preferredAudioLanguage = state.preferredAudioLanguage,
+        capabilities = state.audioSelectionCapabilities,
+    )
+    val automaticAudioResolutionKnown = state.audioSelectionCapabilities != null
     val hasTrackOverride = selectorAudioIndex != null || selectorSubtitleIndex != null
     // Exactly what the Subtitles pill is displaying — including the Auto
     // preview — so playback starts on that track instead of re-deciding from
@@ -1033,7 +1417,9 @@ private fun HeroActionRow(
         selectedSubtitleTrackIndex = selectorSubtitleIndex,
         // No displayed version means no displayed pill: stay silent and let the
         // player resolve, rather than asserting an "Auto - None" nobody saw.
-        autoContext = selectedVersion?.let { version ->
+        autoContext = selectedVersion?.takeIf {
+            selectorAudioIndex != null || automaticAudioResolutionKnown
+        }?.let { version ->
             TvPlaybackFormatting.SubtitleAutoContext(
                 preferredLanguage = state.preferredSubtitleLanguage,
                 mode = state.subtitleMode,
@@ -1041,115 +1427,127 @@ private fun HeroActionRow(
                 audioLanguage = TvPlaybackFormatting.resolvedAudioLanguage(
                     version,
                     selectorAudioIndex,
+                    automaticAudioTrackOrdinal,
                 ),
             )
         },
     )
     val playFileId = selectorSelectedFileId ?: selectedFileId.takeIf { hasTrackOverride }
-    // The effective playable version drives the inline playback selector row.
-    val isAudiobook = isAudiobookItemType(detail.type)
-    // Down from the action cluster lands on the selector row (when shown) rather
-    // than skipping into the body — mirrors Apple's full-width `.focusSection()`.
-    // The selectorFocus requester itself is hoisted to the screen so body Up
-    // traversal can target the row too.
-    // While the next-up playback detail is still loading we hold a placeholder in
-    // the selector slot (Apple's `TVVersionPillPlaceholder`); once resolved the
-    // real selector binds to the next-up versions/tracks.
-    val showsNextUpPlaceholder = isSeriesOrSeason && nextUp != null &&
-        (state.isLoadingNextUpPlaybackDetail ||
-            (!state.didLoadNextUpPlaybackDetail && nextUpDetail == null))
-    val showsSelectorRow = !isAudiobook && !showsNextUpPlaceholder && selectedVersion != null
-
     // No separate next-up autofocus: the Play button is always rendered and
     // focusable, and the screen already focuses it on detail load, so re-focusing
     // when next-up resolves would only risk yanking focus back if the viewer had
     // already moved into the seasons/episodes rails.
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        // Action row — tvOS `HStack(spacing: 36)` mapped through the same
-        // half-scale dp port as the button internals. One
-        // focusGroup; Down from the far-right toggle is redirected onto the
-        // selector row via focusProperties.
-        Row(
+        // Action row — approved tvOS `HStack(spacing: 18)` mapped through the
+        // half-scale dp port as the button internals. Version and Subtitles use
+        // the same circular chrome as the utility actions, so this cluster never
+        // changes shape while focus moves across it.
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .focusProperties {
                     // Entering the cluster from outside (Down from the
-                    // synopsis/facts, Up from the selectors or body) always
+                    // synopsis/facts, Up from the body) always
                     // lands on Play — geometric nearest-child search would
                     // otherwise pick whichever toggle sits closest.
                     enter = { playFocus }
                 }
                 .focusGroup(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(18.dp),
         ) {
-            TvPrimaryPillButton(
-                icon = Icons.Filled.PlayArrow,
-                title = playButtonLabel(
-                    isSeriesOrSeason = isSeriesOrSeason,
-                    seriesContainer = detail.type == "series",
-                    nextUp = nextUp,
-                    hasResume = hasResume,
-                    resumePosition = resumePosition,
-                ),
-                onClick = {
-                    if (playReady && !playLaunchPending) {
-                        playLaunchPending = true
-                        onPlay(
-                            playContentId, playFileId,
-                            selectorAudioIndex, selectorAudioPicked, subtitleLaunchSelection,
-                            playType, resumePosition,
-                        )
-                    }
-                },
-                focusRequester = playFocus,
-            )
-
-            if (hasResume) {
-                // tvOS Start Over uses `backward.end.fill` (skip-to-start),
-                // not a circular replay arrow.
-                TvSecondaryPillButton(
-                    icon = Icons.Filled.SkipPrevious,
-                    title = "Start Over",
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(9.dp),
+            ) {
+                TvPrimaryPillButton(
+                    icon = Icons.Filled.PlayArrow,
+                    title = playButtonLabel(
+                        isSeriesOrSeason = isSeriesOrSeason,
+                        seriesContainer = detail.type == "series",
+                        nextUp = nextUp,
+                        hasResume = hasResume,
+                        resumePosition = resumePosition,
+                    ),
                     onClick = {
                         if (playReady && !playLaunchPending) {
                             playLaunchPending = true
                             onPlay(
                                 playContentId, playFileId,
-                                selectorAudioIndex, selectorAudioPicked, subtitleLaunchSelection,
-                                playType, 0.0,
+                                selectorAudioIndex ?: automaticAudioTrackOrdinal,
+                                selectorAudioPicked,
+                                subtitleLaunchSelection,
+                                playType, resumePosition,
                             )
                         }
                     },
+                    focusRequester = playFocus,
                 )
-            }
 
-            TvSquareToggleButton(
-                icon = Icons.Outlined.FavoriteBorder,
-                iconActive = Icons.Filled.Favorite,
-                isActive = state.isFavorite,
-                contentDescription = if (state.isFavorite) "Remove from favorites" else "Add to favorites",
-                onClick = viewModel::onToggleFavorite,
-            )
+                TvPlaybackActionSelectors(
+                    versions = selectorVersions,
+                    currentVersion = selectedVersion,
+                    selectedVersionFileId = selectorSelectedFileId,
+                    selectedAudioTrackIndex = selectorAudioIndex,
+                    selectedSubtitleTrackIndex = selectorSubtitleIndex,
+                    automaticAudioTrackOrdinal = automaticAudioTrackOrdinal,
+                    automaticAudioResolutionKnown = automaticAudioResolutionKnown,
+                    preferredSubtitleLanguage = state.preferredSubtitleLanguage,
+                    subtitleMode = state.subtitleMode,
+                    showForcedSubtitles = state.showForcedSubtitles,
+                    onSelectVersion = if (isSeriesOrSeason) {
+                        viewModel::onNextUpVersionSelected
+                    } else {
+                        viewModel::onVersionSelected
+                    },
+                    onSelectAudioTrack = if (isSeriesOrSeason) {
+                        viewModel::onNextUpAudioTrackSelected
+                    } else {
+                        viewModel::onAudioTrackSelected
+                    },
+                    onSelectSubtitleTrack = if (isSeriesOrSeason) {
+                        viewModel::onNextUpSubtitleTrackSelected
+                    } else {
+                        viewModel::onSubtitleTrackSelected
+                    },
+                    versionFocusRequester = selectorFocus,
+                )
 
-            TvSquareToggleButton(
-                icon = Icons.Outlined.BookmarkBorder,
-                iconActive = Icons.Filled.BookmarkAdded,
-                isActive = state.inWatchlist,
-                contentDescription = if (state.inWatchlist) "Remove from watchlist" else "Add to watchlist",
-                onClick = viewModel::onToggleWatchlist,
-            )
+                if (hasResume) {
+                    // tvOS Start Over uses `backward.end.fill` (skip-to-start),
+                    // not a replay arrow. It is an icon-only circular companion
+                    // to the primary Play/Resume pill.
+                    TvSquareToggleButton(
+                        icon = Icons.Filled.SkipPrevious,
+                        iconActive = Icons.Filled.SkipPrevious,
+                        contentDescription = "Start Over",
+                        isActive = false,
+                        onClick = {
+                            if (playReady && !playLaunchPending) {
+                                playLaunchPending = true
+                                onPlay(
+                                    playContentId, playFileId,
+                                    selectorAudioIndex ?: automaticAudioTrackOrdinal,
+                                    selectorAudioPicked,
+                                    subtitleLaunchSelection,
+                                    playType, 0.0,
+                                )
+                            }
+                        },
+                    )
+                }
 
-            TvSquareToggleButton(
-                icon = Icons.Outlined.CheckCircle,
-                iconActive = Icons.Filled.CheckCircle,
-                isActive = state.isWatched,
-                contentDescription = if (state.isWatched) watchedUnmarkLabel(detail) else watchedMarkLabel(detail),
-                onClick = viewModel::onToggleWatched,
-            )
+                TvSquareToggleButton(
+                    icon = Icons.Filled.BookmarkBorder,
+                    iconActive = Icons.Filled.Bookmark,
+                    isActive = state.inWatchlist,
+                    contentDescription = if (state.inWatchlist) {
+                        "Remove from watchlist"
+                    } else {
+                        "Add to watchlist"
+                    },
+                    onClick = viewModel::onToggleWatchlist,
+                )
 
-            if (hasOverflowMenu) {
                 TvSquareToggleButton(
                     icon = Icons.Filled.MoreHoriz,
                     iconActive = Icons.Filled.MoreHoriz,
@@ -1159,47 +1557,32 @@ private fun HeroActionRow(
                 )
             }
         }
-
-        // Audiobooks have no meaningful video "version"/quality (the "720p" was
-        // the cover-art mjpeg stream); hide the selector row for them. For
-        // series/season detail the row binds to the *next-up* episode's
-        // versions/tracks; while that detail loads we hold a placeholder pill
-        // (Apple's `TVVersionPillPlaceholder`). Movie / episode detail bind to
-        // the container's own versions.
-        if (showsNextUpPlaceholder) {
-            TvVersionPillPlaceholder()
-        } else if (showsSelectorRow) {
-            TvPlaybackSelectorRow(
-                modifier = Modifier.focusRequester(selectorFocus),
-                versions = selectorVersions,
-                currentVersion = selectedVersion,
-                selectedVersionFileId = selectorSelectedFileId,
-                selectedAudioTrackIndex = selectorAudioIndex,
-                selectedSubtitleTrackIndex = selectorSubtitleIndex,
-                preferredSubtitleLanguage = state.preferredSubtitleLanguage,
-                subtitleMode = state.subtitleMode,
-                showForcedSubtitles = state.showForcedSubtitles,
-                onSelectVersion = if (isSeriesOrSeason) {
-                    viewModel::onNextUpVersionSelected
-                } else {
-                    viewModel::onVersionSelected
-                },
-                onSelectAudioTrack = if (isSeriesOrSeason) {
-                    viewModel::onNextUpAudioTrackSelected
-                } else {
-                    viewModel::onAudioTrackSelected
-                },
-                onSelectSubtitleTrack = if (isSeriesOrSeason) {
-                    viewModel::onNextUpSubtitleTrackSelected
-                } else {
-                    viewModel::onSubtitleTrackSelected
-                },
-            )
-        }
     }
 
-    if (moreOpen && hasOverflowMenu) {
+    if (moreOpen) {
         val options = buildList {
+            add(
+                TvDialogOption(
+                    key = "favorite",
+                    title = if (state.isFavorite) "Remove from Favorites" else "Add to Favorites",
+                    selected = state.isFavorite,
+                    onClick = {
+                        moreOpen = false
+                        viewModel.onToggleFavorite()
+                    },
+                ),
+            )
+            add(
+                TvDialogOption(
+                    key = "watched",
+                    title = if (state.isWatched) watchedUnmarkLabel(detail) else watchedMarkLabel(detail),
+                    selected = state.isWatched,
+                    onClick = {
+                        moreOpen = false
+                        viewModel.onToggleWatched()
+                    },
+                ),
+            )
             if (canSuggestToRoom) {
                 add(
                     TvDialogOption(
@@ -1313,125 +1696,178 @@ private fun HeroActionRow(
     }
 }
 
-private fun watchedMarkLabel(detail: ItemDetail): String =
-    if (detail.type == "episode") "Mark Episode Watched" else "Mark as Watched"
+internal data class SeriesEpisodePlaybackLaunch(
+    val fileId: Int?,
+    val audioTrackIndex: Int?,
+    val audioPickedThisSession: Boolean,
+    val subtitleSelection: TvSubtitleLaunchSelection?,
+    val resumePositionSeconds: Double?,
+)
 
-private fun watchedUnmarkLabel(detail: ItemDetail): String =
-    if (detail.type == "episode") "Mark Episode Unwatched" else "Mark as Unwatched"
-
-@OptIn(ExperimentalTvMaterial3Api::class)
-@Composable
-private fun CircleAction(
-    icon: ImageVector,
-    onClick: () -> Unit,
-    contentDescription: String,
-    isActive: Boolean,
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isFocused by interactionSource.collectIsFocusedAsState()
-    val shape = CircleShape
-
-    Surface(
-        onClick = onClick,
-        interactionSource = interactionSource,
-        shape = ClickableSurfaceDefaults.shape(shape = shape),
-        colors = ClickableSurfaceDefaults.colors(
-            containerColor = if (isActive) Color.White.copy(alpha = 0.14f) else Color.Black.copy(alpha = 0.34f),
-            contentColor = Color.White,
-            focusedContainerColor = Color.White,
-            focusedContentColor = Color.Black,
-            pressedContainerColor = Color.White,
-            pressedContentColor = Color.Black,
-        ),
-        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.05f),
-        border = ClickableSurfaceDefaults.border(
-            border = Border(
-                border = BorderStroke(1.2.dp, Color.White.copy(alpha = 0.32f)),
-                shape = shape,
-            ),
-            focusedBorder = Border(
-                border = BorderStroke(2.0.dp, Color.Black.copy(alpha = 0.82f)),
-                shape = shape,
-            ),
-        ),
-        glow = ClickableSurfaceDefaults.glow(
-            focusedGlow = Glow(
-                elevationColor = Color.White.copy(alpha = 0.16f),
-                elevation = 14.dp,
-            ),
-        ),
-        modifier = Modifier
-            .then(
-                if (isFocused) {
-                    Modifier.border(
-                        width = 2.dp,
-                        color = Color.White.copy(alpha = 0.98f),
-                        shape = shape,
-                    )
-                } else {
-                    Modifier
-                },
+/**
+ * Builds the quick-play intent for one Series episode. Selection state is used
+ * only when it belongs to this exact episode; a fast OK during an episode
+ * focus hand-off must never carry the previous episode's file or track IDs.
+ */
+internal fun seriesEpisodePlaybackLaunch(
+    state: TvItemDetailUiState,
+    episode: EpisodeListItem,
+): SeriesEpisodePlaybackLaunch {
+    val selectionMatchesEpisode =
+        state.nextUpEpisode?.contentId == episode.contentId &&
+            state.nextUpPlaybackDetail?.contentId == episode.contentId
+    val playbackDetail = state.nextUpPlaybackDetail.takeIf { selectionMatchesEpisode }
+    val versions = playbackDetail?.versions.orEmpty()
+    val explicitFileId = state.selectedNextUpFileId
+        ?.takeIf { selectionMatchesEpisode }
+        ?.takeIf { selected -> versions.any { it.fileId == selected } }
+    val audioTrackIndex = state.selectedNextUpAudioIndex.takeIf { selectionMatchesEpisode }
+    val subtitleTrackIndex = state.selectedNextUpSubtitleIndex.takeIf { selectionMatchesEpisode }
+    val selectedVersion = selectTvDetailDisplayVersion(
+        versions = versions,
+        selectedFileId = explicitFileId,
+        lastFileId = playbackDetail?.userData?.lastFileId,
+        preferredQuality = state.preferredQuality,
+    )
+    val automaticAudioTrackOrdinal = resolveTvAutomaticAudioTrackOrdinal(
+        version = selectedVersion,
+        preferredAudioLanguage = state.preferredAudioLanguage,
+        capabilities = state.audioSelectionCapabilities,
+    )
+    val automaticAudioResolutionKnown = state.audioSelectionCapabilities != null
+    val hasTrackOverride = audioTrackIndex != null || subtitleTrackIndex != null
+    val subtitleSelection = TvPlaybackFormatting.subtitleLaunchSelection(
+        version = selectedVersion,
+        selectedSubtitleTrackIndex = subtitleTrackIndex,
+        autoContext = selectedVersion?.takeIf {
+            audioTrackIndex != null || automaticAudioResolutionKnown
+        }?.let { version ->
+            TvPlaybackFormatting.SubtitleAutoContext(
+                preferredLanguage = state.preferredSubtitleLanguage,
+                mode = state.subtitleMode,
+                showForced = state.showForcedSubtitles,
+                audioLanguage = TvPlaybackFormatting.resolvedAudioLanguage(
+                    version,
+                    audioTrackIndex,
+                    automaticAudioTrackOrdinal,
+                ),
             )
-            .size(38.dp),
-    ) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = contentDescription,
-                tint = if (isFocused) Color.Black else Color.White,
-                modifier = Modifier.size(18.dp),
-            )
-        }
-    }
+        },
+    )
+    return SeriesEpisodePlaybackLaunch(
+        fileId = explicitFileId ?: selectedVersion?.fileId?.takeIf { hasTrackOverride },
+        audioTrackIndex = audioTrackIndex ?: automaticAudioTrackOrdinal,
+        audioPickedThisSession = selectionMatchesEpisode && state.nextUpAudioPickedThisSession,
+        subtitleSelection = subtitleSelection,
+        resumePositionSeconds = episode.userData?.resumePositionSeconds(),
+    )
 }
+
+private fun openTvYoutubeTrailer(context: android.content.Context, video: ItemVideo) {
+    val appIntent = Intent(Intent.ACTION_VIEW, Uri.parse("vnd.youtube:${video.siteKey}"))
+    val webIntent = Intent(
+        Intent.ACTION_VIEW,
+        Uri.parse("https://www.youtube.com/watch?v=${video.siteKey}"),
+    )
+    val intent = if (appIntent.resolveActivity(context.packageManager) != null) {
+        appIntent
+    } else {
+        webIntent
+    }
+    runCatching { context.startActivity(intent) }
+        .onFailure {
+            Toast.makeText(context, "No app is available to open this trailer", Toast.LENGTH_SHORT).show()
+        }
+}
+
+private fun watchedMarkLabel(detail: ItemDetail): String = when (detail.type) {
+    "series" -> "Mark Series Watched"
+    "season" -> "Mark Season Watched"
+    "episode" -> "Mark Episode Watched"
+    "movie" -> "Mark Movie Watched"
+    else -> "Mark as Watched"
+}
+
+private fun watchedUnmarkLabel(detail: ItemDetail): String = when (detail.type) {
+    "series" -> "Mark Series Unwatched"
+    "season" -> "Mark Season Unwatched"
+    "episode" -> "Mark Episode Unwatched"
+    "movie" -> "Mark Movie Unwatched"
+    else -> "Mark as Unwatched"
+}
+
+/** Tiny breathing room between the fixed hero controls and the series modes. */
+private val SeriesSeasonPickerTopPadding = 3.dp
 
 @Composable
 private fun EpisodesSection(
     detail: ItemDetail,
     state: TvItemDetailUiState,
+    entryEpisodeContentId: String?,
     showsSeasonChips: Boolean,
+    isShowingSeriesOverview: Boolean,
+    onShowSelected: () -> Unit,
     onReturnToHero: () -> Boolean,
+    onReturnToSeriesSelector: (() -> Boolean)? = null,
     onSeasonSelected: (org.siloserver.silo.model.catalog.Season) -> Unit,
     onEpisodeSelected: (EpisodeListItem) -> Unit,
+    onEpisodeFocused: (EpisodeListItem) -> Unit = {},
     onSetEpisodeWatched: (contentId: String, watched: Boolean) -> Unit,
     onSetEpisodeFavorite: (contentId: String, favorite: Boolean) -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = Spacing.safeArea),
-            verticalAlignment = Alignment.Bottom,
-        ) {
-            TvDetailSectionHeader(
-                eyebrow = episodeEyebrowLabel(detail, state),
-                title = "Episodes",
-            )
-            Spacer(modifier = Modifier.weight(1f))
-            val count = state.episodes.size
-            if (count > 0) {
-                Text(
-                    text = "$count episode${if (count == 1) "" else "s"}",
-                    style = MaterialTheme.typography.titleMedium.copy(
-                        fontWeight = FontWeight.Medium,
-                        fontSize = 16.sp,
-                    ),
-                    color = Color.White.copy(alpha = 0.55f),
+    val isSeries = detail.type == "series"
+    Column(verticalArrangement = Arrangement.spacedBy(if (isSeries) 7.dp else 20.dp)) {
+        if (!isSeries) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = TvDetailHorizontalInset),
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                TvDetailSectionHeader(
+                    eyebrow = episodeEyebrowLabel(detail, state),
+                    title = "Episodes",
                 )
+                Spacer(modifier = Modifier.weight(1f))
+                val count = state.episodes.size
+                if (count > 0) {
+                    Text(
+                        text = "$count episode${if (count == 1) "" else "s"}",
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 16.sp,
+                        ),
+                        color = Color.White.copy(alpha = 0.55f),
+                    )
+                }
             }
         }
 
         if (showsSeasonChips) {
-            TvSeasonPicker(
-                seasons = state.seasons,
-                selectedSeason = state.selectedSeason,
-                onSeasonSelected = onSeasonSelected,
-                onDirectionUp = onReturnToHero,
-                horizontalContentPadding = Spacing.safeArea,
-            )
+            if (isSeries) {
+                TvSeriesModePicker(
+                    seasons = state.seasons,
+                    isShowingSeriesOverview = isShowingSeriesOverview,
+                    selectedSeason = state.selectedSeason,
+                    onShowSelected = onShowSelected,
+                    onSeasonSelected = onSeasonSelected,
+                    // Keep the approved row geometry, adding only the small
+                    // requested breathing room below the compact hero.
+                    modifier = Modifier.padding(top = SeriesSeasonPickerTopPadding),
+                    // Return to the circular Version control in the hero; if
+                    // it is not attached yet, fall back to Play.
+                    onDirectionUp = onReturnToSeriesSelector ?: onReturnToHero,
+                    horizontalContentPadding = TvDetailHorizontalInset,
+                )
+            } else {
+                TvSeasonPicker(
+                    seasons = state.seasons,
+                    selectedSeason = state.selectedSeason,
+                    onSeasonSelected = onSeasonSelected,
+                    onDirectionUp = onReturnToHero,
+                    horizontalContentPadding = TvDetailHorizontalInset,
+                )
+            }
         }
 
         // Reserve the rail's measured height while a newly-selected season
@@ -1439,7 +1875,13 @@ private fun EpisodesSection(
         // collapse the section and flash Cast & Crew up into the viewport.
         var railHeightPx by remember { mutableStateOf(0) }
         val railMinHeight = with(LocalDensity.current) { railHeightPx.toDp() }
-        Box(modifier = Modifier.heightIn(min = railMinHeight)) {
+        Box(
+            modifier = Modifier
+                .heightIn(min = railMinHeight)
+                // Keep a small separation from Seasons while reclaiming the
+                // space previously occupied by the selector band.
+                .padding(top = if (isSeries && showsSeasonChips) 10.dp else 0.dp),
+        ) {
             when {
                 // Spinner while a newly-selected season loads, instead of leaving the
                 // previous season's episodes under the new season header (T15b). The
@@ -1449,7 +1891,7 @@ private fun EpisodesSection(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = Spacing.safeArea, vertical = 24.dp),
+                            .padding(horizontal = TvDetailHorizontalInset, vertical = 24.dp),
                         contentAlignment = Alignment.CenterStart,
                     ) {
                         CircularProgressIndicator()
@@ -1464,36 +1906,46 @@ private fun EpisodesSection(
                         text = "No episodes available",
                         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Medium),
                         color = Color.White.copy(alpha = 0.55f),
-                        modifier = Modifier.padding(horizontal = Spacing.safeArea, vertical = 8.dp),
+                        modifier = Modifier.padding(horizontal = TvDetailHorizontalInset, vertical = 8.dp),
                     )
                 }
                 else -> {
                     TvDetailEpisodeRail(
                         episodes = state.episodes,
-                        currentContentId = currentEpisodeRailContentId(detail, state),
+                        currentContentId = currentEpisodeRailContentId(
+                            detail = detail,
+                            state = state,
+                            entryEpisodeContentId = entryEpisodeContentId,
+                        ),
                         favoriteStates = state.episodeFavoriteStates,
                         onEpisodeSelected = onEpisodeSelected,
+                        onEpisodeFocused = onEpisodeFocused.takeIf { isSeries },
                         onSetWatched = onSetEpisodeWatched,
                         onSetFavorite = onSetEpisodeFavorite,
                         // Up returns to the hero only when the season chips aren't above
                         // the rail (the chips own the Up traversal when present).
                         onDirectionUp = if (showsSeasonChips) null else onReturnToHero,
+                        hidesEpisodeTitle = isSeries,
+                        usesSeriesGeometry = isSeries,
                         modifier = Modifier.onSizeChanged { railHeightPx = it.height },
                     )
                 }
             }
         }
+
     }
 }
 
-private fun currentEpisodeRailContentId(detail: ItemDetail, state: TvItemDetailUiState): String? =
+internal fun currentEpisodeRailContentId(
+    detail: ItemDetail,
+    state: TvItemDetailUiState,
+    entryEpisodeContentId: String? = null,
+): String? =
     when (detail.type) {
         "episode" -> detail.contentId
         "series",
         "season",
-        -> state.nextUpEpisode
-            ?.takeIf { it.userData?.isInProgress == true }
-            ?.contentId
+        -> entryEpisodeContentId ?: state.nextUpEpisode?.contentId
         else -> null
     }
 
@@ -1508,48 +1960,6 @@ internal fun episodeEyebrowLabel(detail: ItemDetail, state: TvItemDetailUiState)
         detail.seasonNumber?.let { return if (it == 0) "Specials" else "Season $it" }
     }
     return "This Season"
-}
-
-/**
- * Static, non-focusable placeholder shown in the selector slot while the
- * next-up episode's playback detail loads. Compose-for-TV analogue of
- * silo-apple's `TVVersionPillPlaceholder` — a dimmed "Version" pill.
- */
-@Composable
-private fun TvVersionPillPlaceholder(modifier: Modifier = Modifier) {
-    // Matches the live selector pill geometry (TvAnchoredSelectorMenu trigger):
-    // squared TvControlCorner shape, 22×12 padding, 13dp glyph, 12sp value.
-    val shape = RoundedCornerShape(TvControlCorner)
-    Row(
-        modifier = modifier
-            .background(Color.Black.copy(alpha = 0.42f), shape)
-            .border(0.6.dp, Color.White.copy(alpha = 0.16f), shape)
-            .padding(horizontal = 22.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.spacedBy(7.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(
-            imageVector = Icons.Filled.Tv,
-            contentDescription = null,
-            tint = Color.White.copy(alpha = 0.75f),
-            modifier = Modifier.size(15.dp),
-        )
-        Text(
-            text = "Version",
-            style = MaterialTheme.typography.titleMedium.copy(
-                fontSize = 14.sp,
-                lineHeight = 18.sp,
-                fontWeight = FontWeight.SemiBold,
-            ),
-            color = Color.White.copy(alpha = 0.75f),
-        )
-        Icon(
-            imageVector = Icons.Filled.KeyboardArrowDown,
-            contentDescription = null,
-            tint = Color.White.copy(alpha = 0.35f),
-            modifier = Modifier.size(9.5.dp),
-        )
-    }
 }
 
 @Composable
@@ -1898,7 +2308,7 @@ private fun org.siloserver.silo.model.catalog.LeafItemUserData.resumePositionSec
 /**
  * Hero Play button label. Movie / episode detail keep the plain Play /
  * Resume<hms> form; series / season detail target the next-up episode and read
- * "Play S2 · E3" / "Resume S2 · E3" (series) or "Play E4" / "Resume E4"
+ * "Play S2:E3" / "Resume S2:E3" (series) or "Play E4" / "Resume E4"
  * (season), mirroring silo-apple's `playButtonLabel(for:)`.
  */
 private fun playButtonLabel(
@@ -1911,7 +2321,7 @@ private fun playButtonLabel(
     if (isSeriesOrSeason && nextUp != null) {
         val verb = if (hasResume) "Resume" else "Play"
         return if (seriesContainer) {
-            "$verb S${nextUp.seasonNumber} · E${nextUp.episodeNumber}"
+            "$verb S${nextUp.seasonNumber}:E${nextUp.episodeNumber}"
         } else {
             "$verb E${nextUp.episodeNumber}"
         }
@@ -1931,21 +2341,27 @@ private fun Double.formatHms(): String {
     }
 }
 
-/**
- * One knob for the detail page's vertical rhythm: every body section gap AND
- * the hero → first-section handoff derive from this, so the selector row →
- * Episodes gap matches Episodes → Cast & Crew, Cast & Crew → Details, etc.
- * The hero already ends with [TvDetailHeroBottomInset] of internal padding
- * below the selector row, so the body's top padding is the remainder.
- */
-internal val TvDetailSectionGap = 28.dp
+/** Approved tvOS 64pt body rhythm and 140pt page tail at Android's 0.5 scale. */
+internal val TvDetailSectionGap = 32.dp
+internal val TvDetailPageBottomPadding = 70.dp
+internal val TvDetailHorizontalInset = 50.dp
+
+private val TvDetailDefaultTint = Color(red = 0.04f, green = 0.12f, blue = 0.14f)
+private const val TvDetailTintOpacity = 0.42f
 
 /**
- * Bottom inset inside the hero, below the action/selector cluster. Trimmed
- * 28 → 16dp per design review so the stack sits lower in the hero. Part of
- * the [TvDetailSectionGap] handoff math — keep them in sync.
+ * The sampled tint is composited over black into a fully opaque color. Keeping
+ * this pure makes it explicit that detail never uses a live blur/material.
  */
-internal val TvDetailHeroBottomInset = 16.dp
+internal fun tvDetailPageSurfaceColor(sampledTint: Color?): Color {
+    val tint = sampledTint ?: TvDetailDefaultTint
+    return Color(
+        red = tint.red * TvDetailTintOpacity,
+        green = tint.green * TvDetailTintOpacity,
+        blue = tint.blue * TvDetailTintOpacity,
+        alpha = 1f,
+    )
+}
 
 internal data class TvDetailHeroArtwork(
     val url: String?,
@@ -1984,6 +2400,10 @@ internal fun resolveTvDetailHeroArtwork(
  * 260ms anchor with a 620ms rail reveal.
  */
 private val DetailAnchorScrollSpec = tween<Float>(durationMillis = 400, easing = FastOutSlowInEasing)
+
+/** tvOS Series uses a slower, single smooth curve when supporting content
+ * hands focus back to the fixed Show/Season/Episodes/Version viewport. */
+private val SeriesPrimaryScrollSpec = tween<Float>(durationMillis = 800, easing = FastOutSlowInEasing)
 
 /**
  * Where a body section's top edge lands when focus enters it, as a fraction
@@ -2053,6 +2473,33 @@ private suspend fun LazyListState.animateScrollToItemPaced(index: Int) {
         )
     } else {
         animateScrollToItem(index)
+    }
+}
+
+/**
+ * Restores the complete Series primary viewport without the stock LazyList
+ * snap that otherwise appears when the hero item has already been disposed.
+ * This page has two vertical list items (hero + body), so the measured hero
+ * height plus the body's current offset gives the exact distance back to zero.
+ */
+private suspend fun LazyListState.animateSeriesPrimaryViewport(heroHeightPx: Int) {
+    if (heroHeightPx <= 0) {
+        animateScrollToItemPaced(0)
+        return
+    }
+    val distance = when (firstVisibleItemIndex) {
+        0 -> -firstVisibleItemScrollOffset.toFloat()
+        1 -> -(heroHeightPx + firstVisibleItemScrollOffset).toFloat()
+        else -> {
+            animateScrollToItem(0)
+            return
+        }
+    }
+    if (distance != 0f) {
+        animateScrollBy(
+            value = distance,
+            animationSpec = SeriesPrimaryScrollSpec,
+        )
     }
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -1,3 +1,5 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
 package org.siloserver.silo.tv.ui.screens.detail
 
 import androidx.lifecycle.ViewModel
@@ -45,6 +47,7 @@ import org.siloserver.silo.repository.port.UserItemStatePort
 import org.siloserver.silo.tv.ui.util.isTvHiddenMediaType
 import org.siloserver.silo.tv.ui.util.visibleOnTv
 import org.siloserver.silo.viewmodel.applyLocalPlaybackProgress
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -52,7 +55,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -60,6 +62,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
 
 data class TvItemDetailUiState(
     val isLoading: Boolean = true,
@@ -380,7 +383,7 @@ class TvItemDetailViewModel(
             }
         }
         observePreferredQuality()
-        observeAutomaticAudioPolicy()
+        capabilityDetector?.let(::observeAutomaticAudioPolicy)
         if (contentId.isNotBlank()) {
             // Restore this title's pre-play track choices (QA 2026-07-08: a
             // manual subtitle selection reset on every return to the page —
@@ -451,10 +454,9 @@ class TvItemDetailViewModel(
         }
     }
 
-    private fun observeAutomaticAudioPolicy() {
+    private fun observeAutomaticAudioPolicy(detector: PlaybackCapabilityDetector) {
         viewModelScope.launch {
-            val outputRoutes = capabilityDetector?.outputRouteGeneration ?: flowOf(0L)
-            combine(playerSettingsStore.audioLanguageFlow, outputRoutes) { language, _ -> language }
+            combine(playerSettingsStore.audioLanguageFlow, detector.outputRouteGeneration) { language, _ -> language }
                 .collectLatest { settingsLanguage ->
                     val profileLanguage = runCatching {
                         profileRepository.getActiveProfile()?.language
@@ -463,13 +465,13 @@ class TvItemDetailViewModel(
                         settingsLanguage = settingsLanguage,
                         profileLanguage = profileLanguage,
                     )
-                    val capabilities = capabilityDetector?.let { detector ->
-                        runCatching {
+                    val capabilities = runCatching {
+                        withContext(Dispatchers.Default) {
                             detector.detect(
                                 dolbyVision = playerSettingsStore.dolbyVisionPolicySnapshot(),
                             )
-                        }.getOrNull()
-                    }
+                        }
+                    }.getOrNull()
                     _uiState.update {
                         it.copy(
                             preferredAudioLanguage = preferredLanguage,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -2,6 +2,8 @@ package org.siloserver.silo.tv.ui.screens.detail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import org.siloserver.silo.common.player.PlaybackCapabilityDetector
+import org.siloserver.silo.common.player.TrackSelectionPresets
 import org.siloserver.silo.common.player.video.EpisodeSelectionHandoff
 import org.siloserver.silo.common.player.video.EpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.EpisodeSubtitleMode
@@ -10,6 +12,7 @@ import org.siloserver.silo.common.player.video.captureEpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.resolveEpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.resolveEpisodeSourceIntent
 import org.siloserver.silo.common.settings.PlayerSettingsStore
+import org.siloserver.silo.common.settings.dolbyVisionPolicySnapshot
 import org.siloserver.silo.domain.settings.ProfileSettingsController
 import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.model.catalog.CastMember
@@ -21,6 +24,7 @@ import org.siloserver.silo.model.catalog.Season
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.catalog.initialSeasonDisplayPlan
 import org.siloserver.silo.model.playback.combinedSubtitleSelectionIndexes
+import org.siloserver.silo.model.playback.ClientCodecCapabilities
 import org.siloserver.silo.model.playback.buildPlaybackSubtitleChoices
 import org.siloserver.silo.playback.SUBTITLE_OFF_FINGERPRINT
 import org.siloserver.silo.playback.audioTrackFingerprint
@@ -46,6 +50,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -72,6 +79,8 @@ data class TvItemDetailUiState(
     val selectedSeason: Int? = null,
     val episodes: List<EpisodeListItem> = emptyList(),
     val episodeFavoriteStates: Map<String, Boolean> = emptyMap(),
+    /** The route's one-shot episode target has been applied (or safely rejected). */
+    val entryEpisodeSelectionApplied: Boolean = false,
     val seasonsLoading: Boolean = false,
     val episodesLoading: Boolean = false,
     // Version selection for multi-file items.
@@ -99,6 +108,12 @@ data class TvItemDetailUiState(
     // exists, else the first unwatched, else the first. Mirrors silo-apple's
     // `nextUpEpisode`.
     val nextUpEpisode: EpisodeListItem? = null,
+    /**
+     * Whether [nextUpEpisode] belongs to the currently selected season and is
+     * safe to launch. During a season swap the old episode remains only as a
+     * geometry placeholder so the stable action row does not jump.
+     */
+    val nextUpTargetReady: Boolean = false,
     // The next-up episode's loaded playback detail (versions / tracks). Loaded
     // asynchronously whenever the next-up episode changes — analogue of Apple's
     // `nextUpPlaybackDetail`.
@@ -113,6 +128,8 @@ data class TvItemDetailUiState(
     val nextUpAudioPickedThisSession: Boolean = false,
     val selectedNextUpSubtitleIndex: Int? = null,
     val preferredQuality: String = "auto",
+    val preferredAudioLanguage: String? = null,
+    val audioSelectionCapabilities: ClientCodecCapabilities? = null,
     // Cascaded subtitle preferences that annotate the selector row's Auto
     // preview ("Auto - <track>" / "Auto - None") so it previews the SAME track
     // the player would auto-select. Resolved canonically — see
@@ -130,6 +147,17 @@ internal data class TvTrackSelectionPersistence(
     val fileId: Int,
     val audioFingerprint: String?,
     val subtitleFingerprint: String?,
+)
+
+internal fun resolveTvTrackSelectionVersion(
+    detail: ItemDetail,
+    selectedFileId: Int?,
+    preferredQuality: String?,
+): FileVersion? = selectTvDetailDisplayVersion(
+    versions = detail.versions,
+    selectedFileId = selectedFileId,
+    lastFileId = detail.userData?.lastFileId,
+    preferredQuality = preferredQuality,
 )
 
 internal fun buildTrackSelectionPersistence(
@@ -329,6 +357,7 @@ class TvItemDetailViewModel(
     private val recommendationRepository: org.siloserver.silo.repository.RecommendationRepository? = null,
     private val tokenManager: TokenManager,
     private val identityTransitions: IdentityTransitionBarrier,
+    private val capabilityDetector: PlaybackCapabilityDetector? = null,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TvItemDetailUiState())
@@ -351,6 +380,7 @@ class TvItemDetailViewModel(
             }
         }
         observePreferredQuality()
+        observeAutomaticAudioPolicy()
         if (contentId.isNotBlank()) {
             // Restore this title's pre-play track choices (QA 2026-07-08: a
             // manual subtitle selection reset on every return to the page —
@@ -359,8 +389,6 @@ class TvItemDetailViewModel(
                 _uiState.update {
                     it.copy(
                         selectedFileId = saved.fileId,
-                        selectedAudioIndex = saved.audio,
-                        selectedSubtitleIndex = saved.subtitle,
                     )
                 }
             }
@@ -423,6 +451,35 @@ class TvItemDetailViewModel(
         }
     }
 
+    private fun observeAutomaticAudioPolicy() {
+        viewModelScope.launch {
+            val outputRoutes = capabilityDetector?.outputRouteGeneration ?: flowOf(0L)
+            combine(playerSettingsStore.audioLanguageFlow, outputRoutes) { language, _ -> language }
+                .collectLatest { settingsLanguage ->
+                    val profileLanguage = runCatching {
+                        profileRepository.getActiveProfile()?.language
+                    }.getOrNull()
+                    val preferredLanguage = TrackSelectionPresets.effectivePreferredAudioLanguage(
+                        settingsLanguage = settingsLanguage,
+                        profileLanguage = profileLanguage,
+                    )
+                    val capabilities = capabilityDetector?.let { detector ->
+                        runCatching {
+                            detector.detect(
+                                dolbyVision = playerSettingsStore.dolbyVisionPolicySnapshot(),
+                            )
+                        }.getOrNull()
+                    }
+                    _uiState.update {
+                        it.copy(
+                            preferredAudioLanguage = preferredLanguage,
+                            audioSelectionCapabilities = capabilities,
+                        )
+                    }
+                }
+        }
+    }
+
     fun openPerson(member: CastMember, onOpenPerson: (Long) -> Unit) {
         member.personId?.trim()?.toLongOrNull()?.let(onOpenPerson) ?: viewModelScope.launch {
             when (val result = catalogRepository.searchPeople(member.name)) {
@@ -465,6 +522,58 @@ class TvItemDetailViewModel(
                 error = null,
             )
         }
+        seedCachedSeriesNavigation(cached)
+    }
+
+    /**
+     * Joins the focused-card prefetch to the first Series frame. Continue
+     * Watching warms Series + season + episode data before navigation; reading
+     * those durable rows here lets the existing detail design appear without
+     * waiting for the freshness requests that still follow in [loadDetail].
+     */
+    private suspend fun seedCachedSeriesNavigation(detail: ItemDetail) {
+        val seriesId = when (detail.type.lowercase()) {
+            "series" -> detail.contentId
+            "season", "episode" -> detail.seriesId?.takeIf { it.isNotBlank() }
+            else -> null
+        } ?: return
+        val cachedSeasons = catalogRepository.getCachedSeasons(seriesId) ?: return
+        val plan = cachedSeasons.seasons.initialSeasonDisplayPlan(detail.seasonNumber)
+        if (_uiState.value.detail?.contentId != detail.contentId) return
+        _uiState.update {
+            if (it.detail?.contentId != detail.contentId) {
+                it
+            } else {
+                it.copy(
+                    seasons = plan.seasons,
+                    selectedSeason = plan.selectedSeasonNumber,
+                    seasonsLoading = false,
+                )
+            }
+        }
+        plan.episodeRequestSeasonNumber?.let { seasonNumber ->
+            seedCachedEpisodes(seriesId, seasonNumber)
+        }
+    }
+
+    /** Publishes a cached season immediately; the caller still refreshes it. */
+    private suspend fun seedCachedEpisodes(seriesContentId: String, seasonNumber: Int): Boolean {
+        val cached = catalogRepository.getCachedEpisodes(seriesContentId, seasonNumber) ?: return false
+        if (_uiState.value.selectedSeason != seasonNumber) return false
+        val episodes = withLocalProgress(cached.episodes.sortedBy { it.episodeNumber })
+        if (_uiState.value.selectedSeason != seasonNumber) return false
+        loadedSeason = seasonNumber
+        episodeListGeneration += 1
+        _uiState.update {
+            if (it.selectedSeason == seasonNumber) {
+                it.copy(episodesLoading = false, episodes = episodes)
+            } else {
+                it
+            }
+        }
+        if (_uiState.value.selectedSeason != seasonNumber) return false
+        refreshNextUp(episodes)
+        return true
     }
 
     private fun loadDetail() {
@@ -491,6 +600,7 @@ class TvItemDetailViewModel(
                             error = null,
                         )
                     }
+                    seedSessionTrackSelection(detail)
                     // Restore a durably-persisted audio/subtitle override (TM4).
                     seedPersistedTrackSelection(detail)
                     when (detail.type.lowercase()) {
@@ -546,11 +656,16 @@ class TvItemDetailViewModel(
         val playbackReturn = TvDetailTrackSelectionSession.consumePlaybackReturn(contentId)
         playbackReturn?.let { saved ->
             _uiState.update {
+                val returnedDetail = it.detail?.withPlaybackReturn(saved)
+                val resolvedFileId = returnedDetail?.let { detail ->
+                    resolveTvTrackSelectionVersion(detail, saved.fileId, it.preferredQuality)?.fileId
+                }
+                val tracksStillMatch = saved.trackFileId == null || saved.trackFileId == resolvedFileId
                 it.copy(
-                    detail = it.detail?.withPlaybackReturn(saved),
+                    detail = returnedDetail,
                     selectedFileId = saved.fileId,
-                    selectedAudioIndex = saved.audio,
-                    selectedSubtitleIndex = saved.subtitle,
+                    selectedAudioIndex = saved.audio.takeIf { tracksStillMatch },
+                    selectedSubtitleIndex = saved.subtitle.takeIf { tracksStillMatch },
                 )
             }
         }
@@ -724,7 +839,14 @@ class TvItemDetailViewModel(
                 selectedSubtitleIndex = null,
             )
         }
-        TvDetailTrackSelectionSession.remember(contentId, fileId, audio = null, subtitle = null)
+        val state = _uiState.value
+        TvDetailTrackSelectionSession.remember(
+            contentId,
+            fileId,
+            audio = null,
+            subtitle = null,
+            trackFileId = state.detail?.let { selectedVersionFor(state, it)?.fileId },
+        )
         // Do NOT persist here: a version switch resets the indexes to null, and
         // persisting null clears the durable row — which would wipe the newly
         // selected file's saved override before seedPersistedTrackSelection can
@@ -736,7 +858,13 @@ class TvItemDetailViewModel(
     fun onAudioTrackSelected(index: Int?) {
         _uiState.update { it.copy(selectedAudioIndex = index, audioPickedThisSession = index != null) }
         val state = _uiState.value
-        TvDetailTrackSelectionSession.remember(contentId, state.selectedFileId, index, state.selectedSubtitleIndex)
+        TvDetailTrackSelectionSession.remember(
+            contentId,
+            state.selectedFileId,
+            index,
+            state.selectedSubtitleIndex,
+            trackFileId = state.detail?.let { selectedVersionFor(state, it)?.fileId },
+        )
         persistTrackSelection()
     }
 
@@ -744,16 +872,19 @@ class TvItemDetailViewModel(
     fun onSubtitleTrackSelected(index: Int?) {
         _uiState.update { it.copy(selectedSubtitleIndex = index) }
         val state = _uiState.value
-        TvDetailTrackSelectionSession.remember(contentId, state.selectedFileId, state.selectedAudioIndex, index)
+        TvDetailTrackSelectionSession.remember(
+            contentId,
+            state.selectedFileId,
+            state.selectedAudioIndex,
+            index,
+            trackFileId = state.detail?.let { selectedVersionFor(state, it)?.fileId },
+        )
         persistTrackSelection()
     }
 
-    /** The version behind [TvItemDetailUiState.selectedFileId], or the default
-     *  (first) version when nothing is explicitly selected. */
+    /** The exact version the Auto/display/player policy currently resolves. */
     private fun selectedVersionFor(state: TvItemDetailUiState, detail: ItemDetail): FileVersion? {
-        val fileId = state.selectedFileId
-        return if (fileId != null) detail.versions.firstOrNull { it.fileId == fileId }
-        else detail.versions.firstOrNull()
+        return resolveTvTrackSelectionVersion(detail, state.selectedFileId, state.preferredQuality)
     }
 
     /**
@@ -774,6 +905,7 @@ class TvItemDetailViewModel(
             selectedFileId = state.selectedFileId,
             selectedAudioIndex = state.selectedAudioIndex,
             selectedSubtitleIndex = state.selectedSubtitleIndex,
+            preferredQuality = state.preferredQuality,
         )
     }
 
@@ -783,11 +915,9 @@ class TvItemDetailViewModel(
         selectedFileId: Int?,
         selectedAudioIndex: Int?,
         selectedSubtitleIndex: Int?,
+        preferredQuality: String?,
     ) {
-        val version = selectedFileId
-            ?.let { fileId -> detail.versions.firstOrNull { it.fileId == fileId } }
-            ?: detail.versions.firstOrNull()
-            ?: return
+        val version = resolveTvTrackSelectionVersion(detail, selectedFileId, preferredQuality) ?: return
         val selection = buildTrackSelectionPersistence(
             targetContentId = targetContentId,
             version = version,
@@ -828,9 +958,35 @@ class TvItemDetailViewModel(
         }
     }
 
+    private fun seedSessionTrackSelection(detail: ItemDetail) {
+        val saved = TvDetailTrackSelectionSession.recall(contentId) ?: return
+        val state = _uiState.value
+        val version = resolveTvTrackSelectionVersion(detail, saved.fileId, state.preferredQuality)
+        val tracksBelongToVersion = saved.trackFileId == null || saved.trackFileId == version?.fileId
+        _uiState.update {
+            it.copy(
+                selectedFileId = saved.fileId?.takeIf { id -> detail.versions.any { version -> version.fileId == id } },
+                selectedAudioIndex = saved.audio.takeIf { tracksBelongToVersion },
+                selectedSubtitleIndex = saved.subtitle.takeIf { tracksBelongToVersion },
+            )
+        }
+    }
+
     fun onSeasonSelected(seasonNumber: Int) {
         if (_uiState.value.selectedSeason == seasonNumber) return
-        _uiState.update { it.copy(selectedSeason = seasonNumber) }
+        seasonSelectionGeneration += 1
+        // A focused episode belongs to the old season. The newly loaded rail
+        // chooses its own suggested/current episode, exactly like tvOS.
+        activeSeriesEpisodeContentId = null
+        _uiState.update {
+            it.copy(
+                selectedSeason = seasonNumber,
+                episodesLoading = true,
+                // Keep the previous episode as a layout placeholder, but never
+                // let Play launch it for the newly selected season.
+                nextUpTargetReady = false,
+            )
+        }
         val detail = _uiState.value.detail ?: return
         val seriesContentId = when (detail.type.lowercase()) {
             "series" -> detail.contentId
@@ -841,24 +997,66 @@ class TvItemDetailViewModel(
         loadEpisodes(seriesContentId, seasonNumber)
     }
 
+    /**
+     * Series is one in-place browsing page: focus, not a pushed episode-detail
+     * route, owns the active episode. `null` restores Show mode's suggested
+     * episode while a concrete id updates the hero and playback selector.
+     */
+    fun onSeriesEpisodeActivated(contentId: String?) {
+        val state = _uiState.value
+        if (state.detail?.type?.lowercase() != "series") return
+        val active = contentId?.let { id -> state.episodes.firstOrNull { it.contentId == id } }
+        activeSeriesEpisodeContentId = active?.contentId
+        updateNextUp(active ?: resolveNextUpEpisode(state.episodes))
+    }
+
+    /**
+     * Applies an episode carried by a Continue Watching detail route exactly
+     * once. Keeping the latch in the ViewModel survives player round-trips but
+     * resets correctly if Android recreates the detail entry after process loss.
+     */
+    fun onEntrySeriesEpisodeRequested(contentId: String) {
+        val state = _uiState.value
+        if (state.entryEpisodeSelectionApplied || state.detail?.type?.lowercase() != "series") return
+        val active = state.episodes.firstOrNull { it.contentId == contentId }
+        _uiState.update { it.copy(entryEpisodeSelectionApplied = true) }
+        if (active != null) {
+            activeSeriesEpisodeContentId = active.contentId
+            updateNextUp(active)
+        }
+    }
+
     private fun loadSeasons(
         seriesContentId: String,
         preferredSeasonNumber: Int? = null,
     ) {
+        val selectionGenerationAtRequest = seasonSelectionGeneration
         viewModelScope.launch {
             _uiState.update { it.copy(seasonsLoading = true) }
             when (val r = catalogRepository.getSeasons(seriesContentId)) {
                 is ApiResult.Success -> {
                     val plan = r.data.seasons.initialSeasonDisplayPlan(preferredSeasonNumber)
+                    val currentSelection = _uiState.value.selectedSeason
+                    val preservesNewerSelection =
+                        seasonSelectionGeneration != selectionGenerationAtRequest &&
+                            currentSelection != null &&
+                            plan.seasons.any { it.seasonNumber == currentSelection }
+                    val selectedSeasonNumber = if (preservesNewerSelection) {
+                        currentSelection
+                    } else {
+                        plan.selectedSeasonNumber
+                    }
                     _uiState.update {
                         it.copy(
                             seasonsLoading = false,
                             seasons = plan.seasons,
-                            selectedSeason = plan.selectedSeasonNumber,
+                            selectedSeason = selectedSeasonNumber,
                         )
                     }
-                    plan.episodeRequestSeasonNumber?.let { seasonNumber ->
-                        loadEpisodes(seriesContentId, seasonNumber)
+                    if (!preservesNewerSelection) {
+                        selectedSeasonNumber?.let { seasonNumber ->
+                            loadEpisodes(seriesContentId, seasonNumber)
+                        }
                     }
                 }
                 else -> _uiState.update { it.copy(seasonsLoading = false) }
@@ -876,6 +1074,11 @@ class TvItemDetailViewModel(
     private var favoritesRevalidatedThrough: Long = TvFavoriteRevalidationSession.currentVersion()
     private var moreLikeThisJob: Job? = null
     private var nextUpDetailJob: Job? = null
+    private var activeSeriesEpisodeContentId: String? = null
+    // A seasons refresh may complete after the viewer has already changed the
+    // selected chip. Preserve that newer choice instead of replaying the
+    // refresh request's initial display plan.
+    private var seasonSelectionGeneration: Long = 0
     // The season number the currently-shown episodes/next-up actually belong to.
     // Lets a failed load revert the optimistic season selection so the chips and
     // the rail stay consistent (T15).
@@ -928,6 +1131,7 @@ class TvItemDetailViewModel(
         episodeLoadJob?.cancel()
         episodeLoadJob = viewModelScope.launch {
             if (!quiet) _uiState.update { it.copy(episodesLoading = true) }
+            seedCachedEpisodes(seriesContentId, seasonNumber)
             when (val r = catalogRepository.getEpisodes(seriesContentId, seasonNumber)) {
                 is ApiResult.Success -> {
                     val episodes = withLocalProgress(r.data.episodes.sortedBy { ep -> ep.episodeNumber })
@@ -959,6 +1163,7 @@ class TvItemDetailViewModel(
                             selectedSeason = loadedSeason ?: it.selectedSeason,
                         )
                     }
+                    refreshNextUp(_uiState.value.episodes)
                 }
             }
         }
@@ -1147,6 +1352,12 @@ class TvItemDetailViewModel(
      * `loadSeriesNextUpPlaybackDetail` / `loadSeasonNextUpPlaybackDetail`.
      */
     private fun refreshNextUp(episodes: List<EpisodeListItem>) {
+        val active = activeSeriesEpisodeContentId
+            ?.let { contentId -> episodes.firstOrNull { it.contentId == contentId } }
+        updateNextUp(active ?: resolveNextUpEpisode(episodes))
+    }
+
+    private fun updateNextUp(nextUp: EpisodeListItem?) {
         val oldState = _uiState.value
         val detail = oldState.detail
         val type = detail?.type?.lowercase()
@@ -1157,6 +1368,7 @@ class TvItemDetailViewModel(
                 _uiState.update {
                     it.copy(
                         nextUpEpisode = null,
+                        nextUpTargetReady = false,
                         nextUpPlaybackDetail = null,
                         isLoadingNextUpPlaybackDetail = false,
                         didLoadNextUpPlaybackDetail = false,
@@ -1170,12 +1382,11 @@ class TvItemDetailViewModel(
             return
         }
 
-        val nextUp = resolveNextUpEpisode(episodes)
         val previousId = _uiState.value.nextUpEpisode?.contentId
         if (nextUp?.contentId == previousId && _uiState.value.nextUpEpisode != null) {
             // Same target — just refresh the snapshot (userData may have changed)
             // without re-loading playback detail.
-            _uiState.update { it.copy(nextUpEpisode = nextUp) }
+            _uiState.update { it.copy(nextUpEpisode = nextUp, nextUpTargetReady = true) }
             return
         }
 
@@ -1184,6 +1395,7 @@ class TvItemDetailViewModel(
             _uiState.update {
                 it.copy(
                     nextUpEpisode = null,
+                    nextUpTargetReady = false,
                     nextUpPlaybackDetail = null,
                     isLoadingNextUpPlaybackDetail = false,
                     didLoadNextUpPlaybackDetail = false,
@@ -1207,6 +1419,7 @@ class TvItemDetailViewModel(
         _uiState.update {
             it.copy(
                 nextUpEpisode = nextUp,
+                nextUpTargetReady = true,
                 nextUpPlaybackDetail = null,
                 isLoadingNextUpPlaybackDetail = true,
                 didLoadNextUpPlaybackDetail = false,
@@ -1423,13 +1636,8 @@ class TvItemDetailViewModel(
         )
             ?: return ResolvedNextUpTrackSelection(selectedFileId, null, null)
 
-        val sessionVersionId = selectTvDetailDisplayVersion(
-            versions = detail.versions,
-            selectedFileId = sessionFileId,
-            lastFileId = detail.userData?.lastFileId,
-            preferredQuality = preferredQuality,
-        )?.fileId
-        val sessionMatchesSelectedVersion = session != null && sessionVersionId == selectedVersion.fileId
+        val sessionMatchesSelectedVersion = session != null &&
+            (session.trackFileId == null || session.trackFileId == selectedVersion.fileId)
         val targetSubtitleChoices = buildPlaybackSubtitleChoices(
             catalogTracks = selectedVersion.subtitleTracks.orEmpty(),
             plannedTracks = emptyList(),
@@ -1530,6 +1738,13 @@ class TvItemDetailViewModel(
             state.selectedNextUpFileId,
             state.selectedNextUpAudioIndex,
             state.selectedNextUpSubtitleIndex,
+            trackFileId = state.nextUpPlaybackDetail?.let { detail ->
+                resolveTvTrackSelectionVersion(
+                    detail,
+                    state.selectedNextUpFileId,
+                    state.preferredQuality,
+                )?.fileId
+            },
         )
     }
 
@@ -1543,6 +1758,7 @@ class TvItemDetailViewModel(
             selectedFileId = state.selectedNextUpFileId,
             selectedAudioIndex = state.selectedNextUpAudioIndex,
             selectedSubtitleIndex = state.selectedNextUpSubtitleIndex,
+            preferredQuality = state.preferredQuality,
         )
     }
 
@@ -1555,10 +1771,11 @@ class TvItemDetailViewModel(
         val selectedFileId = _uiState.value.selectedNextUpFileId
         val selectorRevision = nextUpSelectorRevision
         val refreshGeneration = nextUpPlaybackDetailGeneration
-        val version = selectedFileId
-            ?.let { fileId -> playbackDetail.versions.firstOrNull { it.fileId == fileId } }
-            ?: playbackDetail.versions.firstOrNull()
-            ?: return
+        val version = resolveTvTrackSelectionVersion(
+            playbackDetail,
+            selectedFileId,
+            _uiState.value.preferredQuality,
+        ) ?: return
         viewModelScope.launch {
             val saved = userItemState.localTrackSelection(targetContentId, version.fileId) ?: return@launch
             val restored = restoreTrackSelection(version, saved)
@@ -1591,6 +1808,7 @@ class TvItemDetailViewModel(
                         fileId = updated.selectedNextUpFileId,
                         audio = updated.selectedNextUpAudioIndex,
                         subtitle = updated.selectedNextUpSubtitleIndex,
+                        trackFileId = version.fileId,
                     )
                     break
                 }
@@ -1604,6 +1822,7 @@ class TvItemDetailViewModel(
                     fileId = selection.fileId,
                     audio = selection.audio,
                     subtitle = selection.subtitle,
+                    trackFileId = selection.trackFileId,
                 )
             }
         }
@@ -1792,15 +2011,23 @@ internal object TvDetailTrackSelectionSession {
         val fileId: Int?,
         val audio: Int?,
         val subtitle: Int?,
+        /** File whose track ordinals belong to; [fileId] remains null for Auto. */
+        val trackFileId: Int? = fileId,
         val positionSeconds: Double? = null,
         val durationSeconds: Double? = null,
     )
 
     private val byContent = HashMap<String, Saved>()
 
-    fun remember(contentId: String, fileId: Int?, audio: Int?, subtitle: Int?) {
+    fun remember(
+        contentId: String,
+        fileId: Int?,
+        audio: Int?,
+        subtitle: Int?,
+        trackFileId: Int? = fileId,
+    ) {
         if (contentId.isBlank()) return
-        byContent[contentId] = Saved(fileId, audio, subtitle)
+        byContent[contentId] = Saved(fileId, audio, subtitle, trackFileId)
     }
 
     fun rememberPlaybackReturn(
@@ -1814,9 +2041,9 @@ internal object TvDetailTrackSelectionSession {
         if (contentId.isBlank() || !positionSeconds.isFinite() || positionSeconds < 0.0) return
         val previous = byContent[contentId]
         byContent[contentId] = Saved(
-            // Exit can race teardown before either player file identifier is
-            // available. Keep the detail page's selected version in that case.
-            fileId = fileId ?: previous?.fileId,
+            // A playback return reports the resolved backing file, not a new
+            // manual Version choice. Preserve Auto/explicit UI intent.
+            fileId = previous?.fileId,
             // The player currently reports subtitle selection on exit but not
             // audio selection. Keep the detail page's explicit audio choice
             // instead of replacing it with an unknown/null value.
@@ -1824,6 +2051,7 @@ internal object TvDetailTrackSelectionSession {
             // A null player result means the mounted track could not be
             // resolved to a stable server index (keep current), not Off.
             subtitle = subtitle ?: previous?.subtitle,
+            trackFileId = fileId ?: previous?.trackFileId,
             positionSeconds = positionSeconds,
             durationSeconds = durationSeconds?.takeIf { it.isFinite() && it > 0.0 },
         )
@@ -1855,7 +2083,7 @@ private fun ItemDetail.withPlaybackReturn(saved: TvDetailTrackSelectionSession.S
             isInProgress = position > 0.0,
             positionSeconds = position.takeIf { it > 0.0 },
             durationSeconds = saved.durationSeconds ?: current.durationSeconds,
-            lastFileId = saved.fileId ?: current.lastFileId,
+            lastFileId = saved.trackFileId ?: current.lastFileId,
         ),
     )
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormatting.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormatting.kt
@@ -1,3 +1,5 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
 package org.siloserver.silo.tv.ui.screens.detail
 
 import org.siloserver.silo.common.player.TrackSelectionPresets
@@ -275,9 +277,7 @@ object TvPlaybackFormatting {
         val summary = audioSummary(track, ordinal)
         // Auto shows what it resolved to ("Auto: English · EAC3 · 5.1"); a
         // manual pick shows just the track (tvOS `annotateAuto`). Audio auto
-        // is the file's default/first track — the same signal the player uses
-        // (there is no client-side language audio resolver; the server drives
-        // audio selection), so unlike subtitles this preview needs no prefs.
+        // follows the same language/capability resolution used by playback.
         return if (selectedAudioTrackIndex == null) "Auto: $summary" else summary
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormatting.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormatting.kt
@@ -1,9 +1,11 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
+import org.siloserver.silo.common.player.TrackSelectionPresets
 import org.siloserver.silo.model.catalog.AudioTrack
 import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.catalog.SubtitleTrack
 import org.siloserver.silo.model.playback.AutoSubtitleContext
+import org.siloserver.silo.model.playback.ClientCodecCapabilities
 import org.siloserver.silo.model.playback.catalogAutoSubtitleCandidates
 import org.siloserver.silo.model.playback.combinedSubtitleSelectionIndexes
 import org.siloserver.silo.model.playback.resolveAutoSubtitle
@@ -15,6 +17,20 @@ import java.util.Locale
 
 internal fun automaticTrackLabel(resolvedLabel: String?): String =
     "Auto - ${resolvedLabel ?: "None"}"
+
+internal fun resolveTvAutomaticAudioTrackOrdinal(
+    version: FileVersion?,
+    preferredAudioLanguage: String?,
+    capabilities: ClientCodecCapabilities?,
+): Int? = if (version == null || capabilities == null) {
+    null
+} else {
+    TrackSelectionPresets.selectBestCompatibleAudioTrackOrdinal(
+        tracks = version.audioTracks.orEmpty(),
+        preferredAudioLanguage = preferredAudioLanguage,
+        capabilities = capabilities,
+    )
+}
 
 /**
  * Pure formatting helpers for the TV detail playback selector row (Version /
@@ -106,6 +122,19 @@ object TvPlaybackFormatting {
                 isHdr(version) -> add("HDR")
             }
             resolvedAudioCodec(version)?.let { add(it) }
+        }
+        return if (tokens.isEmpty()) "Auto" else tokens.joinToString(" · ")
+    }
+
+    /** Resting connected-segment value: resolution plus HDR family. */
+    fun versionCompactLabel(version: FileVersion?): String {
+        if (version == null) return "Auto"
+        val tokens = buildList {
+            resolvedResolution(version)?.let(::displayResolution)?.let { add(it) }
+            when {
+                isDolbyVision(version) -> add("DV")
+                isHdr(version) -> add("HDR")
+            }
         }
         return if (tokens.isEmpty()) "Auto" else tokens.joinToString(" · ")
     }
@@ -231,9 +260,17 @@ object TvPlaybackFormatting {
         }
     }
 
-    fun audioValueLabel(version: FileVersion?, selectedAudioTrackIndex: Int?): String {
+    fun audioValueLabel(
+        version: FileVersion?,
+        selectedAudioTrackIndex: Int?,
+        automaticAudioTrackOrdinal: Int? = null,
+    ): String {
         val tracks = version?.audioTracks ?: return "Unknown"
-        val ordinal = resolvedAudioOrdinal(version, selectedAudioTrackIndex) ?: return "Unknown"
+        val ordinal = resolvedAudioOrdinal(
+            version,
+            selectedAudioTrackIndex,
+            automaticAudioTrackOrdinal,
+        ) ?: return "Unknown"
         val track = tracks.getOrNull(ordinal) ?: return "Unknown"
         val summary = audioSummary(track, ordinal)
         // Auto shows what it resolved to ("Auto: English · EAC3 · 5.1"); a
@@ -250,17 +287,32 @@ object TvPlaybackFormatting {
      * is already in the preferred subtitle language. Mirrors silo-apple's
      * `DetailPlaybackFormatting.resolvedAudioLanguage`.
      */
-    fun resolvedAudioLanguage(version: FileVersion?, selectedAudioTrackIndex: Int?): String? {
+    fun resolvedAudioLanguage(
+        version: FileVersion?,
+        selectedAudioTrackIndex: Int?,
+        automaticAudioTrackOrdinal: Int? = null,
+    ): String? {
         val tracks = version?.audioTracks ?: return null
-        val ordinal = resolvedAudioOrdinal(version, selectedAudioTrackIndex) ?: return null
+        val ordinal = resolvedAudioOrdinal(
+            version,
+            selectedAudioTrackIndex,
+            automaticAudioTrackOrdinal,
+        ) ?: return null
         return tracks.getOrNull(ordinal)?.language
     }
 
-    private fun resolvedAudioOrdinal(version: FileVersion?, selectedAudioTrackIndex: Int?): Int? {
+    private fun resolvedAudioOrdinal(
+        version: FileVersion?,
+        selectedAudioTrackIndex: Int?,
+        automaticAudioTrackOrdinal: Int? = null,
+    ): Int? {
         val tracks = version?.audioTracks ?: return null
         if (tracks.isEmpty()) return null
         if (selectedAudioTrackIndex != null && selectedAudioTrackIndex in tracks.indices) {
             return selectedAudioTrackIndex
+        }
+        if (automaticAudioTrackOrdinal != null && automaticAudioTrackOrdinal in tracks.indices) {
+            return automaticAudioTrackOrdinal
         }
         // Server-resolved effective track beats the isDefault flag (Apple
         // parity: selected → effective → default → first).

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackSelectorRow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackSelectorRow.kt
@@ -1,21 +1,43 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.Movie
 import androidx.compose.material.icons.filled.Tv
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Icon
+import androidx.tv.material3.Text
 import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.tv.ui.components.TvAnchoredSelectorMenu
 import org.siloserver.silo.tv.ui.components.TvSelectorOption
+import org.siloserver.silo.tv.ui.components.TvSelectorTriggerStyle
 
 // ---------------------------------------------------------------------------
 // Inline playback-selection row — Compose-for-TV port of silo-apple's
@@ -54,6 +76,173 @@ internal fun isAudioSelectorOptionSelected(
  */
 internal fun selectorIsInteractive(realChoiceCount: Int): Boolean = realChoiceCount > 1
 
+/**
+ * Compact tvOS-style playback controls used in every video detail action row.
+ * Version, Audio and Subtitles are circular peers of the utility actions.
+ * Audio starts in Auto (the Playback preference) and can be overridden for the
+ * current title/episode without changing that global preference.
+ */
+@Composable
+internal fun TvPlaybackActionSelectors(
+    versions: List<FileVersion>,
+    currentVersion: FileVersion?,
+    selectedVersionFileId: Int?,
+    selectedAudioTrackIndex: Int?,
+    selectedSubtitleTrackIndex: Int?,
+    automaticAudioTrackOrdinal: Int?,
+    automaticAudioResolutionKnown: Boolean,
+    preferredSubtitleLanguage: String?,
+    subtitleMode: String?,
+    showForcedSubtitles: Boolean,
+    onSelectVersion: (Int?) -> Unit,
+    onSelectAudioTrack: (Int?) -> Unit,
+    onSelectSubtitleTrack: (Int?) -> Unit,
+    versionFocusRequester: FocusRequester,
+) {
+    val versionOptions = buildList {
+        add(
+            TvSelectorOption(
+                key = "version:auto",
+                title = "Auto",
+                detail = "Best match for this device",
+                selected = selectedVersionFileId == null,
+                onSelect = { onSelectVersion(null) },
+            ),
+        )
+        versions.forEach { version ->
+            add(
+                TvSelectorOption(
+                    key = "version:${version.fileId}",
+                    title = TvPlaybackFormatting.versionShortLabel(version),
+                    detail = TvPlaybackFormatting.versionDetailLabel(version),
+                    selected = selectedVersionFileId == version.fileId,
+                    onSelect = { onSelectVersion(version.fileId) },
+                ),
+            )
+        }
+    }
+    val formattedSubtitleOptions = TvPlaybackFormatting.subtitleOptions(
+        version = currentVersion,
+        selectedSubtitleTrackIndex = selectedSubtitleTrackIndex,
+        preferredLanguage = preferredSubtitleLanguage,
+    )
+    val formattedAudioOptions =
+        TvPlaybackFormatting.audioOptions(currentVersion, selectedAudioTrackIndex)
+    val audioOptions = buildList {
+        add(
+            TvSelectorOption(
+                key = "audio:auto",
+                title = "Auto",
+                detail = "Use your Playback audio preference",
+                selected = selectedAudioTrackIndex == null,
+                onSelect = { onSelectAudioTrack(null) },
+            ),
+        )
+        formattedAudioOptions.forEach { option ->
+            add(
+                TvSelectorOption(
+                    key = "audio:${option.ordinal}",
+                    title = option.title,
+                    detail = option.detail,
+                    selected = option.isSelected,
+                    onSelect = { onSelectAudioTrack(option.ordinal) },
+                ),
+            )
+        }
+    }
+    val subtitleOptions = buildList {
+        add(
+            TvSelectorOption(
+                key = "subtitle:auto",
+                title = "Auto",
+                detail = "Use your subtitle preferences",
+                selected = selectedSubtitleTrackIndex == null,
+                onSelect = { onSelectSubtitleTrack(null) },
+            ),
+        )
+        add(
+            TvSelectorOption(
+                key = "subtitle:off",
+                title = "Off",
+                detail = "Start without subtitles",
+                selected = selectedSubtitleTrackIndex == -1,
+                onSelect = { onSelectSubtitleTrack(-1) },
+            ),
+        )
+        formattedSubtitleOptions.forEach { option ->
+            add(
+                TvSelectorOption(
+                    key = "subtitle:${option.stableId}",
+                    title = option.title,
+                    detail = option.detail,
+                    selected = option.isSelected,
+                    onSelect = { onSelectSubtitleTrack(option.selectionIndex) },
+                ),
+            )
+        }
+    }
+    val versionValue = currentVersion?.let {
+        TvPlaybackFormatting.versionValueLabel(it, selectedVersionFileId)
+    }.orEmpty()
+    val audioValue = currentVersion?.let {
+        if (selectedAudioTrackIndex == null && !automaticAudioResolutionKnown) {
+            "Auto"
+        } else {
+            TvPlaybackFormatting.audioValueLabel(
+                it,
+                selectedAudioTrackIndex,
+                automaticAudioTrackOrdinal,
+            )
+        }
+    }.orEmpty()
+    val subtitleValue = currentVersion?.let { version ->
+        TvPlaybackFormatting.subtitleValueLabel(
+            version = version,
+            selectedSubtitleTrackIndex = selectedSubtitleTrackIndex,
+            autoContext = if (selectedAudioTrackIndex != null || automaticAudioResolutionKnown) {
+                TvPlaybackFormatting.SubtitleAutoContext(
+                    preferredLanguage = preferredSubtitleLanguage,
+                    mode = subtitleMode,
+                    showForced = showForcedSubtitles,
+                    audioLanguage = TvPlaybackFormatting.resolvedAudioLanguage(
+                        version,
+                        selectedAudioTrackIndex,
+                        automaticAudioTrackOrdinal,
+                    ),
+                )
+            } else {
+                null
+            },
+        )
+    }.orEmpty()
+
+    TvAnchoredSelectorMenu(
+        icon = Icons.Filled.Movie,
+        label = "Version",
+        value = versionValue,
+        options = versionOptions,
+        triggerFocusRequester = versionFocusRequester,
+        interactive = currentVersion != null && versions.isNotEmpty(),
+        triggerStyle = TvSelectorTriggerStyle.CircularAction,
+    )
+    TvAnchoredSelectorMenu(
+        icon = Icons.AutoMirrored.Filled.VolumeUp,
+        label = "Audio",
+        value = audioValue,
+        options = audioOptions,
+        interactive = currentVersion != null && formattedAudioOptions.isNotEmpty(),
+        triggerStyle = TvSelectorTriggerStyle.CircularAction,
+    )
+    TvAnchoredSelectorMenu(
+        icon = Icons.AutoMirrored.Filled.Chat,
+        label = "Subtitles",
+        value = subtitleValue,
+        options = subtitleOptions,
+        interactive = currentVersion != null,
+        triggerStyle = TvSelectorTriggerStyle.CircularAction,
+    )
+}
+
 @Composable
 fun TvPlaybackSelectorRow(
     versions: List<FileVersion>,
@@ -61,6 +250,8 @@ fun TvPlaybackSelectorRow(
     selectedVersionFileId: Int?,
     selectedAudioTrackIndex: Int?,
     selectedSubtitleTrackIndex: Int?,
+    automaticAudioTrackOrdinal: Int? = null,
+    automaticAudioResolutionKnown: Boolean = false,
     // Cascaded subtitle prefs (profile-sourced) that let the Subtitles pill
     // preview the concrete track Auto will resolve to — the same rules the
     // player runs at launch.
@@ -71,6 +262,8 @@ fun TvPlaybackSelectorRow(
     onSelectAudioTrack: (Int?) -> Unit,
     onSelectSubtitleTrack: (Int?) -> Unit,
     modifier: Modifier = Modifier,
+    /** Give every visible segment an equal, fixed share of the supplied width. */
+    stretchSegments: Boolean = false,
 ) {
     // hasAnySelector — only show once an effective playable version is known.
     if (currentVersion == null) return
@@ -194,70 +387,182 @@ fun TvPlaybackSelectorRow(
         }
     }
 
-    // fillMaxWidth + a focus container so a Down press from any top-row control
-    // (including the far-right circle toggles) lands on the nearest selector
-    // rather than skipping the row — the Compose analogue of Apple's
-    // full-width `.focusSection()`.
-    Row(
+    val audioValue = if (selectedAudioTrackIndex == null && !automaticAudioResolutionKnown) {
+        "Auto"
+    } else {
+        TvPlaybackFormatting.audioValueLabel(
+            currentVersion,
+            selectedAudioTrackIndex,
+            automaticAudioTrackOrdinal,
+        )
+    }
+    val subtitleValue = TvPlaybackFormatting.subtitleValueLabel(
+        currentVersion,
+        selectedSubtitleTrackIndex,
+        autoContext = if (selectedAudioTrackIndex != null || automaticAudioResolutionKnown) {
+            TvPlaybackFormatting.SubtitleAutoContext(
+                preferredLanguage = preferredSubtitleLanguage,
+                mode = subtitleMode,
+                showForced = showForcedSubtitles,
+                audioLanguage = TvPlaybackFormatting.resolvedAudioLanguage(
+                    currentVersion,
+                    selectedAudioTrackIndex,
+                    automaticAudioTrackOrdinal,
+                ),
+            )
+        } else {
+            null
+        },
+    )
+    var groupExpanded by remember { mutableStateOf(false) }
+
+    // Series supplies the measured action-row width and stretches its segments
+    // across that stable footprint. Other detail pages retain the compact,
+    // leading capsule. In fixed mode the values do not expand on focus, so the
+    // selector never changes shape while the viewer moves through it.
+    PlaybackSelectorCapsule(
         modifier = modifier
             .fillMaxWidth()
+            .onFocusChanged { groupExpanded = it.hasFocus }
             .focusGroup(),
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
-        verticalAlignment = Alignment.CenterVertically,
+        stretchContent = stretchSegments,
     ) {
+        val segmentModifier = if (stretchSegments) Modifier.weight(1f) else Modifier
         if (editions.size > 1) {
             TvAnchoredSelectorMenu(
-                modifier = Modifier.weight(1f),
+                modifier = segmentModifier,
                 icon = Icons.Filled.Layers,
                 label = "Edition",
                 value = currentEdition?.label ?: "Standard",
+                compactValue = currentEdition?.label ?: "Standard",
                 options = editionOptions,
                 interactive = selectorIsInteractive(editions.size),
+                triggerStyle = TvSelectorTriggerStyle.ConnectedSegment,
+                groupExpanded = groupExpanded,
+                connectedFillWidth = stretchSegments,
+                connectedExpandValue = !stretchSegments,
+            )
+            SelectorDivider()
+        }
+
+        TvAnchoredSelectorMenu(
+            modifier = segmentModifier,
+            icon = Icons.Filled.Tv,
+            label = "Version",
+            value = TvPlaybackFormatting.versionValueLabel(currentVersion, selectedVersionFileId),
+            compactValue = TvPlaybackFormatting.versionCompactLabel(currentVersion),
+            options = versionOptions,
+            interactive = selectorIsInteractive(scopedVersions.size),
+            triggerStyle = TvSelectorTriggerStyle.ConnectedSegment,
+            groupExpanded = groupExpanded,
+            connectedFillWidth = stretchSegments,
+            connectedExpandValue = !stretchSegments,
+        )
+
+        if (formattedAudioOptions.isNotEmpty()) {
+            SelectorDivider()
+            TvAnchoredSelectorMenu(
+                modifier = segmentModifier,
+                icon = Icons.AutoMirrored.Filled.VolumeUp,
+                label = "Audio",
+                value = audioValue,
+                compactValue = audioValue.removePrefix("Auto: "),
+                options = audioSelectorOptions,
+                interactive = selectorIsInteractive(formattedAudioOptions.size),
+                triggerStyle = TvSelectorTriggerStyle.ConnectedSegment,
+                groupExpanded = groupExpanded,
+                connectedFillWidth = stretchSegments,
+                connectedExpandValue = !stretchSegments,
             )
         }
 
-        // Version — tvOS uses the `tv` display glyph, not an HQ badge.
-        TvAnchoredSelectorMenu(
-            modifier = Modifier.weight(1f),
-            icon = Icons.Filled.Tv,
-            label = "Version",
-            value = TvPlaybackFormatting.versionShortLabel(currentVersion),
-            options = versionOptions,
-            interactive = selectorIsInteractive(scopedVersions.size),
-        )
+        if (formattedSubtitleOptions.isNotEmpty()) {
+            SelectorDivider()
+            TvAnchoredSelectorMenu(
+                modifier = segmentModifier,
+                icon = Icons.AutoMirrored.Filled.Chat,
+                label = "Subtitles",
+                value = "Subtitles $subtitleValue",
+                compactValue = compactSubtitleSelectorValue(subtitleValue),
+                options = subtitleSelectorOptions,
+                interactive = selectorIsInteractive(formattedSubtitleOptions.size),
+                triggerStyle = TvSelectorTriggerStyle.ConnectedSegment,
+                groupExpanded = groupExpanded,
+                connectedFillWidth = stretchSegments,
+                connectedExpandValue = !stretchSegments,
+            )
+        }
+    }
+}
 
-        // Audio
-        TvAnchoredSelectorMenu(
-            modifier = Modifier.weight(1f),
-            icon = Icons.AutoMirrored.Filled.VolumeUp,
-            label = "Audio",
-            value = TvPlaybackFormatting.audioValueLabel(currentVersion, selectedAudioTrackIndex),
-            options = audioSelectorOptions,
-            interactive = selectorIsInteractive(formattedAudioOptions.size),
-        )
-
-        // Subtitles — tvOS uses `captions.bubble`; Chat (bubble with text
-        // lines) is the closest Material glyph, and reads as subtitles rather
-        // than the narrower CC (closed captions).
-        TvAnchoredSelectorMenu(
-            modifier = Modifier.weight(1f),
-            icon = Icons.AutoMirrored.Filled.Chat,
-            label = "Subtitles",
-            value = TvPlaybackFormatting.subtitleValueLabel(
-                currentVersion,
-                selectedSubtitleTrackIndex,
-                autoContext = TvPlaybackFormatting.SubtitleAutoContext(
-                    preferredLanguage = preferredSubtitleLanguage,
-                    mode = subtitleMode,
-                    showForced = showForcedSubtitles,
-                    audioLanguage = TvPlaybackFormatting.resolvedAudioLanguage(
-                        currentVersion,
-                        selectedAudioTrackIndex,
-                    ),
-                ),
-            ),
-            options = subtitleSelectorOptions,
-            interactive = selectorIsInteractive(formattedSubtitleOptions.size),
+/** The one chrome shell shared by both the live selector and its loading state. */
+@Composable
+private fun PlaybackSelectorCapsule(
+    modifier: Modifier = Modifier,
+    stretchContent: Boolean = false,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            modifier = (if (stretchContent) Modifier.fillMaxWidth() else Modifier)
+                .height(25.dp)
+                .background(Color.Black.copy(alpha = 0.26f), CircleShape)
+                .border(0.75.dp, Color.White.copy(alpha = 0.42f), CircleShape)
+                .padding(1.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            content = content,
         )
     }
 }
+
+/**
+ * Non-focusable loading state shown while a newly focused episode's playback
+ * detail resolves. It deliberately uses [PlaybackSelectorCapsule], so moving
+ * across episodes can change the value but never flash a rectangular control.
+ */
+@Composable
+internal fun TvVersionPillPlaceholder(modifier: Modifier = Modifier) {
+    PlaybackSelectorCapsule(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .height(23.dp)
+                .clip(CircleShape)
+                .padding(horizontal = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Tv,
+                contentDescription = null,
+                tint = Color.White.copy(alpha = 0.75f),
+                modifier = Modifier.size(15.dp),
+            )
+            Text(
+                text = "Version",
+                color = Color.White.copy(alpha = 0.75f),
+                fontWeight = FontWeight.Medium,
+                fontSize = 14.sp,
+                lineHeight = 17.sp,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SelectorDivider() {
+    androidx.compose.foundation.layout.Box(
+        modifier = Modifier
+            .width(0.5.dp)
+            .height(17.dp)
+            .background(Color.White.copy(alpha = 0.22f)),
+    )
+}
+
+internal fun compactSubtitleSelectorValue(value: String): String = value
+    .removePrefix("Auto: ")
+    .removePrefix("Auto - ")
+    .substringBefore(" · ")

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt
@@ -203,7 +203,7 @@ fun TvSeriesModePicker(
             TvSeriesModeTab(
                 title = "Show",
                 isSelected = isShowingSeriesOverview,
-                onClick = onShowSelected,
+                onActivated = onShowSelected,
                 modifier = if (isShowingSeriesOverview) {
                     Modifier.focusRequester(selectedFocusRequester)
                 } else {
@@ -220,7 +220,7 @@ fun TvSeriesModePicker(
             TvSeriesModeTab(
                 title = tvSeasonPickerLabel(season),
                 isSelected = selected,
-                onClick = { onSeasonSelected(season) },
+                onActivated = { onSeasonSelected(season) },
                 modifier = if (selected) {
                     Modifier.focusRequester(selectedFocusRequester)
                 } else {
@@ -235,7 +235,7 @@ fun TvSeriesModePicker(
 private fun TvSeriesModeTab(
     title: String,
     isSelected: Boolean,
-    onClick: () -> Unit,
+    onActivated: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -286,10 +286,18 @@ private fun TvSeriesModeTab(
             .seriesModeFocusRing(visible = isFocused)
             .background(fill, CircleShape)
             .border(borderWidth, borderColor, CircleShape)
+            // tvOS treats Show and each season as focus-driven modes: moving
+            // laterally updates the page immediately, without an extra Select.
+            // The ViewModel ignores the already-selected season and generation-
+            // guards quick successive loads while the existing selectedIndex
+            // effect keeps the newly focused tab centered.
+            .onFocusChanged { focusState ->
+                if (focusState.isFocused && !isSelected) onActivated()
+            }
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
-                onClick = onClick,
+                onClick = onActivated,
             )
             .padding(horizontal = 12.dp),
         contentAlignment = Alignment.Center,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt
@@ -9,15 +9,18 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -31,8 +34,14 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -112,7 +121,7 @@ fun TvSeasonPicker(
     ) {
         items(
             seasons,
-            key = { it.seasonNumber },
+            key = { "season-${it.seasonNumber}-${it.contentId}" },
             contentType = { "season-chip" },
         ) { season ->
             TvSeasonChip(
@@ -127,6 +136,188 @@ fun TvSeasonPicker(
             )
         }
     }
+}
+
+/**
+ * Combined Series mode row from the approved tvOS page: Show first, followed
+ * by every season. These are true capsules with a fixed footprint and no focus
+ * scale, so lateral movement never shifts its neighbours.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun TvSeriesModePicker(
+    seasons: List<Season>,
+    isShowingSeriesOverview: Boolean,
+    selectedSeason: Int?,
+    onShowSelected: () -> Unit,
+    onSeasonSelected: (Season) -> Unit,
+    modifier: Modifier = Modifier,
+    horizontalContentPadding: Dp = 0.dp,
+    onDirectionUp: (() -> Boolean)? = null,
+) {
+    val listState = rememberLazyListState()
+    val selectedFocusRequester = remember { FocusRequester() }
+    val selectedIndex = remember(isShowingSeriesOverview, selectedSeason, seasons) {
+        if (isShowingSeriesOverview) {
+            0
+        } else {
+            seasons.indexOfFirst { it.seasonNumber == selectedSeason }
+                .takeIf { it >= 0 }
+                ?.plus(1)
+                ?: 0
+        }
+    }
+
+    LaunchedEffect(selectedIndex, seasons.size) {
+        listState.scrollToItem(selectedIndex)
+        val info = listState.layoutInfo
+        val item = info.visibleItemsInfo.firstOrNull { it.index == selectedIndex }
+            ?: return@LaunchedEffect
+        val viewportCenter = (info.viewportStartOffset + info.viewportEndOffset) / 2f
+        val itemCenter = item.offset + item.size / 2f
+        listState.animateScrollBy(itemCenter - viewportCenter)
+    }
+
+    LazyRow(
+        modifier = modifier
+            .focusProperties { enter = { selectedFocusRequester } }
+            .then(
+                if (onDirectionUp != null) {
+                    Modifier.onPreviewKeyEvent { event ->
+                        if (event.type == KeyEventType.KeyDown && event.key == Key.DirectionUp) {
+                            onDirectionUp()
+                        } else {
+                            false
+                        }
+                    }
+                } else {
+                    Modifier
+                },
+            )
+            .focusGroup(),
+        state = listState,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(horizontal = horizontalContentPadding, vertical = 2.dp),
+    ) {
+        item(key = "series-show-overview", contentType = "series-mode") {
+            TvSeriesModeTab(
+                title = "Show",
+                isSelected = isShowingSeriesOverview,
+                onClick = onShowSelected,
+                modifier = if (isShowingSeriesOverview) {
+                    Modifier.focusRequester(selectedFocusRequester)
+                } else {
+                    Modifier
+                },
+            )
+        }
+        items(
+            seasons,
+            key = { "series-season-${it.seasonNumber}-${it.contentId}" },
+            contentType = { "series-mode" },
+        ) { season ->
+            val selected = !isShowingSeriesOverview && season.seasonNumber == selectedSeason
+            TvSeriesModeTab(
+                title = tvSeasonPickerLabel(season),
+                isSelected = selected,
+                onClick = { onSeasonSelected(season) },
+                modifier = if (selected) {
+                    Modifier.focusRequester(selectedFocusRequester)
+                } else {
+                    Modifier
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TvSeriesModeTab(
+    title: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val fill by animateColorAsState(
+        targetValue = when {
+            isFocused -> Color.White
+            isSelected -> Color.White.copy(alpha = 0.20f)
+            else -> Color.White.copy(alpha = 0.05f)
+        },
+        animationSpec = spring(dampingRatio = 0.78f, stiffness = 420f),
+        label = "seriesModeFill",
+    )
+    val labelColor by animateColorAsState(
+        targetValue = if (isFocused) Color.Black else Color.White,
+        animationSpec = spring(dampingRatio = 0.78f, stiffness = 420f),
+        label = "seriesModeLabel",
+    )
+    val borderWidth = when {
+        isFocused -> 0.75.dp
+        isSelected -> 1.dp
+        else -> 0.75.dp
+    }
+    val borderColor = if (isFocused) {
+        Color.Black.copy(alpha = 0.12f)
+    } else {
+        Color.White.copy(alpha = if (isSelected) 0.70f else 0.30f)
+    }
+
+    Box(
+        modifier = modifier
+            .graphicsLayer {
+                val pressScale = if (isPressed) 0.98f else 1f
+                scaleX = pressScale
+                scaleY = pressScale
+            }
+            .shadow(
+                elevation = if (isFocused) 6.dp else 0.dp,
+                shape = CircleShape,
+                clip = false,
+                ambientColor = Color.White.copy(alpha = if (isFocused) 0.08f else 0f),
+                spotColor = Color.White.copy(alpha = if (isFocused) 0.08f else 0f),
+            )
+            .height(26.dp)
+            // Same outward white focus outline as Play and the selector
+            // controls, without changing this row's stable measurements.
+            .seriesModeFocusRing(visible = isFocused)
+            .background(fill, CircleShape)
+            .border(borderWidth, borderColor, CircleShape)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .padding(horizontal = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontSize = 14.sp,
+                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+            ),
+            color = labelColor,
+            maxLines = 1,
+        )
+    }
+}
+
+private fun Modifier.seriesModeFocusRing(visible: Boolean): Modifier = drawWithContent {
+    drawContent()
+    if (!visible) return@drawWithContent
+    val inset = 1.5.dp.toPx()
+    val stroke = 1.25.dp.toPx()
+    drawRoundRect(
+        color = Color.White.copy(alpha = 0.98f),
+        topLeft = Offset(-inset, -inset),
+        size = Size(size.width + inset * 2f, size.height + inset * 2f),
+        cornerRadius = CornerRadius((size.height + inset * 2f) / 2f),
+        style = Stroke(width = stroke),
+    )
 }
 
 /**

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -26,12 +27,17 @@ import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.siloserver.silo.model.section.ResolvedSection
+import org.siloserver.silo.model.section.SectionItem
+import org.siloserver.silo.tv.data.preferences.TvHomeSectionPreferences
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvLoadingScreen
 import org.siloserver.silo.tv.ui.components.TvMediaCardActions
+import org.siloserver.silo.tv.ui.components.TvSkylineDetailPrefetchTarget
 import org.siloserver.silo.tv.ui.components.TvSkylineSectionFeed
+import org.siloserver.silo.tv.ui.components.isTvContinueWatchingRow
 import org.siloserver.silo.tv.ui.components.isTvProgressRow
 import org.siloserver.silo.tv.ui.focus.TvContentInitialFocusMaxAttempts
 import org.siloserver.silo.tv.ui.focus.TvObservedFocusResult
@@ -52,9 +58,15 @@ internal fun shouldShowHomeEmptyState(
 @Composable
 fun TvHomeScreen(
     onItemClick: (contentId: String) -> Unit,
+    onItemDetailSelection: (
+        contentId: String,
+        seasonNumber: Int?,
+        episodeContentId: String?,
+    ) -> Unit = { contentId, _, _ -> onItemClick(contentId) },
     onPlayItem: (contentId: String, type: String?, resumePositionSeconds: Double?) -> Unit = { _, _, _ -> },
     onSeeAll: () -> Unit = {},
     onOpenForYou: () -> Unit = {},
+    onOpenSettings: () -> Unit = {},
     onInitialContentFocus: () -> Unit = {},
     focusRequest: Int = 0,
     detailReturnFocusRequest: Int = 0,
@@ -66,7 +78,21 @@ fun TvHomeScreen(
     viewModel: HomeViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
-    val visibleSections = remember(state.sections) { state.sections.normalizeTvHomeSections() }
+    val homeSectionPreferences: TvHomeSectionPreferences = koinInject()
+    val homeSectionPreferenceState by homeSectionPreferences.state.collectAsState()
+    val normalizedSections = remember(state.sections) { state.sections.normalizeTvHomeSections() }
+    val visibleSections = remember(normalizedSections, homeSectionPreferenceState.layout) {
+        TvHomeSectionPreferences.arrange(
+            sections = normalizedSections,
+            layout = homeSectionPreferenceState.layout,
+        )
+    }
+    val sectionsHiddenByPreference =
+        normalizedSections.isNotEmpty() && visibleSections.isEmpty()
+
+    LaunchedEffect(homeSectionPreferences) {
+        homeSectionPreferences.refresh()
+    }
 
     // TV has no pull-to-refresh, so ON_RESUME is the only manual freshness
     // path — refresh quietly whenever the user returns to Home (e.g. after
@@ -96,35 +122,43 @@ fun TvHomeScreen(
         shouldShowHomeEmptyState(state.isLoading, state.error, visibleSections.size) ->
             TvHomeEmptyState(
                 onRefresh = viewModel::loadSections,
+                onOpenSettings = onOpenSettings,
+                sectionsHiddenByPreference = sectionsHiddenByPreference,
                 focusRequester = firstRowFocusRequester,
                 focusRequest = focusRequest,
                 onInitialContentFocus = onInitialContentFocus,
             )
-        else -> TvHomeContent(
-            sections = visibleSections,
-            sectionsFullyResolved = state.sectionsFullyResolved,
-            onItemClick = onItemClick,
-            onSeeAll = onSeeAll,
-            onOpenForYou = onOpenForYou,
-            onInitialContentFocus = onInitialContentFocus,
-            focusRequest = focusRequest,
-            detailReturnFocusRequest = detailReturnFocusRequest,
-            detailReturnCardFocusRequester = detailReturnCardFocusRequester,
-            firstRowFocusRequester = firstRowFocusRequester,
-            firstRowContainerFocusRequester = firstRowContainerFocusRequester,
-            onContentUpFallbackChanged = onContentUpFallbackChanged,
-            onSetWatched = viewModel::setWatched,
-            onToggleFavorite = viewModel::toggleFavorite,
-            onToggleWatchlist = viewModel::toggleWatchlist,
-            onDismissContinueWatching = viewModel::dismissContinueWatching,
-            onDismissNextUp = viewModel::dismissNextUp,
-        )
+        else -> key(homeSectionPreferenceState.layoutRevision) {
+            TvHomeContent(
+                sections = visibleSections,
+                sectionsFullyResolved = state.sectionsFullyResolved,
+                onItemClick = onItemClick,
+                onItemDetailSelection = onItemDetailSelection,
+                onPlayItem = onPlayItem,
+                onSeeAll = onSeeAll,
+                onOpenForYou = onOpenForYou,
+                onInitialContentFocus = onInitialContentFocus,
+                focusRequest = focusRequest,
+                detailReturnFocusRequest = detailReturnFocusRequest,
+                detailReturnCardFocusRequester = detailReturnCardFocusRequester,
+                firstRowFocusRequester = firstRowFocusRequester,
+                firstRowContainerFocusRequester = firstRowContainerFocusRequester,
+                onContentUpFallbackChanged = onContentUpFallbackChanged,
+                onSetWatched = viewModel::setWatched,
+                onToggleFavorite = viewModel::toggleFavorite,
+                onToggleWatchlist = viewModel::toggleWatchlist,
+                onDismissContinueWatching = viewModel::dismissContinueWatching,
+                onDismissNextUp = viewModel::dismissNextUp,
+            )
+        }
     }
 }
 
 @Composable
 private fun TvHomeEmptyState(
     onRefresh: () -> Unit,
+    onOpenSettings: () -> Unit,
+    sectionsHiddenByPreference: Boolean,
     focusRequester: FocusRequester?,
     focusRequest: Int,
     onInitialContentFocus: () -> Unit,
@@ -153,21 +187,32 @@ private fun TvHomeEmptyState(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(
-                text = "Nothing to show yet",
+                text = if (sectionsHiddenByPreference) {
+                    "Home sections are hidden"
+                } else {
+                    "Nothing to watch yet"
+                },
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.onBackground,
             )
             Text(
-                text = "Refresh Home after adding or watching something.",
+                text = if (sectionsHiddenByPreference) {
+                    "Choose which rows appear in Settings → General → Home Sections."
+                } else {
+                    "Add media to your libraries or start watching to see it here."
+                },
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Button(
-                onClick = onRefresh,
+                onClick = if (sectionsHiddenByPreference) onOpenSettings else onRefresh,
                 modifier = Modifier.focusRequester(refreshFocusRequester),
                 contentPadding = PaddingValues(horizontal = 32.dp, vertical = 12.dp),
             ) {
-                Text("Refresh", style = MaterialTheme.typography.labelLarge)
+                Text(
+                    text = if (sectionsHiddenByPreference) "Open Settings" else "Refresh",
+                    style = MaterialTheme.typography.labelLarge,
+                )
             }
         }
     }
@@ -177,6 +222,8 @@ private fun TvHomeEmptyState(
 private fun TvHomeContent(
     sections: List<ResolvedSection>,
     onItemClick: (String) -> Unit,
+    onItemDetailSelection: (String, Int?, String?) -> Unit,
+    onPlayItem: (contentId: String, type: String?, resumePositionSeconds: Double?) -> Unit,
     onSeeAll: () -> Unit = {},
     onOpenForYou: () -> Unit = {},
     onInitialContentFocus: () -> Unit,
@@ -195,6 +242,9 @@ private fun TvHomeContent(
 ) {
     TvSkylineSectionFeed(
         surfaceKey = "home",
+        // tvOS Home drops the foreground marquee + row band by 56pt while
+        // keeping the ambient art and top navigation fixed (28dp at TV scale).
+        contentVerticalOffset = 28.dp,
         sections = sections,
         sectionsComplete = sectionsFullyResolved,
         onItemClick = onItemClick,
@@ -217,11 +267,45 @@ private fun TvHomeContent(
         styleForSection = { section ->
             section.tvHomeRowStyle()
         },
+        clickActionForSection = { section, item ->
+            if (section.isTvContinueWatchingRow()) {
+                {
+                    val target = item.tvContinueWatchingDetailTarget()
+                    onItemDetailSelection(
+                        target.contentId,
+                        target.seasonNumber,
+                        target.episodeContentId,
+                    )
+                }
+            } else {
+                null
+            }
+        },
+        priorityDetailPrefetchTargetForSection = { section, item ->
+            if (section.isTvContinueWatchingRow()) {
+                item.tvContinueWatchingPrefetchTarget()
+            } else {
+                null
+            }
+        },
         cardActions = { section, item ->
             val isProgressRow = section.isTvProgressRow()
+            val isContinueWatching = section.isTvContinueWatchingRow()
             val progressUpdatedAt = item.progressUpdatedAt
             val seriesId = item.seriesId
             TvMediaCardActions(
+                onPlay = if (isContinueWatching) {
+                    {
+                        onPlayItem(
+                            item.contentId,
+                            item.type,
+                            item.positionSeconds,
+                        )
+                    }
+                } else {
+                    null
+                },
+                playLabel = if (item.positionSeconds != null) "Resume" else "Play",
                 onSetWatched = { watched -> onSetWatched(item.contentId, watched) },
                 onToggleFavorite = { fav -> onToggleFavorite(item.contentId, fav) },
                 onToggleWatchlist = { wl -> onToggleWatchlist(item.contentId, wl) },
@@ -237,6 +321,38 @@ private fun TvHomeContent(
                 },
             )
         },
+    )
+}
+
+internal data class TvContinueWatchingDetailTarget(
+    val contentId: String,
+    val seasonNumber: Int? = null,
+    val episodeContentId: String? = null,
+)
+
+/** Opens episode progress on the combined Series page; movies keep their own detail. */
+internal fun SectionItem.tvContinueWatchingDetailTarget(): TvContinueWatchingDetailTarget {
+    val seriesContentId = seriesId?.takeIf { it.isNotBlank() }
+    val isEpisode = type.equals("episode", ignoreCase = true) || episodeNumber != null
+    return if (isEpisode && seriesContentId != null && seasonNumber != null) {
+        TvContinueWatchingDetailTarget(
+            contentId = seriesContentId,
+            seasonNumber = seasonNumber,
+            episodeContentId = contentId,
+        )
+    } else {
+        TvContinueWatchingDetailTarget(contentId = contentId)
+    }
+}
+
+/** Warms exactly what the Continue Watching Select action will open. */
+internal fun SectionItem.tvContinueWatchingPrefetchTarget(): TvSkylineDetailPrefetchTarget {
+    val navigation = tvContinueWatchingDetailTarget()
+    return TvSkylineDetailPrefetchTarget(
+        detailContentId = navigation.contentId,
+        seriesId = navigation.contentId.takeIf { navigation.episodeContentId != null },
+        seasonNumber = navigation.seasonNumber,
+        episodeContentId = navigation.episodeContentId,
     )
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/personal/TvPersonalScreens.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -42,6 +43,7 @@ import org.koin.core.parameter.parametersOf
 import org.siloserver.silo.tv.ui.components.TvCatalogGrid
 import org.siloserver.silo.tv.ui.components.TvErrorScreen
 import org.siloserver.silo.tv.ui.components.TvLoadingScreen
+import org.siloserver.silo.tv.ui.components.TvFilterChip
 import org.siloserver.silo.tv.ui.screens.library.TvBrowseControlRow
 import org.siloserver.silo.tv.ui.screens.library.TvBrowseFilterPanel
 import org.siloserver.silo.tv.ui.screens.library.TvBrowseSortPanel
@@ -89,6 +91,14 @@ private const val WatchlistSource = "watchlist"
  * non-audiobook-like value and selects the video facet set.
  */
 private const val PersonalListFacetType = "mixed"
+
+private enum class TvFavoriteMediaKind(
+    val label: String,
+    val mediaType: String,
+) {
+    Movies(label = "Movies", mediaType = "movie"),
+    TvShows(label = "TV Shows", mediaType = "series"),
+}
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -146,18 +156,28 @@ fun TvFavoritesInline(
     firstItemFocusRequester: FocusRequester? = null,
     viewModel: FavoritesViewModel = koinViewModel(),
 ) {
+    var selectedMediaKind by rememberSaveable { mutableStateOf(TvFavoriteMediaKind.Movies) }
     val state by viewModel.uiState.collectAsState()
-    val controls = rememberPersonalListControls(FavoritesSource, viewModel)
+    val controls = rememberPersonalListControls(
+        source = FavoritesSource,
+        listViewModel = viewModel,
+        mediaType = selectedMediaKind.mediaType,
+    )
     PersonalListResumeRefresh(viewModel)
     PersonalInlineGrid(
         state = state,
         controls = controls,
-        emptyMessage = "No favorites yet",
+        emptyMessage = when (selectedMediaKind) {
+            TvFavoriteMediaKind.Movies -> "No favorite movies yet"
+            TvFavoriteMediaKind.TvShows -> "No favorite TV shows yet"
+        },
         emptyIcon = Icons.Filled.Favorite,
         onItemClick = onItemClick,
         onLoadMore = viewModel::loadMore,
         onRetry = viewModel::retry,
         firstItemFocusRequester = firstItemFocusRequester,
+        favoriteMediaKind = selectedMediaKind,
+        onFavoriteMediaKindSelected = { selectedMediaKind = it },
         modifier = modifier,
     )
 }
@@ -226,6 +246,7 @@ fun TvHistoryScreen(
 private fun rememberPersonalListControls(
     source: String,
     listViewModel: PersonalListViewModel,
+    mediaType: String? = null,
 ): TvPersonalListControlsViewModel {
     val sharedOwner = LocalActivity.current as? ViewModelStoreOwner
         ?: LocalViewModelStoreOwner.current
@@ -238,8 +259,8 @@ private fun rememberPersonalListControls(
     val controlsState by controls.uiState.collectAsState()
     // applyQuery no-ops on an unchanged query, so this is safe to re-run on
     // recomposition and on re-entry to the composition.
-    LaunchedEffect(controlsState.query) {
-        listViewModel.applyQuery(controlsState.query)
+    LaunchedEffect(controlsState.query, mediaType) {
+        listViewModel.applyQuery(controlsState.query.copy(mediaType = mediaType))
     }
     return controls
 }
@@ -467,6 +488,8 @@ private fun PersonalInlineGrid(
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
     firstItemFocusRequester: FocusRequester? = null,
+    favoriteMediaKind: TvFavoriteMediaKind? = null,
+    onFavoriteMediaKindSelected: ((TvFavoriteMediaKind) -> Unit)? = null,
 ) {
     val controlsState by controls.uiState.collectAsState()
     var openPanel by remember { mutableStateOf<TvPersonalPanel?>(null) }
@@ -511,15 +534,32 @@ private fun PersonalInlineGrid(
             fixedColumnCount = tvPresetGridColumns(6),
             firstItemFocusRequester = firstItemFocusRequester.takeIf { !listIsEmpty },
             header = {
-                PersonalControlHeader(
-                    controlsState = controlsState,
-                    total = state.total,
-                    isLoading = state.isLoading,
-                    onSort = { openPanel = TvPersonalPanel.Sort },
-                    onFilter = { openPanel = TvPersonalPanel.Filter },
-                    onClearFilters = controls::clearFilters,
-                    sortPillFocusRequester = firstItemFocusRequester.takeIf { listIsEmpty },
-                )
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    if (favoriteMediaKind != null && onFavoriteMediaKindSelected != null) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            TvFavoriteMediaKind.entries.forEach { kind ->
+                                TvFilterChip(
+                                    text = kind.label,
+                                    selected = kind == favoriteMediaKind,
+                                    onClick = { onFavoriteMediaKindSelected(kind) },
+                                    contentPadding = PaddingValues(
+                                        horizontal = 16.dp,
+                                        vertical = 7.dp,
+                                    ),
+                                )
+                            }
+                        }
+                    }
+                    PersonalControlHeader(
+                        controlsState = controlsState,
+                        total = state.total,
+                        isLoading = state.isLoading,
+                        onSort = { openPanel = TvPersonalPanel.Sort },
+                        onFilter = { openPanel = TvPersonalPanel.Filter },
+                        onClearFilters = controls::clearFilters,
+                        sortPillFocusRequester = firstItemFocusRequester.takeIf { listIsEmpty },
+                    )
+                }
             },
             emptyState = {
                 // Inside the grid, not over it: the pills have to stay

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -1,11 +1,13 @@
 package org.siloserver.silo.tv.ui.screens.player
 
 import android.util.Log
+import androidx.media3.common.util.UnstableApi
 import org.siloserver.silo.common.network.ServerReachabilityMonitor
 import org.siloserver.silo.common.player.PlaybackCapabilityDetector
 import org.siloserver.silo.common.player.PlaybackSessionLifecycle
 import org.siloserver.silo.common.player.PlaybackSessionManager
 import org.siloserver.silo.common.player.StartParams
+import org.siloserver.silo.common.player.TrackSelectionPresets
 import org.siloserver.silo.common.player.VideoSessionStartV3
 import org.siloserver.silo.common.player.video.VideoPlaybackStartRequest
 import org.siloserver.silo.common.player.video.VideoPlaybackStartResult
@@ -39,6 +41,7 @@ import org.siloserver.silo.tv.BuildConfig
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 
+@UnstableApi
 class TvVideoPlaybackStarter(
     private val catalogRepository: CatalogRepository,
     private val playbackSessionManager: PlaybackSessionManager,
@@ -125,6 +128,26 @@ class TvVideoPlaybackStarter(
                     dolbyVision = dolbyVision,
                     capabilities = capabilities,
                 )
+            val effectivePreferredAudioLanguage = TrackSelectionPresets.effectivePreferredAudioLanguage(
+                settingsLanguage = preferredAudioLanguage,
+                profileLanguage = activeProfile?.language,
+            )
+            // A detail/HUD choice or episode handoff is explicit and always
+            // wins. Otherwise resolve the automatic language + quality policy
+            // before asking the server for a plan, so an HLS/transcode route
+            // receives the same best-compatible source track that Media3 would
+            // choose for a direct-play container.
+            val automaticAudioTrackIndex =
+                TrackSelectionPresets.selectBestCompatibleAudioTrackOrdinal(
+                    tracks = version.audioTracks.orEmpty(),
+                    preferredAudioLanguage = effectivePreferredAudioLanguage,
+                    capabilities = capabilities,
+                )
+            val startAudioTrackIndex = resolveTvStartAudioTrackIndex(
+                requestedTitleTrackIndex = request.audioTrackIndex,
+                episodeHandoffTrackIndex = resolvedEpisodeSelection.audioTrackIndex,
+                automaticPreferenceTrackIndex = automaticAudioTrackIndex,
+            )
             // Skip-back-on-resume — see MobileVideoPlaybackStarter for the rationale.
             // Suppressed for Start Over / retry (request flag) and Watch Together
             // (roomId); the one rewound value drives both the server seek and the
@@ -158,8 +181,7 @@ class TvVideoPlaybackStarter(
                     // the carry-over resolved a track and then threw it away,
                     // and a dubbed household was returned to the server default
                     // at every automatic transition.
-                    audioTrackIndex = request.audioTrackIndex
-                        ?: resolvedEpisodeSelection.audioTrackIndex,
+                    audioTrackIndex = startAudioTrackIndex,
                     subtitleTrackIndex = serverSubtitleTrackIndex,
                     qualityPreference = playbackQualityIntent,
                     startPosition = startRequestPosition,
@@ -288,7 +310,7 @@ class TvVideoPlaybackStarter(
                     catalogTracks = effectiveVersion?.subtitleTracks.orEmpty(),
                     plannedTracks = resolved.subtitleUrls.orEmpty(),
                 ),
-                preferredAudioLanguage = preferredAudioLanguage ?: activeProfile?.language,
+                preferredAudioLanguage = effectivePreferredAudioLanguage ?: "en",
                 // Blank normalizes to null on every rung: a canonical row
                 // holding JSON null ("no preference") arrives here as a
                 // present-but-empty string, and TV auto-selection reads a
@@ -406,6 +428,20 @@ fun resolveTvPlaybackStartSelection(
         audioTrackIndex = resolvedAudioIndex,
     )
 }
+
+/**
+ * Playback authority for audio at launch. A track chosen on the movie/show
+ * detail is title-level intent and therefore outranks both a carried episode
+ * choice and the global language/quality preference. The preference is only
+ * the fallback when neither manual source supplied a track.
+ */
+internal fun resolveTvStartAudioTrackIndex(
+    requestedTitleTrackIndex: Int?,
+    episodeHandoffTrackIndex: Int?,
+    automaticPreferenceTrackIndex: Int?,
+): Int? = requestedTitleTrackIndex
+    ?: episodeHandoffTrackIndex
+    ?: automaticPreferenceTrackIndex
 
 /** Converts the client-side selection to the server's non-negative index contract. */
 fun resolveTvServerSubtitleTrackIndex(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvHomeSectionsEditor.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvHomeSectionsEditor.kt
@@ -1,0 +1,504 @@
+package org.siloserver.silo.tv.ui.screens.settings
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.tv.material3.Border
+import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.Icon
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Surface
+import androidx.tv.material3.Text
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
+import org.siloserver.silo.model.section.ResolvedSection
+import org.siloserver.silo.tv.data.preferences.TvHomeSectionPreferences
+import org.siloserver.silo.tv.ui.focus.TvContentInitialFocusMaxAttempts
+import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
+import org.siloserver.silo.tv.ui.screens.home.normalizeTvHomeSections
+import org.siloserver.silo.tv.ui.theme.FocusedContainer
+import org.siloserver.silo.tv.ui.theme.FocusedContent
+import org.siloserver.silo.viewmodel.HomeViewModel
+
+/** Full-screen, remote-first Home row editor matching the tvOS settings flow. */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+internal fun TvHomeSectionsEditor(
+    onDismiss: () -> Unit,
+    viewModel: HomeViewModel = koinViewModel(),
+    preferences: TvHomeSectionPreferences = koinInject(),
+) {
+    val homeState by viewModel.uiState.collectAsState()
+    val preferenceState by preferences.state.collectAsState()
+    val sections = remember(homeState.sections) {
+        homeState.sections.normalizeTvHomeSections()
+    }
+    val arrangedSections = remember(sections, preferenceState.layout) {
+        TvHomeSectionPreferences.arrange(
+            sections = sections,
+            layout = preferenceState.layout,
+            includingHidden = true,
+        )
+    }
+    val rowFocusRequesters = remember(sections.map { it.id }) {
+        sections.associate { section ->
+            section.id to HomeSectionRowFocusRequesters(
+                moveUp = FocusRequester(),
+                moveDown = FocusRequester(),
+            )
+        }
+    }
+    val doneFocusRequester = remember { FocusRequester() }
+    val scope = rememberCoroutineScope()
+    var isEditing by remember { mutableStateOf(false) }
+    var editorHasFocus by remember { mutableStateOf(false) }
+    var isClosing by remember { mutableStateOf(false) }
+
+    fun close() {
+        if (isClosing) return
+        isClosing = true
+        onDismiss()
+    }
+
+    fun move(section: ResolvedSection, offset: Int) {
+        val ids = arrangedSections.map { it.id }.toMutableList()
+        val index = ids.indexOf(section.id)
+        val target = index + offset
+        if (index < 0 || target !in ids.indices) return
+        ids[index] = ids[target]
+        ids[target] = section.id
+
+        scope.launch {
+            preferences.setOrder(ids)
+            withFrameNanos { }
+            val requesters = rowFocusRequesters[section.id] ?: return@launch
+            when (target) {
+                0 -> requesters.moveDown.requestFocus()
+                ids.lastIndex -> requesters.moveUp.requestFocus()
+                else -> if (offset < 0) {
+                    requesters.moveUp.requestFocus()
+                } else {
+                    requesters.moveDown.requestFocus()
+                }
+            }
+        }
+    }
+
+    BackHandler(onBack = ::close)
+
+    LaunchedEffect(preferences, viewModel) {
+        preferences.refresh()
+        // The shell normally already owns populated Home state. A direct
+        // Settings entry can still arrive before that first load completes,
+        // so explicitly retry only while there is nothing useful to edit.
+        if (homeState.sections.isEmpty()) viewModel.loadSections()
+    }
+
+    LaunchedEffect(Unit) {
+        requestFocusUntilObserved(
+            maxAttempts = TvContentInitialFocusMaxAttempts,
+            awaitAttempt = { withFrameNanos { } },
+            requestFocus = doneFocusRequester::requestFocus,
+            isFocused = { editorHasFocus },
+        )
+    }
+
+    Dialog(
+        onDismissRequest = ::close,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .onFocusChanged { editorHasFocus = it.hasFocus }
+                .background(SettingsBackground),
+            contentAlignment = Alignment.TopCenter,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .widthIn(max = 560.dp)
+                    .padding(horizontal = 36.dp, vertical = 18.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = "Home Sections",
+                    style = MaterialTheme.typography.displaySmall.copy(
+                        fontSize = 22.sp,
+                        lineHeight = 26.sp,
+                    ),
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White,
+                )
+                Text(
+                    text = "HOME SECTIONS",
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 14.sp,
+                        lineHeight = 17.sp,
+                        letterSpacing = 1.5.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                HomeSectionsCard {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                        ) {
+                            Text(
+                                text = "Home Sections",
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontSize = 15.sp,
+                                    lineHeight = 18.sp,
+                                ),
+                                fontWeight = FontWeight.Medium,
+                                color = Color.White,
+                            )
+                            Text(
+                                text = if (isEditing) {
+                                    "Move rows into your preferred order."
+                                } else {
+                                    "Choose which rows appear on Home."
+                                },
+                                style = MaterialTheme.typography.bodyMedium.copy(
+                                    fontSize = 14.sp,
+                                    lineHeight = 17.sp,
+                                ),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        HomeSectionsControlButton(
+                            label = if (isEditing) "Done Editing" else "Edit",
+                            onClick = { isEditing = !isEditing },
+                            enabled = arrangedSections.size >= 2,
+                        )
+                        HomeSectionsControlButton(
+                            label = "Done",
+                            onClick = ::close,
+                            focusRequester = doneFocusRequester,
+                        )
+                    }
+                }
+
+                when {
+                    arrangedSections.isEmpty() && homeState.isLoading -> {
+                        HomeSectionsMessage("Loading Home sections…")
+                    }
+                    arrangedSections.isEmpty() && homeState.error != null -> {
+                        HomeSectionsMessage(
+                            "Silo couldn’t refresh the Home rows. Try again when the server is reachable.",
+                        )
+                    }
+                    arrangedSections.isEmpty() -> {
+                        HomeSectionsMessage("Home has no populated rows to arrange yet.")
+                    }
+                    else -> {
+                        LazyColumn(
+                            modifier = Modifier.weight(1f),
+                            contentPadding = PaddingValues(bottom = 4.dp),
+                            verticalArrangement = Arrangement.spacedBy(5.dp),
+                        ) {
+                            items(arrangedSections, key = { it.id }) { section ->
+                                val visible = section.id !in preferenceState.layout.hiddenSectionIds
+                                val index = arrangedSections.indexOfFirst { it.id == section.id }
+                                HomeSectionEditorRow(
+                                    section = section,
+                                    visible = visible,
+                                    editing = isEditing,
+                                    canMoveUp = index > 0,
+                                    canMoveDown = index in 0 until arrangedSections.lastIndex,
+                                    focusRequesters = rowFocusRequesters.getValue(section.id),
+                                    onMoveUp = { move(section, -1) },
+                                    onMoveDown = { move(section, 1) },
+                                    onToggleVisibility = {
+                                        scope.launch {
+                                            preferences.setVisible(section.id, visible = !visible)
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                        Text(
+                            text = if (isEditing) {
+                                "Use the arrow buttons to move rows. The new order saves immediately."
+                            } else {
+                                "Open eye: visible on Home. Closed eye: hidden. Hidden rows leave no gap."
+                            },
+                            style = MaterialTheme.typography.bodySmall.copy(
+                                fontSize = 14.sp,
+                                lineHeight = 18.sp,
+                            ),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private data class HomeSectionRowFocusRequesters(
+    val moveUp: FocusRequester,
+    val moveDown: FocusRequester,
+)
+
+@Composable
+private fun HomeSectionsCard(content: @Composable () -> Unit) {
+    val shape = RoundedCornerShape(7.dp)
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White.copy(alpha = 0.07f), shape)
+            .border(1.dp, Color.White.copy(alpha = 0.09f), shape),
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun HomeSectionsMessage(message: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(100.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium.copy(fontSize = 14.sp, lineHeight = 18.sp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun HomeSectionEditorRow(
+    section: ResolvedSection,
+    visible: Boolean,
+    editing: Boolean,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    focusRequesters: HomeSectionRowFocusRequesters,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onToggleVisibility: () -> Unit,
+) {
+    HomeSectionsCard {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(7.dp),
+        ) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .alpha(if (visible) 1f else 0.42f),
+                verticalArrangement = Arrangement.spacedBy(1.dp),
+            ) {
+                Text(
+                    text = section.title,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontSize = 14.sp,
+                        lineHeight = 17.sp,
+                    ),
+                    fontWeight = FontWeight.Medium,
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = "${section.items.size} item${if (section.items.size == 1) "" else "s"}",
+                    style = MaterialTheme.typography.bodySmall.copy(fontSize = 14.sp, lineHeight = 18.sp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            if (editing) {
+                HomeSectionsControlButton(
+                    icon = Icons.Filled.KeyboardArrowUp,
+                    contentDescription = "Move ${section.title} earlier",
+                    onClick = onMoveUp,
+                    enabled = canMoveUp,
+                    compact = true,
+                    focusRequester = focusRequesters.moveUp,
+                )
+                HomeSectionsControlButton(
+                    icon = Icons.Filled.KeyboardArrowDown,
+                    contentDescription = "Move ${section.title} later",
+                    onClick = onMoveDown,
+                    enabled = canMoveDown,
+                    compact = true,
+                    focusRequester = focusRequesters.moveDown,
+                )
+            }
+            HomeSectionsControlButton(
+                icon = if (visible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
+                contentDescription = if (visible) {
+                    "Hide ${section.title}"
+                } else {
+                    "Show ${section.title}"
+                },
+                onClick = onToggleVisibility,
+                compact = true,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun HomeSectionsControlButton(
+    onClick: () -> Unit,
+    label: String? = null,
+    icon: ImageVector? = null,
+    contentDescription: String? = null,
+    enabled: Boolean = true,
+    compact: Boolean = false,
+    focusRequester: FocusRequester? = null,
+) {
+    val shape = RoundedCornerShape(6.dp)
+    Surface(
+        onClick = onClick,
+        enabled = enabled,
+        shape = ClickableSurfaceDefaults.shape(shape = shape),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = Color.White.copy(alpha = 0.09f),
+            contentColor = Color.White,
+            focusedContainerColor = FocusedContainer,
+            focusedContentColor = FocusedContent,
+            pressedContainerColor = FocusedContainer,
+            pressedContentColor = FocusedContent,
+            disabledContainerColor = Color.White.copy(alpha = 0.04f),
+            disabledContentColor = Color.White.copy(alpha = 0.28f),
+        ),
+        border = ClickableSurfaceDefaults.border(
+            border = Border(BorderStroke(1.dp, Color.White.copy(alpha = 0.10f)), shape = shape),
+            focusedBorder = Border.None,
+            pressedBorder = Border.None,
+        ),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.04f),
+        modifier = (focusRequester?.let { Modifier.focusRequester(it) } ?: Modifier)
+            .then(
+                if (compact) {
+                    Modifier.size(38.dp)
+                } else {
+                    // A label control is wrap-content horizontally. Its child
+                    // must not use fillMaxSize(): this button sits in a Row
+                    // whose main axis is intentionally unbounded while its
+                    // children are measured, so fillMaxSize made the first
+                    // "Edit" control consume the entire editor panel and
+                    // pushed Done + every section row off-screen.
+                    Modifier
+                        .height(38.dp)
+                        .widthIn(min = 68.dp)
+                }
+            ),
+    ) {
+        if (compact) {
+            // A fixed square needs a fixed centering box. A wrap-content Row
+            // only centred inside its own measured width, which left the eye
+            // and reorder arrows visibly offset within the 38dp surface.
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                icon?.let {
+                    Icon(
+                        imageVector = it,
+                        contentDescription = contentDescription,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+        } else {
+            Row(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    // Mirror the Surface's minimum width inside its content.
+                    // Surface does not centre a wrap-content child when its
+                    // own width is enlarged by widthIn(), so Edit/Done were
+                    // left-biased inside their focus boxes.
+                    .widthIn(min = 68.dp)
+                    .padding(horizontal = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                if (icon != null) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = contentDescription,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                if (label != null) {
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.labelLarge.copy(
+                            fontSize = 14.sp,
+                            lineHeight = 17.sp,
+                        ),
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvHomeSectionsEditor.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvHomeSectionsEditor.kt
@@ -61,6 +61,7 @@ import org.koin.compose.viewmodel.koinViewModel
 import org.siloserver.silo.model.section.ResolvedSection
 import org.siloserver.silo.tv.data.preferences.TvHomeSectionPreferences
 import org.siloserver.silo.tv.ui.focus.TvContentInitialFocusMaxAttempts
+import org.siloserver.silo.tv.ui.focus.TvFrameRelocationMaxAttempts
 import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
 import org.siloserver.silo.tv.ui.screens.home.normalizeTvHomeSections
 import org.siloserver.silo.tv.ui.theme.FocusedContainer
@@ -99,6 +100,7 @@ internal fun TvHomeSectionsEditor(
     val scope = rememberCoroutineScope()
     var isEditing by remember { mutableStateOf(false) }
     var editorHasFocus by remember { mutableStateOf(false) }
+    var focusedMoveControl by remember { mutableStateOf<Pair<String, Int>?>(null) }
     var isClosing by remember { mutableStateOf(false) }
 
     fun close() {
@@ -117,17 +119,18 @@ internal fun TvHomeSectionsEditor(
 
         scope.launch {
             preferences.setOrder(ids)
-            withFrameNanos { }
             val requesters = rowFocusRequesters[section.id] ?: return@launch
-            when (target) {
-                0 -> requesters.moveDown.requestFocus()
-                ids.lastIndex -> requesters.moveUp.requestFocus()
-                else -> if (offset < 0) {
-                    requesters.moveUp.requestFocus()
-                } else {
-                    requesters.moveDown.requestFocus()
-                }
+            val (requester, direction) = when (target) {
+                0 -> requesters.moveDown to 1
+                ids.lastIndex -> requesters.moveUp to -1
+                else -> if (offset < 0) requesters.moveUp to -1 else requesters.moveDown to 1
             }
+            requestFocusUntilObserved(
+                maxAttempts = TvFrameRelocationMaxAttempts,
+                awaitAttempt = { withFrameNanos { } },
+                requestFocus = requester::requestFocus,
+                isFocused = { focusedMoveControl == (section.id to direction) },
+            )
         }
     }
 
@@ -264,6 +267,13 @@ internal fun TvHomeSectionsEditor(
                                     canMoveUp = index > 0,
                                     canMoveDown = index in 0 until arrangedSections.lastIndex,
                                     focusRequesters = rowFocusRequesters.getValue(section.id),
+                                    onMoveFocusChanged = { direction, focused ->
+                                        val control = section.id to direction
+                                        when {
+                                            focused -> focusedMoveControl = control
+                                            focusedMoveControl == control -> focusedMoveControl = null
+                                        }
+                                    },
                                     onMoveUp = { move(section, -1) },
                                     onMoveDown = { move(section, 1) },
                                     onToggleVisibility = {
@@ -335,6 +345,7 @@ private fun HomeSectionEditorRow(
     canMoveUp: Boolean,
     canMoveDown: Boolean,
     focusRequesters: HomeSectionRowFocusRequesters,
+    onMoveFocusChanged: (direction: Int, focused: Boolean) -> Unit,
     onMoveUp: () -> Unit,
     onMoveDown: () -> Unit,
     onToggleVisibility: () -> Unit,
@@ -379,6 +390,7 @@ private fun HomeSectionEditorRow(
                     enabled = canMoveUp,
                     compact = true,
                     focusRequester = focusRequesters.moveUp,
+                    onFocusChanged = { onMoveFocusChanged(-1, it) },
                 )
                 HomeSectionsControlButton(
                     icon = Icons.Filled.KeyboardArrowDown,
@@ -387,6 +399,7 @@ private fun HomeSectionEditorRow(
                     enabled = canMoveDown,
                     compact = true,
                     focusRequester = focusRequesters.moveDown,
+                    onFocusChanged = { onMoveFocusChanged(1, it) },
                 )
             }
             HomeSectionsControlButton(
@@ -413,6 +426,7 @@ private fun HomeSectionsControlButton(
     enabled: Boolean = true,
     compact: Boolean = false,
     focusRequester: FocusRequester? = null,
+    onFocusChanged: ((Boolean) -> Unit)? = null,
 ) {
     val shape = RoundedCornerShape(6.dp)
     Surface(
@@ -436,6 +450,9 @@ private fun HomeSectionsControlButton(
         ),
         scale = ClickableSurfaceDefaults.scale(focusedScale = 1.04f),
         modifier = (focusRequester?.let { Modifier.focusRequester(it) } ?: Modifier)
+            .then(onFocusChanged?.let { callback ->
+                Modifier.onFocusChanged { callback(it.isFocused) }
+            } ?: Modifier)
             .then(
                 if (compact) {
                     Modifier.size(38.dp)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvSettingsScreen.kt
@@ -114,6 +114,7 @@ import org.siloserver.silo.tv.ui.theme.FocusedContainer
 import org.siloserver.silo.tv.ui.theme.FocusedContent
 import org.siloserver.silo.tv.ui.theme.Spacing
 import org.koin.compose.viewmodel.koinViewModel
+import org.siloserver.silo.viewmodel.HomeViewModel
 import kotlinx.coroutines.delay
 
 /**
@@ -136,6 +137,7 @@ fun TvSettingsScreen(
     onManageServersReturnFocusConsumed: () -> Unit = {},
     viewModel: TvSettingsViewModel = koinViewModel(),
     diagnosticsViewModel: TvDiagnosticsViewModel = koinViewModel(),
+    homeSectionsViewModel: HomeViewModel = koinViewModel(key = "settings-home-sections"),
 ) {
     val state by viewModel.uiState.collectAsState()
     val diagnosticsState by diagnosticsViewModel.state.collectAsState()
@@ -242,6 +244,7 @@ fun TvSettingsScreen(
         state = state,
         diagnosticsState = diagnosticsState,
         diagnosticsViewModel = diagnosticsViewModel,
+        homeSectionsViewModel = homeSectionsViewModel,
         selectedCategory = selectedCategory,
         categoryFocusRequesters = categoryFocusRequesters,
         detailFocusRequester = detailFocusRequester,
@@ -382,6 +385,7 @@ private fun SettingsSplitLayout(
     state: TvSettingsViewModel.UiState,
     diagnosticsState: org.siloserver.silo.common.diagnostics.DiagnosticsUiState,
     diagnosticsViewModel: TvDiagnosticsViewModel,
+    homeSectionsViewModel: HomeViewModel,
     selectedCategory: TvSettingsCategory,
     categoryFocusRequesters: Map<TvSettingsCategory, FocusRequester>,
     detailFocusRequester: FocusRequester,
@@ -466,6 +470,7 @@ private fun SettingsSplitLayout(
             state = state,
             diagnosticsState = diagnosticsState,
             diagnosticsViewModel = diagnosticsViewModel,
+            homeSectionsViewModel = homeSectionsViewModel,
             selectedCategory = selectedCategory,
             detailFocusRequester = detailFocusRequester,
             onDetailFocusChanged = onDetailFocusChanged,
@@ -730,6 +735,7 @@ private fun SettingsDetailPane(
     state: TvSettingsViewModel.UiState,
     diagnosticsState: org.siloserver.silo.common.diagnostics.DiagnosticsUiState,
     diagnosticsViewModel: TvDiagnosticsViewModel,
+    homeSectionsViewModel: HomeViewModel,
     selectedCategory: TvSettingsCategory,
     detailFocusRequester: FocusRequester,
     onDetailFocusChanged: (Boolean) -> Unit,
@@ -795,6 +801,7 @@ private fun SettingsDetailPane(
         when (selectedCategory) {
             TvSettingsCategory.General -> TvGeneralSettingsPane(
                 state = state,
+                homeSectionsViewModel = homeSectionsViewModel,
                 firstFocusRequester = detailFocusRequester,
                 onShowAudiobooksTabChanged = onShowAudiobooksTabChanged,
                 onCardPresentationChanged = onCardPresentationChanged,
@@ -866,6 +873,7 @@ private fun SettingsDetailPane(
 @Composable
 private fun TvGeneralSettingsPane(
     state: TvSettingsViewModel.UiState,
+    homeSectionsViewModel: HomeViewModel,
     firstFocusRequester: FocusRequester,
     onShowAudiobooksTabChanged: (Boolean) -> Unit,
     onCardPresentationChanged: (CardPresentation) -> Unit,
@@ -873,6 +881,7 @@ private fun TvGeneralSettingsPane(
     onUseProfileCardDefault: () -> Unit,
 ) {
     var activeCardPicker by remember { mutableStateOf<CardPresentationPicker?>(null) }
+    var showHomeSectionsEditor by remember { mutableStateOf(false) }
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -880,18 +889,17 @@ private fun TvGeneralSettingsPane(
         contentPadding = PaddingValues(bottom = Spacing.xxxl),
     ) {
         item {
-            // tvOS TVGeneralSettingsPane TOP MENU parity: the Audiobooks tab
-            // is opt-in (hidden by default) even when the server has an
-            // audiobook library.
-            SettingsGroup(title = "Top Menu") {
-                SettingsToggleRow(
-                    label = "Show Audiobooks",
-                    checked = state.showAudiobooksTab,
-                    onCheckedChange = onShowAudiobooksTabChanged,
+            // Device-local, server/profile-specific visibility and order for
+            // the populated rows returned by Home, matching tvOS General.
+            SettingsGroup(title = "Home Sections") {
+                SettingsValueRow(
+                    label = "Home Sections",
+                    value = "",
+                    onClick = { showHomeSectionsEditor = true },
                     focusRequester = firstFocusRequester,
                 )
                 SettingsFooterText(
-                    text = "Adds an Audiobooks tab to the top menu when your server has an audiobook library. Hidden by default.",
+                    text = "Choose which Home rows are visible and edit the order in which they appear on this Android TV.",
                 )
             }
         }
@@ -938,6 +946,21 @@ private fun TvGeneralSettingsPane(
                             "unless \"Only This Device\" is on.",
                     )
                 }
+            }
+        }
+        item {
+            // tvOS TVGeneralSettingsPane TOP MENU parity: the Audiobooks tab
+            // is opt-in (hidden by default) even when the server has an
+            // audiobook library.
+            SettingsGroup(title = "Top Menu") {
+                SettingsToggleRow(
+                    label = "Show Audiobooks",
+                    checked = state.showAudiobooksTab,
+                    onCheckedChange = onShowAudiobooksTabChanged,
+                )
+                SettingsFooterText(
+                    text = "Adds an Audiobooks tab to the top menu when your server has an audiobook library. Hidden by default.",
+                )
             }
         }
         // No Library group — tvOS parity: Apple's TVSettingsView has no such
@@ -994,6 +1017,13 @@ private fun TvGeneralSettingsPane(
         )
         null -> Unit
     }
+
+    if (showHomeSectionsEditor) {
+        TvHomeSectionsEditor(
+            onDismiss = { showHomeSectionsEditor = false },
+            viewModel = homeSectionsViewModel,
+        )
+    }
 }
 
 private enum class CardPresentationPicker {
@@ -1045,14 +1075,6 @@ private fun TvPlaybackSettingsPane(
                     onClick = { activePicker = PlaybackPicker.Quality },
                     focusRequester = firstFocusRequester,
                 )
-                SettingsValueRow(
-                    label = "Audio Language",
-                    value = LanguageOptions.label(
-                        state.audioLanguage,
-                        SettingKeys.PLAYBACK_AUDIO_LANGUAGE,
-                    ),
-                    onClick = { activePicker = PlaybackPicker.AudioLanguage },
-                )
                 // tvOS TVPlaybackSettingsPane STREAMING parity: Dolby Vision
                 // (default on; off plays the HDR10 base layer) with the
                 // narrower Profile 7 fallback nested under it — the P7 row
@@ -1073,6 +1095,27 @@ private fun TvPlaybackSettingsPane(
                     label = "Match Content Frame Rate",
                     checked = state.matchContentFrameRate,
                     onCheckedChange = onMatchContentFrameRateChanged,
+                )
+            }
+        }
+        item {
+            SettingsGroup(title = "Audio") {
+                SettingsValueRow(
+                    label = "Preferred Audio Language",
+                    value = LanguageOptions.label(
+                        state.audioLanguage,
+                        SettingKeys.PLAYBACK_AUDIO_LANGUAGE,
+                    ),
+                    onClick = { activePicker = PlaybackPicker.AudioLanguage },
+                )
+                SettingsInfoRow(
+                    label = "Audio Quality",
+                    value = "Best Compatible",
+                )
+                SettingsFooterText(
+                    text = "Uses the preferred language when available, then English. " +
+                        "Within that language, Silo chooses the highest-quality track " +
+                        "supported by this TV and its current audio output.",
                 )
             }
         }
@@ -1143,7 +1186,7 @@ private fun TvPlaybackSettingsPane(
             onDismiss = { activePicker = null },
         )
         PlaybackPicker.AudioLanguage -> TvSettingsPickerSheet(
-            title = "Audio Language",
+            title = "Preferred Audio Language",
             options = audioLanguages.map { PickerOption(it.first, it.second) },
             selectedId = state.audioLanguage,
             onSelect = { onAudioLanguageChanged(it); activePicker = null },

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -56,7 +56,6 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusDirection
@@ -163,6 +162,7 @@ import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.siloserver.silo.tv.ui.focus.TvObservedFocusResult
 import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
+import org.siloserver.silo.viewmodel.HomeViewModel
 
 /**
  * Frames the shell will wait for content to actually take focus after it
@@ -191,6 +191,11 @@ fun TvMainShell(
     onManageServers: () -> Unit,
     onOpenDiagnosticsReport: (reportId: String) -> Unit,
     onOpenItemDetail: (contentId: String) -> Unit,
+    onOpenItemDetailSelection: (
+        contentId: String,
+        seasonNumber: Int?,
+        episodeContentId: String?,
+    ) -> Unit,
     onOpenLibraryCollectionDetail: (
         libraryId: Int,
         collectionId: String,
@@ -221,6 +226,10 @@ fun TvMainShell(
     val requestsEnabled by requestsFeatureStore.isEnabled.collectAsState()
     val activeServerEntry by serverRegistry.activeEntry.collectAsState()
     val tvLibraryScopeStore: TvLibraryScopeStore = koinInject()
+    // One shell-scoped Home owner feeds both the Home screen and General's
+    // Home Sections editor. A Settings-scoped second instance could be empty
+    // while the already-visible Home instance held the populated rows.
+    val homeViewModel: HomeViewModel = koinViewModel(key = "tv-main-home")
     val serverUrl = rememberProfileServerUrl()
     val watchTogetherViewModel = koinViewModel<TvWatchTogetherViewModel>()
     val watchTogetherState by watchTogetherViewModel.uiState.collectAsState()
@@ -449,6 +458,12 @@ fun TvMainShell(
         detailReturnRoot = TvMainRoute.Home.route
         suppressHomeRefreshAfterDetail = true
         onOpenItemDetail(contentId)
+    }
+    val openHomeItemDetailSelection: (String, Int?, String?) -> Unit = { contentId, seasonNumber, episodeContentId ->
+        restoreContentAfterDetail = true
+        detailReturnRoot = TvMainRoute.Home.route
+        suppressHomeRefreshAfterDetail = true
+        onOpenItemDetailSelection(contentId, seasonNumber, episodeContentId)
     }
     val openForYouItemDetail: (String) -> Unit = { contentId ->
         restoreContentAfterDetail = true
@@ -1114,7 +1129,9 @@ fun TvMainShell(
             ) {
                 shellComposable(TvMainRoute.Video.route) {
                     TvHomeScreen(
+                        viewModel = homeViewModel,
                         onItemClick = openHomeItemDetail,
+                        onItemDetailSelection = openHomeItemDetailSelection,
                         onPlayItem = onPlayItem,
                         onSeeAll = {
                             navigateToSecondary(TvMainRoute.Browse.route)
@@ -1122,6 +1139,10 @@ fun TvMainShell(
                         },
                         onOpenForYou = {
                             openForYou(null)
+                        },
+                        onOpenSettings = {
+                            navigateToRoute(TvMainRoute.Settings.route)
+                            moveFocusToContent(TvMainRoute.Settings.route)
                         },
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                         focusRequest = contentFocusRequest,
@@ -1135,7 +1156,9 @@ fun TvMainShell(
                 }
                 shellComposable(TvMainRoute.Home.route) {
                     TvHomeScreen(
+                        viewModel = homeViewModel,
                         onItemClick = openHomeItemDetail,
+                        onItemDetailSelection = openHomeItemDetailSelection,
                         onPlayItem = onPlayItem,
                         onSeeAll = {
                             navigateToSecondary(TvMainRoute.Browse.route)
@@ -1143,6 +1166,10 @@ fun TvMainShell(
                         },
                         onOpenForYou = {
                             openForYou(null)
+                        },
+                        onOpenSettings = {
+                            navigateToRoute(TvMainRoute.Settings.route)
+                            moveFocusToContent(TvMainRoute.Settings.route)
                         },
                         onInitialContentFocus = { focusState.closeProfileMenuForContent() },
                         focusRequest = contentFocusRequest,
@@ -1325,6 +1352,7 @@ fun TvMainShell(
                 }
                 shellComposable(TvMainRoute.Settings.route) {
                     TvSettingsScreen(
+                        homeSectionsViewModel = homeViewModel,
                         onManageServers = onManageServers,
                         onOpenDiagnosticsReport = onOpenDiagnosticsReport,
                         initialManageServersFocus = returnToManageServers,
@@ -1391,28 +1419,12 @@ fun TvMainShell(
             }
         }
 
-        // The scrim TvTopMenuBar documents but the shell had stopped drawing.
-        // The bar deliberately has no background band of its own ("the SHELL
-        // draws a fixed top scrim behind the bar", QA 2026-07-08); without it
-        // the labels sit directly on whatever scrolled underneath. The gradient
-        // keeps the hero visible behind the bar on every route.
-        if (currentRoute != TvMainRoute.Settings.route) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(TvTopMenuLayout.contentTopInset)
-                    .align(Alignment.TopCenter)
-                    .background(
-                        Brush.verticalGradient(
-                            listOf(
-                                MaterialTheme.colorScheme.background.copy(alpha = 0.92f),
-                                MaterialTheme.colorScheme.background.copy(alpha = 0.72f),
-                                MaterialTheme.colorScheme.background.copy(alpha = 0f),
-                            ),
-                        ),
-                    ),
-            )
-        }
+        // Shared one-layer nav shadow. Root artwork no longer draws a second
+        // scrim, so Home and flat shell pages have identical chrome.
+        TvTopMenuDropShadow(
+            visibility = if (currentRoute == TvMainRoute.Settings.route) 0f else menuVisibility.value,
+            modifier = Modifier.align(Alignment.TopCenter),
+        )
 
         // Menu overlay — content remains visible behind the transparent bar,
         // matching tvOS without a heavy top-edge shadow.

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
@@ -3,7 +3,6 @@ package org.siloserver.silo.tv.ui.shell
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.focusGroup
@@ -47,7 +46,6 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.res.painterResource
 import kotlinx.coroutines.delay
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -60,7 +58,6 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
-import org.siloserver.silo.tv.R
 import org.siloserver.silo.tv.ui.focus.claimFocusOrReport
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.common.ui.components.ProfileAvatarRef
@@ -118,6 +115,36 @@ object TvTopMenuLayout {
 }
 
 /**
+ * One shared, soft shadow behind the floating top navigation.
+ *
+ * Root artwork used to paint its own black top scrim while the shell painted a
+ * second background-coloured gradient. Home therefore had a much heavier band
+ * than flat pages, and the two different colours could expose a visible seam.
+ * Keeping this layer beside the bar gives every route exactly one shadow and
+ * lets it disappear with the bar on full-screen surfaces such as Settings.
+ */
+@Composable
+internal fun TvTopMenuDropShadow(
+    visibility: Float,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(TvTopMenuLayout.contentTopInset)
+            .graphicsLayer { alpha = visibility.coerceIn(0f, 1f) }
+            .background(
+                Brush.verticalGradient(
+                    0.00f to Color.Black.copy(alpha = 0.58f),
+                    0.58f to Color.Black.copy(alpha = 0.42f),
+                    0.80f to Color.Black.copy(alpha = 0.14f),
+                    1.00f to Color.Transparent,
+                ),
+            ),
+    )
+}
+
+/**
  * Identifies which menu button currently holds focus. Library-type tabs share
  * the [Tab] case keyed by [TvLibraryTabType]; the remaining cases are the
  * fixed Home/Calendar tabs plus the Search icon and trailing profile avatar.
@@ -135,8 +162,7 @@ private sealed class TvTopMenuFocus {
  * The custom top menu bar — the Skyline grammar from tvOS `TVTopMenuBar.swift`.
  *
  * Layout (three zones):
- * - Leading: the Silo brand lockup (`R.drawable.silo_wordmark`, see
- *   [TvSiloWordmark]).
+ * - Leading: the tracked SILO wordmark used by tvOS (see [TvSiloWordmark]).
  * - Center: Search icon · `Home` · one inverted-capsule tab per visible
  *   library-type · `Calendar`, derived from [destinations] (the shell's
  *   `visibleRoots`), with an invisible search-size twin trailing the tabs so
@@ -677,41 +703,19 @@ data class TvAccountState(
 )
 
 /**
- * The Silo brand lockup at the bar's leading edge (§5.1).
- *
- * This is the shipped trademark artwork, not type: silo-branding's
- * `silo-wordmark-white.svg` as its `derive.py` renders it for Android
- * (`R.drawable.silo_wordmark`, 764x400). Branding's own rules pick both the
- * variant and the treatment:
- * - *"Pick the variant that contrasts with its background: dark art on light,
- *   white on dark."* The menu bar is dark chrome, so the **white** lockup is the
- *   correct cut — and it is the only wordmark `derive.py` emits for Android.
- * - *"Don't recolour the mark, or add shadows, outlines or effects."* So, unlike
- *   the `Text` this replaced, no `SiloOnSurface` tint is applied. The lockup's
- *   type is already `#FFFFFF` and its three bars carry the signal palette; a
- *   `ColorFilter` would flatten them and breach the trademark guidance.
- * - *"Typeset 'Silo' in place of the supplied wordmark"* is on branding's
- *   **Don't** list — which is precisely what the old `Text("SILO")` did.
- *
- * The PNG is used rather than a hand-built `VectorDrawable` because `derive.py`
- * is branding's declared source of truth for downstream Android assets and emits
- * exactly this file at exactly this path; a transcribed vector would fork the
- * mark out of that pipeline and go stale the next time the artwork changes. It
- * costs nothing in sharpness: the source is 764px wide against a ~46dp render
- * (92px at the 320dpi TV reference, 184px even on a 4x surface).
- *
- * Height comes from [TvSkyline.wordmarkHeight]; the width follows the drawable's
- * intrinsic 764:400 ratio (~45.8.dp) with [ContentScale.Fit], so the artwork is
- * never stretched or cropped — also forbidden. Decorative: an `Image` adds no
- * focusable node, so the bar's D-pad order is unchanged.
+ * The approved Apple TV bar deliberately uses a heavy text mark rather than
+ * the multicolour image lockup: 26pt with 0.34-em tracking. Android's TV canvas
+ * is half scale, with a 14sp floor for ten-foot readability.
  */
 @Composable
 private fun TvSiloWordmark() {
-    Image(
-        painter = painterResource(id = R.drawable.silo_wordmark),
-        contentDescription = "Silo",
-        contentScale = ContentScale.Fit,
-        modifier = Modifier.height(TvSkyline.wordmarkHeight),
+    Text(
+        text = "SILO",
+        color = Color.White,
+        fontSize = 14.sp,
+        fontWeight = FontWeight.ExtraBold,
+        letterSpacing = 4.42.sp,
+        maxLines = 1,
     )
 }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvControlWiringCallSiteTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvControlWiringCallSiteTest.kt
@@ -141,14 +141,15 @@ class TvControlWiringCallSiteTest {
     fun singleChoiceSelectorPillStaysFocusableAndNoOps() {
         val selector = source("ui/components/TvAnchoredSelectorMenu.kt")
             .declarationBody("TvAnchoredSelectorMenu")
+        val pillArguments = selector.argumentsOf("SquaredPillSurface(")
 
         assertFalse(
-            selector.argumentsOf("SquaredPillSurface(").containsLoosely("enabled ="),
+            pillArguments.containsLoosely("enabled ="),
             "the selector pill must stay focusable, so it must not hand its trigger an enabled flag",
         )
         assertEquals(
             1,
-            selector.countLoosely("onClick = { if (interactive) expansionRequested = true }"),
+            pillArguments.countLoosely("onClick = { if (interactive) expansionRequested = true }"),
             "a non-interactive selector pill must swallow Select rather than leave the focus graph",
         )
         assertEquals(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarqueeModelTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarqueeModelTest.kt
@@ -1,13 +1,16 @@
 package org.siloserver.silo.tv.ui.components
 
+import java.io.File
 import org.siloserver.silo.model.catalog.OverlaySummary
 import org.siloserver.silo.model.section.SectionItem
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class TvFocusMarqueeModelTest {
     @Test
-    fun movieHeroPrioritizesEditorialMetadataAndOmitsStreamQuality() {
+    fun movieHeroSeparatesEditorialMetadataFromFormatBadges() {
         val content = TvMarqueeContent.from(
             item = SectionItem(
                 contentId = "movie-1",
@@ -32,6 +35,7 @@ class TvFocusMarqueeModelTest {
             listOf("2016", "1h 56m", "7.9", "Science Fiction"),
             content.metaParts,
         )
+        assertEquals("4K · Dolby Vision · Atmos", content.specLine)
     }
 
     @Test
@@ -57,10 +61,45 @@ class TvFocusMarqueeModelTest {
 
         assertEquals("The Last of Us", content.title)
         assertEquals(listOf("TV-MA"), content.badges)
-        assertEquals(
-            listOf("S1 E3", "Long, Long Time", "1h 16m", "8.6"),
-            content.metaParts,
+        assertEquals(listOf("S1 E3", "Long, Long Time"), content.metaParts)
+        assertEquals("1080P · EAC3", content.specLine)
+    }
+
+    @Test
+    fun homeHeroOmitsEpisodeRuntimeAndRemainingTime() {
+        val content = TvMarqueeContent.from(
+            item = SectionItem(
+                contentId = "episode-progress",
+                type = "episode",
+                title = "Persuader",
+                seriesTitle = "Reacher",
+                seasonNumber = 3,
+                episodeNumber = 1,
+                runtime = 53,
+                positionSeconds = 240.0,
+                durationSeconds = 3_180.0,
+            ),
+            rowTitle = "Continue Watching",
         )
+
+        assertEquals(listOf("S3 E1", "Persuader"), content.metaParts)
+        assertFalse(content.metaParts.any { it.contains("left", ignoreCase = true) })
+        assertFalse(content.metaParts.any { it.contains("min", ignoreCase = true) })
+    }
+
+    @Test
+    fun homeHeroUsesOneOutlinedBadgeStyleForRatingAndFormats() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvFocusMarquee.kt",
+        ).readText()
+
+        assertTrue(source.contains("content.specLine"))
+        assertTrue(source.contains("?.split(\" · \")"))
+        assertTrue(source.contains("badges.forEach { badge -> MarqueeBadge(badge.uppercase()) }"))
+        assertTrue(source.contains("Color.White.copy(alpha = 0.08f)"))
+        assertTrue(source.contains("Color.White.copy(alpha = 0.24f)"))
+        assertTrue(source.contains("private val MarqueeBadgeSize = 10.5.sp"))
+        assertFalse(source.contains("FontFamily.Monospace"))
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvStockKeyboardPolicyTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/components/TvStockKeyboardPolicyTest.kt
@@ -51,4 +51,16 @@ class TvStockKeyboardPolicyTest {
             "these raise the stock TV keyboard without dismissing it on disposal: $offenders",
         )
     }
+
+    @Test
+    fun escapeUsesNormalBackDispatchSoPopupsCloseBeforeThePage() {
+        val source = File("src/androidMain/kotlin/org/siloserver/silo/tv/MainTvActivity.kt").readText()
+        val dispatch = source
+            .substringAfter("override fun dispatchKeyEvent(event: KeyEvent): Boolean")
+            .substringBefore("private fun handleIntent")
+
+        assertTrue(dispatch.contains("KeyEvent.KEYCODE_BACK"))
+        assertTrue(dispatch.contains("super.dispatchKeyEvent(translatedEvent)"))
+        assertFalse(dispatch.contains("onBackPressedDispatcher.onBackPressed()"))
+    }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/navigation/TvItemDetailNavigationTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/navigation/TvItemDetailNavigationTest.kt
@@ -73,6 +73,48 @@ class TvItemDetailNavigationTest {
     }
 
     @Test
+    fun `the same continue watching episode is the current page`() {
+        assertTrue(
+            tvIsAlreadyShowingItemDetail(
+                currentRoute = TvRoute.ItemDetail.ROUTE,
+                currentContentId = "series-a",
+                currentSeasonNumber = 3,
+                currentEpisodeContentId = "episode-1",
+                contentId = "series-a",
+                seasonNumber = 3,
+                episodeContentId = "episode-1",
+            ),
+        )
+    }
+
+    @Test
+    fun `another episode in the same season is a different detail request`() {
+        assertFalse(
+            tvIsAlreadyShowingItemDetail(
+                currentRoute = TvRoute.ItemDetail.ROUTE,
+                currentContentId = "series-a",
+                currentSeasonNumber = 3,
+                currentEpisodeContentId = "episode-1",
+                contentId = "series-a",
+                seasonNumber = 3,
+                episodeContentId = "episode-2",
+            ),
+        )
+    }
+
+    @Test
+    fun `continue watching route carries encoded series season and episode`() {
+        assertEquals(
+            "item/series%2Fa?seasonNumber=3&episodeContentId=episode%2F1",
+            TvRoute.ItemDetail(
+                contentId = "series/a",
+                seasonNumber = 3,
+                episodeContentId = "episode/1",
+            ).route,
+        )
+    }
+
+    @Test
     fun `the identical request on the same entry is suppressed`() {
         val destination = TvRoute.Player(contentId = "movie-a").route
         assertEquals(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
@@ -1,8 +1,11 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TvDetailFocusPolicyTest {
     @Test
@@ -11,4 +14,141 @@ class TvDetailFocusPolicyTest {
         assertEquals(2, restoredRailIndex(5, 3))
         assertNull(restoredRailIndex(0, 0))
     }
+
+    @Test
+    fun episodeRailInitialCenterDoesNotRestartForEachFocusedEpisode() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt",
+        ).readText()
+
+        assertTrue(source.contains("LaunchedEffect(episodeSetKey)"))
+        assertFalse(source.contains("LaunchedEffect(currentContentId, episodes.size)"))
+    }
+
+    @Test
+    fun seriesPrimaryControlsKeepActionsAndOrderSeasonsBeforeEpisodes() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
+        ).readText()
+        val episodesSection = source
+            .substringAfter("private fun EpisodesSection(")
+            .substringBefore("private fun currentEpisodeRailContentId")
+
+        val seasons = episodesSection.indexOf("if (showsSeasonChips)")
+        val episodes = episodesSection.indexOf("TvDetailEpisodeRail(")
+
+        assertFalse(source.contains("seriesPlaybackSelector"))
+        assertTrue(seasons < episodes)
+        assertTrue(episodesSection.contains("padding(top = SeriesSeasonPickerTopPadding)"))
+        assertFalse(source.contains("if (!isSeriesDetail || isShowingSeriesOverview)"))
+        assertFalse(source.contains("onItemDetail(episode.contentId)"))
+    }
+
+    @Test
+    fun videoDetailsUseCircularPlaybackControlsAndSharedOverflow() {
+        val detailSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
+        ).readText()
+        val selectorSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackSelectorRow.kt",
+        ).readText()
+        val menuSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt",
+        ).readText()
+
+        assertTrue(detailSource.contains("TvPlaybackActionSelectors("))
+        assertFalse(detailSource.contains("if (showsSelectorRow) down = selectorFocus"))
+        assertTrue(detailSource.contains("contentDescription = if (state.inWatchlist)"))
+        assertTrue(detailSource.contains("icon = Icons.Filled.BookmarkBorder"))
+        assertTrue(detailSource.contains("key = \"favorite\""))
+        assertTrue(detailSource.contains("key = \"watched\""))
+        assertTrue(selectorSource.contains("icon = Icons.Filled.Movie"))
+        assertTrue(selectorSource.contains("icon = Icons.AutoMirrored.Filled.VolumeUp"))
+        assertTrue(selectorSource.contains("icon = Icons.AutoMirrored.Filled.Chat"))
+        assertTrue(selectorSource.contains("triggerStyle = TvSelectorTriggerStyle.CircularAction"))
+        assertTrue(menuSource.contains("TvSelectorTriggerStyle.CircularAction -> TvSquareToggleButton("))
+    }
+
+    @Test
+    fun seriesActionChromeAndCurrentEpisodeLabelsRemainCompactAndReadable() {
+        val detailSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
+        ).readText()
+        val buttonSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSquaredButtons.kt",
+        ).readText()
+        val episodeSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt",
+        ).readText()
+
+        assertTrue(buttonSource.contains("Color.White.copy(alpha = 0.76f)"))
+        assertFalse(detailSource.contains("private fun CircleAction("))
+        assertTrue(detailSource.contains("iconActive = Icons.Filled.SkipPrevious"))
+        assertTrue(episodeSource.contains("text = \"NOW VIEWING\""))
+        assertTrue(episodeSource.contains("fontSize = 14.sp"))
+    }
+
+    @Test
+    fun playbackSelectionReadoutSitsUnderFactsAndUsesNoPillChrome() {
+        val heroSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt",
+        ).readText()
+        val detailSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
+        ).readText()
+        val editorial = heroSource
+            .substringAfter("private fun EditorialColumn(")
+            .substringBefore("private fun TitleBlock(")
+        val playbackReadout = detailSource
+            .substringAfter("private fun TvDetailPlaybackSelectionSummary(")
+            .substringBefore("private fun HeroActionRow(")
+
+        val facts = editorial.indexOf("MetadataRow(")
+        val playback = editorial.indexOf("playbackSummary?.invoke()")
+        val synopsis = editorial.indexOf("TvExpandableSynopsis(")
+
+        assertTrue(facts >= 0)
+        assertTrue(facts < playback)
+        assertTrue(playback < synopsis)
+        assertTrue(detailSource.contains("label = \"VERSION\""))
+        assertTrue(detailSource.contains("label = \"AUDIO\""))
+        assertTrue(detailSource.contains("label = \"SUBTITLES\""))
+        assertTrue(detailSource.contains("includePlaybackFormats = false"))
+        assertFalse(playbackReadout.contains("Modifier.weight("))
+        assertTrue(playbackReadout.contains("Arrangement.spacedBy(12.dp)"))
+        assertTrue(playbackReadout.contains("Modifier.height(TV_PLAYBACK_SUMMARY_HEIGHT)"))
+        assertTrue(playbackReadout.contains("TvPlaybackSummarySkeleton(valueWidth)"))
+        assertTrue(playbackReadout.contains("modifier = Modifier.width(valueWidth)"))
+        assertFalse(playbackReadout.contains("Spacer(modifier = Modifier.size"))
+    }
+
+    @Test
+    fun episodeMetadataKeepsTheShowOverviewActionBaseline() {
+        val heroSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt",
+        ).readText()
+
+        assertTrue(heroSource.contains("seriesOverviewEditorialHeightPx"))
+        assertTrue(heroSource.contains("seriesTitle == null"))
+        assertTrue(heroSource.contains("Modifier.height(with(density)"))
+        assertTrue(heroSource.contains("isCombinedSeriesEpisode"))
+        assertTrue(heroSource.contains("SERIES_METADATA_SLOT_HEIGHT"))
+        assertTrue(heroSource.contains("SERIES_EPISODE_SYNOPSIS_HEIGHT"))
+        assertTrue(heroSource.contains("previewText = if (isCombinedSeriesEpisode)"))
+        assertFalse(heroSource.contains("Spacer(modifier = Modifier.weight(1f))"))
+    }
+
+    @Test
+    fun synopsisOpensScrollablePopupWithoutExpandingThePage() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvExpandableSynopsis.kt",
+        ).readText()
+
+        assertTrue(source.contains("showFullSynopsis = true"))
+        assertTrue(source.contains("private fun TvSynopsisDialog("))
+        assertTrue(source.contains("PopupProperties(focusable = true, dismissOnBackPress = true)"))
+        assertTrue(source.contains(".verticalScroll(scrollState)"))
+        assertFalse(source.contains("expanded = !expanded"))
+    }
+
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.siloserver.silo.model.catalog.Season
 
 class TvDetailFocusPolicyTest {
     @Test
@@ -86,12 +87,17 @@ class TvDetailFocusPolicyTest {
         assertTrue(buttonSource.contains("Color.White.copy(alpha = 0.76f)"))
         assertFalse(detailSource.contains("private fun CircleAction("))
         assertTrue(detailSource.contains("iconActive = Icons.Filled.SkipPrevious"))
+        assertTrue(detailSource.contains("Modifier.width(170.dp)"))
         assertTrue(episodeSource.contains("text = \"NOW VIEWING\""))
-        assertTrue(episodeSource.contains("fontSize = 14.sp"))
+        assertTrue(episodeSource.contains("val eyebrowFontSize = if (usesSeriesGeometry) 11.sp else 14.sp"))
+        assertTrue(episodeSource.contains("fontSize = 11.5.sp"))
+        assertTrue(episodeSource.contains("tvEpisodeCardWidth()"))
+        assertTrue(episodeSource.contains("cardWidth * (9f / 16f)"))
+        assertTrue(episodeSource.contains("Modifier else Modifier.scale(scale)"))
     }
 
     @Test
-    fun playbackSelectionReadoutSitsUnderFactsAndUsesNoPillChrome() {
+    fun seriesCreditAndPlaybackReadoutStayLockedBelowSynopsisWithoutPillChrome() {
         val heroSource = File(
             "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt",
         ).readText()
@@ -106,21 +112,33 @@ class TvDetailFocusPolicyTest {
             .substringBefore("private fun HeroActionRow(")
 
         val facts = editorial.indexOf("MetadataRow(")
-        val playback = editorial.indexOf("playbackSummary?.invoke()")
         val synopsis = editorial.indexOf("TvExpandableSynopsis(")
+        val credit = editorial.indexOf("SERIES_CREDIT_SLOT_HEIGHT")
+        val playback = editorial.lastIndexOf("playbackSummary?.invoke()")
 
         assertTrue(facts >= 0)
-        assertTrue(facts < playback)
-        assertTrue(playback < synopsis)
+        assertTrue(facts < synopsis)
+        assertTrue(synopsis < credit)
+        assertTrue(credit < playback)
+        assertTrue(heroSource.contains("if (!compactSeries && sourceTokens.isNotEmpty())"))
+        assertTrue(heroSource.contains("sourceTokens = sourceTokens"))
+        assertTrue(heroSource.contains("compactRating = true"))
+        assertFalse(editorial.contains("if (!compactSeries) playbackSummary?.invoke()"))
+        assertTrue(editorial.lastIndexOf("HeroCreditLine(line)") < playback)
+        assertTrue(heroSource.contains("fontSize = if (compact) 10.5.sp else 14.sp"))
+        assertTrue(heroSource.contains("SERIES_HERO_HEIGHT_FRACTION = 610f / 1080f"))
         assertTrue(detailSource.contains("label = \"VERSION\""))
         assertTrue(detailSource.contains("label = \"AUDIO\""))
         assertTrue(detailSource.contains("label = \"SUBTITLES\""))
         assertTrue(detailSource.contains("includePlaybackFormats = false"))
-        assertFalse(playbackReadout.contains("Modifier.weight("))
-        assertTrue(playbackReadout.contains("Arrangement.spacedBy(12.dp)"))
+        assertTrue(playbackReadout.contains("Modifier.weight(1f)"))
+        assertTrue(playbackReadout.contains("Arrangement.spacedBy(6.dp)"))
         assertTrue(playbackReadout.contains("Modifier.height(TV_PLAYBACK_SUMMARY_HEIGHT)"))
-        assertTrue(playbackReadout.contains("TvPlaybackSummarySkeleton(valueWidth)"))
-        assertTrue(playbackReadout.contains("modifier = Modifier.width(valueWidth)"))
+        assertTrue(playbackReadout.contains("TvPlaybackSummarySkeleton(modifier = Modifier.weight(1f))"))
+        assertTrue(playbackReadout.contains("modifier = Modifier.width(itemWidth)"))
+        assertTrue(playbackReadout.contains("TV_PLAYBACK_VERSION_ITEM_WIDTH = 120.dp"))
+        assertTrue(playbackReadout.contains("TV_PLAYBACK_AUDIO_ITEM_WIDTH = 160.dp"))
+        assertTrue(playbackReadout.contains("TV_PLAYBACK_SUBTITLE_ITEM_WIDTH = 130.dp"))
         assertFalse(playbackReadout.contains("Spacer(modifier = Modifier.size"))
     }
 
@@ -136,8 +154,83 @@ class TvDetailFocusPolicyTest {
         assertTrue(heroSource.contains("isCombinedSeriesEpisode"))
         assertTrue(heroSource.contains("SERIES_METADATA_SLOT_HEIGHT"))
         assertTrue(heroSource.contains("SERIES_EPISODE_SYNOPSIS_HEIGHT"))
+        assertTrue(heroSource.contains("SERIES_CREDIT_SLOT_HEIGHT"))
         assertTrue(heroSource.contains("previewText = if (isCombinedSeriesEpisode)"))
         assertFalse(heroSource.contains("Spacer(modifier = Modifier.weight(1f))"))
+    }
+
+    @Test
+    fun seriesSeasonSelectionKeepsAppleStyleCenteredPan() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt",
+        ).readText()
+        val seriesPicker = source
+            .substringAfter("fun TvSeriesModePicker(")
+            .substringBefore("private fun TvSeriesModeTab(")
+        val modeTab = source
+            .substringAfter("private fun TvSeriesModeTab(")
+            .substringBefore("private fun Modifier.seriesModeFocusRing")
+
+        assertTrue(seriesPicker.contains("LaunchedEffect(selectedIndex, seasons.size)"))
+        assertTrue(seriesPicker.contains("listState.scrollToItem(selectedIndex)"))
+        assertTrue(seriesPicker.contains("val viewportCenter"))
+        assertTrue(seriesPicker.contains("val itemCenter"))
+        assertTrue(seriesPicker.contains("listState.animateScrollBy(itemCenter - viewportCenter)"))
+        assertTrue(modeTab.contains("if (focusState.isFocused && !isSelected) onActivated()"))
+        assertTrue(modeTab.contains("onClick = onActivated"))
+    }
+
+    @Test
+    fun seriesEpisodesSlideAsOneDirectionalSeasonCarousel() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
+        ).readText()
+        val episodesSection = source
+            .substringAfter("private fun EpisodesSection(")
+            .substringBefore("private fun currentEpisodeRailContentId")
+        val seasons = listOf(
+            Season(contentId = "season-1", seasonNumber = 1),
+            Season(contentId = "season-2", seasonNumber = 2),
+            Season(contentId = "specials", seasonNumber = 0, isSpecials = true),
+        )
+
+        assertEquals(1, seriesEpisodeCarouselDirection(1, 2, seasons))
+        assertEquals(-1, seriesEpisodeCarouselDirection(2, 1, seasons))
+        assertEquals(1, seriesEpisodeCarouselDirection(2, 0, seasons))
+        assertTrue(episodesSection.contains("AnimatedContent("))
+        assertTrue(episodesSection.contains("contentKey = { it.seasonNumber }"))
+        assertTrue(episodesSection.contains("slideInHorizontally("))
+        assertTrue(episodesSection.contains("slideOutHorizontally("))
+        assertTrue(episodesSection.contains("SizeTransform(clip = false)"))
+        assertTrue(source.contains("SERIES_EPISODE_CAROUSEL_DURATION_MS = 360"))
+        assertFalse(episodesSection.contains("durationMillis = 280"))
+        assertTrue(
+            episodesSection.contains(
+                "state.episodesLoading && (!isSeries || state.episodes.isEmpty())",
+            ),
+        )
+    }
+
+    @Test
+    fun entryRouteSeasonIsConsumedBeforeFocusDrivenSelection() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
+        ).readText()
+        val hydration = source
+            .substringAfter("var pendingEntrySeasonNumber")
+            .substringBefore("initialEpisodeContentId,")
+        val effectKeys = hydration
+            .substringAfter("LaunchedEffect(")
+            .substringBefore(") {")
+
+        assertTrue(hydration.contains("rememberSaveable(contentId, seasonNumber)"))
+        assertTrue(effectKeys.contains("pendingEntrySeasonNumber"))
+        assertFalse(effectKeys.contains("state.selectedSeason"))
+        assertTrue(hydration.contains("pendingEntrySeasonNumber = null"))
+        assertTrue(
+            hydration.indexOf("pendingEntrySeasonNumber = null") <
+                hydration.lastIndexOf("viewModel.onSeasonSelected(entrySeason)"),
+        )
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
@@ -38,6 +38,8 @@ class TvDetailFocusPolicyTest {
         val episodes = episodesSection.indexOf("TvDetailEpisodeRail(")
 
         assertFalse(source.contains("seriesPlaybackSelector"))
+        assertTrue(seasons >= 0)
+        assertTrue(episodes >= 0)
         assertTrue(seasons < episodes)
         assertTrue(episodesSection.contains("padding(top = SeriesSeasonPickerTopPadding)"))
         assertFalse(source.contains("if (!isSeriesDetail || isShowingSeriesOverview)"))

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHeroArtworkTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHeroArtworkTest.kt
@@ -1,9 +1,12 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
+import androidx.compose.ui.graphics.Color
+import java.io.File
 import org.siloserver.silo.model.catalog.EpisodeListItem
 import org.siloserver.silo.model.catalog.ItemDetail
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 class TvDetailHeroArtworkTest {
@@ -65,5 +68,40 @@ class TvDetailHeroArtworkTest {
 
         assertNull(artwork.url)
         assertNull(artwork.thumbhash)
+    }
+
+    @Test
+    fun detailPageTintIsOpaqueAndCompositedOverBlack() {
+        val surface = tvDetailPageSurfaceColor(Color(red = 1f, green = 0.5f, blue = 0f))
+
+        assertEquals(0.42f, surface.red, absoluteTolerance = ColorChannelTolerance)
+        assertEquals(0.21f, surface.green, absoluteTolerance = ColorChannelTolerance)
+        assertEquals(0f, surface.blue, absoluteTolerance = ColorChannelTolerance)
+        assertEquals(1f, surface.alpha, absoluteTolerance = ColorChannelTolerance)
+    }
+
+    @Test
+    fun detailPageUsesApprovedDefaultTintBeforeArtworkSamplingCompletes() {
+        val surface = tvDetailPageSurfaceColor(null)
+
+        assertEquals(0.0168f, surface.red, absoluteTolerance = ColorChannelTolerance)
+        assertEquals(0.0504f, surface.green, absoluteTolerance = ColorChannelTolerance)
+        assertEquals(0.0588f, surface.blue, absoluteTolerance = ColorChannelTolerance)
+        assertEquals(1f, surface.alpha, absoluteTolerance = ColorChannelTolerance)
+    }
+
+    @Test
+    fun seriesArtworkDoesNotExposeATintedStripAboveTheImage() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt",
+        ).readText()
+
+        assertFalse(source.contains("SERIES_ARTWORK_TOP_OFFSET"))
+        assertFalse(source.contains(".offset(y = if (compactSeries)"))
+    }
+
+    private companion object {
+        // Compose packs sRGB Color channels to 8-bit precision.
+        const val ColorChannelTolerance = 1f / 255f
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadataTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadataTest.kt
@@ -2,6 +2,7 @@ package org.siloserver.silo.tv.ui.screens.detail
 
 import org.siloserver.silo.model.audiobook.AudiobookMetadata
 import org.siloserver.silo.model.catalog.AudioTrack
+import org.siloserver.silo.model.catalog.EpisodeListItem
 import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.catalog.SubtitleTrack
@@ -12,6 +13,44 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class TvDetailMetadataTest {
+    @Test
+    fun seriesEpisodeEditorialMatchesTvOsHierarchy() {
+        val episode = EpisodeListItem(
+            contentId = "e1",
+            seasonNumber = 3,
+            episodeNumber = 1,
+            title = "Smells Like Mean Spirit",
+            airDate = "2026-03-30T00:00:00Z",
+            runtime = 52,
+        )
+
+        assertEquals(
+            listOf("Season 3", "Episode 1"),
+            TvDetailMetadata.seriesEpisodeSourceTokens(episode),
+        )
+        assertEquals(
+            listOf(
+                TvHeroFactToken.TextToken("Mar 30, 2026"),
+                TvHeroFactToken.TextToken("52 min"),
+            ),
+            TvDetailMetadata.seriesEpisodeFactsLine(episode, zone = ZoneId.of("UTC")),
+        )
+    }
+
+    @Test
+    fun seriesSpecialEditorialUsesSpecialsLabel() {
+        val episode = EpisodeListItem(
+            contentId = "special-1",
+            seasonNumber = 0,
+            episodeNumber = 1,
+        )
+
+        assertEquals(
+            listOf("Specials", "Episode 1"),
+            TvDetailMetadata.seriesEpisodeSourceTokens(episode),
+        )
+    }
+
     @Test
     fun episodeFactsPutAirDateBeforeRuntime() {
         val detail = ItemDetail(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadataTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadataTest.kt
@@ -5,6 +5,7 @@ import org.siloserver.silo.model.catalog.AudioTrack
 import org.siloserver.silo.model.catalog.EpisodeListItem
 import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.catalog.ItemDetail
+import org.siloserver.silo.model.catalog.ItemVideo
 import org.siloserver.silo.model.catalog.SubtitleTrack
 import org.siloserver.silo.model.catalog.VideoTrack
 import org.siloserver.silo.model.ebook.MediaPerson
@@ -48,6 +49,36 @@ class TvDetailMetadataTest {
         assertEquals(
             listOf("Specials", "Episode 1"),
             TvDetailMetadata.seriesEpisodeSourceTokens(episode),
+        )
+    }
+
+    @Test
+    fun seriesEditorialOmitsUnknownEpisodeNumber() {
+        val episode = EpisodeListItem(
+            contentId = "special",
+            seasonNumber = 0,
+            episodeNumber = 0,
+        )
+
+        assertEquals(
+            listOf("Specials"),
+            TvDetailMetadata.seriesEpisodeSourceTokens(episode),
+        )
+    }
+
+    @Test
+    fun trailerEntriesDeduplicateProviderKeysUsedByTheRail() {
+        val duplicate = ItemVideo(kind = "trailer", site = "youtube", siteKey = "abc")
+        val detail = ItemDetail(
+            contentId = "m1",
+            type = "movie",
+            title = "Movie",
+            videos = listOf(duplicate, duplicate.copy(name = "Duplicate")),
+        )
+
+        assertEquals(
+            listOf("remote:youtube:abc"),
+            tvDetailTrailerEntries(detail).map { it.key },
         )
     }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDirectorCreditSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDirectorCreditSourceTest.kt
@@ -14,17 +14,24 @@ class TvDirectorCreditSourceTest {
 
     @Test
     fun tvMovieHeroUsesSharedDirectorCredit() {
-        assertTrue(screen.contains("directorText = movieDirectorCredit(detail)"))
+        assertTrue(screen.contains("val heroCreditText = if (isSeriesDetail)"))
+        assertTrue(screen.contains("movieDirectorCredit(detail).takeIf"))
+        assertTrue(screen.contains("directorText = heroCreditText"))
     }
 
     @Test
-    fun approvedMetadataPrecedesSynopsisAndTvCreditFollowsTranslation() {
-        val metadata = hero.indexOf("MetadataRow(tokens = factsLine")
+    fun approvedMetadataPrecedesSynopsisAndPlaybackFollowsTvCredit() {
+        val metadata = hero.indexOf("MetadataRow(")
         val synopsis = hero.indexOf("overview?.takeIf")
         val translation = hero.indexOf("translation?.invoke()")
         val director = hero.indexOf("directorText?.takeIf")
+        val playback = hero.lastIndexOf("playbackSummary?.invoke()")
         assertTrue(
-            metadata >= 0 && metadata < synopsis && synopsis < translation && translation < director,
+            metadata >= 0 &&
+                metadata < synopsis &&
+                synopsis < translation &&
+                translation < director &&
+                director < playback,
         )
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDirectorCreditSourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDirectorCreditSourceTest.kt
@@ -18,10 +18,13 @@ class TvDirectorCreditSourceTest {
     }
 
     @Test
-    fun tvCreditStaysBetweenTranslationAndFacts() {
+    fun approvedMetadataPrecedesSynopsisAndTvCreditFollowsTranslation() {
+        val metadata = hero.indexOf("MetadataRow(tokens = factsLine")
+        val synopsis = hero.indexOf("overview?.takeIf")
         val translation = hero.indexOf("translation?.invoke()")
         val director = hero.indexOf("directorText?.takeIf")
-        val facts = hero.indexOf("if (factsLine.isNotEmpty())", startIndex = director)
-        assertTrue(translation >= 0 && translation < director && director < facts)
+        assertTrue(
+            metadata >= 0 && metadata < synopsis && synopsis < translation && translation < director,
+        )
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
@@ -59,6 +59,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -69,6 +70,61 @@ import kotlin.test.assertTrue
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvNextUpSelectionHandoffTest {
+    @Test
+    fun delayedSeasonRefreshPreservesNewerSelectionAndInvalidatesOldPlayTarget() = runDetailTest {
+        val scenario = Scenario(suffix = "-season-refresh")
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+
+        val seasonsBeforeRefresh = scenario.seasonsRequests.get()
+        scenario.seasonsGate = CompletableDeferred()
+        scenario.seasonTwoEpisodesGate = CompletableDeferred()
+        fixture.viewModel.loadAll()
+        awaitCondition { scenario.seasonsRequests.get() > seasonsBeforeRefresh }
+
+        fixture.viewModel.onSeasonSelected(2)
+        awaitCondition {
+            fixture.viewModel.uiState.value.let { it.selectedSeason == 2 && it.episodesLoading }
+        }
+        assertEquals(
+            scenario.episodeOneId,
+            fixture.viewModel.uiState.value.nextUpEpisode?.contentId,
+            "the previous target stays rendered so the action row keeps its geometry",
+        )
+        assertFalse(
+            fixture.viewModel.uiState.value.nextUpTargetReady,
+            "the placeholder must not remain playable while season 2 loads",
+        )
+
+        scenario.seasonsGate?.complete(Unit)
+        awaitCondition { !fixture.viewModel.uiState.value.seasonsLoading }
+        assertEquals(
+            2,
+            fixture.viewModel.uiState.value.selectedSeason,
+            "a late seasons refresh must not replay its older initial selection",
+        )
+
+        scenario.seasonTwoEpisodesGate?.complete(Unit)
+        awaitCondition {
+            fixture.viewModel.uiState.value.episodes.any { it.seasonNumber == 2 }
+        }
+        assertEquals(2, fixture.viewModel.uiState.value.selectedSeason)
+        assertTrue(fixture.viewModel.uiState.value.nextUpTargetReady)
+    }
+
+    @Test
+    fun focusedSeriesEpisodeBecomesHeroPlayAndSelectorTarget() = runDetailTest {
+        val scenario = Scenario(suffix = "-focus-target")
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+
+        fixture.viewModel.onSeriesEpisodeActivated(scenario.episodeTwoId)
+        awaitEpisode(fixture.viewModel, scenario.episodeTwoId)
+
+        val state = fixture.viewModel.uiState.value
+        assertEquals(scenario.episodeTwoId, state.nextUpEpisode?.contentId)
+        assertEquals(scenario.episodeTwoId, state.nextUpPlaybackDetail?.contentId)
+    }
 
     @Test
     fun absentVersionCodecAndContainerDecodeAsNull() = runDetailTest {
@@ -596,10 +652,14 @@ class TvNextUpSelectionHandoffTest {
         val seriesId = "series$suffix"
         val episodeOneId = "episode-1$suffix"
         val episodeTwoId = "episode-2$suffix"
+        val seasonTwoEpisodeId = "season-2-episode-1$suffix"
         var episodeOneWatched = false
         var episodeTwoWatched = false
         var episodeTwoGate: CompletableDeferred<Unit>? = null
         var episodeOneWatchGate: CompletableDeferred<Unit>? = null
+        var seasonsGate: CompletableDeferred<Unit>? = null
+        var seasonTwoEpisodesGate: CompletableDeferred<Unit>? = null
+        val seasonsRequests = AtomicInteger()
         val episodeTwoRequests = AtomicInteger()
         val pendingEpisodeOneResponses = AtomicInteger()
         var episodeOneDefaultVersions = oldVersions
@@ -616,10 +676,25 @@ class TvNextUpSelectionHandoffTest {
                     "/api/v1/catalog/items/$seriesId" -> json(
                         """{"content_id":"$seriesId","type":"series","title":"Series"}""",
                     )
-                    "/api/v1/catalog/series/$seriesId/seasons" -> json(
-                        """{"seasons":[{"content_id":"season$suffix","season_number":1,"title":"Season 1"}]}""",
-                    )
+                    "/api/v1/catalog/series/$seriesId/seasons" -> {
+                        seasonsRequests.incrementAndGet()
+                        seasonsGate?.await()
+                        json(
+                            """{"seasons":[
+                                {"content_id":"season-1$suffix","season_number":1,"title":"Season 1"},
+                                {"content_id":"season-2$suffix","season_number":2,"title":"Season 2"}
+                            ]}""".trimIndent(),
+                        )
+                    }
                     "/api/v1/catalog/series/$seriesId/seasons/1/episodes" -> json(episodesJson())
+                    "/api/v1/catalog/series/$seriesId/seasons/2/episodes" -> {
+                        seasonTwoEpisodesGate?.await()
+                        json(
+                            """{"episodes":[
+                                {"content_id":"$seasonTwoEpisodeId","season_number":2,"episode_number":1,"title":"Season Two"}
+                            ]}""".trimIndent(),
+                        )
+                    }
                     "/api/v1/catalog/items/$episodeOneId" -> {
                         val queued = episodeOneResponses.pollFirst()
                         if (queued == null) {
@@ -635,6 +710,8 @@ class TvNextUpSelectionHandoffTest {
                         episodeTwoGate?.await()
                         json(itemDetailJson(episodeTwoId, newVersions, newLastFileId))
                     }
+                    "/api/v1/catalog/items/$seasonTwoEpisodeId" ->
+                        json(itemDetailJson(seasonTwoEpisodeId, newVersions, newLastFileId))
                     "/api/v1/watched/$episodeOneId" -> {
                         episodeOneWatchGate?.await()
                         episodeOneWatched = request.method.value != "DELETE"

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormattingTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvPlaybackFormattingTest.kt
@@ -255,6 +255,22 @@ class TvPlaybackFormattingTest {
         assertEquals("Auto", TvPlaybackFormatting.versionShortLabel(fileVersion(resolution = null, hdr = false)))
     }
 
+    @Test fun versionCompactLabel_keepsResolutionAndDynamicRangeOnly() {
+        val v = fileVersion(
+            resolution = "2160p",
+            codecVideo = "hevc",
+            codecAudio = "truehd",
+            hdr = true,
+        )
+
+        assertEquals("4K · HDR", TvPlaybackFormatting.versionCompactLabel(v))
+    }
+
+    @Test fun compactSubtitleSelectorValue_dropsAutoAndTechnicalSuffixes() {
+        assertEquals("English", compactSubtitleSelectorValue("Auto - English · SRT"))
+        assertEquals("Off", compactSubtitleSelectorValue("Off"))
+    }
+
     @Test fun versionValueLabel_matchesTvOsDolbyVisionSummary() {
         val v = fileVersion(
             resolution = "2160p",

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeriesEpisodePlaybackLaunchTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeriesEpisodePlaybackLaunchTest.kt
@@ -1,0 +1,82 @@
+package org.siloserver.silo.tv.ui.screens.detail
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import org.siloserver.silo.model.catalog.EpisodeListItem
+import org.siloserver.silo.model.catalog.FileVersion
+import org.siloserver.silo.model.catalog.ItemDetail
+import org.siloserver.silo.model.catalog.LeafItemUserData
+import org.siloserver.silo.tv.ui.navigation.TvSubtitleLaunchSelection
+
+class TvSeriesEpisodePlaybackLaunchTest {
+    @Test
+    fun `quick play never carries a previous episode selection`() {
+        val previous = EpisodeListItem(
+            contentId = "previous",
+            seasonNumber = 1,
+            episodeNumber = 1,
+        )
+        val target = EpisodeListItem(
+            contentId = "target",
+            seasonNumber = 1,
+            episodeNumber = 2,
+            userData = LeafItemUserData(
+                isInProgress = true,
+                positionSeconds = 120.0,
+                durationSeconds = 1_800.0,
+            ),
+        )
+        val state = TvItemDetailUiState(
+            nextUpEpisode = previous,
+            nextUpPlaybackDetail = ItemDetail(
+                contentId = previous.contentId,
+                type = "episode",
+                title = "Previous",
+                versions = listOf(FileVersion(fileId = 7, resolution = "2160p")),
+            ),
+            selectedNextUpFileId = 7,
+            selectedNextUpAudioIndex = 2,
+            nextUpAudioPickedThisSession = true,
+            selectedNextUpSubtitleIndex = -1,
+        )
+
+        val launch = seriesEpisodePlaybackLaunch(state, target)
+
+        assertNull(launch.fileId)
+        assertNull(launch.audioTrackIndex)
+        assertFalse(launch.audioPickedThisSession)
+        assertNull(launch.subtitleSelection)
+        assertEquals(120.0, launch.resumePositionSeconds)
+    }
+
+    @Test
+    fun `quick play honors selections belonging to the focused episode`() {
+        val episode = EpisodeListItem(
+            contentId = "target",
+            seasonNumber = 3,
+            episodeNumber = 1,
+        )
+        val state = TvItemDetailUiState(
+            nextUpEpisode = episode,
+            nextUpPlaybackDetail = ItemDetail(
+                contentId = episode.contentId,
+                type = "episode",
+                title = "Target",
+                versions = listOf(FileVersion(fileId = 11, resolution = "1080p")),
+            ),
+            selectedNextUpFileId = 11,
+            selectedNextUpAudioIndex = 0,
+            nextUpAudioPickedThisSession = true,
+            selectedNextUpSubtitleIndex = -1,
+        )
+
+        val launch = seriesEpisodePlaybackLaunch(state, episode)
+
+        assertEquals(11, launch.fileId)
+        assertEquals(0, launch.audioTrackIndex)
+        assertEquals(true, launch.audioPickedThisSession)
+        assertEquals(TvSubtitleLaunchSelection(-1, autoResolved = false), launch.subtitleSelection)
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvStarringOverlaySourceTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvStarringOverlaySourceTest.kt
@@ -2,7 +2,6 @@ package org.siloserver.silo.tv.ui.screens.detail
 
 import java.io.File
 import kotlin.test.Test
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class TvStarringOverlaySourceTest {
@@ -15,15 +14,24 @@ class TvStarringOverlaySourceTest {
     private val metadata = File(
         "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailMetadata.kt",
     ).readText()
-    private val presentationSources = listOf(hero, screen, metadata)
-
     @Test
-    fun tvDetailDoesNotDeriveOrRenderDuplicatedStarringOverlay() {
-        assertFalse(
-            presentationSources.any { source ->
-                source.contains("starring", ignoreCase = true)
-            },
+    fun tvDetailRendersOneStableSeriesStarringCreditAbovePlaybackSummary() {
+        val lockedSeriesFooter = hero
+            .substringAfter("translation?.invoke()")
+            .substringBefore("@Composable\nprivate fun HeroCreditLine")
+
+        assertTrue(screen.contains("internal fun seriesStarringCredit(detail: ItemDetail)"))
+        assertTrue(screen.contains("prefix = \"Starring \""))
+        assertTrue(screen.contains("val heroCreditText = if (isSeriesDetail)"))
+        assertTrue(hero.contains("SERIES_CREDIT_SLOT_HEIGHT"))
+        assertTrue(lockedSeriesFooter.indexOf("SERIES_CREDIT_SLOT_HEIGHT") >= 0)
+        assertTrue(
+            lockedSeriesFooter.indexOf("SERIES_CREDIT_SLOT_HEIGHT") <
+                lockedSeriesFooter.indexOf("playbackSummary?.invoke()"),
         )
+        // The general metadata helper must not independently derive a second
+        // Starring overlay.
+        assertTrue(!metadata.contains("starring", ignoreCase = true))
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeSectionsTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/home/TvHomeSectionsTest.kt
@@ -1,13 +1,85 @@
 package org.siloserver.silo.tv.ui.screens.home
 
+import java.io.File
 import org.siloserver.silo.model.section.ResolvedSection
 import org.siloserver.silo.model.section.SectionItem
+import org.siloserver.silo.tv.data.preferences.TvHomeSectionLayout
+import org.siloserver.silo.tv.data.preferences.TvHomeSectionPreferences
+import org.siloserver.silo.tv.ui.components.isTvContinueWatchingRow
 import org.siloserver.silo.tv.ui.components.TvRowStyle
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class TvHomeSectionsTest {
+    @Test
+    fun continueRowsAreRecognizedForDetailHandoff() {
+        assertTrue(homeSection("continue_watching", "Continue Watching").isTvContinueWatchingRow())
+        assertTrue(homeSection("in_progress", "In Progress").isTvContinueWatchingRow())
+        assertTrue(homeSection("continue_listening", "Continue Listening").isTvContinueWatchingRow())
+        assertFalse(homeSection("next_up", "Next Up").isTvContinueWatchingRow())
+        assertFalse(homeSection("recently_added", "Recently Added").isTvContinueWatchingRow())
+    }
+
+    @Test
+    fun continueWatchingEpisodeTargetsItsSeriesSeasonAndEpisode() {
+        val target = SectionItem(
+            contentId = "episode-7",
+            type = "episode",
+            title = "The Dive",
+            seriesId = "series-1",
+            seasonNumber = 3,
+            episodeNumber = 7,
+        ).tvContinueWatchingDetailTarget()
+
+        assertEquals(
+            TvContinueWatchingDetailTarget(
+                contentId = "series-1",
+                seasonNumber = 3,
+                episodeContentId = "episode-7",
+            ),
+            target,
+        )
+    }
+
+    @Test
+    fun continueWatchingMovieTargetsItsMovieDetail() {
+        val target = SectionItem(
+            contentId = "movie-1",
+            type = "movie",
+            title = "Obsession",
+            positionSeconds = 121.0,
+        ).tvContinueWatchingDetailTarget()
+
+        assertEquals(TvContinueWatchingDetailTarget(contentId = "movie-1"), target)
+    }
+
+    @Test
+    fun continueWatchingPrefetchWarmsTheScreenSelectWillOpen() {
+        val episode = SectionItem(
+            contentId = "episode-7",
+            type = "episode",
+            title = "The Dive",
+            seriesId = "series-1",
+            seasonNumber = 3,
+            episodeNumber = 7,
+        ).tvContinueWatchingPrefetchTarget()
+        val movie = SectionItem(
+            contentId = "movie-1",
+            type = "movie",
+            title = "Obsession",
+        ).tvContinueWatchingPrefetchTarget()
+
+        assertEquals("series-1", episode.detailContentId)
+        assertEquals("series-1", episode.seriesId)
+        assertEquals(3, episode.seasonNumber)
+        assertEquals("episode-7", episode.episodeContentId)
+        assertEquals("movie-1", movie.detailContentId)
+        assertEquals(null, movie.seriesId)
+        assertEquals(null, movie.episodeContentId)
+    }
+
     @Test
     fun mixedContinueRowsSplitAudiobooksIntoContinueListening() {
         val sections = listOf(
@@ -52,4 +124,62 @@ class TvHomeSectionsTest {
         assertTrue(normalized.single().isTvAudioProgressSection())
         assertEquals(TvRowStyle.Poster, normalized.single().tvHomeRowStyle())
     }
+
+    @Test
+    fun savedOrderAndVisibilityProjectPopulatedRowsWithoutAGap() {
+        val sections = listOf(
+            homeSection("continue", "Continue Watching"),
+            homeSection("recent", "Recently Added"),
+            homeSection("because", "Because You Watched"),
+        )
+        val layout = TvHomeSectionLayout(
+            orderedSectionIds = listOf("recent", "continue"),
+            hiddenSectionIds = setOf("recent"),
+        )
+
+        val visible = TvHomeSectionPreferences.arrange(sections, layout)
+        val editor = TvHomeSectionPreferences.arrange(
+            sections,
+            layout,
+            includingHidden = true,
+        )
+
+        assertEquals(listOf("continue", "because"), visible.map { it.id })
+        assertEquals(listOf("recent", "continue", "because"), editor.map { it.id })
+    }
+
+    @Test
+    fun reorderedKnownRowsRetainTemporarilyAbsentRememberedRows() {
+        assertEquals(
+            listOf("recent", "continue", "temporarily-empty"),
+            TvHomeSectionPreferences.retainedOrder(
+                sectionIds = listOf("recent", "continue", "recent"),
+                rememberedSectionIds = listOf("continue", "temporarily-empty"),
+            ),
+        )
+    }
+
+    @Test
+    fun editorButtonsCenterTheirContentWithoutExpandingOverTheSectionRows() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/settings/TvHomeSectionsEditor.kt",
+        ).readText()
+        val control = source.substringAfter("private fun HomeSectionsControlButton(")
+        val labelControl = control.substringAfter("} else {")
+
+        assertTrue(control.contains(".fillMaxHeight()"))
+        assertTrue(control.contains(".widthIn(min = 68.dp)"))
+        assertTrue(control.contains("modifier = Modifier.fillMaxSize()"))
+        assertTrue(control.contains("contentAlignment = Alignment.Center"))
+        assertTrue(labelControl.contains(".fillMaxHeight()\n                    // Mirror the Surface's minimum width inside its content."))
+        assertTrue(labelControl.contains(".widthIn(min = 68.dp)\n                    .padding(horizontal = 12.dp)"))
+        assertTrue(labelControl.contains("horizontalArrangement = Arrangement.Center"))
+    }
+
+    private fun homeSection(id: String, title: String) = ResolvedSection(
+        id = id,
+        sectionType = id,
+        title = title,
+        items = listOf(SectionItem(contentId = "$id-item", type = "movie", title = title)),
+    )
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvEpisodeHandoffPlaybackStartTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvEpisodeHandoffPlaybackStartTest.kt
@@ -37,6 +37,18 @@ class TvEpisodeHandoffPlaybackStartTest {
     }
 
     @Test
+    fun episodeHandoffAudioWinsOverAutomaticPlaybackSetting() {
+        assertEquals(
+            1,
+            resolveTvStartAudioTrackIndex(
+                requestedTitleTrackIndex = null,
+                episodeHandoffTrackIndex = 1,
+                automaticPreferenceTrackIndex = 0,
+            ),
+        )
+    }
+
+    @Test
     fun explicitDetailFileIdWinsOverEpisodeHandoff() {
         val resolved = resolveTvPlaybackStartSelection(
             preferredFileId = 1080,

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvEpisodeHandoffPlaybackStartTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvEpisodeHandoffPlaybackStartTest.kt
@@ -13,6 +13,30 @@ import org.siloserver.silo.model.catalog.SubtitleTrack
 
 class TvEpisodeHandoffPlaybackStartTest {
     @Test
+    fun manualTitleAudioChoiceWinsOverHandoffAndPlaybackSettings() {
+        assertEquals(
+            2,
+            resolveTvStartAudioTrackIndex(
+                requestedTitleTrackIndex = 2,
+                episodeHandoffTrackIndex = 1,
+                automaticPreferenceTrackIndex = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun playbackAudioSettingIsOnlyTheAutomaticFallback() {
+        assertEquals(
+            0,
+            resolveTvStartAudioTrackIndex(
+                requestedTitleTrackIndex = null,
+                episodeHandoffTrackIndex = null,
+                automaticPreferenceTrackIndex = 0,
+            ),
+        )
+    }
+
+    @Test
     fun explicitDetailFileIdWinsOverEpisodeHandoff() {
         val resolved = resolveTvPlaybackStartSelection(
             preferredFileId = 1080,

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuFocusRequestTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuFocusRequestTest.kt
@@ -1,10 +1,31 @@
 package org.siloserver.silo.tv.ui.shell
 
+import java.io.File
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class TvTopMenuFocusRequestTest {
+    @Test
+    fun shellPagesShareOneTopNavigationShadow() {
+        val barSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt",
+        ).readText()
+        val shellSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt",
+        ).readText()
+        val rootBackdropSource = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvRootHeroBackdrop.kt",
+        ).readText()
+
+        assertTrue(barSource.contains("internal fun TvTopMenuDropShadow("))
+        assertTrue(shellSource.contains("TvTopMenuDropShadow("))
+        assertTrue(shellSource.contains("visibility = if (currentRoute == TvMainRoute.Settings.route)"))
+        assertFalse(rootBackdropSource.contains("TopScrimHeight"))
+    }
+
     @Test
     fun focusIsRequestedOnlyAfterTheTargetHasHadAFrameToCompose() = runTest {
         val events = mutableListOf<String>()

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/theme/TvTypographyReadabilityTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/theme/TvTypographyReadabilityTest.kt
@@ -2,6 +2,7 @@ package org.siloserver.silo.tv.ui.theme
 
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -12,6 +13,11 @@ class TvTypographyReadabilityTest {
     private val source = File(
         "src/androidMain/kotlin/org/siloserver/silo/tv/ui/theme/Type.kt",
     ).readText()
+    private val tvOsMappedCompactTextLines = listOf(
+        "org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt|fontSize = 11.5.sp,",
+        "org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt|fontSize = 11.sp,",
+        "org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt|fontSize = 11.5.sp,",
+    )
 
     @Test
     fun sharedTvTypographyAvoidsTinyTenFootText() {
@@ -50,25 +56,38 @@ class TvTypographyReadabilityTest {
 
     @Test
     fun tvScreensAvoidHardcodedTinyTextOutsideTheTheme() {
-        // Post readability-remediation the whole TV surface honours a 14sp
-        // metadata floor, so anything 9-13sp is a real ten-foot-readability
-        // regression. 14sp is now the allowed floor, so the old
-        // "tvOsMappedSmallTextFiles" allowlist is retired — every screen must
-        // comply without exception.
+        // Normal TV copy honours a 14sp metadata floor. These three exact
+        // assignments are approved half-scale mappings of compact tvOS chrome;
+        // the matched-count assertion keeps this exception line-specific and
+        // prevents it from becoming a file-wide escape hatch.
+        val approvedMatches = mutableListOf<String>()
         val offenders = File("src/androidMain/kotlin/org/siloserver/silo/tv")
             .walkTopDown()
             .filter { it.isFile && it.extension == "kt" }
             .filterNot { it.invariantSeparatorsPath.endsWith("/ui/theme/Type.kt") }
             .flatMap { file ->
+                val relativePath = file.relativeTo(File("src/androidMain/kotlin")).invariantSeparatorsPath
                 file.readLines().mapIndexedNotNull { index, line ->
                     if (tinyFontPattern.containsMatchIn(line)) {
-                        "${file.relativeTo(File("src/androidMain/kotlin")).invariantSeparatorsPath}:${index + 1}: ${line.trim()}"
+                        val approvedKey = "$relativePath|${line.trim()}"
+                        if (approvedKey in tvOsMappedCompactTextLines) {
+                            approvedMatches += approvedKey
+                            null
+                        } else {
+                            "$relativePath:${index + 1}: ${line.trim()}"
+                        }
                     } else {
                         null
                     }
                 }
             }
             .toList()
+
+        assertEquals(
+            tvOsMappedCompactTextLines.sorted(),
+            approvedMatches.sorted(),
+            "The compact tvOS typography exception list must match exactly",
+        )
 
         assertTrue(
             offenders.isEmpty(),

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/catalog/CatalogModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/catalog/CatalogModels.kt
@@ -213,6 +213,29 @@ data class ItemDetail(
     val book: org.siloserver.silo.model.book.BookMetadata? = null,
     /** Populated only when [type] is "ebook" on current servers. */
     val ebook: org.siloserver.silo.model.ebook.EbookMetadata? = null,
+    /** Remote provider trailers/teasers, pre-ordered by the server. */
+    val videos: List<ItemVideo>? = null,
+    /** Scanner-discovered local trailers and featurettes. */
+    val extras: List<ItemExtra>? = null,
+)
+
+@Serializable
+data class ItemVideo(
+    val kind: String,
+    val site: String,
+    @SerialName("site_key") val siteKey: String,
+    val name: String? = null,
+    val language: String? = null,
+    @SerialName("is_official") val isOfficial: Boolean = false,
+)
+
+@Serializable
+data class ItemExtra(
+    @SerialName("content_id") val contentId: String,
+    val kind: String,
+    val title: String? = null,
+    @SerialName("duration_seconds") val durationSeconds: Int? = null,
+    @SerialName("file_id") val fileId: Int? = null,
 )
 
 @Serializable
@@ -392,7 +415,8 @@ fun Season.isSpecialsForDisplay(): Boolean =
 
 fun List<Season>.sortedForDisplay(): List<Season> =
     sortedWith(
-        compareByDescending<Season> { it.isSpecialsForDisplay() }
+        // Match tvOS: numbered seasons first, Specials last.
+        compareBy<Season> { it.isSpecialsForDisplay() }
             .thenBy { it.seasonNumber }
             .thenBy { it.title.orEmpty() }
             .thenBy { it.contentId },
@@ -401,7 +425,16 @@ fun List<Season>.sortedForDisplay(): List<Season> =
 private fun List<Season>.selectedSeasonForDisplay(preferredSeasonNumber: Int?): Season? {
     return preferredSeasonNumber
         ?.let { preferred -> firstOrNull { it.seasonNumber == preferred } }
-        ?: firstOrNull { !it.isSpecialsForDisplay() }
+        // Open the Show overview while preloading the viewer's actual browse
+        // target: Continue Watching first, then a partially watched season,
+        // then the first not-yet-complete season. This lets the first Down land
+        // on e.g. Season 3 Episode 1 exactly as tvOS does.
+        ?: firstOrNull { (it.userData?.inProgressCount ?: 0) > 0 }
+        ?: firstOrNull { season ->
+            val watched = season.userData?.watchedCount ?: 0
+            watched > 0 && watched < season.episodeCount
+        }
+        ?: firstOrNull { it.userData?.played != true }
         ?: firstOrNull()
 }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/CatalogRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/CatalogRepository.kt
@@ -170,6 +170,16 @@ class CatalogRepository(
         return result
     }
 
+    /** Returns the last cached season list without touching the network. */
+    suspend fun getCachedSeasons(seriesId: String): SeasonsResponse? =
+        catalogCache.getCachedSeasons(seriesId)
+
+    /** Cache-first season list for a focused card that may open imminently. */
+    suspend fun getSeasonsForPrefetch(seriesId: String): ApiResult<SeasonsResponse> {
+        catalogCache.getCachedSeasons(seriesId)?.let { return ApiResult.Success(it) }
+        return getSeasons(seriesId)
+    }
+
     /** Lists episodes for a specific season of a series (offline: last cached episodes). */
     suspend fun getEpisodes(seriesId: String, seasonNumber: Int): ApiResult<EpisodesResponse> {
         val requestIdentityGeneration = identityTransitions.generation.value
@@ -184,6 +194,19 @@ class CatalogRepository(
             catalogCache.getCachedEpisodes(seriesId, seasonNumber)?.let { return ApiResult.Success(it) }
         }
         return result
+    }
+
+    /** Returns cached episodes without touching the network. */
+    suspend fun getCachedEpisodes(seriesId: String, seasonNumber: Int): EpisodesResponse? =
+        catalogCache.getCachedEpisodes(seriesId, seasonNumber)
+
+    /** Cache-first episode list for a focused Continue Watching season. */
+    suspend fun getEpisodesForPrefetch(
+        seriesId: String,
+        seasonNumber: Int,
+    ): ApiResult<EpisodesResponse> {
+        catalogCache.getCachedEpisodes(seriesId, seasonNumber)?.let { return ApiResult.Success(it) }
+        return getEpisodes(seriesId, seasonNumber)
     }
 
     /** Lists all episodes directly attached to an item (e.g. a season content ID). */

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModels.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.launch
  * `/catalog?source=…`, the only route that accepts sort and facets.
  */
 data class PersonalListQuery(
+    /** Optional top-level catalog type (for example `movie` or `series`). */
+    val mediaType: String? = null,
     /** null = send no sort, i.e. keep the server's stored list order. */
     val sort: String? = null,
     val order: String? = null,
@@ -30,7 +32,7 @@ data class PersonalListQuery(
     /** "all" | "any"; only meaningful when [queryGroups] is non-empty. */
     val match: String? = null,
 ) {
-    val isDefault: Boolean get() = sort == null && queryGroups.isEmpty()
+    val isDefault: Boolean get() = mediaType == null && sort == null && queryGroups.isEmpty()
 }
 
 /**
@@ -285,6 +287,7 @@ class FavoritesViewModel(
     override suspend fun fetchPage(offset: Int, limit: Int, query: PersonalListQuery) =
         catalogRepository.browse(
             source = "favorites",
+            mediaType = query.mediaType,
             sort = query.sort,
             order = query.order,
             offset = offset,
@@ -322,6 +325,7 @@ class WatchlistViewModel(
     override suspend fun fetchPage(offset: Int, limit: Int, query: PersonalListQuery) =
         catalogRepository.browse(
             source = "watchlist",
+            mediaType = query.mediaType,
             sort = query.sort,
             order = query.order,
             offset = offset,

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/catalog/SeasonDisplayOrderTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/catalog/SeasonDisplayOrderTest.kt
@@ -9,23 +9,27 @@ class SeasonDisplayOrderTest {
         specials: Boolean = false,
         id: String = "season-$number-$specials",
         title: String? = null,
+        episodeCount: Int = 10,
+        userData: SeasonUserData? = null,
     ) = Season(
         contentId = id,
         seasonNumber = number,
         isSpecials = specials,
         title = title,
+        episodeCount = episodeCount,
+        userData = userData,
     )
 
     @Test
-    fun `specials sort before regular seasons`() {
+    fun `specials sort after regular seasons`() {
         val result = listOf(season(2), season(0), season(1)).sortedForDisplay()
-        assertEquals(listOf(0, 1, 2), result.map(Season::seasonNumber))
+        assertEquals(listOf(1, 2, 0), result.map(Season::seasonNumber))
     }
 
     @Test
     fun `specials flag is authoritative even for nonzero season number`() {
         val result = listOf(season(1), season(99, specials = true), season(2)).sortedForDisplay()
-        assertEquals(listOf(99, 1, 2), result.map(Season::seasonNumber))
+        assertEquals(listOf(1, 2, 99), result.map(Season::seasonNumber))
     }
 
     @Test
@@ -33,6 +37,29 @@ class SeasonDisplayOrderTest {
         val result = listOf(season(0), season(2), season(1))
             .initialSeasonForDisplay(preferredSeasonNumber = null)
         assertEquals(1, result?.seasonNumber)
+    }
+
+    @Test
+    fun `opening preloads the season containing the in progress episode`() {
+        val result = listOf(
+            season(1),
+            season(3, userData = SeasonUserData(inProgressCount = 1)),
+            season(2),
+            season(0),
+        ).initialSeasonForDisplay(preferredSeasonNumber = null)
+
+        assertEquals(3, result?.seasonNumber)
+    }
+
+    @Test
+    fun `opening falls back to a partially watched season`() {
+        val result = listOf(
+            season(1, userData = SeasonUserData(played = true, watchedCount = 10)),
+            season(2, userData = SeasonUserData(watchedCount = 4)),
+            season(3),
+        ).initialSeasonForDisplay(preferredSeasonNumber = null)
+
+        assertEquals(2, result?.seasonNumber)
     }
 
     @Test
@@ -74,7 +101,7 @@ class SeasonDisplayOrderTest {
         val plan = listOf(season(2), season(0), season(1))
             .initialSeasonDisplayPlan(preferredSeasonNumber = null)
 
-        assertEquals(listOf(0, 1, 2), plan.seasons.map(Season::seasonNumber))
+        assertEquals(listOf(1, 2, 0), plan.seasons.map(Season::seasonNumber))
         assertEquals(1, plan.selectedSeasonNumber)
         assertEquals(1, plan.episodeRequestSeasonNumber)
     }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/CatalogRepositoryDetailCacheTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/CatalogRepositoryDetailCacheTest.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.repository
 
 import org.siloserver.silo.model.catalog.ItemDetail
+import org.siloserver.silo.model.catalog.EpisodesResponse
 import org.siloserver.silo.model.catalog.SeasonsResponse
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
@@ -31,6 +32,7 @@ class CatalogRepositoryDetailCacheTest {
     private class FakeCache(
         val preset: ItemDetail? = null,
         val seasonsPreset: SeasonsResponse? = null,
+        val episodesPreset: EpisodesResponse? = null,
         val identityTransitions: IdentityTransitionBarrier? = null,
         val beforeItemCache: suspend () -> Unit = {},
     ) : CatalogCachePort {
@@ -50,6 +52,8 @@ class CatalogRepositoryDetailCacheTest {
         }
         override suspend fun getCachedItemDetail(contentId: String): ItemDetail? = preset
         override suspend fun getCachedSeasons(seriesId: String): SeasonsResponse? = seasonsPreset
+        override suspend fun getCachedEpisodes(seriesId: String, seasonNumber: Int): EpisodesResponse? =
+            episodesPreset
     }
 
     private fun repo(status: HttpStatusCode, body: String, cache: CatalogCachePort): CatalogRepository {
@@ -122,6 +126,20 @@ class CatalogRepositoryDetailCacheTest {
         val cache = FakeCache(seasonsPreset = SeasonsResponse(seasons = emptyList()))
         val result = repo(HttpStatusCode.ServiceUnavailable, "{}", cache).getSeasons("series-1")
         assertTrue(result is ApiResult.Success)
+    }
+
+    @Test
+    fun continueWatchingSeasonPrefetchUsesCachedNavigationWithoutNetwork() = runTest {
+        val cache = FakeCache(
+            seasonsPreset = SeasonsResponse(seasons = emptyList()),
+            episodesPreset = EpisodesResponse(episodes = emptyList()),
+        )
+        val repository = repoThatFailsOnNetwork(cache)
+
+        assertTrue(repository.getSeasonsForPrefetch("series-1") is ApiResult.Success)
+        assertTrue(repository.getEpisodesForPrefetch("series-1", 3) is ApiResult.Success)
+        assertEquals(cache.seasonsPreset, repository.getCachedSeasons("series-1"))
+        assertEquals(cache.episodesPreset, repository.getCachedEpisodes("series-1", 3))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModelGenerationTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/viewmodel/PersonalListViewModelGenerationTest.kt
@@ -49,6 +49,17 @@ class PersonalListViewModelGenerationTest {
         CatalogResponse(items = ids.map(::item), hasMore = hasMore, total = ids.size),
     )
 
+    @Test
+    fun mediaTypeParticipatesInPersonalListQueryIdentity() {
+        val movies = PersonalListQuery(mediaType = "movie")
+        val series = PersonalListQuery(mediaType = "series")
+
+        assertFalse(movies.isDefault)
+        assertFalse(series.isDefault)
+        assertTrue(PersonalListQuery().isDefault)
+        assertTrue(movies != series)
+    }
+
     private class TestList : PersonalListViewModel(pageSize = 2) {
         val pending = ArrayDeque<CompletableDeferred<ApiResult<CatalogResponse>>>()
         val offsets = mutableListOf<Int>()


### PR DESCRIPTION
## What this fixes

The Android TV experience had drifted away from the tvOS layout and interaction model. Series and movie details used different control patterns, episode navigation could fall back to the old detail flow, metadata and controls moved while episode data loaded, Continue Watching reopened legacy screens, and the Home Sections editor was not usable on TV.

I designed this Android TV pass against the tvOS experience and tested each layout/focus iteration in the Android TV emulator. The goal is one stable, remote-first interface that feels like the same Silo app on both platforms without changing the established Android mobile design.

## What changed

### Home and navigation

- Reworked the Android TV home hero, Silo wordmark, top navigation spacing, focus treatment, and backdrop shadow to match the tvOS presentation.
- Matched the tvOS Home metadata hierarchy: a compact outlined content-rating badge before the episode label, then separate outlined quality, dynamic-range, and audio badges beneath the aired/cast line.
- Removed episode runtime and remaining-time text from the Home hero so its episode line ends cleanly at the episode title, matching tvOS.
- Added working Home Sections settings with visible section rows, hide/show controls, and reorder controls.
- Fixed the Edit/Done, eye, and reorder controls so their artwork is centred in the focus boxes.
- Added Movies/Series switching to Favourites and swapped the Favourites/Watchlist placement to match the intended navigation order.
- Kept D-pad and desktop-emulator keyboard navigation consistent, including Escape-to-Back handling.

### Series details and episodes

- Rebuilt series detail as one tvOS-style page with Show, season, and episode modes instead of pushing the old episode-detail screen.
- Episode focus now updates the hero metadata, description, artwork, playback summary, and Play/Resume target in place.
- Pressing an episode plays it directly; Continue Watching opens the new series page on the correct season and episode.
- Season tabs now activate on focus, keep the active tab centred, and switch immediately without requiring a second Select press.
- Changing seasons moves the complete outgoing and incoming episode rails as one directional, full-width carousel page, with a deliberately slower 360 ms transition.
- Season selection follows the watched/in-progress episode, keeps Specials last, and preserves deterministic ordering.
- Matched the compact tvOS episode-card footprint and single-line `EPISODE n · Title` caption while preserving the existing legacy episode routes.
- Kept the hero, metadata, fixed-width Play action, Starring credit, playback summary, season row, and episode rail geometry stable while episode data changes so controls do not bounce.
- Kept Version, Audio, and Subtitles compact and aligned directly above the action row without truncating the selected audio value.
- Preserved the focused season/episode across the locked primary viewport transition and fixed left/right episode movement.
- Added stable placeholders while new episode metadata loads and prevented a stale previous-season episode from launching.
- Hardened duplicate season identities so unusual catalogs cannot crash a Compose rail.

### Movie and shared detail layout

- Matched the movie and series backdrop positioning, gradient, title treatment, metadata order, play-button shape, circular controls, and rating styling to the tvOS design.
- Movie ratings now use the same compact outlined badge as series ratings.
- Moved the movie Version, Audio, and Subtitles readout below the Directed by credit and directly above the action row, matching the series hierarchy.
- Moved media type and genres above the description and aligned quality/version presentation with Home cards.
- Added Cast & Crew, Trailers, and Recommended sections to movie details.
- Added a popup for expanded show/movie information rather than expanding and shifting the page.
- Restored the three-dot menu with watched-series and favourite actions while keeping Watchlist visible as a white bookmark action.
- Changed Start Over to the circular icon-only control.

### Playback selection

- Added circular Version, Audio, and Subtitle selectors beside Play for movies and episodes.
- Manual per-title Version, Audio, and Subtitle choices override global Playback settings.
- Added preferred audio language under Playback settings, with English fallback when the preferred language is unavailable.
- Automatic audio selection is language-first, then chooses the highest-quality track compatible with the current device/output; the server can adapt an available preferred-language source rather than incorrectly switching to English.
- Kept the displayed Auto audio/subtitle result, the subtitle auto decision, and the track sent to playback on the same resolution path.
- Fixed Auto version persistence so track choices are saved against the version actually selected by last-file/preferred-quality policy instead of the first catalog file.

### Continue Watching and loading

- Continue Watching now opens the redesigned movie/series detail state instead of the legacy detail route.
- Long-press actions include Play and watched-state controls without forcing direct play on a normal click.
- Added detail and season/episode cache seeding so Continue Watching can show the correct screen faster while refreshing in the background.

## Validation and benchmarks

Measured locally on this branch with warm Gradle caches:

- Supply-chain regression suite: **3.25 s**, passed.
- Supply-chain policy check: **0.43 s**, passed.
- Full debug unit suite: **6.89 s**, passed across all debug modules; Android TV completed **1,099 tests**.
- Android TV lint: **28.05 s**, passed with no unbaselined errors.
- Focused TV typography/control suite: **4.62 s**, passed.
- Focused series navigation, next-up handoff, and shared audio-policy tests: **6 s total**, passed.
- Final Home-marquee and detail-focus regression suites: **passed**.
- Final `:androidTvApp:assembleDebug`: **passed**.

The final APK was installed and cold-launched on the `Silo_TV_API_36` Android TV emulator. Emulator validation covered D-pad/keyboard focus, focus-driven season changes, the directional episode carousel, compact metadata and ratings, selector alignment, audio-value width, Continue Watching routing, Home Sections editing, and movie/series visual parity.

## Screenshots

### Home hero and Continue Watching

The rebuilt Home hero now matches the tvOS rating placement and uses separate compact badges for resolution, dynamic range, and audio. Episode runtime and remaining-time copy are omitted, while the focused-card treatment and section rhythm remain unchanged.

<img width="950" alt="Android TV Home hero with tvOS-style rating and playback-format badges" src="https://github.com/user-attachments/assets/387f1f28-89b6-48e4-970a-8040d54e7b83" />

### Series detail and season carousel

The series page keeps the hero, stable Starring and playback rows, full action set, season picker, and compact episode rail in one layout. Moving focus between seasons activates and centres the new season immediately, then slides the complete episode rails as a directional carousel.

<img width="950" alt="Android TV series detail with focus-driven season navigation and compact episode rail" src="https://github.com/user-attachments/assets/126bcaee-cff2-43e5-955c-979c84870819" />

### Movie detail and shared metadata hierarchy

Movie detail now uses the same compact rating treatment as series and places Version, Audio, and Subtitles below the director credit and immediately above the action row.

<img width="950" alt="Android TV movie detail with compact rating and aligned playback metadata" src="https://github.com/user-attachments/assets/5683b758-c37e-4287-9a99-c9342e7a17a9" />

## Risks and follow-up

- This is a broad TV UI/focus change, so physical remotes and different overscan/output configurations remain the main device-specific risk.
- Audio capability results depend on the active HDMI/receiver route; the preview now refreshes with output-route changes and playback still performs its authoritative capability check.
- Android mobile keeps its existing layout and its no-preference audio behavior; the TV-specific English fallback is intentionally scoped to TV.
- Full GitHub Actions results should remain the merge gate.

## AI Disclosure
- Harness: OpenAI Codex desktop app
- Tool(s): Codex local command execution, Android SDK/Gradle, GitHub CLI, Codex in-app browser
- Model(s): gpt-5.6-sol (ultra reasoning)
- Involvement: AI-assisted. I designed the experience, set the layout and interaction rules, and reviewed and tested each emulator iteration. Codex helped implement, debug, test, review, benchmark, and prepare the pull request.
- Adversarial review: A separate read-only Codex agent reviewed the complete diff across focus/navigation, playback selection and override precedence, caching/concurrency, persistence, cross-client effects, and accessibility. It found and helped resolve stale season Play targeting, duplicate season keys, Auto version persistence, preferred-language audio ordering, keyboard Back dispatch, and selector/typography regressions. No design decisions were delegated to AI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Android TV series detail pages with Show/Season navigation, focused-episode playback, trailers, improved metadata, and full-synopsis popups.
  * Added Home section customization, including row reordering and visibility controls.
  * Added Movies/TV Shows filters to Favorites.
  * Added Play to media-card menus and customizable long-press actions.
* **Improvements**
  * Improved automatic audio-track selection and preferred-language handling.
  * Added episode deep linking and more reliable playback handoff.
  * Refined TV navigation, focus behavior, artwork presentation, and selector controls.
* **Bug Fixes**
  * Escape now closes TV popups using standard back navigation.
  * Improved season selection and Continue Watching navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
