### PR TITLE
Modernize Android Mobile/Tablet

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -382,6 +382,12 @@ val androidModule = module {
             serverRegistry = get(),
         )
     }
+    single {
+        org.siloserver.silo.android.ui.screens.home.HomeSectionPreferencesStore(
+            context = get(),
+            serverRegistry = get(),
+        )
+    }
     viewModel { params ->
         BrowseViewModel(
             get(),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/BackdropCard.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/BackdropCard.kt
@@ -42,7 +42,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.siloserver.silo.common.cards.LocalCardPresentation
+import org.siloserver.silo.common.overlays.CardOverlayVariant
+import org.siloserver.silo.common.overlays.CardOverlays
+import org.siloserver.silo.common.overlays.LocalCardOverlayUiState
 import org.siloserver.silo.model.catalog.MediaItemUserState
+import org.siloserver.silo.overlays.OverlayData
 
 /**
  * Reserved height for the text block under a backdrop card: title (bodySmall)
@@ -81,6 +85,7 @@ fun BackdropCard(
     modifier: Modifier = Modifier,
     width: Dp = 280.dp * LocalCardPresentation.current.posterSize.posterScale,
     userState: MediaItemUserState? = null,
+    overlay: OverlayData? = null,
     actions: MediaCardActions = MediaCardActions(),
     // Center overlay glyph — play for watch/listen, a book for reading.
     overlayIcon: ImageVector = Icons.Default.PlayArrow,
@@ -89,6 +94,7 @@ fun BackdropCard(
      *  null keeps it decorative and the whole card opens the item page. */
     onOverlayClick: (() -> Unit)? = null,
 ) {
+    val overlayState = LocalCardOverlayUiState.current
     var menuExpanded by remember { mutableStateOf(false) }
     Column(
         modifier = modifier
@@ -129,6 +135,18 @@ fun BackdropCard(
                         ),
                     ),
             )
+
+            // Continue Watching / Next Up use the same server-configured
+            // badges as Apple, tvOS, and Android TV. The wide preset leaves
+            // the lower corners clear of the resume progress treatment.
+            if (overlayState.enabled && overlay != null) {
+                CardOverlays(
+                    data = overlay,
+                    prefs = overlayState.prefs,
+                    variant = CardOverlayVariant.Wide,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
 
             // Play button circle
             Box(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MainAppTopBar.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MainAppTopBar.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.android.ui.components
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -55,7 +56,7 @@ fun MainAppTopBar(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .topBarGlass(hazeState),
+            .background(Color(0xFF1C1C1E)),
     ) {
         Box(
             modifier = Modifier
@@ -84,6 +85,7 @@ fun MainAppTopBar(
                 onSwitchProfileClick = onSwitchProfileClick,
                 onSwitchServerClick = onSwitchServerClick,
                 onSignOutClick = onSignOutClick,
+                opaque = true,
             )
         }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaCard.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaCard.kt
@@ -110,6 +110,11 @@ fun MediaCard(
                     // Record which exact placement was tapped so the detail hero
                     // pairs with this card, not a duplicate elsewhere on screen.
                     if (heroKey != null) heroHandoff?.pendingKey = heroKey
+                    // Generic fallback for cards whose caller only knows the
+                    // poster. Rows/grids with a backdrop overwrite this before
+                    // navigating so detail can warm the wide art.
+                    heroHandoff?.pendingArtworkUrl = posterUrl
+                    heroHandoff?.pendingArtworkThumbhash = posterThumbhash
                     onClick()
                 },
                 onLongClick = if (actions.isEmpty) null else { { menuExpanded = true } },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
@@ -21,15 +21,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import kotlin.math.roundToInt
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
 import org.siloserver.silo.common.diagnostics.DiagnosticsKeyAnomalyLogger
 import org.siloserver.silo.common.diagnostics.DiagnosticsKeyCollection
@@ -37,6 +43,8 @@ import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
 import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.overlays.OverlayData
 import org.siloserver.silo.overlays.OverlayDataExtractor
+import org.siloserver.silo.android.ui.navigation.LocalHeroSourceHandoff
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 enum class CardStyle { Poster, Backdrop }
 
@@ -71,7 +79,13 @@ fun MediaRow(
     icon: ImageVector? = null,
     modifier: Modifier = Modifier,
     cardActions: (SectionItem) -> MediaCardActions = { MediaCardActions() },
+    /** Publishes the card nearest the viewport centre after a row settles. */
+    onCenteredItemChanged: ((SectionItem?) -> Unit)? = null,
 ) {
+    val context = LocalContext.current
+    val heroHandoff = LocalHeroSourceHandoff.current
+    val browseContentIds = remember(items) { items.map { it.contentId } }
+    val browseOrigin = remember(title, browseContentIds) { "media-row-$title-${browseContentIds.hashCode()}" }
     val diagnosticsKeySnapshot = remember(items) {
         DiagnosticsListSnapshot.fromKeys(items.map { it.contentId })
     }
@@ -193,6 +207,55 @@ fun MediaRow(
         // A row fling defers artwork presentation just like the parent feed's
         // vertical fling (the helper ORs in any deferral already in scope).
         val rowState = rememberLazyListState()
+        fun openDetail(item: SectionItem) {
+            // Keep one full-size backdrop request alive across the loading-
+            // skeleton -> detail-content composition swap. Without this, the
+            // skeleton's differently-sized request can be cancelled as soon as
+            // metadata arrives and the real hero then starts from zero again.
+            item.backdropUrl?.takeIf { it.isNotBlank() }?.let { backdropUrl ->
+                val metrics = context.resources.displayMetrics
+                val widthPx = metrics.widthPixels.coerceAtLeast(1)
+                val heightPx = minOf(
+                    metrics.heightPixels.coerceAtLeast(1),
+                    (widthPx * 1.18f).roundToInt().coerceAtLeast(1),
+                )
+                context.imageLoader.enqueue(
+                    ImageRequest.Builder(context)
+                        .data(backdropUrl)
+                        .size(widthPx, heightPx)
+                        .build(),
+                )
+            }
+            heroHandoff?.pendingBrowseContentIds = browseContentIds
+            heroHandoff?.pendingBrowseOrigin = browseOrigin
+            heroHandoff?.pendingArtworkUrl = item.backdropUrl ?: item.posterUrl
+            heroHandoff?.pendingArtworkThumbhash = item.backdropThumbhash ?: item.posterThumbhash
+            onItemClick(item.contentId)
+        }
+        val currentItems = rememberUpdatedState(rowItems)
+        val currentOnCenteredItemChanged = rememberUpdatedState(onCenteredItemChanged)
+        LaunchedEffect(rowState, onCenteredItemChanged) {
+            if (onCenteredItemChanged == null) return@LaunchedEffect
+            snapshotFlow {
+                if (rowState.isScrollInProgress) {
+                    null
+                } else {
+                    val info = rowState.layoutInfo
+                    val viewportCenter = (info.viewportStartOffset + info.viewportEndOffset) / 2
+                    info.visibleItemsInfo.minByOrNull { visible ->
+                        kotlin.math.abs((visible.offset + visible.size / 2) - viewportCenter)
+                    }?.key as? String
+                }
+            }
+                .distinctUntilChanged()
+                .collect { contentId ->
+                    if (contentId != null) {
+                        currentOnCenteredItemChanged.value?.invoke(
+                            currentItems.value.firstOrNull { it.item.contentId == contentId }?.item,
+                        )
+                    }
+                }
+        }
         DeferImagePresentationWhileScrolling(rowState) {
         CompositionLocalProvider(LocalViewConfiguration provides rowViewConfiguration) {
         LazyRow(
@@ -218,8 +281,9 @@ fun MediaRow(
                             episodeNumber = item.episodeNumber,
                             progress = rowItem.progress,
                             remainingMinutes = rowItem.remainingMinutes,
-                            onClick = { onItemClick(item.contentId) },
+                            onClick = { openDetail(item) },
                             userState = item.userState,
+                            overlay = rowItem.overlay,
                             actions = cardActions(item),
                             overlayIcon = if (rowItem.isBook) Icons.AutoMirrored.Filled.MenuBook else Icons.Default.PlayArrow,
                             overlayContentDescription = if (rowItem.isBook) "Read" else "Play",
@@ -240,7 +304,7 @@ fun MediaRow(
                             type = item.type,
                             userState = item.userState,
                             progress = rowItem.progress,
-                            onClick = { onItemClick(item.contentId) },
+                            onClick = { openDetail(item) },
                             overlay = rowItem.overlay,
                             actions = cardActions(item),
                             modifier = Modifier.animateItem(),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/Skeleton.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/Skeleton.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -26,10 +27,12 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.siloserver.silo.android.ui.theme.SiloSurfaceElevated
 import org.siloserver.silo.common.cards.LocalCardPresentation
+import org.siloserver.silo.common.ui.components.ThumbhashImage
 
 private val ShimmerHighlight = Color.White.copy(alpha = 0.06f)
 
@@ -165,15 +168,37 @@ private val GridSkeletonInset = 16.dp
  * first frame instead of a spinner over black that snaps into the full screen.
  */
 @Composable
-fun DetailLoadingSkeleton(modifier: Modifier = Modifier) {
+fun DetailLoadingSkeleton(
+    modifier: Modifier = Modifier,
+    artworkUrl: String? = null,
+    artworkThumbhash: String? = null,
+) {
     val shimmer = rememberShimmerProgress()
     Column(modifier = modifier.fillMaxWidth()) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(16f / 10f)
-                .skeleton(shimmer, RoundedCornerShape(0.dp)),
-        )
+        val heroModifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(16f / 10f)
+        if (!artworkUrl.isNullOrBlank() || !artworkThumbhash.isNullOrBlank()) {
+            Box(modifier = heroModifier) {
+                ThumbhashImage(
+                    url = artworkUrl,
+                    thumbhash = artworkThumbhash,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    crossfadeMillis = 120,
+                    modifier = Modifier.fillMaxSize(),
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .drawBehind { drawRect(Color.Black.copy(alpha = 0.20f)) },
+                )
+            }
+        } else {
+            Box(
+                modifier = heroModifier.skeleton(shimmer, RoundedCornerShape(0.dp)),
+            )
+        }
         Spacer(modifier = Modifier.height(20.dp))
         Box(
             modifier = Modifier

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/SortFilterControls.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/SortFilterControls.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -34,11 +33,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.siloserver.silo.android.ui.theme.SiloOnOpaqueControl
+import org.siloserver.silo.android.ui.theme.SiloOpaqueControl
+import org.siloserver.silo.android.ui.theme.SiloOpaqueControlBorder
+import org.siloserver.silo.android.ui.theme.SiloOpaqueControlSelected
 
 /** One entry in the sort dropdown. [selectedLabel] (e.g. "Title · A–Z") shows while active. */
 data class SortMenuOption(
@@ -153,9 +155,10 @@ private fun ControlPill(
         onClick = onClick,
         shape = CircleShape,
         contentPadding = PaddingValues(horizontal = 12.dp),
-        border = BorderStroke(1.5.dp, Color.White.copy(alpha = if (active) 0.9f else 0.3f)),
+        border = BorderStroke(1.dp, SiloOpaqueControlBorder),
         colors = ButtonDefaults.outlinedButtonColors(
-            contentColor = MaterialTheme.colorScheme.onSurface,
+            contentColor = SiloOnOpaqueControl,
+            containerColor = if (active) SiloOpaqueControlSelected else SiloOpaqueControl,
         ),
         modifier = Modifier.height(34.dp),
     ) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/SwipeBack.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/SwipeBack.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,6 +23,10 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.Velocity
 import kotlinx.coroutines.launch
 
 private const val DismissFraction = 0.35f
@@ -29,6 +34,30 @@ private val FlingMinTravel = 24.dp
 private const val FlingVelocityPxPerSec = 1800f
 private const val MinScale = 0.96f
 private val CornerRadius = 24.dp
+
+class SwipeDownDismissState internal constructor() {
+    // Gesture callbacks update this synchronously on the UI thread. The old
+    // implementation launched one snap coroutine per pointer delta, which
+    // could queue updates and make the card trail the finger.
+    internal var offsetPx by mutableFloatStateOf(0f)
+    internal var dismissing by mutableStateOf(false)
+
+    /**
+     * Pop immediately so Navigation restores the real source page and moves
+     * the outgoing card itself. Keeping no separate local exit animation
+     * avoids leaving an invisible, touch-blocking destination after the card
+     * has visibly cleared the screen.
+     */
+    fun dismiss(onDismiss: () -> Unit) {
+        if (dismissing) return
+        dismissing = true
+        onDismiss()
+    }
+}
+
+@Composable
+fun rememberSwipeDownDismissState(): SwipeDownDismissState =
+    remember { SwipeDownDismissState() }
 
 /**
  * iOS-style interactive "swipe back": a rightward drag on the page moves it
@@ -103,5 +132,81 @@ fun Modifier.swipeBackToDismiss(
             transformOrigin = TransformOrigin(0f, 0.5f)
             clip = progress > 0f
             shape = RoundedCornerShape(cornerPx * (progress * 4f).coerceAtMost(1f))
+        }
+}
+
+/**
+ * Sheet-style downward dismissal that activates only from unconsumed downward
+ * scroll (normally when the detail list is already at its top). This preserves
+ * ordinary vertical scrolling in the page while matching the mobile detail
+ * card's pull-down-to-close interaction.
+ */
+@Composable
+fun Modifier.swipeDownToDismiss(
+    state: SwipeDownDismissState,
+    onDismiss: () -> Unit,
+    enabled: Boolean = true,
+): Modifier {
+    if (!enabled) return this
+    val density = LocalDensity.current
+    val thresholdPx = with(density) { 140.dp.toPx() }
+    val flingMinTravelPx = with(density) { 24.dp.toPx() }
+    val currentOnDismiss by rememberUpdatedState(onDismiss)
+    val connection = remember(state, thresholdPx, flingMinTravelPx) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: androidx.compose.ui.input.nestedscroll.NestedScrollSource): Offset {
+                if (state.dismissing || state.offsetPx <= 0f || available.y >= 0f) return Offset.Zero
+                val consumed = maxOf(available.y, -state.offsetPx)
+                state.offsetPx = (state.offsetPx + consumed).coerceAtLeast(0f)
+                return Offset(0f, consumed)
+            }
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: androidx.compose.ui.input.nestedscroll.NestedScrollSource,
+            ): Offset {
+                // Only a real finger pull on the detail page may arm its
+                // dismissal. Modal picker sheets also animate downward when an
+                // option is selected; accepting their side-effect scroll here
+                // popped the entire detail route as the selector closed.
+                if (source != androidx.compose.ui.input.nestedscroll.NestedScrollSource.UserInput ||
+                    available.y <= 0f || state.dismissing
+                ) {
+                    return Offset.Zero
+                }
+                state.offsetPx = (state.offsetPx + available.y * 0.72f)
+                    .coerceAtMost(thresholdPx * 1.4f)
+                return Offset(0f, available.y)
+            }
+
+            override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                val intentionalFlick = state.offsetPx >= flingMinTravelPx &&
+                    available.y > FlingVelocityPxPerSec
+                if (state.offsetPx >= thresholdPx || intentionalFlick) {
+                    state.dismiss(onDismiss = currentOnDismiss)
+                } else if (state.offsetPx > 0f) {
+                    Animatable(state.offsetPx).animateTo(
+                        targetValue = 0f,
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioNoBouncy,
+                            stiffness = Spring.StiffnessLow,
+                        ),
+                    ) {
+                        state.offsetPx = value
+                    }
+                }
+                return Velocity.Zero
+            }
+        }
+    }
+    return this
+        .nestedScroll(connection)
+        .graphicsLayer {
+            translationY = state.offsetPx
+            val progress = (state.offsetPx / thresholdPx).coerceIn(0f, 1f)
+            val scale = 1f - progress * 0.025f
+            scaleX = scale
+            scaleY = scale
         }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/TopBarActions.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/TopBarActions.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.android.ui.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -28,6 +29,7 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeTint
 import dev.chrisbanes.haze.hazeEffect
 import org.siloserver.silo.android.ui.screens.profiles.ProfileAvatar
+import org.siloserver.silo.android.ui.theme.SiloDetailActionControlActive
 import org.siloserver.silo.common.ui.components.avatarRef
 import org.siloserver.silo.model.profile.Profile
 
@@ -48,16 +50,23 @@ fun TopBarIconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     isActive: Boolean = false,
+    opaque: Boolean = false,
     content: @Composable BoxScope.() -> Unit,
 ) {
     Surface(
         onClick = onClick,
         modifier = modifier,
-        color = if (isActive) MaterialTheme.colorScheme.onSurface else Color.Transparent,
-        contentColor = if (isActive) MaterialTheme.colorScheme.background else MaterialTheme.colorScheme.onSurface,
+        color = when {
+            isActive && opaque -> Color.White.copy(alpha = 0.38f)
+            isActive -> Color.White.copy(alpha = 0.18f)
+            opaque -> SiloDetailActionControlActive
+            else -> Color.Transparent
+        },
+        contentColor = if (opaque) Color.White else MaterialTheme.colorScheme.onSurface,
         shape = CircleShape,
         tonalElevation = 0.dp,
-        shadowElevation = 0.dp,
+        shadowElevation = if (opaque) 5.dp else 0.dp,
+        border = if (opaque) BorderStroke(1.dp, Color.White.copy(alpha = 0.24f)) else null,
     ) {
         Box(
             modifier = Modifier.size(40.dp),
@@ -77,15 +86,16 @@ fun TopBarProfileMenu(
     onSwitchProfileClick: () -> Unit,
     onSwitchServerClick: () -> Unit,
     onSignOutClick: () -> Unit,
+    opaque: Boolean = false,
 ) {
     var menuExpanded by rememberSaveable { mutableStateOf(false) }
     Box {
-        TopBarIconButton(onClick = { menuExpanded = true }) {
+        TopBarIconButton(onClick = { menuExpanded = true }, opaque = opaque) {
             if (activeProfile != null) {
                 ProfileAvatar(
                     avatar = activeProfile.avatarRef(),
                     name = activeProfile.name,
-                    size = 36.dp,
+                    size = if (opaque) 30.dp else 36.dp,
                 )
             } else {
                 Box(
@@ -131,6 +141,7 @@ fun TabTopBarActions(
     onSwitchServerClick: () -> Unit,
     onSignOutClick: () -> Unit,
     modifier: Modifier = Modifier,
+    opaque: Boolean = false,
     leadingActions: @Composable () -> Unit = {},
 ) {
     Row(
@@ -139,7 +150,7 @@ fun TabTopBarActions(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         leadingActions()
-        TopBarIconButton(onClick = onSearchClick) {
+        TopBarIconButton(onClick = onSearchClick, opaque = opaque) {
             Icon(
                 imageVector = Icons.Outlined.Search,
                 contentDescription = "Search",
@@ -153,6 +164,7 @@ fun TabTopBarActions(
             onSwitchProfileClick = onSwitchProfileClick,
             onSwitchServerClick = onSwitchServerClick,
             onSignOutClick = onSignOutClick,
+            opaque = opaque,
         )
     }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
@@ -1,14 +1,21 @@
 package org.siloserver.silo.android.ui.navigation
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.rememberCoroutineScope
@@ -27,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -56,6 +64,7 @@ import org.siloserver.silo.android.ui.screens.collections.CollectionsScreen
 import org.siloserver.silo.android.ui.screens.collections.LibraryCollectionsScreen
 import org.siloserver.silo.android.ui.screens.detail.ItemDetailScreen
 import org.siloserver.silo.android.ui.screens.detail.ItemDetailViewModel
+import org.koin.core.parameter.parametersOf
 import org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherEntrySheet
 import org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherLobbyScreen
 import org.siloserver.silo.android.ui.screens.people.PersonDetailScreen
@@ -97,6 +106,10 @@ import org.koin.compose.viewmodel.koinViewModel
 
 /** Page-to-page cross-fade duration (ms). Snappier than Compose Nav's 700ms default. */
 private const val PageFadeDurationMs = 200
+private const val DetailCardOpenDurationMs = 600
+private const val DetailCardCloseDurationMs = 440
+private val DetailCardOpenEasing = CubicBezierEasing(0.32f, 0.00f, 0.20f, 1.00f)
+private val DetailCardCloseEasing = CubicBezierEasing(0.40f, 0.00f, 0.20f, 1.00f)
 
 internal class PlayerTargetProviderRegistration(
     val backStackEntryId: String,
@@ -288,8 +301,8 @@ fun AppNavigation(
     // (a poster card, the detail hero) can opt in without threading it through
     // every composable signature in between.
     SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
-    // One hand-off shared by every poster source and the detail hero target, so
-    // the tapped card's unique key reaches the backdrop (iOS pendingZoomSourceID).
+    // One hand-off shared by every media source. It also carries the browse
+    // deck used by the horizontally paged detail sheet.
     val heroSourceHandoff = remember { HeroSourceHandoff() }
     CompositionLocalProvider(
         LocalSharedTransitionScope provides this,
@@ -303,13 +316,39 @@ fun AppNavigation(
         // this the host wraps to content, leaking unbounded height into screens
         // like the reader whose WebView paginates against the viewport height.
         modifier = Modifier.fillMaxSize(),
-        // Compose Navigation defaults to a 700ms cross-fade, which reads as
-        // sluggish page-to-page (Jim, Fold). Snap it to a quick fade; the
-        // poster→detail hero morph rides the same scope, so keep it long enough
-        // to stay smooth.
-        enterTransition = { fadeIn(tween(PageFadeDurationMs)) },
-        exitTransition = { fadeOut(tween(PageFadeDurationMs)) },
-        popEnterTransition = { fadeIn(tween(PageFadeDurationMs)) },
+        // Keep the source destination painted underneath an item-detail sheet
+        // while its rounded card rises from the bottom. Every other route keeps
+        // the app's short page fade.
+        enterTransition = {
+            if (targetState.destination.route == Route.ItemDetail.ROUTE) {
+                EnterTransition.None
+            } else {
+                fadeIn(tween(PageFadeDurationMs))
+            }
+        },
+        exitTransition = {
+            if (targetState.destination.route == Route.ItemDetail.ROUTE) {
+                // Hold the exact source page under the rising card, then let
+                // only the final part of the motion dissolve it into the
+                // opaque app background. Once settled, no Home artwork leaks
+                // through the safe-area strip above the rounded card.
+                fadeOut(
+                    tween(
+                        durationMillis = 180,
+                        delayMillis = DetailCardOpenDurationMs - 180,
+                    ),
+                )
+            } else {
+                fadeOut(tween(PageFadeDurationMs))
+            }
+        },
+        popEnterTransition = {
+            if (initialState.destination.route == Route.ItemDetail.ROUTE) {
+                EnterTransition.None
+            } else {
+                fadeIn(tween(PageFadeDurationMs))
+            }
+        },
         popExitTransition = { fadeOut(tween(PageFadeDurationMs)) },
     ) {
         // ---- Auth flow ----
@@ -877,14 +916,83 @@ fun AppNavigation(
                     nullable = true
                     defaultValue = null
                 },
+                navArgument("episodeContentId") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
             ),
-        ) {
-            // Publish this destination's visibility scope so the detail backdrop
-            // (and the "More Like This" rail) take part in the hero morph.
+            enterTransition = {
+                slideInVertically(
+                    initialOffsetY = { fullHeight -> fullHeight },
+                    animationSpec = tween(
+                        durationMillis = DetailCardOpenDurationMs,
+                        easing = DetailCardOpenEasing,
+                    ),
+                )
+            },
+            exitTransition = { fadeOut(tween(durationMillis = 140)) },
+            popEnterTransition = { EnterTransition.None },
+            // Move the actual outgoing destination and remove it when the
+            // visible slide finishes. A delayed transparent exit leaves an
+            // invisible destination over Home and swallows the next card tap.
+            popExitTransition = {
+                slideOutVertically(
+                    targetOffsetY = { fullHeight -> fullHeight },
+                    animationSpec = tween(
+                        durationMillis = DetailCardCloseDurationMs,
+                        easing = DetailCardCloseEasing,
+                    ),
+                )
+            },
+        ) { backStackEntry ->
+            // Keep the destination scope available to media cards nested in
+            // the detail page while the page itself uses the native-sheet style
+            // bottom transition above.
             CompositionLocalProvider(LocalNavAnimatedVisibilityScope provides this) {
-            val detailViewModel = koinViewModel<ItemDetailViewModel>()
             var wtTarget by remember { mutableStateOf<Pair<String, Int?>?>(null) }
+            val initialContentId = backStackEntry.arguments?.getString("contentId").orEmpty()
+            val openingArtworkUrl = remember(initialContentId) { heroSourceHandoff.pendingArtworkUrl }
+            val openingArtworkThumbhash = remember(initialContentId) {
+                heroSourceHandoff.pendingArtworkThumbhash
+            }
+            val browseContentIds = remember(initialContentId) {
+                heroSourceHandoff.pendingBrowseContentIds
+                    ?.takeIf { initialContentId in it }
+                    .orEmpty()
+                    .ifEmpty { listOf(initialContentId) }
+            }
+            val initialPage = browseContentIds.indexOf(initialContentId).coerceAtLeast(0)
+            val detailPagerState = rememberPagerState(initialPage = initialPage) { browseContentIds.size }
+            LaunchedEffect(Unit) {
+                heroSourceHandoff.pendingBrowseContentIds = null
+                heroSourceHandoff.pendingBrowseOrigin = null
+                heroSourceHandoff.pendingArtworkUrl = null
+                heroSourceHandoff.pendingArtworkThumbhash = null
+            }
+            HorizontalPager(
+                state = detailPagerState,
+                beyondViewportPageCount = 1,
+                pageSpacing = 10.dp,
+                modifier = Modifier.fillMaxSize(),
+            ) { page ->
+            val pageContentId = browseContentIds[page]
+            val detailViewModel = if (page == initialPage) {
+                koinViewModel<ItemDetailViewModel>()
+            } else {
+                koinViewModel(
+                    key = "detail-deck-${backStackEntry.id}-$pageContentId",
+                    parameters = {
+                        parametersOf(SavedStateHandle(mapOf("contentId" to pageContentId)))
+                    },
+                )
+            }
+            CompositionLocalProvider(
+                LocalHeroSourceHandoff provides if (page == initialPage) heroSourceHandoff else null,
+            ) {
             ItemDetailScreen(
+                openingArtworkUrl = openingArtworkUrl.takeIf { page == initialPage },
+                openingArtworkThumbhash = openingArtworkThumbhash.takeIf { page == initialPage },
                 onBackClick = { navController.popBackStack() },
                 onPlayClick = { contentId, fileId, audioTrackIndex, subtitleTrackIndex, resumePositionSeconds ->
                     val launchedRemotely = siloCastController.launchOnConnectedTarget(
@@ -939,13 +1047,15 @@ fun AppNavigation(
                 },
                 viewModel = detailViewModel,
             )
-            wtTarget?.let { (cid, fid) ->
+            if (page == detailPagerState.currentPage) wtTarget?.let { (cid, fid) ->
                 WatchTogetherEntrySheet(
                     contentId = cid,
                     fileId = fid,
                     onNavigate = { route -> navController.navigate(route) },
                     onDismiss = { wtTarget = null },
                 )
+            }
+            }
             }
             }
         }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/BottomNavBar.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/BottomNavBar.kt
@@ -1,12 +1,13 @@
 package org.siloserver.silo.android.ui.navigation
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
@@ -29,7 +31,6 @@ import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.GridView
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
@@ -48,9 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
-import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.HazeTint
-import dev.chrisbanes.haze.hazeEffect
+import org.siloserver.silo.android.ui.theme.SiloDetailActionControlActive
 
 /**
  * Total height of the translucent bottom chrome (cast mini bar + nav bar +
@@ -130,40 +129,38 @@ internal fun NavOptionsBuilder.tabSwitchNavOptions(anchorRoute: String?) {
 }
 
 private val PillHeight = 60.dp
+// Keep foldable/tablet chrome at the same physical footprint as the phone
+// capsule instead of stretching one tab item across the expanded window.
+private val PillExpandedMaxWidth = 380.dp
+// BoxWithConstraints measures after the bar's 20dp side margins, so 560dp
+// corresponds to the app's 600dp expanded-window breakpoint.
+private val PillExpandedWindowBreakpoint = 560.dp
 private val PillHorizontalMargin = 20.dp
 private val PillBottomMargin = 10.dp
 private val PillTopMargin = 8.dp
-// Glass recipe: content beneath is blurred by Haze, then tinted with this
-// wash so labels stay legible over bright posters. On API < 31 Haze cannot
-// blur and paints only the tint, so the fallback fill is heavier.
-private val PillGlassTint = Color(0xFF1C1C1E).copy(alpha = 0.72f)
-private val PillFallbackFill = Color(0xFF1C1C1E).copy(alpha = 0.96f)
-private val PillBlurRadius = 24.dp
-private val PillHairline = Color.White.copy(alpha = 0.12f)
-private val SelectedChipFill = Color.White.copy(alpha = 0.14f)
 
 /**
  * Floating pill tab bar, matching the iOS app's detached bottom capsule.
  *
  * The bar draws no full-width scrim: tab content scrolls edge-to-edge and
- * shows around the capsule. The capsule itself is real glass — [hazeState]
- * must be the state the tab content is registered on via `hazeSource`, so
- * the pill blurs whatever scrolls beneath it and tints the result. The selected tab
- * carries a soft chip highlight and a filled icon; unselected tabs are
- * outlined and muted. Colors animate on switch so the highlight reads as
- * moving rather than popping.
+ * shows around the faint artwork-tinted capsule used by detail's X/remote
+ * buttons. Bright white glyphs keep the tab symbols legible without turning
+ * the material into a pale solid bar.
  */
 @Composable
 fun SiloBottomNavBar(
     currentTab: Tab,
     onTabSelected: (Tab) -> Unit,
-    hazeState: HazeState,
+    /** iOS `tabBarMinimizeBehavior(.onScrollDown)`: Home collapses the full
+     *  capsule into one still-tappable Home control until it is reselected or
+     *  the feed returns to its top. Other tabs always render expanded. */
+    minimizedToCurrentTab: Boolean = false,
     // Caller decides which tabs to render — used to hide the Downloads tab
     // when the user has no downloads in flight or on disk. Defaults to all
     // tabs for backwards-compat.
     tabs: List<Tab> = Tab.entries.toList(),
 ) {
-    Box(
+    BoxWithConstraints(
         modifier = Modifier
             .fillMaxWidth()
             .navigationBarsPadding()
@@ -174,27 +171,37 @@ fun SiloBottomNavBar(
                 bottom = PillBottomMargin,
             ),
     ) {
+        val isExpandedWindow = maxWidth >= PillExpandedWindowBreakpoint
+        val pillWidth by animateDpAsState(
+            targetValue = if (minimizedToCurrentTab) {
+                PillHeight
+            } else {
+                maxWidth.coerceAtMost(PillExpandedMaxWidth)
+            },
+            animationSpec = tween(durationMillis = 260),
+            label = "bottomNavWidth",
+        )
+        val displayedTabs = if (minimizedToCurrentTab) listOf(currentTab) else tabs
         Row(
             modifier = Modifier
-                .fillMaxWidth()
+                // Keep alignment stable for the entire width animation:
+                // mobile grows from the left; the already-approved expanded
+                // foldable/tablet bar remains centered in both states.
+                .align(if (isExpandedWindow) Alignment.Center else Alignment.CenterStart)
+                .width(pillWidth)
                 .height(PillHeight)
-                .shadow(elevation = 16.dp, shape = CircleShape, clip = false)
+                .shadow(elevation = 20.dp, shape = CircleShape, clip = false)
                 .clip(CircleShape)
-                .hazeEffect(state = hazeState) {
-                    blurRadius = PillBlurRadius
-                    noiseFactor = 0f
-                    backgroundColor = PillFallbackFill
-                    tints = listOf(HazeTint(PillGlassTint))
-                    fallbackTint = HazeTint(PillFallbackFill)
-                }
-                .border(0.75.dp, PillHairline, CircleShape)
+                .background(SiloDetailActionControlActive)
+                .border(1.dp, Color.White.copy(alpha = 0.24f), CircleShape)
                 .padding(horizontal = 6.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            tabs.forEach { tab ->
+            displayedTabs.forEach { tab ->
                 PillTabItem(
                     tab = tab,
                     selected = tab == currentTab,
+                    showSelectedChip = !minimizedToCurrentTab,
                     onClick = { onTabSelected(tab) },
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                 )
@@ -207,19 +214,33 @@ fun SiloBottomNavBar(
 private fun PillTabItem(
     tab: Tab,
     selected: Boolean,
+    showSelectedChip: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val chip by animateColorAsState(
-        targetValue = if (selected) SelectedChipFill else Color.Transparent,
+        targetValue = if (selected && showSelectedChip) {
+            Color.White.copy(alpha = 0.28f)
+        } else {
+            Color.Transparent
+        },
         animationSpec = tween(durationMillis = 220),
         label = "tabChip",
     )
+    val chipBorder by animateColorAsState(
+        targetValue = if (selected && showSelectedChip) {
+            Color.White.copy(alpha = 0.46f)
+        } else {
+            Color.Transparent
+        },
+        animationSpec = tween(durationMillis = 220),
+        label = "tabChipBorder",
+    )
     val tint by animateColorAsState(
         targetValue = if (selected) {
-            MaterialTheme.colorScheme.onSurface
+            Color.White
         } else {
-            MaterialTheme.colorScheme.onSurfaceVariant
+            Color.White.copy(alpha = 0.96f)
         },
         animationSpec = tween(durationMillis = 220),
         label = "tabTint",
@@ -229,6 +250,7 @@ private fun PillTabItem(
         modifier = modifier
             .clip(CircleShape)
             .background(chip)
+            .border(1.dp, chipBorder, CircleShape)
             // selectable (not clickable) so TalkBack announces which tab is
             // active — the chip and filled icon alone are not perceivable.
             .selectable(
@@ -245,14 +267,14 @@ private fun PillTabItem(
             imageVector = if (selected) tab.selectedIcon else tab.icon,
             contentDescription = tab.label,
             tint = tint,
-            modifier = Modifier.size(22.dp),
+            modifier = Modifier.size(25.dp),
         )
         Spacer(modifier = Modifier.height(2.dp))
         Text(
             text = tab.label,
             color = tint,
-            fontSize = 10.sp,
-            lineHeight = 12.sp,
+            fontSize = 11.sp,
+            lineHeight = 13.sp,
             fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
             maxLines = 1,
         )

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/MobileMediaTabs.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/MobileMediaTabs.kt
@@ -10,13 +10,16 @@ val Tab.isUtilityTab: Boolean
 // library content (video / audio / reading) is reached through the Libraries picker.
 fun visibleMobileTabs(
     @Suppress("UNUSED_PARAMETER") capabilities: MediaModeCapabilities,
-    showDownloads: Boolean,
+    @Suppress("UNUSED_PARAMETER") showDownloads: Boolean,
 ): List<Tab> = buildList {
     add(Tab.Home)
     add(Tab.Libraries)
     add(Tab.ForYou)
     add(Tab.Calendar)
-    if (showDownloads) add(Tab.Downloads)
+    // Keep Downloads present from the first authenticated frame. Capability
+    // and local-record hydration may finish later, but navigation must not
+    // shift underneath the user while that optional data arrives.
+    add(Tab.Downloads)
 }
 
 fun fallbackMobileTab(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/Routes.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/Routes.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import org.siloserver.silo.common.player.video.VideoPlayerRouteArgs
+import org.siloserver.silo.model.section.SectionItem
 
 /**
  * All navigation routes for the Silo app.
@@ -123,15 +124,19 @@ sealed class Route(val route: String) {
     data class ItemDetail(
         val contentId: String,
         val seasonNumber: Int? = null,
+        val episodeContentId: String? = null,
     ) : Route(
-        if (seasonNumber != null) {
-            "item/${contentId.routeEncode()}?seasonNumber=$seasonNumber"
-        } else {
-            "item/${contentId.routeEncode()}"
-        }
+        "item/${contentId.routeEncode()}" +
+            listOfNotNull(
+                seasonNumber?.let { "seasonNumber=$it" },
+                episodeContentId
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { "episodeContentId=${it.routeEncode()}" },
+            ).let { params -> if (params.isEmpty()) "" else "?" + params.joinToString("&") },
     ) {
         companion object {
-            const val ROUTE = "item/{contentId}?seasonNumber={seasonNumber}"
+            const val ROUTE =
+                "item/{contentId}?seasonNumber={seasonNumber}&episodeContentId={episodeContentId}"
         }
     }
 
@@ -263,6 +268,24 @@ sealed class Route(val route: String) {
         }
     }
 
+}
+
+/**
+ * Continue Watching episodes belong to the unified series detail surface.
+ * Preserve the episode as route state so opening (for example) S3E1 loads the
+ * parent series, selects Season 3, and focuses that exact episode in its rail.
+ */
+internal fun continueWatchingDetailRoute(item: SectionItem): String {
+    val seriesId = item.seriesId?.takeIf { it.isNotBlank() }
+    return if (item.type.equals("episode", ignoreCase = true) && seriesId != null) {
+        Route.ItemDetail(
+            contentId = seriesId,
+            seasonNumber = item.seasonNumber,
+            episodeContentId = item.contentId,
+        ).route
+    } else {
+        Route.ItemDetail(item.contentId).route
+    }
 }
 
 /**

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/SharedElementTransition.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/SharedElementTransition.kt
@@ -62,6 +62,12 @@ fun heroSharedKeyPrefix(contentId: String): String = "hero-$contentId"
  */
 class HeroSourceHandoff {
     var pendingKey: String? by mutableStateOf(null)
+    var pendingBrowseContentIds: List<String>? by mutableStateOf(null)
+    var pendingBrowseOrigin: String? by mutableStateOf(null)
+    // Artwork already known by the tapped card. The detail loading state uses
+    // it immediately, starting the full backdrop request before metadata lands.
+    var pendingArtworkUrl: String? by mutableStateOf(null)
+    var pendingArtworkThumbhash: String? by mutableStateOf(null)
 }
 
 val LocalHeroSourceHandoff = compositionLocalOf<HeroSourceHandoff?> { null }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt
@@ -50,6 +50,7 @@ import org.siloserver.silo.android.ui.navigation.fallbackMobileTab
 import org.siloserver.silo.android.ui.navigation.scopedLocalDownloadBytes
 import org.siloserver.silo.android.ui.navigation.shouldShowDownloadsTab
 import org.siloserver.silo.android.ui.navigation.visibleMobileTabs
+import org.siloserver.silo.android.ui.navigation.continueWatchingDetailRoute
 import org.siloserver.silo.android.ui.screens.calendar.CalendarScreen
 import org.siloserver.silo.android.ui.screens.home.HomeScreen
 import org.siloserver.silo.android.cast.SiloCastController
@@ -60,6 +61,7 @@ import org.siloserver.silo.android.ui.screens.libraries.LibrariesSelectorSheet
 import org.siloserver.silo.android.ui.screens.libraries.LibrariesViewModel
 import org.siloserver.silo.android.ui.screens.recommendations.ForYouList
 import org.siloserver.silo.android.ui.screens.recommendations.RecommendationsScreen
+import org.siloserver.silo.viewmodel.RecommendationsViewModel
 import org.siloserver.silo.android.ui.screens.recommendations.headerTitle
 import org.siloserver.silo.android.ui.screens.watchtogether.WatchTogetherMenuEntrySheet
 import org.siloserver.silo.cast.SiloCastPlaybackRequest
@@ -131,9 +133,13 @@ fun MainScreen(
         null
     }
     var showLibrarySelector by rememberSaveable(currentTab) { mutableStateOf(false) }
-    // Bumped when the Home tab is re-tapped while already on Home; HomeScreen
-    // reacts by scrolling back to the top.
-    var homeScrollToTopTick by remember { mutableStateOf(0) }
+    var homeBottomNavMinimized by rememberSaveable { mutableStateOf(false) }
+
+    // Entering (or re-entering) any tab starts with the complete tab capsule.
+    // Home alone can minimize it after the user begins scrolling downward.
+    LaunchedEffect(currentTab) {
+        homeBottomNavMinimized = false
+    }
 
     // Downloads tab visibility: show whenever EITHER the server says there
     // are records OR we have bytes on disk. The on-disk check is what makes
@@ -312,6 +318,9 @@ fun MainScreen(
     // What For You is actually showing (the empty-feed fallback shows the
     // Watchlist without making it an explicit selection); drives the title.
     var forYouDisplayed by remember { mutableStateOf<ForYouList?>(null) }
+    // Instantiate with the shell, not when the lazy tab is first opened, so
+    // Discover and taste-profile requests run alongside profile/header setup.
+    val recommendationsViewModel = koinViewModel<RecommendationsViewModel>()
     Scaffold(
         bottomBar = {
             // The cast bar rests above the nav menu (iOS tabViewBottomAccessory
@@ -325,11 +334,13 @@ fun MainScreen(
                 )
                 SiloBottomNavBar(
                     currentTab = currentTab,
+                    minimizedToCurrentTab = currentTab == Tab.Home && homeBottomNavMinimized,
                     onTabSelected = { tab ->
                         if (tab == Tab.Home && currentTab == Tab.Home) {
-                            // Re-tapping Home while on Home scrolls it back to the
-                            // top (standard Android bottom-nav convention).
-                            homeScrollToTopTick += 1
+                            // The minimized Home control remains tappable. A
+                            // repeat tap expands the full capsule without
+                            // disturbing the user's feed position.
+                            homeBottomNavMinimized = false
                         } else {
                             navController.navigate(tab.route) {
                                 // Pop to the tab stack's live anchor, not a
@@ -344,7 +355,6 @@ fun MainScreen(
                         }
                     },
                     tabs = visibleTabs,
-                    hazeState = hazeState,
                 )
             }
         },
@@ -377,9 +387,14 @@ fun MainScreen(
                     Tab.Home -> {
                         val homeViewModel = koinViewModel<HomeViewModel>()
                         HomeScreen(
-                            scrollToTopTick = homeScrollToTopTick,
+                            onBottomNavMinimizedChange = { minimized ->
+                                homeBottomNavMinimized = minimized
+                            },
                             onItemClick = { contentId ->
                                 navController.navigate(Route.ItemDetail(contentId).route)
+                            },
+                            onContinueWatchingItemClick = { item ->
+                                navController.navigate(continueWatchingDetailRoute(item))
                             },
                             onPlayClick = { contentId, resumePositionSeconds ->
                                 playVideo(contentId, resumePositionSeconds = resumePositionSeconds)
@@ -438,6 +453,7 @@ fun MainScreen(
                             onSavedListSelectionChange = { forYouList = it },
                             onDisplayedListChange = { forYouDisplayed = it },
                             contentTopPadding = headerContentTop,
+                            viewModel = recommendationsViewModel,
                         )
                     }
                     Tab.Calendar -> {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/audiobook/AudiobookDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/audiobook/AudiobookDetailContent.kt
@@ -272,6 +272,7 @@ fun AudiobookDetailContent(
                         contentDescription = if (isFavorite) "Remove from favorites" else "Add to favorites",
                         onClick = onFavoriteClick,
                         activeTint = Color(0xFFEF5350),
+                        label = "Favorite",
                     )
                     CircleActionButton(
                         icon = Icons.Filled.BookmarkBorder,
@@ -279,6 +280,7 @@ fun AudiobookDetailContent(
                         isActive = isInWatchlist,
                         contentDescription = if (isInWatchlist) "Remove from watchlist" else "Add to watchlist",
                         onClick = onWatchlistClick,
+                        label = "Watchlist",
                     )
                 }
                 OutlinedButton(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/book/BookDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/book/BookDetailContent.kt
@@ -271,6 +271,7 @@ fun BookDetailContent(
                         contentDescription = if (isFavorite) "Remove from favorites" else "Add to favorites",
                         onClick = onFavoriteClick,
                         activeTint = Color(0xFFEF5350),
+                        label = "Favorite",
                     )
                     CircleActionButton(
                         icon = Icons.Filled.BookmarkBorder,
@@ -278,6 +279,7 @@ fun BookDetailContent(
                         isActive = isInWatchlist,
                         contentDescription = if (isInWatchlist) "Remove from watchlist" else "Add to watchlist",
                         onClick = onWatchlistClick,
+                        label = "Watchlist",
                     )
                 }
                 downloadProgress?.let { progress ->

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
@@ -70,6 +70,7 @@ import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
 import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrolling
 import org.siloserver.silo.model.catalog.BrowseItem
 import org.siloserver.silo.overlays.OverlayDataExtractor
+import org.siloserver.silo.android.ui.navigation.LocalHeroSourceHandoff
 
 /**
  * A vertical grid of media cards with infinite-scroll support.
@@ -102,6 +103,11 @@ fun CatalogGrid(
     header: (@Composable () -> Unit)? = null,
 ) {
     val gridState = rememberLazyGridState()
+    val heroHandoff = LocalHeroSourceHandoff.current
+    val browseContentIds = remember(items) { items.map { it.contentId } }
+    val browseOrigin = remember(items.firstOrNull()?.contentId) {
+        "catalog-${items.firstOrNull()?.contentId.orEmpty()}"
+    }
     // The session density picks the base cell; the server-driven poster-size
     // preference multiplies it, shifting the adaptive column count.
     val cardWidth = viewDensity.minCardWidth * LocalCardPresentation.current.posterSize.posterScale
@@ -171,10 +177,17 @@ fun CatalogGrid(
                     subtitle = cardSubtitle?.invoke(item),
                     type = item.type,
                     userState = userState,
-                    onClick = { onItemClick(item.contentId) },
+                    onClick = {
+                        heroHandoff?.pendingBrowseContentIds = browseContentIds
+                        heroHandoff?.pendingBrowseOrigin = browseOrigin
+                        heroHandoff?.pendingArtworkUrl = item.backdropUrl ?: item.posterUrl
+                        heroHandoff?.pendingArtworkThumbhash = item.backdropThumbhash ?: item.posterThumbhash
+                        onItemClick(item.contentId)
+                    },
                     width = cardWidth,
                     overlay = OverlayDataExtractor.fromBrowseItem(item),
                     actions = actions,
+                    sharedContentId = item.contentId,
                 )
             }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -32,8 +33,6 @@ import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -54,6 +53,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
@@ -64,9 +64,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.siloserver.silo.android.ui.theme.SiloBackground
 import org.siloserver.silo.android.ui.theme.SiloOnSurface
+import org.siloserver.silo.android.ui.theme.SiloOnOpaqueControl
+import org.siloserver.silo.android.ui.theme.SiloDetailActionControl
+import org.siloserver.silo.android.ui.theme.SiloDetailActionControlActive
+import org.siloserver.silo.android.ui.theme.SiloOpaqueControl
+import org.siloserver.silo.android.ui.theme.SiloOpaqueControlBorder
 import org.siloserver.silo.android.ui.theme.SiloSecondaryText
 import org.siloserver.silo.android.ui.theme.SiloSurfaceElevated
-import org.siloserver.silo.android.ui.navigation.heroTarget
 import org.siloserver.silo.android.ui.theme.PillShape
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.catalog.ItemDetail
@@ -82,17 +86,19 @@ internal val DetailTertiaryText = SiloOnSurface.copy(alpha = 0.55f)
 internal val SafePadding = 16.dp
 internal val SmallPadding = 8.dp
 internal val LargePadding = 24.dp
+private const val DetailArtworkCrossfadeMs = 120
 
 // ── Dynamic palette ───────────────────────────────────────────
 
-fun detailScreenBackgroundBrush(dominantColor: Color): Brush =
-    Brush.verticalGradient(
-        0.00f to dominantColor.copy(alpha = 0.10f),
-        0.22f to Color.Transparent,
-        1.00f to Color.Transparent,
+fun detailScreenBackgroundBrush(dominantColor: Color): Brush {
+    val surface = lerp(Color.Black, dominantColor, 0.42f)
+    return Brush.verticalGradient(
+        0.00f to surface,
+        1.00f to surface,
     )
+}
 
-private val ExpandedDetailBreakpoint = 600.dp
+internal val ExpandedDetailBreakpoint = 600.dp
 
 data class DetailPortraitArtwork(
     val url: String?,
@@ -120,13 +126,24 @@ fun AdaptiveDetailHero(
     modifier: Modifier = Modifier,
     dominantColor: Color = SiloBackground,
     directorText: String? = null,
+    isCreditLoading: Boolean = false,
+    reserveCreditSpace: Boolean = false,
+    overviewText: String? = detail.overview,
+    reserveOverviewSpace: Boolean = false,
     translation: (@Composable () -> Unit)? = null,
+    belowOverview: (@Composable () -> Unit)? = null,
+    /** Expanded-window replacement for [belowOverview]. Compact phones always
+     *  keep [belowOverview], so tablet/fold sections can be reordered safely. */
+    expandedBelowOverview: (@Composable () -> Unit)? = belowOverview,
     actions: @Composable () -> Unit,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
         if (maxWidth >= ExpandedDetailBreakpoint) {
             val horizontalPadding = if (maxWidth >= 840.dp) 48.dp else 32.dp
-            val posterWidth = (maxWidth * 0.25f).coerceIn(164.dp, 224.dp)
+            // The expanded header keeps Play + the bottom action row inside
+            // the portrait's vertical boundary. A 200pt minimum gives that
+            // control stack the same breathing room as the tablet reference.
+            val posterWidth = (maxWidth * 0.25f).coerceIn(200.dp, 224.dp)
             ExpandedDetailHero(
                 detail = detail,
                 portraitArtwork = portraitArtwork,
@@ -135,8 +152,14 @@ fun AdaptiveDetailHero(
                 factsLine = factsLine,
                 horizontalPadding = horizontalPadding,
                 posterWidth = posterWidth,
+                dominantColor = dominantColor,
                 directorText = directorText,
+                isCreditLoading = isCreditLoading,
+                reserveCreditSpace = reserveCreditSpace,
+                overviewText = overviewText,
+                reserveOverviewSpace = reserveOverviewSpace,
                 translation = translation,
+                belowOverview = expandedBelowOverview,
                 actions = actions,
             )
         } else {
@@ -147,7 +170,12 @@ fun AdaptiveDetailHero(
                 factsLine = factsLine,
                 dominantColor = dominantColor,
                 directorText = directorText,
+                isCreditLoading = isCreditLoading,
+                reserveCreditSpace = reserveCreditSpace,
+                overviewText = overviewText,
+                reserveOverviewSpace = reserveOverviewSpace,
                 translation = translation,
+                belowOverview = belowOverview,
                 actions = actions,
             )
         }
@@ -156,8 +184,8 @@ fun AdaptiveDetailHero(
 
 /**
  * Expanded-window detail hero inspired by the reference foldable layout:
- * a full-bleed backdrop carries the page while the poster and editorial
- * metadata form a readable two-column foreground.
+ * artwork ends at the shared poster/action baseline, then fades into the
+ * opaque title-derived page surface used by the centered editorial column.
  */
 @Composable
 private fun ExpandedDetailHero(
@@ -168,113 +196,160 @@ private fun ExpandedDetailHero(
     factsLine: List<String>,
     horizontalPadding: Dp,
     posterWidth: Dp,
+    dominantColor: Color,
     directorText: String?,
+    isCreditLoading: Boolean,
+    reserveCreditSpace: Boolean,
+    overviewText: String?,
+    reserveOverviewSpace: Boolean,
     translation: (@Composable () -> Unit)?,
+    belowOverview: (@Composable () -> Unit)?,
     actions: @Composable () -> Unit,
 ) {
-    Box(modifier = Modifier.fillMaxWidth()) {
-        ThumbhashImage(
-            url = detail.backdropUrl,
-            thumbhash = detail.backdropThumbhash,
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier.matchParentSize(),
-        )
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-                .background(
-                    Brush.horizontalGradient(
-                        0.00f to Color.Black.copy(alpha = 0.88f),
-                        0.48f to Color.Black.copy(alpha = 0.58f),
-                        1.00f to Color.Black.copy(alpha = 0.32f),
-                    ),
-                ),
-        )
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-                .background(
-                    Brush.verticalGradient(
-                        0.00f to Color.Black.copy(alpha = 0.08f),
-                        0.68f to Color.Black.copy(alpha = 0.18f),
-                        1.00f to SiloBackground,
-                    ),
-                ),
-        )
+    val hasPortrait = portraitArtwork.reserveSpace || !portraitArtwork.url.isNullOrBlank()
+    val posterHeight = posterWidth * 1.5f
+    val pageSurface = lerp(Color.Black, dominantColor, 0.42f)
 
-        Row(
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(pageSurface),
+    ) {
+        // This cinematic box is measured by the row. Its last opaque gradient
+        // stop therefore lands exactly at the bottom of the poster/buttons.
+        Box(modifier = Modifier.fillMaxWidth()) {
+            ThumbhashImage(
+                url = detail.backdropUrl,
+                thumbhash = detail.backdropThumbhash,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                crossfadeMillis = DetailArtworkCrossfadeMs,
+                modifier = Modifier.matchParentSize(),
+            )
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(
+                        Brush.horizontalGradient(
+                            0.00f to Color.Black.copy(alpha = 0.88f),
+                            0.48f to Color.Black.copy(alpha = 0.58f),
+                            1.00f to Color.Black.copy(alpha = 0.32f),
+                        ),
+                    ),
+            )
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(
+                        Brush.verticalGradient(
+                            0.00f to Color.Black.copy(alpha = 0.08f),
+                            0.56f to Color.Black.copy(alpha = 0.18f),
+                            0.82f to pageSurface.copy(alpha = 0.62f),
+                            1.00f to pageSurface,
+                        ),
+                    ),
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = horizontalPadding)
+                    .padding(top = 88.dp),
+                horizontalArrangement = Arrangement.spacedBy(28.dp),
+                verticalAlignment = Alignment.Top,
+            ) {
+                if (hasPortrait) {
+                    Box(
+                        modifier = Modifier
+                            .width(posterWidth)
+                            .aspectRatio(2f / 3f)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(Color.White.copy(alpha = 0.06f))
+                            .border(
+                                width = 1.dp,
+                                color = Color.White.copy(alpha = 0.16f),
+                                shape = RoundedCornerShape(12.dp),
+                            ),
+                    ) {
+                        if (!portraitArtwork.url.isNullOrBlank()) {
+                            ThumbhashImage(
+                                url = portraitArtwork.url,
+                                thumbhash = portraitArtwork.thumbhash,
+                                contentDescription = detail.title,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
+                    }
+                }
+
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .then(if (hasPortrait) Modifier.height(posterHeight) else Modifier),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        if (!eyebrow.isNullOrBlank()) {
+                            EyebrowChip(text = eyebrow)
+                        }
+                        ExpandedHeroTitle(detail = detail)
+                        val metadataTokens = (factsLine + sourceTokens).distinct()
+                        if (metadataTokens.isNotEmpty() || detail.contentRating != null) {
+                            SourceRow(
+                                tokens = metadataTokens,
+                                ratingChip = detail.contentRating,
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                            )
+                        }
+                    }
+                    if (hasPortrait) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    } else {
+                        Spacer(modifier = Modifier.height(20.dp))
+                    }
+                    // Expanded/tablet only: Play and its bottom action row end
+                    // no lower than the portrait. The compact phone branch is
+                    // intentionally unchanged.
+                    actions()
+                }
+            }
+        }
+
+        // Overview, fixed Starring and selectors are entirely off the artwork,
+        // centered on the exact opaque surface used by the fade's final stop.
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = horizontalPadding)
-                .padding(top = 88.dp, bottom = 40.dp),
-            horizontalArrangement = Arrangement.spacedBy(28.dp),
-            verticalAlignment = Alignment.Top,
+                .padding(top = 24.dp, bottom = 40.dp),
+            contentAlignment = Alignment.TopCenter,
         ) {
-            if (portraitArtwork.reserveSpace || !portraitArtwork.url.isNullOrBlank()) {
-                Box(
-                    modifier = Modifier
-                        .width(posterWidth)
-                        .aspectRatio(2f / 3f)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(Color.White.copy(alpha = 0.06f))
-                        .border(
-                            width = 1.dp,
-                            color = Color.White.copy(alpha = 0.16f),
-                            shape = RoundedCornerShape(12.dp),
-                        )
-                        .heroTarget(),
-                ) {
-                    if (!portraitArtwork.url.isNullOrBlank()) {
-                        ThumbhashImage(
-                            url = portraitArtwork.url,
-                            thumbhash = portraitArtwork.thumbhash,
-                            contentDescription = detail.title,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier.fillMaxSize(),
-                        )
-                    }
-                }
-            }
-
             Column(
-                modifier = Modifier.weight(1f),
-                horizontalAlignment = Alignment.Start,
-                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier
+                    .widthIn(max = 920.dp)
+                    .fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
-                if (!eyebrow.isNullOrBlank()) {
-                    EyebrowChip(text = eyebrow)
-                }
-                ExpandedHeroTitle(detail = detail)
-                if (sourceTokens.isNotEmpty() || detail.contentRating != null) {
-                    SourceRow(
-                        tokens = sourceTokens,
-                        ratingChip = detail.contentRating,
-                        horizontalAlignment = Alignment.Start,
+                if (reserveOverviewSpace || !overviewText.isNullOrBlank()) {
+                    OverviewBlock(
+                        text = overviewText.orEmpty(),
+                        reserveCollapsedSpace = reserveOverviewSpace,
                     )
                 }
-                if (factsLine.isNotEmpty()) {
-                    FactsRow(
-                        tokens = factsLine,
-                        horizontalAlignment = Alignment.Start,
-                    )
-                }
-                actions()
-                detail.overview?.takeIf { it.isNotBlank() }?.let { overview ->
-                    OverviewBlock(text = overview)
-                }
+                DetailCreditBlock(
+                    text = directorText,
+                    isLoading = isCreditLoading,
+                    reserveSpace = reserveCreditSpace,
+                    expanded = true,
+                )
                 translation?.invoke()
-                directorText?.takeIf { it.isNotBlank() }?.let { line ->
-                    Text(
-                        text = line,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Medium,
-                        color = Color.White.copy(alpha = 0.62f),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
+                belowOverview?.invoke()
             }
         }
     }
@@ -286,15 +361,21 @@ private fun ExpandedHeroTitle(detail: ItemDetail) {
     val seriesTitle = detail.seriesTitle?.takeIf { it.isNotBlank() }
     if (isEpisode && seriesTitle != null) {
         val (episodePrimary, episodeSubtitle) = splitHeroTitle(detail.title)
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
             Text(
                 text = seriesTitle,
                 fontSize = 34.sp,
                 lineHeight = 39.sp,
                 fontWeight = FontWeight.ExtraBold,
                 color = DetailPrimaryText,
+                textAlign = TextAlign.Center,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
             )
             Text(
                 text = episodePrimary,
@@ -302,8 +383,10 @@ private fun ExpandedHeroTitle(detail: ItemDetail) {
                 lineHeight = 27.sp,
                 fontWeight = FontWeight.SemiBold,
                 color = DetailPrimaryText.copy(alpha = 0.9f),
+                textAlign = TextAlign.Center,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
             )
             if (episodeSubtitle != null) {
                 Text(
@@ -313,8 +396,10 @@ private fun ExpandedHeroTitle(detail: ItemDetail) {
                     fontWeight = FontWeight.ExtraBold,
                     letterSpacing = 1.0.sp,
                     color = DetailPrimaryText.copy(alpha = 0.76f),
+                    textAlign = TextAlign.Center,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }
@@ -337,15 +422,21 @@ private fun ExpandedHeroTitle(detail: ItemDetail) {
     }
 
     val (primary, subtitle) = splitHeroTitle(detail.title)
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
         Text(
             text = primary,
             fontSize = 36.sp,
             lineHeight = 41.sp,
             fontWeight = FontWeight.ExtraBold,
             color = DetailPrimaryText,
+            textAlign = TextAlign.Center,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth(),
         )
         if (subtitle != null) {
             Text(
@@ -355,8 +446,10 @@ private fun ExpandedHeroTitle(detail: ItemDetail) {
                 fontWeight = FontWeight.ExtraBold,
                 letterSpacing = 1.2.sp,
                 color = DetailPrimaryText.copy(alpha = 0.8f),
+                textAlign = TextAlign.Center,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }
@@ -380,59 +473,149 @@ fun DetailHero(
     modifier: Modifier = Modifier,
     dominantColor: Color = SiloBackground,
     directorText: String? = null,
+    isCreditLoading: Boolean = false,
+    reserveCreditSpace: Boolean = false,
+    overviewText: String? = detail.overview,
+    reserveOverviewSpace: Boolean = false,
     // Optional viewer-facing description-translation affordance, rendered
     // directly under the overview (Apple parity: DescriptionTranslationView).
     translation: (@Composable () -> Unit)? = null,
+    belowOverview: (@Composable () -> Unit)? = null,
     actions: @Composable () -> Unit,
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Backdrop(
-            backdropUrl = detail.backdropUrl,
-            backdropThumbhash = detail.backdropThumbhash,
-            contentDescription = detail.title,
-            contentId = detail.contentId,
-        )
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val artworkHeight = (maxWidth * 1.18f).coerceIn(430.dp, 540.dp)
+        val pageSurface = lerp(Color.Black, dominantColor, 0.42f)
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(artworkHeight),
+                contentAlignment = Alignment.BottomCenter,
+            ) {
+                ThumbhashImage(
+                    url = detail.backdropUrl ?: detail.posterUrl,
+                    thumbhash = detail.backdropThumbhash ?: detail.posterThumbhash,
+                    contentDescription = detail.title,
+                    contentScale = ContentScale.Crop,
+                    crossfadeMillis = DetailArtworkCrossfadeMs,
+                    modifier = Modifier.fillMaxSize(),
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                0.00f to Color.Black.copy(alpha = 0.34f),
+                                0.30f to Color.Transparent,
+                                0.72f to Color.Transparent,
+                                1.00f to pageSurface,
+                            ),
+                        ),
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 28.dp, vertical = 6.dp),
+                    contentAlignment = Alignment.BottomCenter,
+                ) {
+                    HeroTitle(detail = detail)
+                }
+            }
 
-        Column(
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = SafePadding)
+                    .padding(top = 8.dp, bottom = 12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                val metadataTokens = (factsLine + sourceTokens).distinct()
+                if (metadataTokens.isNotEmpty() || detail.contentRating != null) {
+                    SourceRow(tokens = metadataTokens, ratingChip = detail.contentRating)
+                }
+                actions()
+                if (reserveOverviewSpace || !overviewText.isNullOrBlank()) {
+                    OverviewBlock(
+                        text = overviewText.orEmpty(),
+                        reserveCollapsedSpace = reserveOverviewSpace,
+                    )
+                }
+                DetailCreditBlock(
+                    text = directorText,
+                    isLoading = isCreditLoading,
+                    reserveSpace = reserveCreditSpace,
+                    expanded = false,
+                )
+                translation?.invoke()
+                belowOverview?.invoke()
+            }
+        }
+    }
+}
+
+/**
+ * Stable credit slot for series episode changes. The skeleton and loaded
+ * starring text share an identical footprint, so replacing one with the
+ * other cannot move the playback panel or episode rail.
+ */
+@Composable
+private fun DetailCreditBlock(
+    text: String?,
+    isLoading: Boolean,
+    reserveSpace: Boolean,
+    expanded: Boolean,
+) {
+    if (isLoading || reserveSpace) {
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = SafePadding)
-                .padding(top = 4.dp, bottom = 8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(14.dp),
+                .height(38.dp),
+            contentAlignment = Alignment.TopStart,
         ) {
-            if (!eyebrow.isNullOrBlank()) {
-                EyebrowChip(text = eyebrow)
-            }
-            HeroTitle(detail = detail)
-            if (sourceTokens.isNotEmpty() || detail.contentRating != null) {
-                SourceRow(
-                    tokens = sourceTokens,
-                    ratingChip = detail.contentRating,
-                )
-            }
-            actions()
-            val overview = detail.overview
-            if (!overview.isNullOrBlank()) {
-                OverviewBlock(text = overview)
-            }
-            translation?.invoke()
-            directorText?.takeIf { it.isNotBlank() }?.let { line ->
+            if (isLoading) {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(0.76f)
+                            .height(12.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(Color.White.copy(alpha = 0.10f)),
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(0.44f)
+                            .height(12.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(Color.White.copy(alpha = 0.08f)),
+                    )
+                }
+            } else if (!text.isNullOrBlank()) {
                 Text(
-                    text = line,
-                    fontSize = 14.sp,
+                    text = text,
+                    fontSize = if (expanded) 14.sp else 13.sp,
+                    lineHeight = 18.sp,
                     fontWeight = FontWeight.Medium,
-                    color = Color.White.copy(alpha = 0.62f),
-                    textAlign = TextAlign.Center,
-                    maxLines = 1,
+                    color = Color.White.copy(alpha = if (expanded) 0.62f else 0.58f),
+                    textAlign = TextAlign.Start,
+                    maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
-            if (factsLine.isNotEmpty()) {
-                FactsRow(tokens = factsLine)
-            }
         }
+    } else if (!text.isNullOrBlank()) {
+        Text(
+            text = text,
+            fontSize = if (expanded) 14.sp else 13.sp,
+            fontWeight = FontWeight.Medium,
+            color = Color.White.copy(alpha = if (expanded) 0.62f else 0.58f),
+            textAlign = TextAlign.Start,
+            maxLines = if (expanded) 1 else 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 
@@ -452,17 +635,14 @@ private fun Backdrop(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(heroHeight)
-                // Hero morph target — pairs with the exact poster placement the
-                // user tapped (read from the hero hand-off) so the artwork bounds
-                // carry from that list card into this backdrop.
-                .heroTarget(),
+                .height(heroHeight),
         ) {
             ThumbhashImage(
                 url = backdropUrl,
                 thumbhash = backdropThumbhash,
                 contentDescription = contentDescription,
                 contentScale = ContentScale.Crop,
+                crossfadeMillis = DetailArtworkCrossfadeMs,
                 modifier = Modifier.fillMaxSize(),
             )
             // Soft single-direction fade — dissolves into the page
@@ -681,7 +861,10 @@ private fun ContentRatingChip(text: String) {
 }
 
 @Composable
-private fun OverviewBlock(text: String) {
+private fun OverviewBlock(
+    text: String,
+    reserveCollapsedSpace: Boolean = false,
+) {
     var expanded by remember(text) { mutableStateOf(false) }
     val canExpand = text.length > 140
 
@@ -698,6 +881,7 @@ private fun OverviewBlock(text: String) {
             lineHeight = 21.sp,
             fontWeight = FontWeight.Normal,
             color = DetailPrimaryText.copy(alpha = 0.78f),
+            minLines = if (reserveCollapsedSpace && !expanded) 3 else 1,
             maxLines = if (expanded) Int.MAX_VALUE else 3,
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.Start,
@@ -782,7 +966,7 @@ fun PrimaryPillButton(
 }
 
 /**
- * 44dp circle toggle used for favorite, watchlist, watched. Active
+ * 42dp circle toggle used for favorite, watchlist, watched. Active
  * state lifts the fill and stroke alpha — same energy as the iOS pill.
  */
 @Composable
@@ -793,26 +977,34 @@ fun CircleActionButton(
     contentDescription: String,
     onClick: () -> Unit,
     activeTint: Color = Color.White,
+    label: String,
+    modifier: Modifier = Modifier,
 ) {
-    Box(
-        modifier = Modifier
-            .size(44.dp)
-            .clip(CircleShape)
-            .background(Color.White.copy(alpha = if (isActive) 0.18f else 0.10f))
-            .border(
-                width = 1.dp,
-                color = Color.White.copy(alpha = if (isActive) 0.55f else 0.25f),
-                shape = CircleShape,
-            )
-            .clickable(onClick = onClick),
-        contentAlignment = Alignment.Center,
+    Column(
+        modifier = modifier.clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        // iOS PhoneCircleActionButton: icon 16pt semibold.
-        Icon(
-            imageVector = if (isActive) activeIcon else icon,
-            contentDescription = contentDescription,
-            tint = if (isActive) activeTint else Color.White,
-            modifier = Modifier.size(16.dp),
+        Box(
+            modifier = Modifier
+                .size(42.dp)
+                .clip(CircleShape)
+                .background(if (isActive) SiloDetailActionControlActive else SiloDetailActionControl),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = if (isActive) activeIcon else icon,
+                contentDescription = contentDescription,
+                tint = if (isActive) activeTint else Color.White,
+                modifier = Modifier.size(19.dp),
+            )
+        }
+        Text(
+            text = label,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Medium,
+            color = Color.White.copy(alpha = if (isActive) 0.92f else 0.60f),
+            maxLines = 1,
         )
     }
 }
@@ -825,24 +1017,30 @@ fun CircleActionButton(
 fun CircleOverflowButton(
     contentDescription: String = "More options",
     menuContent: @Composable (dismiss: () -> Unit) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    Box {
-        Box(
-            modifier = Modifier
-                .size(44.dp)
-                .clip(CircleShape)
-                .background(Color.White.copy(alpha = 0.10f))
-                .border(1.dp, Color.White.copy(alpha = 0.25f), CircleShape)
-                .clickable { expanded = true },
-            contentAlignment = Alignment.Center,
+    Box(modifier = modifier) {
+        Column(
+            modifier = Modifier.clickable { expanded = true },
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            Icon(
-                imageVector = Icons.Filled.MoreHoriz,
-                contentDescription = contentDescription,
-                tint = Color.White,
-                modifier = Modifier.size(16.dp),
-            )
+            Box(
+                modifier = Modifier
+                    .size(42.dp)
+                    .clip(CircleShape)
+                    .background(SiloDetailActionControl),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Filled.MoreHoriz,
+                    contentDescription,
+                    tint = Color.White,
+                    modifier = Modifier.size(19.dp),
+                )
+            }
+            Text("More", fontSize = 10.sp, fontWeight = FontWeight.Medium, color = Color.White.copy(alpha = 0.60f))
         }
         DropdownMenu(
             expanded = expanded,
@@ -854,7 +1052,7 @@ fun CircleOverflowButton(
 }
 
 /**
- * Compact dark capsule sitting under the action row that surfaces the
+ * Compact opaque capsule sitting under the action row that surfaces the
  * currently selected video version and opens the picker on tap.
  */
 @Composable
@@ -866,8 +1064,8 @@ fun VersionPillButton(
 ) {
     Surface(
         shape = PillShape,
-        color = Color.White.copy(alpha = 0.10f),
-        border = androidx.compose.foundation.BorderStroke(1.dp, Color.White.copy(alpha = 0.20f)),
+        color = SiloOpaqueControl,
+        border = androidx.compose.foundation.BorderStroke(1.dp, SiloOpaqueControlBorder),
         modifier = modifier
             .height(36.dp)
             .clickable(onClick = onClick),
@@ -882,27 +1080,27 @@ fun VersionPillButton(
             Icon(
                 imageVector = Icons.Filled.Layers,
                 contentDescription = null,
-                tint = Color.White.copy(alpha = 0.78f),
+                tint = SiloOnOpaqueControl.copy(alpha = 0.78f),
                 modifier = Modifier.size(13.dp),
             )
             Text(
                 text = label,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Medium,
-                color = Color.White.copy(alpha = 0.7f),
+                color = SiloOnOpaqueControl.copy(alpha = 0.7f),
             )
             Text(
                 text = currentValue,
                 fontSize = 13.sp,
                 fontWeight = FontWeight.SemiBold,
-                color = Color.White,
+                color = SiloOnOpaqueControl,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
             Icon(
                 imageVector = Icons.Outlined.KeyboardArrowDown,
                 contentDescription = null,
-                tint = Color.White.copy(alpha = 0.6f),
+                tint = SiloOnOpaqueControl.copy(alpha = 0.6f),
                 modifier = Modifier.size(10.dp),
             )
         }
@@ -927,8 +1125,6 @@ fun HeroActionStack(
     onToggleFavorite: () -> Unit,
     onToggleWatchlist: () -> Unit,
     onToggleWatched: () -> Unit,
-    userRating: Int? = null,
-    onRateClick: (() -> Unit)? = null,
     versionLabel: String? = null,
     onVersionClick: (() -> Unit)? = null,
     overflow: (@Composable (dismiss: () -> Unit) -> Unit)? = null,
@@ -951,8 +1147,9 @@ fun HeroActionStack(
             onClick = { if (onPlayFromBeginning != null) showResumeDialog = true else onPlay() },
         )
         Row(
-            horizontalArrangement = Arrangement.spacedBy(14.dp),
-            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.Top,
         ) {
             CircleActionButton(
                 icon = Icons.Filled.FavoriteBorder,
@@ -960,6 +1157,8 @@ fun HeroActionStack(
                 isActive = isFavorite,
                 contentDescription = if (isFavorite) "Remove from favorites" else "Add to favorites",
                 onClick = onToggleFavorite,
+                label = "Favorite",
+                modifier = Modifier.weight(1f),
             )
             CircleActionButton(
                 icon = Icons.Filled.BookmarkBorder,
@@ -967,6 +1166,8 @@ fun HeroActionStack(
                 isActive = isInWatchlist,
                 contentDescription = if (isInWatchlist) "Remove from watchlist" else "Add to watchlist",
                 onClick = onToggleWatchlist,
+                label = "Watchlist",
+                modifier = Modifier.weight(1f),
             )
             CircleActionButton(
                 icon = Icons.Filled.CheckCircleOutline,
@@ -974,23 +1175,32 @@ fun HeroActionStack(
                 isActive = isWatched,
                 contentDescription = if (isWatched) "Mark as unwatched" else "Mark as watched",
                 onClick = onToggleWatched,
+                label = "Watched",
+                modifier = Modifier.weight(1f),
             )
-            if (onRateClick != null) {
-                CircleActionButton(
-                    icon = Icons.Filled.StarBorder,
-                    activeIcon = Icons.Filled.Star,
-                    isActive = userRating != null,
-                    contentDescription = userRating?.let { "Rated $it of 5" } ?: "Rate",
-                    onClick = onRateClick,
-                )
-            }
             if (downloadSlot != null) {
-                downloadSlot()
+                Column(
+                    modifier = Modifier.weight(1f),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    downloadSlot()
+                    Text("Download", fontSize = 10.sp, fontWeight = FontWeight.Medium, color = Color.White.copy(alpha = 0.60f))
+                }
             }
             if (overflow != null) {
-                CircleOverflowButton(menuContent = overflow)
+                CircleOverflowButton(
+                    menuContent = overflow,
+                    modifier = Modifier.weight(1f),
+                )
             }
         }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(0.5.dp)
+                .background(Color.White.copy(alpha = 0.08f)),
+        )
         if (versionLabel != null && onVersionClick != null) {
             VersionPillButton(
                 currentValue = versionLabel,
@@ -1089,7 +1299,10 @@ fun SeasonChips(
     onSeasonSelected: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (seasons.size <= 1) return
+    // The series overview deliberately keeps its single selected chip. iOS
+    // renders "Season 1" even when there is no alternative season because it
+    // anchors the browser before the "Season 1 Episodes" heading.
+    if (seasons.isEmpty()) return
 
     val selectedSeasonIndex = seasons.indexOfFirst {
         it.seasonNumber == selectedSeasonNumber
@@ -1162,11 +1375,10 @@ fun SeasonChips(
 
 object HeroMetadata {
 
-    fun movieEyebrow(detail: ItemDetail): String? {
-        val rating = detail.ratingImdb?.let { "IMDb %.1f".format(it) }
-            ?: detail.ratingTmdb?.let { "TMDB %.1f".format(it) }
-        return rating
-    }
+    // iOS does not float a provider rating above movie artwork/title. Ratings
+    // that belong in the facts row remain there; the standalone TMDB/IMDb pill
+    // made the logo stack look vertically off-centre on tablets and folds.
+    fun movieEyebrow(@Suppress("UNUSED_PARAMETER") detail: ItemDetail): String? = null
 
     fun seriesEyebrow(detail: ItemDetail): String? = movieEyebrow(detail)
 
@@ -1180,30 +1392,26 @@ object HeroMetadata {
         }
     }
 
-    fun movieSourceTokens(detail: ItemDetail): List<String> = buildList {
-        if (detail.year > 0) add(detail.year.toString())
-        if (detail.runtime > 0) add(formatRuntime(detail.runtime))
-        detail.studios.firstOrNull()?.takeIf { it.isNotBlank() }?.let { add(it) }
-    }
+    fun movieSourceTokens(detail: ItemDetail): List<String> =
+        detail.genres.take(2).takeIf { it.isNotEmpty() }
+            ?.let { listOf(it.joinToString(", ")) }
+            .orEmpty()
 
-    fun seriesSourceTokens(detail: ItemDetail): List<String> = buildList {
-        if (detail.year > 0) add(detail.year.toString())
-        detail.seasonCount?.takeIf { it > 0 }?.let {
-            add("$it Season${if (it > 1) "s" else ""}")
-        }
-        detail.networks.firstOrNull()?.takeIf { it.isNotBlank() }?.let { add(it) }
-    }
+    fun seriesSourceTokens(detail: ItemDetail): List<String> =
+        detail.genres.take(2).takeIf { it.isNotEmpty() }
+            ?.let { listOf(it.joinToString(", ")) }
+            .orEmpty()
 
     fun movieFactsLine(detail: ItemDetail): List<String> = buildList {
-        if (detail.genres.isNotEmpty()) {
-            add(detail.genres.take(3).joinToString(" · "))
-        }
+        if (detail.year > 0) add(detail.year.toString())
+        if (detail.runtime > 0) add(formatRuntime(detail.runtime))
         detail.ratingImdb?.let { add("IMDb %.1f".format(it)) }
     }
 
     fun seriesFactsLine(detail: ItemDetail): List<String> = buildList {
-        if (detail.genres.isNotEmpty()) {
-            add(detail.genres.take(3).joinToString(" · "))
+        if (detail.year > 0) add(detail.year.toString())
+        detail.seasonCount?.takeIf { it > 0 }?.let {
+            add("$it Season${if (it > 1) "s" else ""}")
         }
         detail.ratingImdb?.let { add("IMDb %.1f".format(it)) }
     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/EpisodeList.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/EpisodeList.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -77,7 +76,7 @@ fun EpisodeList(
     tapToFocusEpisode: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
-    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+    Box(modifier = modifier.fillMaxWidth()) {
         val cardWidth = 240.dp
         val listState = rememberLazyListState()
         val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
@@ -358,7 +357,7 @@ internal fun EpisodeListSkeleton(
     showsEpisodeDetails: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
-    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+    Box(modifier = modifier.fillMaxWidth()) {
         val cardWidth = 240.dp
         LazyRow(
             modifier = Modifier.fillMaxWidth(),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/EpisodeList.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/EpisodeList.kt
@@ -3,11 +3,15 @@ package org.siloserver.silo.android.ui.screens.detail
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,269 +19,321 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.DownloadDone
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.outlined.FileDownload
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.flow.distinctUntilChanged
+import org.siloserver.silo.android.ui.util.formatCardDate
 import org.siloserver.silo.android.ui.util.playbackResumePosition
-import org.siloserver.silo.common.overlays.CardOverlayVariant
-import org.siloserver.silo.common.overlays.CardOverlays
-import org.siloserver.silo.common.overlays.LocalCardOverlayUiState
 import org.siloserver.silo.common.ui.components.ThumbhashImage
 import org.siloserver.silo.model.catalog.EpisodeListItem
-import org.siloserver.silo.overlays.OverlayDataExtractor
+import kotlin.math.abs
 
 /**
- * Vertical list of episodes for a season.
- *
- * Each row shows a 160×90 16:9 thumbnail with progress overlay,
- * then S/E label, title, runtime, and overview. Tapping the
- * thumbnail plays; tapping the text section opens episode detail.
- *
- * Embedded in a parent scrollable container — does not scroll itself.
+ * PR #212's phone episode carousel: a 240dp card settles in the centre and,
+ * when scrolling becomes idle, that centred episode becomes the series Play
+ * and playback-selector target.
  */
 @Composable
 fun EpisodeList(
     episodes: List<EpisodeListItem>,
-    onEpisodePlayClick: (String, Double?) -> Unit,
+    onEpisodePlayClick: ((String, Double?) -> Unit)? = null,
     onEpisodeDetailClick: (String) -> Unit,
-    onEpisodeDownloadClick: ((EpisodeListItem) -> Unit)? = null,
-    episodeDownloadState: (EpisodeListItem) -> DetailDownloadState = { DetailDownloadState() },
-    /** Episode pages: the episode whose detail is open, marked "Now viewing". */
+    onEpisodeWatchedChange: ((String, Boolean) -> Unit)? = null,
     highlightContentId: String? = null,
+    selectsCenteredEpisode: Boolean = false,
+    /** Expanded tablet/fold cards include their full editorial caption. */
+    showsEpisodeDetails: Boolean = false,
+    /** Expanded rails select on tap and never force the card into centre. */
+    tapToFocusEpisode: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier.padding(horizontal = SafePadding),
-        verticalArrangement = Arrangement.spacedBy(14.dp),
-    ) {
-        episodes.forEach { episode ->
-            EpisodeRow(
-                episode = episode,
-                onPlayClick = { onEpisodePlayClick(episode.contentId, playbackResumePosition(episode)) },
-                onDetailClick = { onEpisodeDetailClick(episode.contentId) },
-                onDownloadClick = onEpisodeDownloadClick?.let { cb -> { cb(episode) } },
-                downloadState = episodeDownloadState(episode),
-                isCurrent = episode.contentId == highlightContentId,
-            )
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val cardWidth = 240.dp
+        val listState = rememberLazyListState()
+        val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+        val currentEpisodes by rememberUpdatedState(episodes)
+        val currentHighlightId by rememberUpdatedState(highlightContentId)
+        val currentOnSelect by rememberUpdatedState(onEpisodeDetailClick)
+        var wasScrolling by remember { mutableStateOf(false) }
+
+        LaunchedEffect(episodes.map(EpisodeListItem::contentId), highlightContentId) {
+            val selectedIndex = episodes.indexOfFirst { it.contentId == highlightContentId }
+            if (selectedIndex >= 0) {
+                val isVisible = listState.layoutInfo.visibleItemsInfo.any { it.index == selectedIndex }
+                val needsScroll = if (tapToFocusEpisode) {
+                    !isVisible
+                } else {
+                    centeredItemIndex(listState) != selectedIndex
+                }
+                if (needsScroll) listState.animateScrollToItem(selectedIndex)
+            }
+        }
+
+        // Do not act on the initial idle emission. A real scroll or centring
+        // animation must finish before the visible card can select an episode.
+        LaunchedEffect(listState) {
+            snapshotFlow { listState.isScrollInProgress }
+                .distinctUntilChanged()
+                .collect { isScrolling ->
+                    if (isScrolling) {
+                        wasScrolling = true
+                    } else if (wasScrolling) {
+                        wasScrolling = false
+                        val episode = centeredItemIndex(listState)
+                            ?.let(currentEpisodes::getOrNull)
+                        if (
+                            selectsCenteredEpisode &&
+                            episode != null &&
+                            episode.contentId != currentHighlightId
+                        ) {
+                            currentOnSelect(episode.contentId)
+                        }
+                    }
+                }
+        }
+
+        LazyRow(
+            state = listState,
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = SafePadding, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            flingBehavior = flingBehavior,
+        ) {
+            items(episodes, key = EpisodeListItem::contentId) { episode ->
+                EpisodeRailCard(
+                    episode = episode,
+                    onPlayClick = onEpisodePlayClick?.let { play -> {
+                        play(
+                            episode.contentId,
+                            playbackResumePosition(episode),
+                        )
+                    } },
+                    onSelect = { onEpisodeDetailClick(episode.contentId) },
+                    onWatchedChange = onEpisodeWatchedChange?.let { change ->
+                        { watched -> change(episode.contentId, watched) }
+                    },
+                    isCurrent = episode.contentId == highlightContentId,
+                    cardWidth = cardWidth,
+                    showsEpisodeDetails = showsEpisodeDetails,
+                )
+            }
         }
     }
 }
 
+private fun centeredItemIndex(state: LazyListState): Int? {
+    val layout = state.layoutInfo
+    val viewportCenter = (layout.viewportStartOffset + layout.viewportEndOffset) / 2
+    return layout.visibleItemsInfo.minByOrNull { item ->
+        abs((item.offset + item.size / 2) - viewportCenter)
+    }?.index
+}
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun EpisodeRow(
+private fun EpisodeRailCard(
     episode: EpisodeListItem,
-    onPlayClick: () -> Unit,
-    onDetailClick: () -> Unit,
-    onDownloadClick: (() -> Unit)? = null,
-    downloadState: DetailDownloadState = DetailDownloadState(),
-    isCurrent: Boolean = false,
+    onPlayClick: (() -> Unit)?,
+    onSelect: () -> Unit,
+    onWatchedChange: ((Boolean) -> Unit)?,
+    isCurrent: Boolean,
+    cardWidth: Dp,
+    showsEpisodeDetails: Boolean,
 ) {
-    val overlayState = LocalCardOverlayUiState.current
-    val userData = episode.userData
-    val isPlayed = userData?.played == true
+    var menuExpanded by remember { mutableStateOf(false) }
+    val isWatched = episode.userData?.played == true
+    val stillShape = RoundedCornerShape(8.dp)
     val progress = episodeProgressFraction(
-        positionSeconds = userData?.positionSeconds,
-        durationSeconds = userData?.durationSeconds,
+        positionSeconds = episode.userData?.positionSeconds,
+        durationSeconds = episode.userData?.durationSeconds,
     )
 
-    Row(
-        modifier = Modifier.fillMaxWidth(),
+    Column(
+        modifier = Modifier
+            .width(cardWidth)
+            .combinedClickable(
+                onClick = onSelect,
+                onLongClick = onWatchedChange?.let { { menuExpanded = true } },
+            ),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Box(
             modifier = Modifier
-                .width(160.dp)
+                .fillMaxWidth()
                 .aspectRatio(16f / 9f)
-                .clip(RoundedCornerShape(8.dp))
-                .then(
-                    // iOS PhoneEpisodeRail: the open episode gets a white
-                    // border + "NOW VIEWING" tag.
-                    if (isCurrent) {
-                        Modifier.border(1.5.dp, Color.White, RoundedCornerShape(8.dp))
-                    } else {
-                        Modifier
-                    },
-                )
-                .clickable(onClick = onPlayClick),
+                .clip(stillShape)
+                .border(
+                    width = 2.dp,
+                    color = if (isCurrent) Color.White.copy(alpha = 0.70f) else Color.Transparent,
+                    shape = stillShape,
+                ),
         ) {
             ThumbhashImage(
                 url = episode.stillUrl,
                 thumbhash = episode.stillThumbhash,
                 contentDescription = episode.title,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxSize(),
             )
 
-            // Card-overlay badge layer (resolution / codec / HDR, etc.).
-            // Over the still but under the play affordance + progress bar.
-            if (overlayState.enabled) {
-                CardOverlays(
-                    data = OverlayDataExtractor.fromEpisode(episode),
-                    prefs = overlayState.prefs,
-                    variant = CardOverlayVariant.Wide,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            }
-
-            if (isCurrent) {
-                Text(
-                    text = "NOW VIEWING",
-                    style = MaterialTheme.typography.labelSmall.copy(
-                        fontSize = 11.sp,
-                        letterSpacing = 0.8.sp,
-                    ),
-                    fontWeight = FontWeight.Bold,
-                    color = Color.Black,
+            if (episode.userData?.played == true) {
+                Box(
                     modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(6.dp)
-                        .clip(RoundedCornerShape(3.dp))
-                        .background(Color.White)
-                        .padding(horizontal = 5.dp, vertical = 2.dp),
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = 0.32f)),
                 )
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp)
+                        .size(22.dp)
+                        .clip(CircleShape)
+                        .background(Color.White),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = "Watched",
+                        tint = Color.Black,
+                        modifier = Modifier.size(12.dp),
+                    )
+                }
             }
 
-            Box(
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .size(34.dp)
-                    .clip(CircleShape)
-                    .background(Color.Black.copy(alpha = 0.55f)),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.PlayArrow,
-                    contentDescription = "Play",
-                    tint = Color.White,
-                    modifier = Modifier.size(22.dp),
-                )
+            if (onPlayClick != null) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(42.dp)
+                        .clip(CircleShape)
+                        .background(Color.White.copy(alpha = 0.94f))
+                        .clickable(onClick = onPlayClick),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.PlayArrow,
+                        contentDescription = "Play Season ${episode.seasonNumber}, Episode ${episode.episodeNumber}",
+                        tint = Color.Black,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
             }
 
-            if (progress != null && progress > 0f) {
+            progress?.takeIf { it > 0f }?.let {
                 LinearProgressIndicator(
-                    progress = { progress },
+                    progress = { it },
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .fillMaxWidth()
                         .height(3.dp),
                     color = Color.White,
-                    trackColor = Color.Black.copy(alpha = 0.55f),
+                    trackColor = Color.Black.copy(alpha = 0.60f),
                 )
             }
         }
 
-        Spacer(modifier = Modifier.width(12.dp))
-
         Column(
-            modifier = Modifier
-                .weight(1f)
-                .clip(RoundedCornerShape(8.dp))
-                .clickable(onClick = onDetailClick)
-                .padding(vertical = 2.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = if (showsEpisodeDetails) Modifier.height(132.dp) else Modifier,
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
                 Text(
-                    text = episodeNumberText(episode),
-                    style = MaterialTheme.typography.labelSmall,
+                    text = "EPISODE ${episode.episodeNumber}",
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.sp,
+                    color = Color.White.copy(alpha = 0.55f),
+                )
+                if (isCurrent) {
+                    Text(
+                        text = "NOW VIEWING",
+                        fontSize = 9.sp,
+                        fontWeight = FontWeight.Black,
+                        letterSpacing = 0.8.sp,
+                        color = Color.Black,
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(50))
+                            .background(Color.White)
+                            .padding(
+                                horizontal = 5.dp,
+                                vertical = if (showsEpisodeDetails) 1.dp else 2.dp,
+                            ),
+                    )
+                }
+            }
+            if (showsEpisodeDetails) {
+                Text(
+                    text = episode.title?.takeIf { it.isNotBlank() }
+                        ?: "Episode ${episode.episodeNumber}",
+                    style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.SemiBold,
                     color = DetailPrimaryText,
-                )
-                if (episode.runtime > 0) {
-                    Text(text = "·", style = MaterialTheme.typography.labelSmall, color = DetailTertiaryText)
-                    Text(
-                        text = "${episode.runtime} min",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = DetailTertiaryText,
-                    )
-                }
-                if (isPlayed) {
-                    Spacer(modifier = Modifier.weight(1f))
-                    Icon(
-                        imageVector = Icons.Default.CheckCircle,
-                        contentDescription = "Watched",
-                        tint = DetailPrimaryText,
-                        modifier = Modifier.size(14.dp),
-                    )
-                }
-            }
-
-            Text(
-                text = episode.title ?: "Episode ${episode.episodeNumber}",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = DetailPrimaryText,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-
-            val overview = episode.overview
-            if (!overview.isNullOrBlank()) {
-                Text(
-                    text = overview,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = DetailSecondaryText,
-                    maxLines = 2,
+                    maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-            }
-        }
-
-        // Trailing download control: ✓ when the episode is downloaded, a spinner
-        // while it's in flight, else the download arrow. Disabled when the episode
-        // has no files (rare guard) but layout-stable so the column doesn't reflow.
-        if (onDownloadClick != null) {
-            val hasFiles = episode.files.isNotEmpty()
-            IconButton(
-                onClick = onDownloadClick,
-                enabled = hasFiles,
-                modifier = Modifier.size(48.dp),
-            ) {
-                when {
-                    downloadState.isDownloaded -> Icon(
-                        imageVector = Icons.Filled.DownloadDone,
-                        contentDescription = "Downloaded",
-                        tint = DetailPrimaryText,
-                        modifier = Modifier.size(22.dp),
+                episodeMetadataLine(episode)?.let { metadata ->
+                    Text(
+                        text = metadata,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = DetailSecondaryText,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
-                    downloadState.progress != null -> CircularProgressIndicator(
-                        progress = { downloadState.progress.coerceIn(0f, 1f) },
-                        modifier = Modifier
-                            .size(20.dp)
-                            .semantics { contentDescription = "Downloading" },
-                        strokeWidth = 2.dp,
-                        color = DetailPrimaryText,
-                    )
-                    else -> Icon(
-                        imageVector = Icons.Outlined.FileDownload,
-                        contentDescription = "Download episode",
-                        tint = if (hasFiles) DetailSecondaryText else DetailTertiaryText,
-                        modifier = Modifier.size(22.dp),
+                }
+                episode.overview?.takeIf { it.isNotBlank() }?.let { overview ->
+                    Text(
+                        text = overview,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = DetailSecondaryText,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
             }
+        }
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(if (isWatched) "Mark as Unwatched" else "Mark as Watched") },
+                onClick = {
+                    menuExpanded = false
+                    onWatchedChange?.invoke(!isWatched)
+                },
+            )
         }
     }
 }
@@ -289,8 +345,62 @@ internal fun episodeProgressFraction(positionSeconds: Double?, durationSeconds: 
     return (position / duration).toFloat().coerceIn(0f, 1f)
 }
 
-private fun episodeNumberText(episode: EpisodeListItem): String {
-    val s = episode.seasonNumber.toString().padStart(2, '0')
-    val e = episode.episodeNumber.toString().padStart(2, '0')
-    return "S${s}E${e}"
+private fun episodeMetadataLine(episode: EpisodeListItem): String? = buildList {
+    val airDate = formatCardDate(episode.airDate)
+        ?: episode.airDate?.takeIf { it.isNotBlank() }
+    if (airDate != null) add(airDate)
+    if (episode.runtime > 0) add("${episode.runtime}m")
+}.takeIf { it.isNotEmpty() }?.joinToString(" · ")
+
+/** Static loading footprint matching the artwork and compact identity row. */
+@Composable
+internal fun EpisodeListSkeleton(
+    showsEpisodeDetails: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val cardWidth = 240.dp
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = SafePadding, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            userScrollEnabled = false,
+        ) {
+            items(3) { index ->
+                Column(
+                    modifier = Modifier.width(cardWidth),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(16f / 9f)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(Color.White.copy(alpha = 0.09f + index * 0.01f)),
+                    )
+                    EpisodeSkeletonLine(width = 82.dp, height = 9.dp)
+                    if (showsEpisodeDetails) {
+                        EpisodeSkeletonLine(width = 150.dp, height = 14.dp)
+                        EpisodeSkeletonLine(width = 112.dp, height = 10.dp)
+                        EpisodeSkeletonLine(width = 224.dp, height = 10.dp)
+                        EpisodeSkeletonLine(width = 196.dp, height = 10.dp)
+                    }
+                }
+            }
+        }
+    }
 }
+
+@Composable
+private fun EpisodeSkeletonLine(width: Dp, height: Dp) {
+    Box(
+        modifier = Modifier
+            .width(width)
+            .height(height)
+            .clip(RoundedCornerShape(4.dp))
+            .background(Color.White.copy(alpha = 0.09f)),
+    )
+}
+
+internal fun episodeNumberText(episode: EpisodeListItem): String =
+    "S${episode.seasonNumber}·E${episode.episodeNumber}"

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
@@ -1,17 +1,26 @@
 package org.siloserver.silo.android.ui.screens.detail
 
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.SettingsRemote
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -28,6 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -35,7 +45,10 @@ import org.siloserver.silo.android.downloads.LEGACY_PUBLIC_DOWNLOAD_PERMISSION
 import org.siloserver.silo.android.downloads.hasLegacyPublicDownloadPermission
 import org.siloserver.silo.android.ui.components.DetailLoadingSkeleton
 import org.siloserver.silo.android.ui.components.ErrorView
+import org.siloserver.silo.android.ui.components.rememberSwipeDownDismissState
 import org.siloserver.silo.android.ui.components.swipeBackToDismiss
+import org.siloserver.silo.android.ui.components.swipeDownToDismiss
+import org.siloserver.silo.android.ui.theme.SiloDetailActionControlActive
 import org.siloserver.silo.android.ui.screens.cast.SiloCastTargetPickerSheet
 import org.siloserver.silo.android.ui.screens.downloads.openDownloadTargetInExternalApp
 import org.siloserver.silo.android.ui.screens.watchtogether.SuggestToRoomViewModel
@@ -76,6 +89,8 @@ private const val PLAY_ON_DEVICE_LABEL = "Play on device"
  */
 @Composable
 fun ItemDetailScreen(
+    openingArtworkUrl: String? = null,
+    openingArtworkThumbhash: String? = null,
     onBackClick: () -> Unit,
     onPlayClick: (String, Int?, Int?, Int?, Double?) -> Unit,
     onItemDetailClick: (String) -> Unit,
@@ -92,6 +107,15 @@ fun ItemDetailScreen(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsState()
+    val swipeDownDismissState = rememberSwipeDownDismissState()
+    val requestDismiss: () -> Unit = {
+        swipeDownDismissState.dismiss(onBackClick)
+    }
+    BackHandler { requestDismiss() }
+
+    LaunchedEffect(state.selectedEpisodeContentId) {
+        if (state.selectedEpisodeContentId != null) viewModel.ensureSelectedEpisodeDetailLoaded()
+    }
     val suggestViewModel: SuggestToRoomViewModel = koinViewModel()
     val suggestRoom by suggestViewModel.room.collectAsState()
     val suggestState by suggestViewModel.uiState.collectAsState()
@@ -293,15 +317,32 @@ fun ItemDetailScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
+            // Match iOS's large detail sheet: the rounded card begins below
+            // the status/camera safe area instead of painting behind it.
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Top))
+            .padding(top = 4.dp)
+            .shadow(
+                elevation = 20.dp,
+                shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+                clip = false,
+            )
+            .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
             // Swipe right on the page to go back (iOS interactive pop) — a
             // lighter alternative to reaching for the back arrow on a tall
             // detail page.
             .swipeBackToDismiss(onDismiss = onBackClick)
+            .swipeDownToDismiss(
+                state = swipeDownDismissState,
+                onDismiss = onBackClick,
+            )
             .background(MaterialTheme.colorScheme.background),
     ) {
         when {
             state.isLoading && state.detail == null -> {
-                DetailLoadingSkeleton()
+                DetailLoadingSkeleton(
+                    artworkUrl = openingArtworkUrl,
+                    artworkThumbhash = openingArtworkThumbhash,
+                )
             }
 
             state.error != null && state.detail == null -> {
@@ -558,6 +599,22 @@ fun ItemDetailScreen(
                         } else {
                             playbackResumePosition(detail.userData)
                         }
+                        val selectedEpisode = state.episodes.firstOrNull {
+                            it.contentId == state.selectedEpisodeContentId
+                        }
+                        val selectedEpisodeDetail = state.selectedEpisodeDetail
+                        val selectedEpisodeVersionIndex = state.selectedVersionIndex
+                            .coerceIn(0, (selectedEpisodeDetail?.versions?.lastIndex ?: 0).coerceAtLeast(0))
+                        val selectedEpisodeFileId = selectedEpisodeDetail?.versions
+                            ?.getOrNull(selectedEpisodeVersionIndex)
+                            ?.fileId
+                            ?.takeIf {
+                                state.hasExplicitVersionSelection ||
+                                    state.hasExplicitAudioSelection ||
+                                    state.hasExplicitSubtitleSelection
+                            }
+                        val selectedEpisodeResume = selectedEpisode?.let(::playbackResumePosition)
+                        val activeSeriesResume = selectedEpisodeResume ?: seriesResume
                         SeriesDetailContent(
                             translation = translationSlot,
                             detail = detail,
@@ -570,8 +627,32 @@ fun ItemDetailScreen(
                             isFavorite = state.isFavorite,
                             isInWatchlist = state.isInWatchlist,
                             nextEpisodeLabel = nextEpisodeLabel,
+                            selectedEpisodeContentId = state.selectedEpisodeContentId,
+                            selectedEpisodeDetail = selectedEpisodeDetail,
+                            isLoadingSelectedEpisodeDetail = state.isLoadingSelectedEpisodeDetail,
+                            selectedVersionIndex = selectedEpisodeVersionIndex,
+                            isAutoVersion = !state.hasExplicitVersionSelection,
+                            selectedAudioIndex = state.selectedAudioIndex.takeIf { state.hasExplicitAudioSelection },
+                            selectedSubtitleIndex = state.selectedSubtitleIndex.takeIf { state.hasExplicitSubtitleSelection },
+                            onVersionSelected = { index ->
+                                if (index == null) viewModel.selectAutoVersion() else viewModel.selectVersion(index)
+                            },
+                            onAudioSelected = { index ->
+                                if (index == null) viewModel.selectAutoAudioTrack() else viewModel.selectAudioTrack(index)
+                            },
+                            onSubtitleSelected = { index ->
+                                if (index == null) viewModel.selectAutoSubtitle() else viewModel.selectSubtitle(index)
+                            },
                             onPlayClick = {
-                                nextEpisode?.let {
+                                selectedEpisode?.let {
+                                    onPlayClick(
+                                        it.contentId,
+                                        selectedEpisodeFileId,
+                                        state.selectedAudioIndex.takeIf { state.hasExplicitAudioSelection },
+                                        state.selectedSubtitleIndex.takeIf { state.hasExplicitSubtitleSelection },
+                                        selectedEpisodeResume,
+                                    )
+                                } ?: nextEpisode?.let {
                                     onPlayClick(it.contentId, null, null, null, playbackResumePosition(it))
                                 } ?: onPlayClick(
                                     detail.contentId,
@@ -581,25 +662,27 @@ fun ItemDetailScreen(
                                     playbackResumePosition(detail.userData),
                                 )
                             },
-                            onPlayFromBeginning = seriesResume?.let {
+                            onPlayFromBeginning = activeSeriesResume?.let {
                                 {
-                                    nextEpisode?.let { ep ->
+                                    selectedEpisode?.let { ep ->
+                                        onPlayClick(ep.contentId, selectedEpisodeFileId, null, null, 0.0)
+                                    } ?: nextEpisode?.let { ep ->
                                         onPlayClick(ep.contentId, null, null, null, 0.0)
                                     } ?: onPlayClick(detail.contentId, null, null, null, 0.0)
                                 }
                             },
-                            resumeStoppedAtLabel = seriesResume?.let { formatResumeStoppedAt(it) },
+                            resumeStoppedAtLabel = activeSeriesResume?.let { formatResumeStoppedAt(it) },
                             onEpisodePlayClick = { contentId, resumePositionSeconds ->
                                 onPlayClick(contentId, null, null, null, resumePositionSeconds)
                             },
-                            onEpisodeDetailClick = onItemDetailClick,
+                            onEpisodeDetailClick = { viewModel.selectSeriesEpisode(it) },
+                            onEpisodeWatchedChange = { episodeContentId, watched ->
+                                viewModel.setEpisodeWatched(episodeContentId, watched)
+                            },
                             onSeasonSelected = { viewModel.selectSeason(it) },
                             onFavoriteClick = { viewModel.toggleFavorite() },
                             onWatchlistClick = { viewModel.toggleWatchlist() },
                             onToggleWatched = { viewModel.toggleWatched() },
-                            userRating = state.userRating,
-                            onSetRating = { viewModel.setRating(it) },
-                            onClearRating = { viewModel.clearRating() },
                             onPersonClick = onPersonClick,
                             onItemDetailClick = onItemDetailClick,
                             onSeriesDownloadClick = {
@@ -615,32 +698,6 @@ fun ItemDetailScreen(
                                         viewModel.onSeriesDownloadTapped()
                                     }
                                 }
-                            },
-                            onSeasonDownloadClick = { season ->
-                                runDownloadAction {
-                                    viewModel.onSeasonDownloadTapped(season)
-                                }
-                            },
-                            onEpisodeDownloadClick = { ep ->
-                                val episodeState = detailDownloadStateForFile(
-                                    fileId = ep.files.firstOrNull()?.fileId,
-                                    records = episodeDownloadRecords,
-                                )
-                                runDownloadTap(
-                                    downloadState = episodeState,
-                                    directAction = { viewModel.onEpisodeDownloadTapped(ep) },
-                                    qualityAction = { quality ->
-                                        viewModel.onEpisodeDownloadTapped(ep, downloadQuality = quality)
-                                    },
-                                    estimate = org.siloserver.silo.model.download.DownloadSizeEstimate
-                                        .estimate(fileSizes = ep.files.map { it.fileSize }),
-                                )
-                            },
-                            episodeDownloadState = { ep ->
-                                detailDownloadStateForFile(
-                                    fileId = ep.files.firstOrNull()?.fileId,
-                                    records = episodeDownloadRecords,
-                                )
                             },
                             seriesDownloadState = seriesDownloadState,
                             playOnDeviceLabel = PLAY_ON_DEVICE_LABEL,
@@ -792,9 +849,6 @@ fun ItemDetailScreen(
                             onFavoriteClick = { viewModel.toggleFavorite() },
                             onWatchlistClick = { viewModel.toggleWatchlist() },
                             onToggleWatched = { viewModel.toggleWatched() },
-                            userRating = state.userRating,
-                            onSetRating = { viewModel.setRating(it) },
-                            onClearRating = { viewModel.clearRating() },
                             onVersionSelected = { index ->
                                 if (index != null) viewModel.selectVersion(index) else viewModel.selectAutoVersion()
                             },
@@ -820,30 +874,9 @@ fun ItemDetailScreen(
                             episodesBySeason = state.episodesBySeason,
                             isLoadingEpisodes = state.isLoadingEpisodes,
                             onSeasonSelected = { viewModel.selectSeason(it) },
-                            onEpisodePlayClick = { contentId, resumePositionSeconds ->
-                                onPlayClick(contentId, null, null, null, resumePositionSeconds)
-                            },
                             onEpisodeDetailClick = onItemDetailClick,
-                            onEpisodeDownloadClick = { ep ->
-                                val episodeState = detailDownloadStateForFile(
-                                    fileId = ep.files.firstOrNull()?.fileId,
-                                    records = downloadRecords,
-                                )
-                                runDownloadTap(
-                                    downloadState = episodeState,
-                                    directAction = { viewModel.onEpisodeDownloadTapped(ep) },
-                                    qualityAction = { quality ->
-                                        viewModel.onEpisodeDownloadTapped(ep, downloadQuality = quality)
-                                    },
-                                    estimate = org.siloserver.silo.model.download.DownloadSizeEstimate
-                                        .estimate(fileSizes = ep.files.map { it.fileSize }),
-                                )
-                            },
-                            episodeDownloadState = { ep ->
-                                detailDownloadStateForFile(
-                                    fileId = ep.files.firstOrNull()?.fileId,
-                                    records = downloadRecords,
-                                )
+                            onEpisodeWatchedChange = { episodeContentId, watched ->
+                                viewModel.setEpisodeWatched(episodeContentId, watched)
                             },
                             isDownloaded = downloadState.isDownloaded,
                             downloadProgress = downloadState.progress,
@@ -963,21 +996,39 @@ fun ItemDetailScreen(
             )
         }
 
-        // Floating back button — sits on the hero artwork without
-        // pushing content down, mirroring iOS's transparent nav bar.
+        // Android's non-glass counterpart to iOS's detail controls: the same
+        // faint artwork-tinted wash and white glyphs, without live blur.
         IconButton(
-            onClick = onBackClick,
+            onClick = requestDismiss,
             modifier = Modifier
                 .align(Alignment.TopStart)
                 .statusBarsPadding()
-                .padding(8.dp)
-                .size(40.dp)
+                .padding(horizontal = 28.dp, vertical = 18.dp)
+                .size(42.dp)
                 .clip(CircleShape)
-                .background(Color.Black.copy(alpha = 0.45f)),
+                .background(SiloDetailActionControlActive.copy(alpha = 0.38f))
+                .border(1.dp, Color.White.copy(alpha = 0.36f), CircleShape),
         ) {
             Icon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
+                imageVector = Icons.Filled.Close,
+                contentDescription = "Close",
+                tint = Color.White,
+            )
+        }
+        IconButton(
+            onClick = onOpenCastRemote,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .statusBarsPadding()
+                .padding(horizontal = 28.dp, vertical = 18.dp)
+                .size(42.dp)
+                .clip(CircleShape)
+                .background(SiloDetailActionControlActive.copy(alpha = 0.38f))
+                .border(1.dp, Color.White.copy(alpha = 0.36f), CircleShape),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.SettingsRemote,
+                contentDescription = "Remote Control",
                 tint = Color.White,
             )
         }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
@@ -614,7 +614,11 @@ fun ItemDetailScreen(
                                     state.hasExplicitSubtitleSelection
                             }
                         val selectedEpisodeResume = selectedEpisode?.let(::playbackResumePosition)
-                        val activeSeriesResume = selectedEpisodeResume ?: seriesResume
+                        val activeSeriesResume = if (selectedEpisode != null) {
+                            selectedEpisodeResume
+                        } else {
+                            seriesResume
+                        }
                         SeriesDetailContent(
                             translation = translationSlot,
                             detail = detail,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -1213,7 +1213,13 @@ class ItemDetailViewModel(
                     userData = (episodeDetail.userData ?: LeafItemUserData()).copy(played = played),
                 )
             }
+            val ownDetail = state.detail?.let { itemDetail ->
+                if (itemDetail.contentId != episodeContentId) itemDetail else itemDetail.copy(
+                    userData = (itemDetail.userData ?: LeafItemUserData()).copy(played = played),
+                )
+            }
             state.copy(
+                detail = ownDetail,
                 episodes = state.episodes.map { it.updated() },
                 episodesBySeason = state.episodesBySeason.mapValues { (_, episodes) ->
                     episodes.map { it.updated() }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -55,6 +55,10 @@ data class ItemDetailUiState(
     val seasons: List<Season> = emptyList(),
     val selectedSeasonNumber: Int = 1,
     val episodes: List<EpisodeListItem> = emptyList(),
+    /** Episode selected inside a series page. Its full detail powers the hero play target and selectors. */
+    val selectedEpisodeContentId: String? = null,
+    val selectedEpisodeDetail: ItemDetail? = null,
+    val isLoadingSelectedEpisodeDetail: Boolean = false,
     /** Parent-series portrait art used when an episode's own artwork is a wide still. */
     val episodeSeriesPosterUrl: String? = null,
     val episodeSeriesPosterThumbhash: String? = null,
@@ -136,10 +140,14 @@ class ItemDetailViewModel(
     private val contentId: String = savedStateHandle.get<String>("contentId") ?: ""
     private val initialSeasonNumber: Int? =
         savedStateHandle.get<String>("seasonNumber")?.toIntOrNull()
+    private val initialEpisodeContentId: String? =
+        savedStateHandle.get<String>("episodeContentId")?.takeIf { it.isNotBlank() }
+    private var pendingInitialEpisodeContentId: String? = initialEpisodeContentId
 
     private val _uiState = MutableStateFlow(ItemDetailUiState())
     val uiState: StateFlow<ItemDetailUiState> = _uiState.asStateFlow()
     private var episodeLoadJob: Job? = null
+    private var selectedEpisodeLoadJob: Job? = null
     private var allEpisodeFileIdsJob: Job? = null
     private data class EpisodeRollupRequest(
         val seriesId: String,
@@ -166,6 +174,7 @@ class ItemDetailViewModel(
     val downloadCapability: StateFlow<DownloadCapability?> = downloadsRepository.capability
 
     private var watchedMutationGeneration = 0
+    private val episodeWatchedMutationGenerations = mutableMapOf<String, Int>()
 
     private val descriptionTranslation = DescriptionTranslationController(
         repository = metadataAiRepository,
@@ -343,9 +352,13 @@ class ItemDetailViewModel(
     fun loadDetail() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
+            // Start the live request immediately. The durable cache read can
+            // still paint an instant first frame, but it no longer delays the
+            // network request that supplies fresh movie/series metadata.
+            val liveDetail = async { catalogRepository.getItemDetail(contentId) }
             seedCachedDetail()
 
-            when (val result = catalogRepository.getItemDetail(contentId)) {
+            when (val result = liveDetail.await()) {
                 is ApiResult.Success -> {
                     val detail = withLocalProgress(result.data)
                     _uiState.update {
@@ -518,7 +531,15 @@ class ItemDetailViewModel(
 
     private fun loadSeasons(seriesId: String) {
         viewModelScope.launch {
-            when (val result = catalogRepository.getSeasons(seriesId)) {
+            // Continue Watching warms the parent series before navigation. Use
+            // that fresh cache immediately only for that targeted route; direct
+            // card opens retain their normal live season refresh.
+            val result = if (initialEpisodeContentId != null) {
+                catalogRepository.getSeasonsForPrefetch(seriesId)
+            } else {
+                catalogRepository.getSeasons(seriesId)
+            }
+            when (result) {
                 is ApiResult.Success -> {
                     val plan = result.data.seasons.initialSeasonDisplayPlan(initialSeasonNumber)
                     _uiState.update {
@@ -532,6 +553,7 @@ class ItemDetailViewModel(
                             seriesId = seriesId,
                             seasonNumber = seasonNumber,
                             seasonsForDownloadRollup = plan.seasons,
+                            preferPrefetched = initialEpisodeContentId != null,
                         )
                     } ?: run {
                         loadAllEpisodeFileIds(seriesId, plan.seasons)
@@ -683,6 +705,9 @@ class ItemDetailViewModel(
                 selectedSeasonNumber = seasonNumber,
                 episodes = cachedEpisodes.orEmpty(),
                 isLoadingEpisodes = cachedEpisodes == null,
+                selectedEpisodeContentId = null,
+                selectedEpisodeDetail = null,
+                isLoadingSelectedEpisodeDetail = false,
             )
         }
         val detail = _uiState.value.detail ?: return
@@ -690,11 +715,95 @@ class ItemDetailViewModel(
         loadEpisodes(seriesId, seasonNumber)
     }
 
+    /** Selects an episode in place instead of pushing a separate episode route. */
+    fun selectSeriesEpisode(contentId: String) {
+        if (_uiState.value.selectedEpisodeContentId == contentId &&
+            _uiState.value.selectedEpisodeDetail != null
+        ) return
+        selectedEpisodeLoadJob?.cancel()
+        _uiState.update {
+            it.copy(
+                selectedEpisodeContentId = contentId,
+                selectedEpisodeDetail = null,
+                isLoadingSelectedEpisodeDetail = true,
+                selectedVersionIndex = 0,
+                selectedAudioIndex = 0,
+                selectedSubtitleIndex = -1,
+                hasExplicitVersionSelection = false,
+                hasExplicitAudioSelection = false,
+                hasExplicitSubtitleSelection = false,
+            )
+        }
+        loadSelectedEpisodeDetail(contentId)
+    }
+
+    fun ensureSelectedEpisodeDetailLoaded() {
+        val state = _uiState.value
+        val contentId = state.selectedEpisodeContentId ?: return
+        if (state.selectedEpisodeDetail != null || state.isLoadingSelectedEpisodeDetail) return
+        _uiState.update { it.copy(isLoadingSelectedEpisodeDetail = true) }
+        loadSelectedEpisodeDetail(contentId)
+    }
+
+    private fun loadSelectedEpisodeDetail(contentId: String) {
+        selectedEpisodeLoadJob = viewModelScope.launch {
+            val result = if (contentId == initialEpisodeContentId) {
+                catalogRepository.getItemDetailForPrefetch(contentId)
+            } else {
+                catalogRepository.getItemDetail(contentId)
+            }
+            when (result) {
+                is ApiResult.Success -> _uiState.update { state ->
+                    if (state.selectedEpisodeContentId != contentId) state else state.copy(
+                        selectedEpisodeDetail = withLocalProgress(result.data),
+                        isLoadingSelectedEpisodeDetail = false,
+                    )
+                }
+                else -> _uiState.update { state ->
+                    if (state.selectedEpisodeContentId != contentId) state else state.copy(
+                        isLoadingSelectedEpisodeDetail = false,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun ensureSeriesEpisodeSelection(episodes: List<EpisodeListItem>) {
+        if (episodes.isEmpty()) return
+        val current = _uiState.value.selectedEpisodeContentId
+        if (episodes.any { it.contentId == current }) return
+        val routedEpisode = pendingInitialEpisodeContentId?.let { requestedContentId ->
+            episodes.firstOrNull { it.contentId == requestedContentId }
+        }
+        // The route's target applies only to its initial season load. If stale
+        // metadata names an episode outside that season, fall back normally
+        // instead of unexpectedly selecting it after a later manual chip tap.
+        pendingInitialEpisodeContentId = null
+        val preferred = routedEpisode ?: episodes.firstOrNull {
+            (it.userData?.positionSeconds ?: 0.0) > 0.0 && it.userData?.played != true
+        } ?: episodes.firstOrNull { it.userData?.played != true }
+            ?: episodes.first()
+        _uiState.update {
+            it.copy(
+                selectedEpisodeContentId = preferred.contentId,
+                selectedEpisodeDetail = null,
+                isLoadingSelectedEpisodeDetail = false,
+                selectedVersionIndex = 0,
+                selectedAudioIndex = 0,
+                selectedSubtitleIndex = -1,
+                hasExplicitVersionSelection = false,
+                hasExplicitAudioSelection = false,
+                hasExplicitSubtitleSelection = false,
+            )
+        }
+    }
+
     private fun loadEpisodes(
         seriesId: String,
         seasonNumber: Int,
         seasonsForDownloadRollup: List<Season>? = null,
         forceRefresh: Boolean = false,
+        preferPrefetched: Boolean = false,
     ) {
         episodeLoadJob?.cancel()
         val cachedEpisodes = _uiState.value.episodesBySeason[seasonNumber]
@@ -707,6 +816,7 @@ class ItemDetailViewModel(
                     isLoadingEpisodes = false,
                 )
             }
+            ensureSeriesEpisodeSelection(cachedEpisodes)
             seasonsForDownloadRollup?.let { seasons ->
                 loadAllEpisodeFileIds(
                     seriesId = seriesId,
@@ -728,7 +838,12 @@ class ItemDetailViewModel(
                     },
                 )
             }
-            when (val result = catalogRepository.getEpisodes(seriesId, seasonNumber)) {
+            val result = if (!forceRefresh && preferPrefetched) {
+                catalogRepository.getEpisodesForPrefetch(seriesId, seasonNumber)
+            } else {
+                catalogRepository.getEpisodes(seriesId, seasonNumber)
+            }
+            when (result) {
                 is ApiResult.Success -> {
                     val episodes = withLocalProgress(result.data.episodes)
                     loadedSeasonNumber = seasonNumber
@@ -740,6 +855,7 @@ class ItemDetailViewModel(
                             episodes = if (it.selectedSeasonNumber == seasonNumber) episodes else it.episodes,
                         )
                     }
+                    ensureSeriesEpisodeSelection(episodes)
                     seasonsForDownloadRollup?.let { seasons ->
                         loadAllEpisodeFileIds(
                             seriesId = seriesId,
@@ -1057,6 +1173,53 @@ class ItemDetailViewModel(
                 is ApiResult.Success -> { /* already updated */ }
                 else -> if (generation == watchedMutationGeneration) updatePlayedState(current)
             }
+        }
+    }
+
+    /** Marks one episode from the in-page rail without navigating away. */
+    fun setEpisodeWatched(episodeContentId: String, watched: Boolean) {
+        val state = _uiState.value
+        val previous = state.episodes.firstOrNull { it.contentId == episodeContentId }
+            ?.userData?.played
+            ?: state.episodesBySeason.values.asSequence()
+                .flatten()
+                .firstOrNull { it.contentId == episodeContentId }
+                ?.userData?.played
+            ?: false
+        if (previous == watched) return
+
+        val generation = (episodeWatchedMutationGenerations[episodeContentId] ?: 0) + 1
+        episodeWatchedMutationGenerations[episodeContentId] = generation
+        updateEpisodePlayedState(episodeContentId, watched)
+        viewModelScope.launch {
+            when (personalDataRepository.setWatched(episodeContentId, watched)) {
+                is ApiResult.Success -> Unit
+                else -> if (episodeWatchedMutationGenerations[episodeContentId] == generation) {
+                    updateEpisodePlayedState(episodeContentId, previous)
+                }
+            }
+        }
+    }
+
+    private fun updateEpisodePlayedState(episodeContentId: String, played: Boolean) {
+        fun EpisodeListItem.updated(): EpisodeListItem =
+            if (contentId != episodeContentId) this else copy(
+                userData = (userData ?: LeafItemUserData()).copy(played = played),
+            )
+
+        _uiState.update { state ->
+            val selectedDetail = state.selectedEpisodeDetail?.let { episodeDetail ->
+                if (episodeDetail.contentId != episodeContentId) episodeDetail else episodeDetail.copy(
+                    userData = (episodeDetail.userData ?: LeafItemUserData()).copy(played = played),
+                )
+            }
+            state.copy(
+                episodes = state.episodes.map { it.updated() },
+                episodesBySeason = state.episodesBySeason.mapValues { (_, episodes) ->
+                    episodes.map { it.updated() }
+                },
+                selectedEpisodeDetail = selectedDetail,
+            )
         }
     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MediaSelectors.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MediaSelectors.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -22,8 +23,8 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Check
-import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -40,6 +41,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.siloserver.silo.android.ui.theme.DarkOutline
@@ -51,10 +53,9 @@ import org.siloserver.silo.model.catalog.SubtitleTrack
 import org.siloserver.silo.player.DolbyVisionDetection
 
 /**
- * Full-width box row for one playback track group (Video / Audio /
- * Subtitles) — the phone counterpart of the TV detail's selector row.
- * Icon + group label on the left, the current value (ellipsized) and a
- * chevron on the right; tap opens the matching bottom-sheet picker.
+ * One iOS-style row inside [PlaybackSelectorCard]. Icon + group label lead,
+ * while the current value and disclosure chevron trail. Rows deliberately do
+ * not draw their own boxes; the three controls share one rounded container.
  *
  * [interactive] = false when the group holds a single real choice (one
  * version, one audio track, one subtitle track), mirroring Apple's
@@ -75,30 +76,30 @@ fun TrackSelectorRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
-            .background(DarkSurfaceVariant.copy(alpha = 0.7f))
-            .border(1.dp, DarkOutline, RoundedCornerShape(8.dp))
             .then(if (interactive) Modifier.clickable(onClick = onClick) else Modifier)
-            .padding(horizontal = 12.dp, vertical = 12.dp),
+            .height(44.dp)
+            .padding(horizontal = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            modifier = Modifier.size(16.dp),
-            tint = Color.White,
-        )
+        Box(modifier = Modifier.width(20.dp), contentAlignment = Alignment.CenterStart) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(13.dp),
+                tint = Color.White.copy(alpha = 0.55f),
+            )
+        }
         Text(
             text = label,
-            style = MaterialTheme.typography.labelSmall,
+            fontSize = 14.sp,
             color = Color.White.copy(alpha = 0.72f),
             fontWeight = FontWeight.Medium,
         )
         Text(
             text = value,
-            style = MaterialTheme.typography.labelMedium,
-            color = Color.White.copy(alpha = 0.9f),
+            fontSize = 14.sp,
+            color = Color.White,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             fontWeight = FontWeight.SemiBold,
@@ -107,13 +108,83 @@ fun TrackSelectorRow(
         )
         if (interactive) {
             Icon(
-                imageVector = Icons.Outlined.KeyboardArrowDown,
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = "Select",
-                modifier = Modifier.size(14.dp),
-                tint = Color.White.copy(alpha = 0.62f),
+                modifier = Modifier.size(11.dp),
+                tint = Color.White.copy(alpha = 0.35f),
             )
         }
     }
+}
+
+/**
+ * The common Version / Audio / Subtitles control: one 12dp rounded card with
+ * shared hairline dividers, matching `PhonePlaybackSelectorRow` on iOS.
+ */
+@Composable
+fun PlaybackSelectorCard(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(133.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.White.copy(alpha = 0.05f))
+            .border(0.5.dp, Color.White.copy(alpha = 0.10f), RoundedCornerShape(12.dp)),
+        content = content,
+    )
+}
+
+@Composable
+fun PlaybackSelectorDivider() {
+    HorizontalDivider(
+        modifier = Modifier.padding(start = 30.dp),
+        thickness = 0.5.dp,
+        color = Color.White.copy(alpha = 0.08f),
+    )
+}
+
+/**
+ * Loading state with the exact same three 44dp rows as [PlaybackSelectorCard].
+ * Keeping the complete card mounted while a newly centred episode hydrates
+ * prevents the season controls and episode rail from moving vertically.
+ */
+@Composable
+fun PlaybackSelectorSkeleton(modifier: Modifier = Modifier) {
+    val labelWidths = listOf(52.dp, 42.dp, 64.dp)
+    val valueWidths = listOf(128.dp, 154.dp, 48.dp)
+
+    PlaybackSelectorCard(modifier = modifier) {
+        repeat(3) { index ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(44.dp)
+                    .padding(horizontal = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                SelectorSkeletonShape(width = 13.dp, height = 13.dp)
+                SelectorSkeletonShape(width = labelWidths[index], height = 12.dp)
+                Spacer(modifier = Modifier.weight(1f))
+                SelectorSkeletonShape(width = valueWidths[index], height = 12.dp)
+            }
+            if (index < 2) PlaybackSelectorDivider()
+        }
+    }
+}
+
+@Composable
+private fun SelectorSkeletonShape(width: Dp, height: Dp) {
+    Box(
+        modifier = Modifier
+            .width(width)
+            .height(height)
+            .clip(RoundedCornerShape(4.dp))
+            .background(Color.White.copy(alpha = 0.10f)),
+    )
 }
 
 // ── Bottom sheet pickers ──────────────────────────────────────

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
@@ -291,9 +291,14 @@ fun MovieDetailContent(
                             onSeasonSelected = onSeasonSelected,
                         )
                     }
+                    val selectedSeason = seasons.firstOrNull {
+                        it.seasonNumber == selectedSeasonNumber
+                    }
                     SectionHeader(
-                        title = if (selectedSeasonNumber == 0) {
-                            "This Season Episodes"
+                        title = selectedSeason?.let(::seriesSeasonSectionTitle) ?: if (
+                            selectedSeasonNumber == 0
+                        ) {
+                            "Specials Episodes"
                         } else {
                             "Season $selectedSeasonNumber Episodes"
                         },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
@@ -1,17 +1,13 @@
 package org.siloserver.silo.android.ui.screens.detail
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
@@ -19,7 +15,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Download
-import androidx.compose.material.icons.filled.DownloadDone
 import androidx.compose.material.icons.outlined.AudioFile
 import androidx.compose.material.icons.outlined.Cast
 import androidx.compose.material.icons.outlined.ClosedCaption
@@ -28,7 +23,6 @@ import androidx.compose.material.icons.outlined.HighQuality
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -41,6 +35,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.siloserver.silo.android.ui.theme.SiloBackground
+import org.siloserver.silo.android.ui.theme.SiloDetailActionControl
+import org.siloserver.silo.android.ui.theme.SiloDetailActionControlActive
 import org.siloserver.silo.android.ui.util.rememberDominantColor
 import org.siloserver.silo.common.ui.movieDirectorCredit
 import org.siloserver.silo.model.catalog.EpisodeListItem
@@ -77,9 +73,6 @@ fun MovieDetailContent(
     onFavoriteClick: () -> Unit,
     onWatchlistClick: () -> Unit,
     onToggleWatched: () -> Unit,
-    userRating: Int? = null,
-    onSetRating: (Int) -> Unit = {},
-    onClearRating: () -> Unit = {},
     onVersionSelected: (Int?) -> Unit,
     onAudioSelected: (Int?) -> Unit,
     onSubtitleSelected: (Int?) -> Unit,
@@ -95,10 +88,8 @@ fun MovieDetailContent(
     episodesBySeason: Map<Int, List<EpisodeListItem>> = emptyMap(),
     isLoadingEpisodes: Boolean = false,
     onSeasonSelected: (Int) -> Unit = {},
-    onEpisodePlayClick: (String, Double?) -> Unit = { _, _ -> },
     onEpisodeDetailClick: (String) -> Unit = {},
-    onEpisodeDownloadClick: ((EpisodeListItem) -> Unit)? = null,
-    episodeDownloadState: (EpisodeListItem) -> DetailDownloadState = { DetailDownloadState() },
+    onEpisodeWatchedChange: (String, Boolean) -> Unit = { _, _ -> },
     isDownloaded: Boolean = false,
     downloadProgress: Float? = null,
     playOnDeviceLabel: String = "Play on device",
@@ -112,9 +103,12 @@ fun MovieDetailContent(
     var showVersionPicker by remember { mutableStateOf(false) }
     var showAudioPicker by remember { mutableStateOf(false) }
     var showSubtitlePicker by remember { mutableStateOf(false) }
-    var showRatingSheet by remember { mutableStateOf(false) }
 
-    val dominantColor by rememberDominantColor(detail.backdropUrl, fallback = SiloBackground)
+    val dominantColor by rememberDominantColor(
+        imageUrl = detail.backdropUrl,
+        fallback = SiloBackground,
+        thumbhash = detail.backdropThumbhash,
+    )
 
     val selectedVersion = detail.versions.getOrNull(selectedVersionIndex)
     val audioTracks = selectedVersion?.audioTracks.orEmpty()
@@ -154,6 +148,45 @@ fun MovieDetailContent(
                 dominantColor = dominantColor,
                 directorText = movieDirectorCredit(detail),
                 translation = translation,
+                belowOverview = {
+                    // PR #212 places the grouped playback card after overview,
+                    // credits, and translation—not inside the action stack.
+                    if (hasTrackSelectors) {
+                        PlaybackSelectorCard {
+                            TrackSelectorRow(
+                                icon = Icons.Outlined.HighQuality,
+                                label = "Version",
+                                value = formatVersionValueLabel(selectedVersion, isAutoVersion),
+                                onClick = { showVersionPicker = true },
+                                interactive = detail.versions.size > 1,
+                            )
+                            if (audioTracks.isNotEmpty()) {
+                                PlaybackSelectorDivider()
+                                TrackSelectorRow(
+                                    icon = Icons.Outlined.AudioFile,
+                                    label = "Audio",
+                                    value = formatAudioValueLabel(
+                                        audioTracks,
+                                        selectedAudioIndex,
+                                        selectedVersion?.effectiveAudioTrackIndex,
+                                    ),
+                                    onClick = { showAudioPicker = true },
+                                    interactive = audioTracks.size > 1,
+                                )
+                            }
+                            if (subtitleTracks.isNotEmpty()) {
+                                PlaybackSelectorDivider()
+                                TrackSelectorRow(
+                                    icon = Icons.Outlined.ClosedCaption,
+                                    label = "Subtitles",
+                                    value = formatSubtitleValueLabel(subtitleTracks, selectedSubtitleIndex),
+                                    onClick = { showSubtitlePicker = true },
+                                    interactive = subtitleTracks.size > 1,
+                                )
+                            }
+                        }
+                    }
+                },
             ) {
                 HeroActionStack(
                     primaryLabel = computePlayLabel(detail),
@@ -166,8 +199,6 @@ fun MovieDetailContent(
                     onToggleFavorite = onFavoriteClick,
                     onToggleWatchlist = onWatchlistClick,
                     onToggleWatched = onToggleWatched,
-                    userRating = userRating,
-                    onRateClick = { showRatingSheet = true },
                     overflow = if (hasOverflow) {
                         { dismiss ->
                             if (onPlayOnDevice != null) {
@@ -240,65 +271,6 @@ fun MovieDetailContent(
                         null
                     },
                 )
-                // Downloaded confirmation under the action row — the circle
-                // button's filled state alone is easy to miss (QA 2026-07-08);
-                // iOS pairs its green check with an accessible "Downloaded".
-                if (isDownloaded) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.DownloadDone,
-                            contentDescription = null,
-                            tint = Color(0xFF30D158),
-                            modifier = Modifier.size(16.dp),
-                        )
-                        Text(
-                            text = "Downloaded",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = Color.White.copy(alpha = 0.85f),
-                        )
-                    }
-                }
-                // Box-style track group list (Video / Audio / Subtitles) —
-                // TV & Apple parity; Auto rows preview the resolved track.
-                if (hasTrackSelectors) {
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        TrackSelectorRow(
-                            icon = Icons.Outlined.HighQuality,
-                            label = "Video",
-                            value = formatVersionValueLabel(selectedVersion, isAutoVersion),
-                            onClick = { showVersionPicker = true },
-                            // Apple's shouldEnable*Selector: a picker is offered
-                            // only when there is more than one real choice. The
-                            // sheets' Auto/Off rows are pseudo-entries and do
-                            // not count toward it.
-                            interactive = detail.versions.size > 1,
-                        )
-                        if (audioTracks.isNotEmpty()) {
-                            TrackSelectorRow(
-                                icon = Icons.Outlined.AudioFile,
-                                label = "Audio",
-                                value = formatAudioValueLabel(audioTracks, selectedAudioIndex, selectedVersion?.effectiveAudioTrackIndex),
-                                onClick = { showAudioPicker = true },
-                                interactive = audioTracks.size > 1,
-                            )
-                        }
-                        if (subtitleTracks.isNotEmpty()) {
-                            TrackSelectorRow(
-                                icon = Icons.Outlined.ClosedCaption,
-                                label = "Subtitles",
-                                value = formatSubtitleValueLabel(subtitleTracks, selectedSubtitleIndex),
-                                onClick = { showSubtitlePicker = true },
-                                interactive = subtitleTracks.size > 1,
-                            )
-                        }
-                    }
-                }
             }
         }
 
@@ -312,9 +284,19 @@ fun MovieDetailContent(
         if (detail.type == "episode" && (seasons.isNotEmpty() || episodes.isNotEmpty() || isLoadingEpisodes)) {
             item(contentType = "detail-episodes") {
                 Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                    if (seasons.isNotEmpty()) {
+                        SeasonChips(
+                            seasons = seasons,
+                            selectedSeasonNumber = selectedSeasonNumber,
+                            onSeasonSelected = onSeasonSelected,
+                        )
+                    }
                     SectionHeader(
-                        label = if (selectedSeasonNumber == 0) "Specials" else "Season $selectedSeasonNumber",
-                        title = "Episodes",
+                        title = if (selectedSeasonNumber == 0) {
+                            "This Season Episodes"
+                        } else {
+                            "Season $selectedSeasonNumber Episodes"
+                        },
                     )
                     SeasonEpisodePager(
                         seasons = seasons,
@@ -323,11 +305,12 @@ fun MovieDetailContent(
                         episodesBySeason = episodesBySeason,
                         isLoadingEpisodes = isLoadingEpisodes,
                         onSeasonSelected = onSeasonSelected,
-                        onEpisodePlayClick = onEpisodePlayClick,
+                        onEpisodePlayClick = null,
                         onEpisodeDetailClick = onEpisodeDetailClick,
-                        onEpisodeDownloadClick = onEpisodeDownloadClick,
-                        episodeDownloadState = episodeDownloadState,
+                        onEpisodeWatchedChange = onEpisodeWatchedChange,
                         highlightContentId = detail.contentId,
+                        showsSeasonSelector = false,
+                        allowsSeasonPaging = false,
                     )
                 }
             }
@@ -404,24 +387,10 @@ fun MovieDetailContent(
         )
     }
 
-    if (showRatingSheet) {
-        RatingSheet(
-            currentRating = userRating,
-            onSetRating = { stars ->
-                onSetRating(stars)
-                showRatingSheet = false
-            },
-            onClearRating = {
-                onClearRating()
-                showRatingSheet = false
-            },
-            onDismiss = { showRatingSheet = false },
-        )
-    }
 }
 
 /**
- * 44dp circle download button styled to sit alongside [CircleActionButton]
+ * 42dp circle download button styled to sit alongside [CircleActionButton]
  * (favorite / watchlist / watched) in [HeroActionStack]. Three visual states:
  *
  *   - Not downloaded:  white download icon over a ghost circle (matches the
@@ -442,17 +411,11 @@ internal fun DownloadCircleButton(
     val isInFlight = progress != null && !isDownloaded
     Box(
         modifier = Modifier
-            .size(44.dp)
+            .size(42.dp)
             .clip(CircleShape)
             .background(
-                if (isDownloaded) Color.White
-                else Color.White.copy(alpha = 0.10f)
-            )
-            .border(
-                width = 1.dp,
-                color = if (isDownloaded) Color.White
-                else Color.White.copy(alpha = 0.25f),
-                shape = CircleShape,
+                if (isDownloaded) SiloDetailActionControlActive
+                else SiloDetailActionControl
             )
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
@@ -469,7 +432,7 @@ internal fun DownloadCircleButton(
         Icon(
             imageVector = if (isDownloaded) Icons.Filled.Check else Icons.Filled.Download,
             contentDescription = if (isDownloaded) "Downloaded" else "Download",
-            tint = if (isDownloaded) Color.Black else Color.White,
+            tint = Color.White,
             modifier = Modifier.size(if (isDownloaded) 22.dp else 18.dp),
         )
     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeasonEpisodePager.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeasonEpisodePager.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.animation.core.animateDpAsState
@@ -47,21 +46,29 @@ internal fun SeasonEpisodePager(
     episodesBySeason: Map<Int, List<EpisodeListItem>>,
     isLoadingEpisodes: Boolean,
     onSeasonSelected: (Int) -> Unit,
-    onEpisodePlayClick: (String, Double?) -> Unit,
+    onEpisodePlayClick: ((String, Double?) -> Unit)?,
     onEpisodeDetailClick: (String) -> Unit,
-    onEpisodeDownloadClick: ((EpisodeListItem) -> Unit)?,
-    episodeDownloadState: (EpisodeListItem) -> DetailDownloadState,
+    onEpisodeWatchedChange: ((String, Boolean) -> Unit)? = null,
     highlightContentId: String? = null,
+    showsSeasonSelector: Boolean = true,
+    selectsCenteredEpisode: Boolean = false,
+    allowsSeasonPaging: Boolean = true,
+    /** Tablet/fold rail cards show title, date/runtime, and overview. */
+    showsEpisodeDetails: Boolean = false,
+    /** Tablet/fold rail selection follows taps rather than centre position. */
+    tapToFocusEpisode: Boolean = false,
 ) {
-    if (seasons.size <= 1) {
+    if (seasons.size <= 1 || !allowsSeasonPaging) {
         SeasonEpisodePage(
             episodes = episodes,
             isLoading = isLoadingEpisodes,
             onEpisodePlayClick = onEpisodePlayClick,
             onEpisodeDetailClick = onEpisodeDetailClick,
-            onEpisodeDownloadClick = onEpisodeDownloadClick,
-            episodeDownloadState = episodeDownloadState,
+            onEpisodeWatchedChange = onEpisodeWatchedChange,
             highlightContentId = highlightContentId,
+            selectsCenteredEpisode = selectsCenteredEpisode,
+            showsEpisodeDetails = showsEpisodeDetails,
+            tapToFocusEpisode = tapToFocusEpisode,
         )
         return
     }
@@ -101,17 +108,19 @@ internal fun SeasonEpisodePager(
     }
 
     Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
-        SeasonChips(
-            seasons = seasons,
-            selectedSeasonNumber = selectedSeasonNumber,
-            onSeasonSelected = { seasonNumber ->
-                val page = seasons.indexOfFirst { it.seasonNumber == seasonNumber }
-                onSeasonSelected(seasonNumber)
-                if (page >= 0 && pagerState.targetPage != page) {
-                    scope.launch { pagerState.animateScrollToPage(page) }
-                }
-            },
-        )
+        if (showsSeasonSelector) {
+            SeasonChips(
+                seasons = seasons,
+                selectedSeasonNumber = selectedSeasonNumber,
+                onSeasonSelected = { seasonNumber ->
+                    val page = seasons.indexOfFirst { it.seasonNumber == seasonNumber }
+                    onSeasonSelected(seasonNumber)
+                    if (page >= 0 && pagerState.targetPage != page) {
+                        scope.launch { pagerState.animateScrollToPage(page) }
+                    }
+                },
+            )
+        }
 
         // A pager with an unconstrained height sizes itself to the TALLEST page
         // it has composed — with the neighbours kept alive, a long season next
@@ -155,9 +164,11 @@ internal fun SeasonEpisodePager(
                         (season.seasonNumber != selectedSeasonNumber || isLoadingEpisodes),
                     onEpisodePlayClick = onEpisodePlayClick,
                     onEpisodeDetailClick = onEpisodeDetailClick,
-                    onEpisodeDownloadClick = onEpisodeDownloadClick,
-                    episodeDownloadState = episodeDownloadState,
+                    onEpisodeWatchedChange = onEpisodeWatchedChange,
                     highlightContentId = highlightContentId,
+                    selectsCenteredEpisode = selectsCenteredEpisode,
+                    showsEpisodeDetails = showsEpisodeDetails,
+                    tapToFocusEpisode = tapToFocusEpisode,
                     modifier = Modifier
                         .onSizeChanged { pageHeightsPx[page] = it.height }
                         .graphicsLayer {
@@ -175,23 +186,21 @@ internal fun SeasonEpisodePager(
 private fun SeasonEpisodePage(
     episodes: List<EpisodeListItem>,
     isLoading: Boolean,
-    onEpisodePlayClick: (String, Double?) -> Unit,
+    onEpisodePlayClick: ((String, Double?) -> Unit)?,
     onEpisodeDetailClick: (String) -> Unit,
-    onEpisodeDownloadClick: ((EpisodeListItem) -> Unit)?,
-    episodeDownloadState: (EpisodeListItem) -> DetailDownloadState,
+    onEpisodeWatchedChange: ((String, Boolean) -> Unit)?,
     highlightContentId: String?,
+    selectsCenteredEpisode: Boolean,
+    showsEpisodeDetails: Boolean,
+    tapToFocusEpisode: Boolean,
     modifier: Modifier = Modifier,
 ) {
     when {
         isLoading -> {
-            Box(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(32.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
+            EpisodeListSkeleton(
+                showsEpisodeDetails = showsEpisodeDetails,
+                modifier = modifier,
+            )
         }
         episodes.isEmpty() -> {
             Text(
@@ -206,9 +215,11 @@ private fun SeasonEpisodePage(
                 episodes = episodes,
                 onEpisodePlayClick = onEpisodePlayClick,
                 onEpisodeDetailClick = onEpisodeDetailClick,
-                onEpisodeDownloadClick = onEpisodeDownloadClick,
-                episodeDownloadState = episodeDownloadState,
+                onEpisodeWatchedChange = onEpisodeWatchedChange,
                 highlightContentId = highlightContentId,
+                selectsCenteredEpisode = selectsCenteredEpisode,
+                showsEpisodeDetails = showsEpisodeDetails,
+                tapToFocusEpisode = tapToFocusEpisode,
                 modifier = modifier,
             )
         }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
@@ -2,33 +2,30 @@ package org.siloserver.silo.android.ui.screens.detail
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DownloadDone
 import androidx.compose.material.icons.outlined.Cast
-import androidx.compose.material.icons.outlined.FileDownload
 import androidx.compose.material.icons.outlined.Groups
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material.icons.outlined.AudioFile
+import androidx.compose.material.icons.outlined.ClosedCaption
+import androidx.compose.material.icons.outlined.HighQuality
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import org.siloserver.silo.android.ui.theme.SiloBackground
 import org.siloserver.silo.android.ui.util.rememberDominantColor
 import org.siloserver.silo.model.catalog.EpisodeListItem
@@ -53,24 +50,29 @@ fun SeriesDetailContent(
     isFavorite: Boolean,
     isInWatchlist: Boolean,
     nextEpisodeLabel: String?,
+    selectedEpisodeContentId: String?,
+    selectedEpisodeDetail: ItemDetail?,
+    isLoadingSelectedEpisodeDetail: Boolean,
+    selectedVersionIndex: Int,
+    isAutoVersion: Boolean,
+    selectedAudioIndex: Int?,
+    selectedSubtitleIndex: Int?,
+    onVersionSelected: (Int?) -> Unit,
+    onAudioSelected: (Int?) -> Unit,
+    onSubtitleSelected: (Int?) -> Unit,
     onPlayClick: () -> Unit,
     onPlayFromBeginning: (() -> Unit)? = null,
     resumeStoppedAtLabel: String? = null,
     onEpisodePlayClick: (String, Double?) -> Unit,
     onEpisodeDetailClick: (String) -> Unit,
+    onEpisodeWatchedChange: (String, Boolean) -> Unit,
     onSeasonSelected: (Int) -> Unit,
     onFavoriteClick: () -> Unit,
     onWatchlistClick: () -> Unit,
     onToggleWatched: () -> Unit,
-    userRating: Int? = null,
-    onSetRating: (Int) -> Unit = {},
-    onClearRating: () -> Unit = {},
     onPersonClick: (String) -> Unit,
     onItemDetailClick: (String) -> Unit,
     onSeriesDownloadClick: (() -> Unit)? = null,
-    onSeasonDownloadClick: ((Int) -> Unit)? = null,
-    onEpisodeDownloadClick: ((EpisodeListItem) -> Unit)? = null,
-    episodeDownloadState: (EpisodeListItem) -> DetailDownloadState = { DetailDownloadState() },
     /** Series-level roll-up across ALL seasons: isDownloaded when every episode
      *  is downloaded, progress = downloaded/total fraction while partial. */
     seriesDownloadState: DetailDownloadState = DetailDownloadState(),
@@ -81,25 +83,139 @@ fun SeriesDetailContent(
     translation: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
-    val dominantColor by rememberDominantColor(detail.backdropUrl, fallback = SiloBackground)
-    var showRatingSheet by remember { mutableStateOf(false) }
+    val dominantColor by rememberDominantColor(
+        imageUrl = detail.backdropUrl,
+        fallback = SiloBackground,
+        thumbhash = detail.backdropThumbhash,
+    )
+    var showVersionPicker by remember { mutableStateOf(false) }
+    var showAudioPicker by remember { mutableStateOf(false) }
+    var showSubtitlePicker by remember { mutableStateOf(false) }
 
     val eyebrow = HeroMetadata.seriesEyebrow(detail)
     val sourceTokens = HeroMetadata.seriesSourceTokens(detail)
     val factsLine = HeroMetadata.seriesFactsLine(detail)
 
     val selectedSeason = seasons.firstOrNull { it.seasonNumber == selectedSeasonNumber }
+    val selectedEpisode = episodes.firstOrNull { it.contentId == selectedEpisodeContentId }
+    val loadedSelectedEpisodeDetail = selectedEpisodeDetail
+        ?.takeIf { it.contentId == selectedEpisodeContentId }
+    val usesEpisodeEditorial = selectedEpisode != null || selectedEpisodeContentId != null
+    val selectedEpisodeOverview = loadedSelectedEpisodeDetail?.overview
+        ?.takeIf { it.isNotBlank() }
+        ?: selectedEpisode?.overview?.takeIf { it.isNotBlank() }
+    // iOS keeps the series cast credit stable while the selected episode's
+    // overview and playback options change. Reusing the series credit avoids
+    // replacing it with a skeleton (and repainting different names) on every
+    // horizontal episode selection.
+    val fixedSeriesCredit = remember(detail.contentId, detail.cast) { seriesStarringCredit(detail) }
     val episodeCountSubtitle = selectedSeason?.episodeCount?.takeIf { it > 0 }?.let { count ->
         "$count episode${if (count == 1) "" else "s"}"
+    }
+
+    val playbackSelector: @Composable () -> Unit = {
+        if (selectedEpisodeContentId != null) {
+            when {
+                isLoadingSelectedEpisodeDetail || loadedSelectedEpisodeDetail == null ->
+                    PlaybackSelectorSkeleton()
+                else -> {
+                    val selectedVersion = loadedSelectedEpisodeDetail.versions.getOrNull(selectedVersionIndex)
+                    val audioTracks = selectedVersion?.audioTracks.orEmpty()
+                    val subtitleTracks = selectedVersion?.subtitleTracks.orEmpty()
+                    PlaybackSelectorCard {
+                        TrackSelectorRow(
+                            icon = Icons.Outlined.HighQuality,
+                            label = "Version",
+                            value = formatVersionValueLabel(selectedVersion, isAutoVersion),
+                            onClick = { showVersionPicker = true },
+                            interactive = loadedSelectedEpisodeDetail.versions.size > 1,
+                        )
+                        PlaybackSelectorDivider()
+                        TrackSelectorRow(
+                            icon = Icons.Outlined.AudioFile,
+                            label = "Audio",
+                            value = if (audioTracks.isEmpty()) "Unavailable" else formatAudioValueLabel(
+                                audioTracks,
+                                selectedAudioIndex,
+                                selectedVersion?.effectiveAudioTrackIndex,
+                            ),
+                            onClick = { showAudioPicker = true },
+                            interactive = audioTracks.size > 1,
+                        )
+                        PlaybackSelectorDivider()
+                        TrackSelectorRow(
+                            icon = Icons.Outlined.ClosedCaption,
+                            label = "Subtitles",
+                            value = if (subtitleTracks.isEmpty()) "Unavailable" else formatSubtitleValueLabel(
+                                subtitleTracks,
+                                selectedSubtitleIndex,
+                            ),
+                            onClick = { showSubtitlePicker = true },
+                            interactive = subtitleTracks.size > 1,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    val episodeSection: @Composable (Boolean) -> Unit = { showsEpisodeDetails ->
+        Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+            if (seasons.isNotEmpty()) {
+                SeasonChips(
+                    seasons = seasons,
+                    selectedSeasonNumber = selectedSeasonNumber,
+                    onSeasonSelected = onSeasonSelected,
+                )
+            }
+            if (showsEpisodeDetails) {
+                Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                    SectionHeader(
+                        title = seriesSeasonSectionTitle(selectedSeason),
+                        trailingText = episodeCountSubtitle,
+                    )
+                    Text(
+                        text = "Tap to focus",
+                        fontSize = 11.sp,
+                        color = DetailTertiaryText,
+                        modifier = Modifier.padding(horizontal = SafePadding),
+                    )
+                }
+            } else {
+                SectionHeader(
+                    title = seriesSeasonSectionTitle(selectedSeason),
+                    trailingText = episodeCountSubtitle,
+                )
+            }
+            SeasonEpisodePager(
+                seasons = seasons,
+                selectedSeasonNumber = selectedSeasonNumber,
+                episodes = episodes,
+                episodesBySeason = episodesBySeason,
+                isLoadingEpisodes = isLoadingEpisodes,
+                onSeasonSelected = onSeasonSelected,
+                onEpisodePlayClick = onEpisodePlayClick,
+                onEpisodeDetailClick = onEpisodeDetailClick,
+                onEpisodeWatchedChange = onEpisodeWatchedChange,
+                highlightContentId = selectedEpisodeContentId,
+                showsSeasonSelector = false,
+                selectsCenteredEpisode = !showsEpisodeDetails,
+                allowsSeasonPaging = false,
+                showsEpisodeDetails = showsEpisodeDetails,
+                tapToFocusEpisode = showsEpisodeDetails,
+            )
+        }
     }
 
     // iOS below-fold section spacing is 36 (hero→first section 32). Use 36
     // uniformly — the closest single-value match to the iOS column rhythm.
     val feedState = rememberLazyListState()
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+    val isExpandedDetailLayout = maxWidth >= ExpandedDetailBreakpoint
     DeferImagePresentationWhileScrolling(feedState) {
     LazyColumn(
         state = feedState,
-        modifier = modifier
+        modifier = Modifier
             .fillMaxSize()
             .background(SiloBackground)
             .background(detailScreenBackgroundBrush(dominantColor)),
@@ -108,14 +224,31 @@ fun SeriesDetailContent(
         item(contentType = "detail-hero") {
             AdaptiveDetailHero(
                 detail = detail,
-                eyebrow = eyebrow,
+                eyebrow = if (isExpandedDetailLayout) null else eyebrow,
                 sourceTokens = sourceTokens,
                 factsLine = factsLine,
                 dominantColor = dominantColor,
-                translation = translation,
+                overviewText = if (isExpandedDetailLayout) {
+                    detail.overview
+                } else if (usesEpisodeEditorial) {
+                    selectedEpisodeOverview
+                } else {
+                    detail.overview
+                },
+                reserveOverviewSpace = !isExpandedDetailLayout && usesEpisodeEditorial,
+                directorText = fixedSeriesCredit,
+                isCreditLoading = false,
+                reserveCreditSpace = !isExpandedDetailLayout && usesEpisodeEditorial,
+                translation = if (isExpandedDetailLayout || !usesEpisodeEditorial) translation else null,
+                belowOverview = if (isExpandedDetailLayout) null else playbackSelector,
+                expandedBelowOverview = {
+                    episodeSection(true)
+                    playbackSelector()
+                },
             ) {
                 HeroActionStack(
-                    primaryLabel = computePlayLabel(detail, nextEpisodeLabel),
+                    primaryLabel = selectedEpisode?.let { "Play ${episodeNumberText(it)}" }
+                        ?: computePlayLabel(detail, nextEpisodeLabel),
                     onPlay = onPlayClick,
                     onPlayFromBeginning = onPlayFromBeginning,
                     resumeStoppedAtLabel = resumeStoppedAtLabel,
@@ -125,8 +258,6 @@ fun SeriesDetailContent(
                     onToggleFavorite = onFavoriteClick,
                     onToggleWatchlist = onWatchlistClick,
                     onToggleWatched = onToggleWatched,
-                    userRating = userRating,
-                    onRateClick = { showRatingSheet = true },
                     overflow = if (
                         onWatchTogether != null || onPlayOnDevice != null ||
                         onSuggestToRoom != null
@@ -185,75 +316,9 @@ fun SeriesDetailContent(
             }
         }
 
-        item(contentType = "detail-episodes") {
-            Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.Bottom,
-                ) {
-                    SectionHeader(
-                        label = seriesSeasonSectionLabel(selectedSeason),
-                        title = "Episodes",
-                        trailingText = episodeCountSubtitle,
-                        modifier = Modifier.weight(1f),
-                    )
-                    // "Download season N" — only when a season is selected
-                    // AND the parent screen wired the callback.
-                    val seasonNumberForDownload = selectedSeason?.seasonNumber
-                    if (seasonNumberForDownload != null && onSeasonDownloadClick != null && episodes.isNotEmpty()) {
-                        // Roll up ONLY the episodes of the selected season (the
-                        // loaded `episodes` can briefly be the previous season's
-                        // during a season switch — don't claim ✓ off stale data).
-                        val seasonEpisodes = episodes.filter { it.seasonNumber == seasonNumberForDownload }
-                        val states = seasonEpisodes.map { episodeDownloadState(it) }
-                        val allDownloaded = seasonEpisodes.isNotEmpty() && states.all { it.isDownloaded }
-                        val anyInFlight = states.any { it.progress != null }
-                        IconButton(
-                            onClick = { onSeasonDownloadClick(seasonNumberForDownload) },
-                            modifier = Modifier
-                                .padding(end = SafePadding)
-                                .size(40.dp),
-                        ) {
-                            when {
-                                allDownloaded -> Icon(
-                                    imageVector = Icons.Filled.DownloadDone,
-                                    contentDescription = seasonDownloadContentDescription(
-                                        selectedSeason,
-                                        isDownloaded = true,
-                                    ),
-                                    tint = DetailPrimaryText,
-                                    modifier = Modifier.size(24.dp),
-                                )
-                                anyInFlight -> CircularProgressIndicator(
-                                    modifier = Modifier.size(22.dp),
-                                    strokeWidth = 2.dp,
-                                    color = DetailPrimaryText,
-                                )
-                                else -> Icon(
-                                    imageVector = Icons.Outlined.FileDownload,
-                                    contentDescription = seasonDownloadContentDescription(
-                                        selectedSeason,
-                                        isDownloaded = false,
-                                    ),
-                                    tint = DetailPrimaryText,
-                                    modifier = Modifier.size(24.dp),
-                                )
-                            }
-                        }
-                    }
-                }
-                SeasonEpisodePager(
-                    seasons = seasons,
-                    selectedSeasonNumber = selectedSeasonNumber,
-                    episodes = episodes,
-                    episodesBySeason = episodesBySeason,
-                    isLoadingEpisodes = isLoadingEpisodes,
-                    onSeasonSelected = onSeasonSelected,
-                    onEpisodePlayClick = onEpisodePlayClick,
-                    onEpisodeDetailClick = onEpisodeDetailClick,
-                    onEpisodeDownloadClick = onEpisodeDownloadClick,
-                    episodeDownloadState = episodeDownloadState,
-                )
+        if (!isExpandedDetailLayout) {
+            item(contentType = "detail-episodes") {
+                episodeSection(false)
             }
         }
 
@@ -287,23 +352,42 @@ fun SeriesDetailContent(
         }
     }
     }
+    }
 
-    if (showRatingSheet) {
-        RatingSheet(
-            currentRating = userRating,
-            onSetRating = { stars ->
-                onSetRating(stars)
-                showRatingSheet = false
-            },
-            onClearRating = {
-                onClearRating()
-                showRatingSheet = false
-            },
-            onDismiss = { showRatingSheet = false },
-        )
+    selectedEpisodeDetail?.let { episodeDetail ->
+        val version = episodeDetail.versions.getOrNull(selectedVersionIndex)
+        if (showVersionPicker) {
+            VersionPickerSheet(
+                versions = episodeDetail.versions,
+                selectedIndex = selectedVersionIndex.takeUnless { isAutoVersion },
+                onSelect = { onVersionSelected(it); showVersionPicker = false },
+                onDismiss = { showVersionPicker = false },
+            )
+        }
+        if (showAudioPicker) {
+            AudioPickerSheet(
+                tracks = version?.audioTracks.orEmpty(),
+                selectedIndex = selectedAudioIndex,
+                onSelect = { onAudioSelected(it); showAudioPicker = false },
+                onDismiss = { showAudioPicker = false },
+            )
+        }
+        if (showSubtitlePicker) {
+            SubtitlePickerSheet(
+                tracks = version?.subtitleTracks.orEmpty(),
+                selectedIndex = selectedSubtitleIndex,
+                onSelect = { onSubtitleSelected(it); showSubtitlePicker = false },
+                onDismiss = { showSubtitlePicker = false },
+            )
+        }
     }
 }
 
+internal fun seriesSeasonSectionTitle(season: Season?): String =
+    season?.let { "${phoneSeasonLabel(it)} Episodes" } ?: "Episodes"
+
+// Retained for formatter tests and non-visual accessibility copy even though
+// the iOS-aligned Episodes header no longer renders a season download button.
 internal fun seriesSeasonSectionLabel(season: Season?): String =
     season?.let(::phoneSeasonLabel) ?: "Episodes"
 
@@ -318,3 +402,9 @@ internal fun seasonDownloadContentDescription(
         "Download ${label.replaceFirstChar(Char::lowercase)}"
     }
 }
+
+private fun seriesStarringCredit(detail: ItemDetail): String? =
+    detail.cast.take(3)
+        .map { it.name }
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(prefix = "Starring ", separator = ", ")

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
@@ -354,7 +354,7 @@ fun SeriesDetailContent(
     }
     }
 
-    selectedEpisodeDetail?.let { episodeDetail ->
+    loadedSelectedEpisodeDetail?.let { episodeDetail ->
         val version = episodeDetail.versions.getOrNull(selectedVersionIndex)
         if (showVersionPicker) {
             VersionPickerSheet(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -36,7 +37,6 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,17 +47,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import org.siloserver.silo.android.ui.components.SiloWordmark
+import androidx.compose.ui.unit.sp
+import coil3.imageLoader
+import coil3.request.ImageRequest
 import org.siloserver.silo.android.ui.components.TabTopBarActions
 import org.siloserver.silo.android.ui.components.TopBarIconButton
-import org.siloserver.silo.android.ui.components.topBarGlass
-import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeSource
-import dev.chrisbanes.haze.rememberHazeState
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.siloserver.silo.android.ui.components.EmptyStateView
 import org.siloserver.silo.android.ui.components.ErrorView
@@ -79,11 +82,27 @@ import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrol
 import org.siloserver.silo.common.ui.components.avatarRef
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.profile.Profile
+import org.siloserver.silo.model.section.SectionItem
 import org.siloserver.silo.viewmodel.HomeViewModel
 import org.siloserver.silo.android.ui.navigation.LocalBottomChromeInset
+import org.siloserver.silo.android.ui.navigation.LocalHeroSourceHandoff
+import org.siloserver.silo.android.ui.util.rememberDominantColor
+import org.siloserver.silo.network.ServerRegistry
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.repository.CatalogRepository
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
-private const val ChromeFadeDistanceDp = 72f
+private data class ContinueWatchingWarmTarget(
+    val seriesId: String,
+    val seasonNumber: Int?,
+    val episodeContentId: String,
+)
+
+private data class WarmedSeriesArtwork(
+    val url: String?,
+    val thumbhash: String?,
+)
 
 /**
  * Phone Home screen.
@@ -100,8 +119,9 @@ private const val ChromeFadeDistanceDp = 72f
 @Composable
 fun HomeScreen(
     onItemClick: (String) -> Unit,
+    onContinueWatchingItemClick: (SectionItem) -> Unit,
     onPlayClick: (String, Double?) -> Unit,
-    scrollToTopTick: Int = 0,
+    onBottomNavMinimizedChange: (Boolean) -> Unit = {},
     viewModel: HomeViewModel,
     activeProfile: Profile?,
     onSearchClick: () -> Unit,
@@ -118,6 +138,11 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsState()
+    val sectionPreferences: HomeSectionPreferencesStore = koinInject()
+    val preferenceRevision by sectionPreferences.revision.collectAsState()
+    val serverRegistry: ServerRegistry = koinInject()
+    val activeServerId by serverRegistry.activeServerId.collectAsState()
+    val activeEntry by serverRegistry.activeEntry.collectAsState()
     val companionPairingViewModel = koinViewModel<CompanionPairingViewModel>()
     val companionTargets by companionPairingViewModel.targets.collectAsState()
     val companionStatus by companionPairingViewModel.status.collectAsState()
@@ -126,11 +151,126 @@ fun HomeScreen(
     var presentedPairingTarget by remember { mutableStateOf<CompanionPairingTarget?>(null) }
     var dismissedPairingSessions by rememberSaveable { mutableStateOf(emptyList<String>()) }
     val sections = state.sections
+    val profileScopeId = activeEntry?.profileId ?: activeProfile?.id
+    val populatedServerSections = remember(sections) { sections.filter { it.items.isNotEmpty() } }
     // No hero billboard on phone (matches iOS): a `featured` section is just
     // another row, rendered in the order the server configured it.
-    val regularSections = remember(sections) {
-        sections.filter { it.items.isNotEmpty() }
+    val regularSections = remember(
+        sections,
+        preferenceRevision,
+        activeServerId,
+        profileScopeId,
+    ) {
+        sectionPreferences.arrangedSections(sections, profileId = profileScopeId)
     }
+    val context = LocalContext.current
+    val catalogRepository: CatalogRepository = koinInject()
+    val heroHandoff = LocalHeroSourceHandoff.current
+    val continueWatchingWarmTargets = remember(regularSections) {
+        regularSections
+            .asSequence()
+            .filter { section ->
+                section.sectionType == "continue_watching" ||
+                    section.sectionType == "in_progress"
+            }
+            .flatMap { it.items.asSequence() }
+            .mapNotNull { item ->
+                val seriesId = item.seriesId?.takeIf { it.isNotBlank() }
+                if (!item.type.equals("episode", ignoreCase = true) || seriesId == null) {
+                    null
+                } else {
+                    ContinueWatchingWarmTarget(
+                        seriesId = seriesId,
+                        seasonNumber = item.seasonNumber,
+                        episodeContentId = item.contentId,
+                    )
+                }
+            }
+            .distinctBy { it.seriesId }
+            // Warming the visible runway covers the row without turning Home
+            // into an unbounded metadata crawl for very large histories.
+            .take(4)
+            .toList()
+    }
+    var warmedSeriesArtwork by remember(activeServerId, profileScopeId) {
+        mutableStateOf<Map<String, WarmedSeriesArtwork>>(emptyMap())
+    }
+    LaunchedEffect(activeServerId, profileScopeId, continueWatchingWarmTargets) {
+        // Warm each Continue Watching destination in row order. Within one
+        // title, its parent detail, exact episode and selector data run in
+        // parallel. CatalogRepository keeps these calls alive/single-flight if
+        // the user taps while this effect is still awaiting them.
+        for (target in continueWatchingWarmTargets) {
+            coroutineScope {
+                val parentDetail = async {
+                    catalogRepository.warmItemDetail(target.seriesId)
+                }
+                val seasons = async {
+                    catalogRepository.warmSeasons(target.seriesId)
+                }
+                val episodes = async {
+                    target.seasonNumber?.let { seasonNumber ->
+                        catalogRepository.warmEpisodes(target.seriesId, seasonNumber)
+                    }
+                }
+                val episodeDetail = async {
+                    catalogRepository.warmItemDetail(target.episodeContentId)
+                }
+
+                val resolvedParent = when (val result = parentDetail.await()) {
+                    is ApiResult.Success -> result.data
+                    else -> null
+                }
+                if (resolvedParent != null) {
+                    val artwork = WarmedSeriesArtwork(
+                        url = resolvedParent.backdropUrl ?: resolvedParent.posterUrl,
+                        thumbhash = resolvedParent.backdropThumbhash
+                            ?: resolvedParent.posterThumbhash,
+                    )
+                    warmedSeriesArtwork = warmedSeriesArtwork + (target.seriesId to artwork)
+                    artwork.url?.takeIf { it.isNotBlank() }?.let { artworkUrl ->
+                        context.imageLoader.enqueue(
+                            ImageRequest.Builder(context)
+                                .data(artworkUrl)
+                                .size(
+                                    context.resources.displayMetrics.widthPixels.coerceAtLeast(1),
+                                    context.resources.displayMetrics.heightPixels.coerceAtLeast(1),
+                                )
+                                .build(),
+                        )
+                    }
+                }
+                seasons.await()
+                episodes.await()
+                episodeDetail.await()
+            }
+        }
+    }
+    var focusedContinueWatchingItem by remember { mutableStateOf<SectionItem?>(null) }
+    val visibleFocusedItem = remember(focusedContinueWatchingItem, regularSections) {
+        focusedContinueWatchingItem?.takeIf { focused ->
+            regularSections.any { section ->
+                section.items.any { it.contentId == focused.contentId }
+            }
+        }
+    }
+    val tintArtworkUrl = visibleFocusedItem?.backdropUrl ?: visibleFocusedItem?.posterUrl
+    val tintArtworkThumbhash =
+        visibleFocusedItem?.backdropThumbhash ?: visibleFocusedItem?.posterThumbhash
+    val homeTint by rememberDominantColor(
+        imageUrl = tintArtworkUrl,
+        fallback = Color(0xFF0A1F24),
+        thumbhash = tintArtworkThumbhash,
+    )
+    // iOS Home paints the normalized artwork tint itself, then lowers its
+    // brightness slightly. Detail pages intentionally use the darker 42%-over-
+    // black composite; applying that detail formula here made Home too flat.
+    val homeSurface = Color(
+        red = (homeTint.red - 0.055f).coerceAtLeast(0f),
+        green = (homeTint.green - 0.055f).coerceAtLeast(0f),
+        blue = (homeTint.blue - 0.055f).coerceAtLeast(0f),
+        alpha = 1f,
+    )
     val diagnosticsContentState = when {
         state.isLoading && regularSections.isEmpty() -> DiagnosticsHomeContentState.LOADING
         state.error != null && regularSections.isEmpty() -> DiagnosticsHomeContentState.ERROR
@@ -155,8 +295,28 @@ fun HomeScreen(
 
     val listState = rememberLazyListState()
     val currentDiagnosticsSections by rememberUpdatedState(regularSections)
-    LaunchedEffect(scrollToTopTick) {
-        if (scrollToTopTick > 0) listState.animateScrollToItem(0)
+    val currentBottomNavCallback by rememberUpdatedState(onBottomNavMinimizedChange)
+    LaunchedEffect(listState) {
+        var previousIndex = listState.firstVisibleItemIndex
+        var previousOffset = listState.firstVisibleItemScrollOffset
+        snapshotFlow {
+            Triple(
+                listState.firstVisibleItemIndex,
+                listState.firstVisibleItemScrollOffset,
+                listState.isScrollInProgress,
+            )
+        }.collect { (index, offset, isScrolling) ->
+            val isAtTop = index == 0 && offset == 0
+            if (isAtTop) {
+                currentBottomNavCallback(false)
+            } else if (isScrolling) {
+                val movingDown = index > previousIndex ||
+                    (index == previousIndex && offset > previousOffset)
+                if (movingDown) currentBottomNavCallback(true)
+            }
+            previousIndex = index
+            previousOffset = offset
+        }
     }
     LaunchedEffect(listState) {
         snapshotFlow { listState.isScrollInProgress }
@@ -197,44 +357,62 @@ fun HomeScreen(
             }
         }
     }
-    val density = LocalDensity.current
-    val chromeFadePx = remember(density) {
-        with(density) { ChromeFadeDistanceDp.dp.toPx() }
-    }
-    val scrollProgress = remember(chromeFadePx) {
-        derivedStateOf {
-            if (listState.firstVisibleItemIndex > 0) {
-                1f
-            } else {
-                (listState.firstVisibleItemScrollOffset / chromeFadePx).coerceIn(0f, 1f)
-            }
-        }
-    }
-
-    // Home's own blur source: the floating chrome blurs the rows scrolling
-    // beneath it. Local rather than the shell's tab-wide source because the
-    // chrome sits inside that source and an effect must not read a source
-    // that contains it.
-    val chromeHaze = rememberHazeState()
-
     // Home can show the same item in several rows at once. Each poster placement
     // now carries a unique hero key (see MediaCard) so duplicates never collide
     // in the shared-transition layout — no per-screen claim registry needed.
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .background(homeSurface),
     ) {
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .drawBehind {
+                    drawRect(
+                        brush = Brush.radialGradient(
+                            colorStops = arrayOf(
+                                0.00f to Color.White.copy(alpha = 0.10f),
+                                0.26f to Color.White.copy(alpha = 0.055f),
+                                0.58f to Color.White.copy(alpha = 0.018f),
+                                1.00f to Color.Transparent,
+                            ),
+                            center = Offset(size.width * 0.46f, size.height * 0.48f),
+                            radius = 470.dp.toPx(),
+                        ),
+                    )
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            colorStops = arrayOf(
+                                0.00f to Color.White.copy(alpha = 0.025f),
+                                0.24f to Color.Transparent,
+                                0.48f to Color.White.copy(alpha = 0.025f),
+                                0.82f to Color.Transparent,
+                                1.00f to Color.White.copy(alpha = 0.012f),
+                            ),
+                        ),
+                    )
+                },
+        )
         when {
             state.isLoading && regularSections.isEmpty() -> HomeLoadingSkeleton()
             state.error != null && regularSections.isEmpty() -> ErrorView(
                 message = state.error ?: "Something went wrong",
                 onRetry = { viewModel.loadSections() },
             )
-            regularSections.isEmpty() -> EmptyStateView(
-                title = "Nothing to watch yet",
-                subtitle = "Add media to your libraries or start watching to see it here.",
-            )
+            regularSections.isEmpty() -> {
+                if (populatedServerSections.isNotEmpty()) {
+                    EmptyStateView(
+                        title = "Home sections are hidden",
+                        subtitle = "Choose which rows appear in Settings → Interface → Home Sections.",
+                    )
+                } else {
+                    EmptyStateView(
+                        title = "Nothing to watch yet",
+                        subtitle = "Add media to your libraries or start watching to see it here.",
+                    )
+                }
+            }
             else -> PullToRefreshBox(
                 isRefreshing = state.isRefreshing,
                 onRefresh = { viewModel.refresh() },
@@ -243,8 +421,7 @@ fun HomeScreen(
                 // the sharp content beneath instead of replacing it.
                 modifier = Modifier
                     .fillMaxSize()
-                    .hazeSource(chromeHaze)
-                    .background(MaterialTheme.colorScheme.background),
+                    .background(Color.Transparent),
             ) {
                 // Feed-scoped: unloaded images hold their thumbhash until the
                 // vertical fling settles (rows add their own horizontal gate).
@@ -259,12 +436,24 @@ fun HomeScreen(
                         // doesn't slide under the status-bar chrome. iOS runway =
                         // topInset + 40 + smallPadding(8) + largePadding(24) +
                         // smallPadding(8) - headerTopReclaim(16) = topInset + 64.
-                        item(key = "topRunway") {
-                            Spacer(
+                        item(key = "homeIdentity") {
+                            Row(
                                 modifier = Modifier
                                     .windowInsetsPadding(WindowInsets.statusBars)
-                                    .height(64.dp),
-                            )
+                                    .fillMaxWidth()
+                                    .height(64.dp)
+                                    .padding(horizontal = 16.dp),
+                                verticalAlignment = Alignment.Top,
+                            ) {
+                                Text(
+                                    text = "SILO",
+                                    color = Color.White,
+                                    fontSize = 26.sp,
+                                    lineHeight = 31.sp,
+                                    fontWeight = FontWeight.Black,
+                                    letterSpacing = (26f * 0.34f).sp,
+                                )
+                            }
                         }
 
                         items(
@@ -272,9 +461,47 @@ fun HomeScreen(
                             key = { it.id },
                             contentType = { "section-row" },
                         ) { section ->
+                            val opensUnifiedSeriesDetail =
+                                section.sectionType == "continue_watching" ||
+                                    section.sectionType == "in_progress"
                             HomeSectionRow(
                                 section = section,
-                                onItemClick = onItemClick,
+                                onItemClick = { contentId ->
+                                    val item = section.items.firstOrNull { it.contentId == contentId }
+                                    if (opensUnifiedSeriesDetail && item != null) {
+                                        item.seriesId
+                                            ?.takeIf {
+                                                item.type.equals("episode", ignoreCase = true) &&
+                                                    it.isNotBlank()
+                                            }
+                                            ?.let { seriesId ->
+                                                val knownParent = regularSections
+                                                    .asSequence()
+                                                    .flatMap { it.items.asSequence() }
+                                                    .firstOrNull { it.contentId == seriesId }
+                                                val artwork = warmedSeriesArtwork[seriesId]
+                                                    ?: knownParent?.let {
+                                                        WarmedSeriesArtwork(
+                                                            url = it.backdropUrl ?: it.posterUrl,
+                                                            thumbhash = it.backdropThumbhash
+                                                                ?: it.posterThumbhash,
+                                                        )
+                                                    }
+                                                // MediaRow initially hands off the episode
+                                                // still. Replace it with the actual parent
+                                                // series artwork before navigation so the
+                                                // loading frame matches a direct series tap.
+                                                artwork?.let {
+                                                    heroHandoff?.pendingArtworkUrl = it.url
+                                                    heroHandoff?.pendingArtworkThumbhash = it.thumbhash
+                                                }
+                                                heroHandoff?.pendingBrowseContentIds = listOf(seriesId)
+                                            }
+                                        onContinueWatchingItemClick(item)
+                                    } else {
+                                        onItemClick(contentId)
+                                    }
+                                },
                                 onItemPlay = { item ->
                                     // Continue Watching can include audiobooks; the play
                                     // glyph must not drop them into the video player. Home
@@ -296,6 +523,11 @@ fun HomeScreen(
                                         viewModel.dismissContinueWatching(item.contentId, ts)
                                     }
                                 },
+                                onCenteredContinueWatchingItemChanged = { item ->
+                                    if (item?.contentId != focusedContinueWatchingItem?.contentId) {
+                                        focusedContinueWatchingItem = item
+                                    }
+                                },
                             )
                         }
 
@@ -311,8 +543,6 @@ fun HomeScreen(
 
         // Floating top chrome — fades in a glass surface as content scrolls under.
         HomeFloatingChrome(
-            scrollProgress = scrollProgress,
-            hazeState = chromeHaze,
             activeProfile = activeProfile,
             onSearchClick = onSearchClick,
             onRemoteControlClick = onRemoteControlClick,
@@ -370,8 +600,6 @@ private fun HomeLoadingSkeleton() {
 
 @Composable
 private fun HomeFloatingChrome(
-    scrollProgress: State<Float>,
-    hazeState: HazeState,
     activeProfile: Profile?,
     onSearchClick: () -> Unit,
     onRemoteControlClick: () -> Unit,
@@ -386,38 +614,17 @@ private fun HomeFloatingChrome(
     onSignOutClick: () -> Unit,
 ) {
     val statusBarPadding = WindowInsets.statusBars.asPaddingValues()
-    // iOS chrome: progressive glass that fades in as rows scroll under and
-    // feathers out along its bottom edge (same recipe as Libraries), so rows
-    // dissolve into the header rather than meeting a hard line. The glass
-    // extends past the action row so the feather has room on a short bar.
-    // headerTopReclaim(16) pulls the row up beside the status-bar glyphs;
-    // horizontal = SiloTheme.padding(16), bottom = SiloTheme.smallPadding(8).
     Box(modifier = Modifier.fillMaxWidth()) {
-        // Glass fades in with scroll; alpha lives on a graphics layer so the
-        // buttons above stay fully visible at rest. It matches the whole
-        // chrome, i.e. the action row plus the feather runway below it.
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-                .graphicsLayer { alpha = scrollProgress.value }
-                .topBarGlass(hazeState, progressive = true),
-        )
         Box(
             modifier = Modifier
                 .padding(top = statusBarPadding.calculateTopPadding())
-                .padding(start = 16.dp, end = 16.dp, bottom = 8.dp + HomeChromeFeatherExtension)
+                .padding(start = 16.dp, end = 16.dp, bottom = 8.dp)
                 .fillMaxWidth(),
         ) {
-            // Leading: Silo wordmark (iOS SiloWordmarkView width: 72).
-            SiloWordmark(
-                modifier = Modifier
-                    .align(Alignment.CenterStart),
-                width = 72.dp,
-            )
-
-            // Trailing: remote-control + search + profile menu cluster.
+            // The SILO identity scrolls with the feed; only utilities remain pinned.
             TabTopBarActions(
                 modifier = Modifier.align(Alignment.CenterEnd),
+                opaque = true,
                 activeProfile = activeProfile,
                 onSearchClick = onSearchClick,
                 onRequestsClick = onRequestsClick,
@@ -441,6 +648,7 @@ private fun HomeFloatingChrome(
                                 }
                             },
                             isActive = isRemoteControlActive,
+                            opaque = true,
                         ) {
                             Icon(
                                 imageVector = Icons.Outlined.SettingsRemote,
@@ -485,6 +693,3 @@ private fun HomeFloatingChrome(
         }
     }
 }
-
-/** How far the Home chrome's glass runs past its action row to feather out. */
-private val HomeChromeFeatherExtension = 40.dp

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeSectionPreferencesStore.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeSectionPreferencesStore.kt
@@ -1,0 +1,99 @@
+package org.siloserver.silo.android.ui.screens.home
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.siloserver.silo.model.section.ResolvedSection
+import org.siloserver.silo.network.ServerRegistry
+
+/**
+ * Device-local Home row order and visibility, scoped to the active server and
+ * profile. The server remains authoritative for row membership and content;
+ * unknown rows append in server order and start visible.
+ */
+class HomeSectionPreferencesStore(
+    context: Context,
+    private val serverRegistry: ServerRegistry,
+) {
+    @Serializable
+    private data class StoredLayout(
+        val orderedSectionIds: List<String> = emptyList(),
+        val hiddenSectionIds: Set<String> = emptySet(),
+    )
+
+    private val preferences = context.getSharedPreferences("home_section_preferences", Context.MODE_PRIVATE)
+    private val json = Json { ignoreUnknownKeys = true }
+    private val _revision = MutableStateFlow(0L)
+    val revision: StateFlow<Long> = _revision.asStateFlow()
+
+    fun isVisible(sectionId: String, profileId: String? = null): Boolean =
+        sectionId !in load(profileId).hiddenSectionIds
+
+    fun setVisible(sectionId: String, visible: Boolean, profileId: String? = null) {
+        val current = load(profileId)
+        val hidden = current.hiddenSectionIds.toMutableSet()
+        if (visible) hidden.remove(sectionId) else hidden.add(sectionId)
+        save(current.copy(hiddenSectionIds = hidden), profileId)
+    }
+
+    /**
+     * Replaces the order of currently-known rows while retaining remembered
+     * identities that are temporarily empty or unavailable.
+     */
+    fun setOrder(sectionIds: List<String>, profileId: String? = null) {
+        val current = load(profileId)
+        val visibleOrder = sectionIds.distinct()
+        val visibleSet = visibleOrder.toSet()
+        save(
+            current.copy(
+                orderedSectionIds = visibleOrder + current.orderedSectionIds.filterNot(visibleSet::contains),
+            ),
+            profileId,
+        )
+    }
+
+    fun arrangedSections(
+        sections: List<ResolvedSection>,
+        includingHidden: Boolean = false,
+        profileId: String? = null,
+    ): List<ResolvedSection> {
+        val layout = load(profileId)
+        val rank = layout.orderedSectionIds.withIndex().associate { it.value to it.index }
+        val arranged = sections
+            .filter { it.items.isNotEmpty() }
+            .withIndex()
+            .sortedWith(
+                compareBy<IndexedValue<ResolvedSection>>(
+                    { rank[it.value.id] ?: Int.MAX_VALUE },
+                    { it.index },
+                ),
+            )
+            .map { it.value }
+        return if (includingHidden) arranged else arranged.filterNot { it.id in layout.hiddenSectionIds }
+    }
+
+    private fun storageKey(profileIdOverride: String? = null): String? {
+        val serverId = serverRegistry.activeServerId.value ?: "default"
+        val profileId = profileIdOverride
+            ?.takeIf { it.isNotBlank() }
+            ?: serverRegistry.activeEntry.value?.profileId
+            ?.takeIf { it.isNotBlank() }
+            ?: return null
+        return "android.homeSections.v1.$serverId.$profileId"
+    }
+
+    private fun load(profileId: String? = null): StoredLayout {
+        val key = storageKey(profileId) ?: return StoredLayout()
+        val raw = preferences.getString(key, null) ?: return StoredLayout()
+        return runCatching { json.decodeFromString<StoredLayout>(raw) }.getOrDefault(StoredLayout())
+    }
+
+    private fun save(layout: StoredLayout, profileId: String? = null) {
+        val key = storageKey(profileId) ?: return
+        preferences.edit().putString(key, json.encodeToString(layout)).apply()
+        _revision.value += 1
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeSectionRow.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeSectionRow.kt
@@ -1,5 +1,7 @@
 package org.siloserver.silo.android.ui.screens.home
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import org.siloserver.silo.android.ui.components.CardStyle
@@ -31,6 +33,7 @@ fun HomeSectionRow(
     onToggleFavorite: ((String, Boolean) -> Unit)? = null,
     onToggleWatchlist: ((String, Boolean) -> Unit)? = null,
     onDismissContinueWatching: ((SectionItem) -> Unit)? = null,
+    onCenteredContinueWatchingItemChanged: ((SectionItem?) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     if (section.items.isEmpty()) return
@@ -51,6 +54,7 @@ fun HomeSectionRow(
         onItemPlay = if (useBackdrop) onItemPlay else null,
         showProgress = showProgress,
         cardStyle = cardStyle,
+        icon = if (isContinueWatching) Icons.Filled.PlayCircle else null,
         modifier = modifier,
         cardActions = { item ->
             MediaCardActions(
@@ -62,5 +66,6 @@ fun HomeSectionRow(
                 } else null,
             )
         },
+        onCenteredItemChanged = if (isContinueWatching) onCenteredContinueWatchingItemChanged else null,
     )
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeSectionsEditor.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeSectionsEditor.kt
@@ -1,0 +1,249 @@
+package org.siloserver.silo.android.ui.screens.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
+import org.siloserver.silo.android.ui.components.EmptyStateView
+import org.siloserver.silo.android.ui.components.ErrorView
+import org.siloserver.silo.android.ui.components.SiloTopBar
+import org.siloserver.silo.android.ui.theme.SiloBackground
+import org.siloserver.silo.model.section.ResolvedSection
+import org.siloserver.silo.network.ServerRegistry
+import org.siloserver.silo.repository.ProfileRepository
+import org.siloserver.silo.viewmodel.HomeViewModel
+
+/** Profile-scoped editor for the populated rows returned by Home. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeSectionsEditor(onDismiss: () -> Unit) {
+    val viewModel: HomeViewModel = koinViewModel(key = "home-sections-editor")
+    val state by viewModel.uiState.collectAsState()
+    val preferences: HomeSectionPreferencesStore = koinInject()
+    val preferenceRevision by preferences.revision.collectAsState()
+    val registry: ServerRegistry = koinInject()
+    val serverId by registry.activeServerId.collectAsState()
+    val entry by registry.activeEntry.collectAsState()
+    val profileRepository: ProfileRepository = koinInject()
+    val profileId by produceState<String?>(
+        initialValue = entry?.profileId,
+        key1 = entry?.id,
+        key2 = entry?.profileId,
+    ) {
+        value = entry?.profileId ?: profileRepository.getActiveProfileId()
+    }
+    val arranged = remember(state.sections, preferenceRevision, serverId, profileId) {
+        preferences.arrangedSections(
+            state.sections,
+            includingHidden = true,
+            profileId = profileId,
+        )
+    }
+    val rows = remember { mutableStateListOf<ResolvedSection>() }
+    var draggingId by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(arranged) {
+        if (draggingId == null) {
+            rows.clear()
+            rows.addAll(arranged)
+        }
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            containerColor = SiloBackground,
+            topBar = {
+                SiloTopBar(
+                    title = "Home Sections",
+                    onBackClick = onDismiss,
+                    containerColor = SiloBackground,
+                )
+            },
+        ) { padding ->
+            PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = viewModel::refresh,
+                modifier = Modifier.fillMaxSize().padding(padding),
+            ) {
+                when {
+                    state.isLoading && rows.isEmpty() -> Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) { CircularProgressIndicator() }
+                    state.error != null && rows.isEmpty() -> ErrorView(
+                        message = state.error ?: "Could not load Home sections",
+                        onRetry = viewModel::loadSections,
+                    )
+                    rows.isEmpty() -> EmptyStateView(
+                        title = "No Home sections",
+                        subtitle = "Home has no populated rows to arrange yet.",
+                    )
+                    else -> HomeSectionReorderList(
+                        rows = rows,
+                        preferences = preferences,
+                        profileId = profileId,
+                        preferenceRevision = preferenceRevision,
+                        draggingId = draggingId,
+                        onDraggingIdChange = { draggingId = it },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeSectionReorderList(
+    rows: MutableList<ResolvedSection>,
+    preferences: HomeSectionPreferencesStore,
+    profileId: String?,
+    preferenceRevision: Long,
+    draggingId: String?,
+    onDraggingIdChange: (String?) -> Unit,
+) {
+    val listState = rememberLazyListState()
+    var dragOffset by remember { mutableFloatStateOf(0f) }
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.fillMaxSize(),
+        userScrollEnabled = draggingId == null,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        item(key = "instructions") {
+            Text(
+                text = "Open eye: shown on Home. Closed eye: hidden. Drag the handle to reorder. Changes save automatically for this profile on this device.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+        items(rows, key = { it.id }) { section ->
+            // SharedPreferences itself is not observable. Reading the store's
+            // revision here makes each row recompose immediately after an eye
+            // toggle instead of showing stale state until the dialog reopens.
+            val isVisible = remember(section.id, profileId, preferenceRevision) {
+                preferences.isVisible(section.id, profileId)
+            }
+            val isDragging = draggingId == section.id
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .graphicsLayer { translationY = if (isDragging) dragOffset else 0f }
+                    .background(if (isDragging) MaterialTheme.colorScheme.surfaceVariant else MaterialTheme.colorScheme.surface)
+                    .padding(horizontal = 8.dp, vertical = 6.dp)
+                    .graphicsLayer { alpha = if (isVisible) 1f else 0.42f },
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(
+                    onClick = {
+                        preferences.setVisible(section.id, !isVisible, profileId)
+                    },
+                ) {
+                    Icon(
+                        imageVector = if (isVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
+                        contentDescription = if (isVisible) "Hide ${section.title}" else "Show ${section.title}",
+                    )
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(text = section.title, style = MaterialTheme.typography.bodyLarge, maxLines = 1)
+                    Text(
+                        text = if (section.items.size == 1) "1 item" else "${section.items.size} items",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .pointerInput(section.id, rows.size) {
+                            detectDragGestures(
+                                onDragStart = {
+                                    onDraggingIdChange(section.id)
+                                    dragOffset = 0f
+                                },
+                                onDragCancel = {
+                                    dragOffset = 0f
+                                    onDraggingIdChange(null)
+                                },
+                                onDragEnd = {
+                                    preferences.setOrder(rows.map { it.id }, profileId)
+                                    dragOffset = 0f
+                                    onDraggingIdChange(null)
+                                },
+                                onDrag = { change, amount ->
+                                    change.consume()
+                                    dragOffset += amount.y
+                                    val fromIndex = rows.indexOfFirst { it.id == section.id }
+                                    val fromInfo = listState.layoutInfo.visibleItemsInfo.firstOrNull { it.key == section.id }
+                                    if (fromIndex < 0 || fromInfo == null) return@detectDragGestures
+                                    val draggedCenter = fromInfo.offset + dragOffset + fromInfo.size / 2f
+                                    val targetInfo = listState.layoutInfo.visibleItemsInfo.firstOrNull { info ->
+                                        info.key != "instructions" && draggedCenter.toInt() in info.offset..(info.offset + info.size)
+                                    } ?: return@detectDragGestures
+                                    val targetId = targetInfo.key as? String ?: return@detectDragGestures
+                                    val toIndex = rows.indexOfFirst { it.id == targetId }
+                                    if (toIndex >= 0 && toIndex != fromIndex) {
+                                        val moved = rows.removeAt(fromIndex)
+                                        rows.add(toIndex, moved)
+                                        // Persist each accepted move. If the
+                                        // system cancels the pointer gesture,
+                                        // the rows never snap back on exit.
+                                        preferences.setOrder(rows.map { it.id }, profileId)
+                                        dragOffset = 0f
+                                    }
+                                },
+                            )
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(Icons.Filled.DragHandle, contentDescription = "Reorder ${section.title}")
+                }
+            }
+        }
+        item(key = "bottom") { Spacer(Modifier.size(24.dp)) }
+    }
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeSectionsEditor.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeSectionsEditor.kt
@@ -82,7 +82,7 @@ fun HomeSectionsEditor(onDismiss: () -> Unit) {
     }
     val rows = remember { mutableStateListOf<ResolvedSection>() }
     var draggingId by remember { mutableStateOf<String?>(null) }
-    LaunchedEffect(arranged) {
+    LaunchedEffect(arranged, draggingId) {
         if (draggingId == null) {
             rows.clear()
             rows.addAll(arranged)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/personal/PersonalMediaGridContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/personal/PersonalMediaGridContent.kt
@@ -77,10 +77,17 @@ import org.siloserver.silo.viewmodel.WatchlistViewModel
 import org.koin.compose.viewmodel.koinViewModel
 import org.siloserver.silo.android.ui.navigation.LocalHeroSourceHandoff
 
-private enum class PersonalMediaType(val label: String) {
-    Movies("Movies"),
-    TvShows("TV Shows"),
+private enum class PersonalMediaType(
+    val label: String,
+    val emptyTitle: String,
+    val emptySubtitle: String,
+) {
+    Movies("Movies", "No movies", "There are no movies in this list."),
+    TvShows("TV Shows", "No TV shows", "There are no TV shows in this list."),
 }
+
+private const val PersonalMediaGridRowSize = 6
+private const val PersonalMediaGridPrefetchRows = 2
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -272,7 +279,7 @@ private fun PersonalMediaGridContent(
         derivedStateOf {
             val layoutInfo = gridState.layoutInfo
             val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-            lastVisible >= layoutInfo.totalItemsCount - 8
+            lastVisible >= layoutInfo.totalItemsCount - PersonalMediaGridPrefetchRows
         }
     }
 
@@ -310,9 +317,18 @@ private fun PersonalMediaGridContent(
                 // A narrowed query with no hits is not an empty list — say so,
                 // and keep the header's controls reachable to widen it (TV parity).
                 val filtered = !state.query.isDefault
+                val selectedTypeEmpty = mediaType != null && state.items.isNotEmpty()
                 EmptyStateView(
-                    title = if (filtered) "No matches" else emptyTitle,
-                    subtitle = if (filtered) "No titles match the current filters." else emptySubtitle,
+                    title = when {
+                        filtered -> "No matches"
+                        selectedTypeEmpty -> mediaType?.emptyTitle ?: emptyTitle
+                        else -> emptyTitle
+                    },
+                    subtitle = when {
+                        filtered -> "No titles match the current filters."
+                        selectedTypeEmpty -> mediaType?.emptySubtitle ?: emptySubtitle
+                        else -> emptySubtitle
+                    },
                     icon = emptyIcon,
                     modifier = Modifier.weight(1f),
                 )
@@ -342,7 +358,7 @@ private fun PersonalMediaGridContent(
                             header(state)
                         }
                     }
-                    visibleItems.chunked(6).forEachIndexed { rowIndex, rowItems ->
+                    visibleItems.chunked(PersonalMediaGridRowSize).forEachIndexed { rowIndex, rowItems ->
                         item(key = "media-row-$rowIndex") {
                             LazyRow(
                                 horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/personal/PersonalMediaGridContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/personal/PersonalMediaGridContent.kt
@@ -14,12 +14,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items as lazyItems
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.FavoriteBorder
@@ -27,6 +32,9 @@ import androidx.compose.material.icons.outlined.History
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -67,6 +75,30 @@ import org.siloserver.silo.viewmodel.PersonalListQuery
 import org.siloserver.silo.viewmodel.PersonalListUiState
 import org.siloserver.silo.viewmodel.WatchlistViewModel
 import org.koin.compose.viewmodel.koinViewModel
+import org.siloserver.silo.android.ui.navigation.LocalHeroSourceHandoff
+
+private enum class PersonalMediaType(val label: String) {
+    Movies("Movies"),
+    TvShows("TV Shows"),
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PersonalMediaTypeSelector(
+    selected: PersonalMediaType,
+    onSelected: (PersonalMediaType) -> Unit,
+) {
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        PersonalMediaType.entries.forEachIndexed { index, type ->
+            SegmentedButton(
+                selected = selected == type,
+                onClick = { onSelected(type) },
+                shape = SegmentedButtonDefaults.itemShape(index, PersonalMediaType.entries.size),
+                label = { androidx.compose.material3.Text(type.label) },
+            )
+        }
+    }
+}
 
 @Composable
 fun FavoritesGridContent(
@@ -79,6 +111,7 @@ fun FavoritesGridContent(
     viewModel: FavoritesViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
+    var mediaType by remember { mutableStateOf(PersonalMediaType.Movies) }
     if (query != null) {
         LaunchedEffect(query) { viewModel.applyQuery(query) }
     }
@@ -87,7 +120,14 @@ fun FavoritesGridContent(
         state = state,
         modifier = modifier,
         contentPadding = contentPadding,
-        header = header,
+        header = { listState ->
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                PersonalMediaTypeSelector(mediaType, onSelected = { mediaType = it })
+                header?.invoke(listState)
+            }
+        },
+        mediaType = mediaType,
+        browseOrigin = "favorites-${mediaType.name}",
         emptyTitle = "No favorites",
         emptySubtitle = "Tap the heart icon on any item to add it here",
         emptyIcon = Icons.Outlined.FavoriteBorder,
@@ -100,6 +140,11 @@ fun FavoritesGridContent(
                 onClick = { onItemClick(item.contentId) },
                 onFavoriteToggle = { viewModel.toggleFavorite(item.contentId) },
                 isFavorite = true,
+                browseContentIds = state.items.filter {
+                    if (mediaType == PersonalMediaType.Movies) it.type.equals("movie", true)
+                    else it.type.equals("series", true) || it.type.equals("show", true)
+                }.map { it.contentId },
+                browseOrigin = "favorites-${mediaType.name}",
             )
         },
     )
@@ -116,6 +161,7 @@ fun WatchlistGridContent(
     viewModel: WatchlistViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
+    var mediaType by remember { mutableStateOf(PersonalMediaType.Movies) }
     if (query != null) {
         LaunchedEffect(query) { viewModel.applyQuery(query) }
     }
@@ -124,7 +170,14 @@ fun WatchlistGridContent(
         state = state,
         modifier = modifier,
         contentPadding = contentPadding,
-        header = header,
+        header = { listState ->
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                PersonalMediaTypeSelector(mediaType, onSelected = { mediaType = it })
+                header?.invoke(listState)
+            }
+        },
+        mediaType = mediaType,
+        browseOrigin = "watchlist-${mediaType.name}",
         emptyTitle = "Watchlist is empty",
         emptySubtitle = "Tap the bookmark icon on any item to add it here",
         emptyIcon = Icons.Outlined.BookmarkBorder,
@@ -137,6 +190,11 @@ fun WatchlistGridContent(
                 onClick = { onItemClick(item.contentId) },
                 onWatchlistToggle = { viewModel.removeFromWatchlist(item.contentId) },
                 isInWatchlist = true,
+                browseContentIds = state.items.filter {
+                    if (mediaType == PersonalMediaType.Movies) it.type.equals("movie", true)
+                    else it.type.equals("series", true) || it.type.equals("show", true)
+                }.map { it.contentId },
+                browseOrigin = "watchlist-${mediaType.name}",
             )
         },
     )
@@ -190,10 +248,26 @@ private fun PersonalMediaGridContent(
     // empty / error views so the controls stay reachable when the list has
     // nothing to show. Receives the state so it can show the item count.
     header: (@Composable (PersonalListUiState) -> Unit)? = null,
+    mediaType: PersonalMediaType? = null,
+    browseOrigin: String? = null,
 ) {
-    val gridState = rememberLazyGridState()
+    val gridState = rememberLazyListState()
+    val heroHandoff = LocalHeroSourceHandoff.current
     val layoutDirection = LocalLayoutDirection.current
-
+    val visibleItems = remember(state.items, mediaType) {
+        when (mediaType) {
+            PersonalMediaType.Movies -> state.items.filter { it.type.equals("movie", ignoreCase = true) }
+            PersonalMediaType.TvShows -> state.items.filter {
+                it.type.equals("series", ignoreCase = true) || it.type.equals("show", ignoreCase = true)
+            }
+            null -> state.items
+        }
+    }
+    LaunchedEffect(visibleItems.isEmpty(), state.hasMore, state.isLoadingMore, state.isLoading) {
+        if (visibleItems.isEmpty() && state.hasMore && !state.isLoadingMore && !state.isLoading) {
+            onLoadMore()
+        }
+    }
     val shouldLoadMore by remember {
         derivedStateOf {
             val layoutInfo = gridState.layoutInfo
@@ -230,7 +304,7 @@ private fun PersonalMediaGridContent(
                 )
             }
         }
-        state.items.isEmpty() -> {
+        visibleItems.isEmpty() -> {
             Column(modifier = modifier.padding(contentPadding)) {
                 header?.let { Box(modifier = Modifier.padding(16.dp)) { it(state) } }
                 // A narrowed query with no hits is not an empty list — say so,
@@ -253,8 +327,7 @@ private fun PersonalMediaGridContent(
                 // contentPadding goes inside the grid so items scroll edge to
                 // edge under any chrome the caller reserved space for.
                 DeferImagePresentationWhileScrolling(gridState) {
-                LazyVerticalGrid(
-                    columns = GridCells.Adaptive(MediaGridDefaults.scaledPosterGridMinWidth),
+                LazyColumn(
                     state = gridState,
                     contentPadding = PaddingValues(
                         start = 16.dp + contentPadding.calculateStartPadding(layoutDirection),
@@ -262,26 +335,29 @@ private fun PersonalMediaGridContent(
                         end = 16.dp + contentPadding.calculateEndPadding(layoutDirection),
                         bottom = 16.dp + contentPadding.calculateBottomPadding(),
                     ),
-                    horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),
                     verticalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridVerticalSpacing),
                 ) {
                     if (header != null) {
-                        item(key = "header", span = { GridItemSpan(maxLineSpan) }) {
+                        item(key = "header") {
                             header(state)
                         }
                     }
-                    items(
-                        items = state.items,
-                        key = { it.contentId },
-                        contentType = { item -> item.type },
-                    ) { item ->
-                        Box(modifier = Modifier.animateItem()) {
-                            itemContent(item)
+                    visibleItems.chunked(6).forEachIndexed { rowIndex, rowItems ->
+                        item(key = "media-row-$rowIndex") {
+                            LazyRow(
+                                horizontalArrangement = Arrangement.spacedBy(MediaGridDefaults.PosterGridHorizontalSpacing),
+                            ) {
+                                lazyItems(rowItems, key = { it.contentId }) { item ->
+                                    Box(modifier = Modifier.width(MediaGridDefaults.scaledPosterGridMinWidth)) {
+                                        itemContent(item)
+                                    }
+                                }
+                            }
                         }
                     }
 
                     if (state.isLoadingMore) {
-                        item(span = { GridItemSpan(maxLineSpan) }) {
+                        item {
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -312,14 +388,25 @@ fun MediaGridItem(
     isFavorite: Boolean = false,
     onWatchlistToggle: (() -> Unit)? = null,
     isInWatchlist: Boolean = false,
+    browseContentIds: List<String>? = null,
+    browseOrigin: String? = null,
 ) {
     val (actions, userState) = rememberBrowseItemCardActions(item)
     val overlayState = LocalCardOverlayUiState.current
     var menuExpanded by remember { mutableStateOf(false) }
+    val heroHandoff = LocalHeroSourceHandoff.current
 
     androidx.compose.foundation.layout.Column(
         modifier = modifier.combinedClickable(
-            onClick = onClick,
+            onClick = {
+                if (browseContentIds != null) {
+                    heroHandoff?.pendingBrowseContentIds = browseContentIds
+                    heroHandoff?.pendingBrowseOrigin = browseOrigin
+                }
+                heroHandoff?.pendingArtworkUrl = item.backdropUrl ?: item.posterUrl
+                heroHandoff?.pendingArtworkThumbhash = item.backdropThumbhash ?: item.posterThumbhash
+                onClick()
+            },
             onLongClick = { menuExpanded = true },
         ),
         verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/recommendations/RecommendationsScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/recommendations/RecommendationsScreen.kt
@@ -51,7 +51,6 @@ import org.siloserver.silo.android.ui.screens.personal.rememberPersonalListContr
 import org.siloserver.silo.viewmodel.PersonalListUiState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -64,6 +63,10 @@ import org.siloserver.silo.common.ui.components.DeferImagePresentationWhileScrol
 import org.siloserver.silo.common.diagnostics.DiagnosticsListLogger
 import org.siloserver.silo.common.diagnostics.DiagnosticsListSnapshot
 import org.siloserver.silo.common.diagnostics.DiagnosticsListSurface
+import org.siloserver.silo.android.ui.theme.SiloOnOpaqueControl
+import org.siloserver.silo.android.ui.theme.SiloOpaqueControl
+import org.siloserver.silo.android.ui.theme.SiloOpaqueControlBorder
+import org.siloserver.silo.android.ui.theme.SiloOpaqueControlSelected
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
@@ -393,9 +396,10 @@ private fun SavedShortcutPill(
         onClick = onClick,
         shape = CircleShape,
         contentPadding = PaddingValues(horizontal = 15.dp),
-        border = BorderStroke(1.5.dp, Color.White.copy(alpha = if (selected) 0.9f else 0.3f)),
+        border = BorderStroke(1.dp, SiloOpaqueControlBorder),
         colors = ButtonDefaults.outlinedButtonColors(
-            contentColor = MaterialTheme.colorScheme.onSurface,
+            contentColor = SiloOnOpaqueControl,
+            containerColor = if (selected) SiloOpaqueControlSelected else SiloOpaqueControl,
         ),
         modifier = Modifier.height(40.dp),
     ) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import org.siloserver.silo.android.ui.components.SiloConfirmDialog
 import org.siloserver.silo.android.ui.components.SiloTopBar
 import org.siloserver.silo.android.ui.screens.downloads.DownloadsViewModel
+import org.siloserver.silo.android.ui.screens.home.HomeSectionsEditor
 import org.siloserver.silo.android.ui.screens.settings.diagnostics.DiagnosticsViewModel
 import org.siloserver.silo.android.ui.screens.settings.diagnostics.shouldShowDiagnosticsEntry
 import org.siloserver.silo.android.ui.theme.SettingsDimens
@@ -112,6 +113,7 @@ fun SettingsScreen(
     val downloadsState by downloadsViewModel.uiState.collectAsState()
     val diagnosticsState by diagnosticsViewModel.state.collectAsState()
     var showRemoveAllDownloadsConfirm by remember { mutableStateOf(false) }
+    var showHomeSectionsEditor by remember { mutableStateOf(false) }
 
     LaunchedEffect(state.loggedOut) {
         if (state.loggedOut) {
@@ -273,6 +275,16 @@ fun SettingsScreen(
             }
 
             item {
+                SettingsSection(title = "Interface") {
+                    SettingsNavigationRow(
+                        label = "Home Sections",
+                        description = "Choose which Home rows are visible and the order they appear in.",
+                        onClick = { showHomeSectionsEditor = true },
+                    )
+                }
+            }
+
+            item {
                 MediaCardsSettings(
                     state = state.cardPresentation,
                     onPresetSelected = viewModel::setCardPreset,
@@ -384,6 +396,10 @@ fun SettingsScreen(
             },
             onDismiss = { showRemoveAllDownloadsConfirm = false },
         )
+    }
+
+    if (showHomeSectionsEditor) {
+        HomeSectionsEditor(onDismiss = { showHomeSectionsEditor = false })
     }
 }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/theme/Color.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/theme/Color.kt
@@ -18,6 +18,23 @@ val SiloOutline = Color.White.copy(alpha = 0.12f)
 val SiloDivider = Color.White.copy(alpha = 0.12f)
 val SiloOverlay = Color.Black.copy(alpha = 0.60f)
 
+// Restrained Android substitute for iOS Liquid Glass. These shared washes keep
+// every migrated circle/capsule in one light material family without a live
+// blur. They remain inexpensive on
+// Android (no live backdrop blur), while allowing the title-derived surface
+// underneath to tint them instead of reading as flat white plastic.
+val SiloOpaqueControl = Color.White.copy(alpha = 0.58f)
+val SiloOpaqueControlSelected = Color.White.copy(alpha = 0.70f)
+val SiloOpaqueControlSelectionOverlay = Color.White.copy(alpha = 0.18f)
+// PR #212 PhoneLabeledAction values. These read as the same adaptive material
+// family as the Home tab bar over a dark detail surface without becoming the
+// pale, nearly solid circles shown in the Android comparison screenshot.
+val SiloDetailActionControl = Color.White.copy(alpha = 0.10f)
+val SiloDetailActionControlActive = Color.White.copy(alpha = 0.30f)
+val SiloOnOpaqueControl = Color(0xFF17171A)
+val SiloOnOpaqueControlMuted = Color(0xFF4F4F55)
+val SiloOpaqueControlBorder = Color.White.copy(alpha = 0.46f)
+
 // --- Grouped-surface palette (Silo web client parity) ---
 //
 // The OLED values above are the app's chrome: pure black grounds with

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/util/DominantColor.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/util/DominantColor.kt
@@ -13,12 +13,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.graphics.ColorUtils
-import androidx.palette.graphics.Palette
 import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.toBitmap
+import java.util.Base64
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -33,29 +32,47 @@ private val dominantColorCache = mutableMapOf<String, Color>()
 private const val CrossfadeDurationMs = 300
 
 /**
- * Sample a saturated dominant tint from [imageUrl] and crossfade to it
- * over 300ms. Returns [fallback] until the bitmap loads and the palette
- * resolves; once a URL has been sampled, subsequent recompositions with
- * the same URL hit the in-memory cache and snap straight to the result.
+ * Resolve the artwork's average tint and crossfade to it over 300ms. When a
+ * [thumbhash] is available its average-colour coefficients resolve locally on
+ * the opening frame; otherwise [imageUrl] is sampled as a fallback. Once a URL
+ * has been resolved, later recompositions hit the in-memory cache immediately.
  *
- * Mirrors iOS `HeroBackdropPalette` semantically — same role (Plex-style
- * page tint above the fold) but driven by androidx.palette instead of
- * `CIAreaAverage`. Vibrant swatches are preferred so the gradient picks
- * up the artwork's character rather than collapsing to a muddy average.
+ * Mirrors iOS `HeroBackdropPalette`: average the small decoded image, then
+ * normalize its luminance to 0.22. Avoiding a "most vibrant" swatch matters
+ * here — it was turning a small red/orange detail in the artwork into a flat,
+ * saturated page colour that did not resemble Apple's faded opaque wash.
  */
 @Composable
-fun rememberDominantColor(imageUrl: String?, fallback: Color): State<Color> {
+fun rememberDominantColor(
+    imageUrl: String?,
+    fallback: Color,
+    thumbhash: String? = null,
+): State<Color> {
     val context = LocalContext.current
-    var sampled by remember(imageUrl) {
-        mutableStateOf(imageUrl?.let { dominantColorCache[it] } ?: fallback)
+    val instantThumbhashTint = remember(thumbhash) { averageTintFromThumbhash(thumbhash) }
+    var sampled by remember(imageUrl, instantThumbhashTint, fallback) {
+        mutableStateOf(
+            imageUrl?.let { dominantColorCache[it] }
+                ?: instantThumbhashTint
+                ?: fallback,
+        )
     }
 
-    LaunchedEffect(imageUrl) {
+    LaunchedEffect(imageUrl, instantThumbhashTint) {
         if (imageUrl.isNullOrBlank()) {
-            sampled = fallback
+            sampled = instantThumbhashTint ?: fallback
             return@LaunchedEffect
         }
         dominantColorCache[imageUrl]?.let {
+            sampled = it
+            return@LaunchedEffect
+        }
+        // The payload already carries a ThumbHash generated from this same
+        // artwork. Its DC coefficients are the average tint, so use them on
+        // the opening frame instead of starting a second backdrop download
+        // beside the full-size image request.
+        instantThumbhashTint?.let {
+            dominantColorCache[imageUrl] = it
             sampled = it
             return@LaunchedEffect
         }
@@ -82,9 +99,11 @@ fun rememberDominantColor(imageUrl: String?, fallback: Color): State<Color> {
             } ?: return@LaunchedEffect
 
             val color = withContext(Dispatchers.Default) {
-                val palette = Palette.from(bitmap).generate()
-                bitmap.recycle()
-                pickTint(palette)
+                try {
+                    sampleAverageTint(bitmap)
+                } finally {
+                    bitmap.recycle()
+                }
             } ?: return@LaunchedEffect
 
             dominantColorCache[imageUrl] = color
@@ -101,18 +120,64 @@ fun rememberDominantColor(imageUrl: String?, fallback: Color): State<Color> {
     )
 }
 
-private fun pickTint(palette: Palette): Color? {
-    val candidates = listOfNotNull(
-        palette.vibrantSwatch,
-        palette.lightVibrantSwatch,
-        palette.darkVibrantSwatch,
-        palette.mutedSwatch,
-        palette.darkMutedSwatch,
-        palette.dominantSwatch,
+private fun sampleAverageTint(bitmap: Bitmap): Color? {
+    if (bitmap.width <= 0 || bitmap.height <= 0) return null
+    val pixels = IntArray(bitmap.width * bitmap.height)
+    bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
+
+    var red = 0.0
+    var green = 0.0
+    var blue = 0.0
+    var totalWeight = 0.0
+    pixels.forEach { pixel ->
+        val alpha = ((pixel ushr 24) and 0xFF) / 255.0
+        if (alpha <= 0.0) return@forEach
+        red += ((pixel ushr 16) and 0xFF) * alpha
+        green += ((pixel ushr 8) and 0xFF) * alpha
+        blue += (pixel and 0xFF) * alpha
+        totalWeight += alpha
+    }
+    if (totalWeight <= 0.0) return null
+
+    return normalizeAverageTint(
+        red = red / totalWeight / 255.0,
+        green = green / totalWeight / 255.0,
+        blue = blue / totalWeight / 255.0,
     )
-    val swatch = candidates.maxByOrNull { it.hsl[1] } ?: return null
-    val hsl = swatch.hsl.copyOf()
-    hsl[1] = maxOf(hsl[1], 0.5f)
-    hsl[2] = 0.42f
-    return Color(ColorUtils.HSLToColor(hsl))
+}
+
+/** Decode ThumbHash's average-colour coefficients without expanding its AC image. */
+internal fun averageTintFromThumbhash(thumbhash: String?): Color? {
+    val value = thumbhash?.takeIf { it.isNotBlank() } ?: return null
+    val bytes = runCatching { Base64.getDecoder().decode(value) }.getOrNull() ?: return null
+    if (bytes.size < 3) return null
+
+    fun byteAt(index: Int): Int = bytes[index].toInt() and 0xFF
+    val header24 = byteAt(0) or (byteAt(1) shl 8) or (byteAt(2) shl 16)
+    val luminanceDc = (header24 and 63) / 63.0
+    val pDc = ((header24 shr 6) and 63) / 31.5 - 1.0
+    val qDc = ((header24 shr 12) and 63) / 31.5 - 1.0
+    val blue = luminanceDc - 2.0 / 3.0 * pDc
+    val red = (3.0 * luminanceDc - blue + qDc) / 2.0
+    val green = red - qDc
+    return normalizeAverageTint(red, green, blue)
+}
+
+private fun normalizeAverageTint(red: Double, green: Double, blue: Double): Color {
+    val r = red.coerceIn(0.0, 1.0)
+    val g = green.coerceIn(0.0, 1.0)
+    val b = blue.coerceIn(0.0, 1.0)
+    val luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+    val targetLuminance = 0.22
+    val scale = when {
+        luminance <= 0.001 -> 0.0
+        luminance > targetLuminance -> targetLuminance / luminance
+        else -> maxOf(1.0, targetLuminance / maxOf(luminance, 0.05))
+    }
+    return Color(
+        red = (r * scale).coerceIn(0.0, 1.0).toFloat(),
+        green = (g * scale).coerceIn(0.0, 1.0).toFloat(),
+        blue = (b * scale).coerceIn(0.0, 1.0).toFloat(),
+        alpha = 1f,
+    )
 }

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/ContentDeepLinkEncodingTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/ContentDeepLinkEncodingTest.kt
@@ -3,6 +3,7 @@ package org.siloserver.silo.android.ui.navigation
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import org.siloserver.silo.model.section.SectionItem
 
 /**
  * `URI.path` is already percent-decoded. The parser used to take that decoded
@@ -35,6 +36,34 @@ class ContentDeepLinkEncodingTest {
             Route.ItemDetail("tt0111161").route,
             contentDeepLinkRouteOrNull("silo://item/tt0111161"),
         )
+    }
+
+    @Test
+    fun `a continue watching episode opens its series and preserves its exact selection`() {
+        val item = SectionItem(
+            contentId = "episode/3-1",
+            type = "episode",
+            title = "Episode 1",
+            seriesId = "series 42",
+            seasonNumber = 3,
+            episodeNumber = 1,
+        )
+
+        assertEquals(
+            "item/series%2042?seasonNumber=3&episodeContentId=episode%2F3-1",
+            continueWatchingDetailRoute(item),
+        )
+    }
+
+    @Test
+    fun `a continue watching movie still opens its own detail`() {
+        val item = SectionItem(
+            contentId = "movie-1",
+            type = "movie",
+            title = "Movie",
+        )
+
+        assertEquals(Route.ItemDetail("movie-1").route, continueWatchingDetailRoute(item))
     }
 
     @Test

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/MobileMediaTabsTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/navigation/MobileMediaTabsTest.kt
@@ -4,25 +4,23 @@ import org.siloserver.silo.model.navigation.MediaMode
 import org.siloserver.silo.model.navigation.MediaModeCapabilities
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MobileMediaTabsTest {
 
-    // Apple-aligned shell: Home · Libraries · For You · Calendar, independent of which
-    // media types the libraries contain. Library content (video / audio /
-    // reading) is reached through the Libraries picker. Downloads only appears
-    // when the user has downloads.
-    private val baseLabels = listOf("Home", "Libraries", "For You", "Calendar")
+    // Apple-aligned shell stays structurally fixed while capabilities and
+    // download records hydrate, so the selected pill never shifts underneath
+    // the user after the first authenticated frame.
+    private val baseLabels = listOf("Home", "Libraries", "For You", "Calendar", "Downloads")
 
     @Test
-    fun fixedTabsAppendDownloadsWhenPresent() {
+    fun fixedTabsIncludeDownloadsWhenPresent() {
         val tabs = visibleMobileTabs(
             capabilities = MediaModeCapabilities(listOf(MediaMode.Video)),
             showDownloads = true,
         )
 
-        assertEquals(baseLabels + "Downloads", tabs.map { it.label })
+        assertEquals(baseLabels, tabs.map { it.label })
     }
 
     @Test
@@ -45,14 +43,14 @@ class MobileMediaTabsTest {
     }
 
     @Test
-    fun downloadsStaysHiddenWhenNoDownloadsExist() {
+    fun downloadsKeepsItsStableSlotBeforeRecordsHydrate() {
         val tabs = visibleMobileTabs(
             capabilities = MediaModeCapabilities(listOf(MediaMode.Video, MediaMode.Audio)),
             showDownloads = false,
         )
 
         assertEquals(baseLabels, tabs.map { it.label })
-        assertFalse(Tab.Downloads in tabs)
+        assertTrue(Tab.Downloads in tabs)
     }
 
     @Test

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/MobileDetailActionsSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/MobileDetailActionsSourceTest.kt
@@ -186,6 +186,13 @@ class MobileDetailActionsSourceTest {
         assertTrue(itemDetail.contains("onEpisodeDetailClick = { viewModel.selectSeriesEpisode(it) }"))
         assertTrue(seriesDetail.contains("selectedEpisode?.let { \"Play \${episodeNumberText(it)}\" }"))
         assertTrue(seriesDetail.contains("loadedSelectedEpisodeDetail.versions.getOrNull(selectedVersionIndex)"))
+        assertTrue(seriesDetail.contains("loadedSelectedEpisodeDetail?.let { episodeDetail ->"))
+    }
+
+    @Test
+    fun selectedEpisodeResumeNeverFallsBackToAnotherEpisode() {
+        assertTrue(itemDetail.contains("val activeSeriesResume = if (selectedEpisode != null)"))
+        assertFalse(itemDetail.contains("val activeSeriesResume = selectedEpisodeResume ?: seriesResume"))
     }
 
     @Test
@@ -209,6 +216,21 @@ class MobileDetailActionsSourceTest {
             true,
             viewModel.uiState.value.episodesBySeason.getValue(1).single().userData?.played,
         )
+    }
+
+    @Test
+    fun episodePageHeroRepaintsAfterLongPressWatchedChange() = runItemDetailTest {
+        val repository = RecordingPersonalDataRepository(
+            mutableListOf({ ApiResult.Success(Unit) }),
+        )
+        val viewModel = itemDetailViewModel(repository)
+        viewModel.seedEpisodeDetail()
+
+        viewModel.setEpisodeWatched("season-1-episode-1", true)
+        advanceUntilIdle()
+
+        assertEquals(true, viewModel.uiState.value.detail?.userData?.played)
+        assertEquals(true, viewModel.uiState.value.episodes.single().userData?.played)
     }
 
     @Test
@@ -523,6 +545,31 @@ class MobileDetailActionsSourceTest {
                 title = "Movie",
                 userData = LeafItemUserData(played = played),
             ),
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun ItemDetailViewModel.seedEpisodeDetail() {
+        val field = ItemDetailViewModel::class.java.getDeclaredField("_uiState")
+        field.isAccessible = true
+        val flow = field.get(this) as MutableStateFlow<ItemDetailUiState>
+        val episode = EpisodeListItem(
+            contentId = "season-1-episode-1",
+            seasonNumber = 1,
+            episodeNumber = 1,
+            userData = LeafItemUserData(played = false),
+        )
+        flow.value = ItemDetailUiState(
+            isLoading = false,
+            detail = ItemDetail(
+                contentId = episode.contentId,
+                type = "episode",
+                title = "Episode",
+                userData = LeafItemUserData(played = false),
+            ),
+            selectedSeasonNumber = 1,
+            episodes = listOf(episode),
+            episodesBySeason = mapOf(1 to listOf(episode)),
         )
     }
 

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/MobileDetailActionsSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/MobileDetailActionsSourceTest.kt
@@ -48,8 +48,44 @@ class MobileDetailActionsSourceTest {
     private val itemDetail = File(
         "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt",
     ).readText()
+    private val episodeList = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/EpisodeList.kt",
+    ).readText()
+    private val detailShared = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt",
+    ).readText()
+    private val mediaSelectors = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MediaSelectors.kt",
+    ).readText()
     private val viewModel = File(
         "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt",
+    ).readText()
+    private val mainScreen = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/MainScreen.kt",
+    ).readText()
+    private val homeScreen = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt",
+    ).readText()
+    private val bottomNav = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/BottomNavBar.kt",
+    ).readText()
+    private val mediaRow = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt",
+    ).readText()
+    private val backdropCard = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/components/BackdropCard.kt",
+    ).readText()
+    private val sharedElementTransition = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/SharedElementTransition.kt",
+    ).readText()
+    private val topBarActions = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/components/TopBarActions.kt",
+    ).readText()
+    private val swipeBack = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/components/SwipeBack.kt",
+    ).readText()
+    private val appNavigation = File(
+        "src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt",
     ).readText()
 
     @Test
@@ -140,6 +176,273 @@ class MobileDetailActionsSourceTest {
         assertTrue(itemDetail.contains("playbackFileId,"))
         assertTrue(itemDetail.contains("explicitAudioIndex,"))
         assertTrue(itemDetail.contains("explicitSubtitleIndex,"))
+    }
+
+    @Test
+    fun settledEpisodeCarouselSelectionDrivesHeroPlaybackState() {
+        assertTrue(seriesDetail.contains("selectsCenteredEpisode = !showsEpisodeDetails"))
+        assertTrue(episodeList.contains("snapshotFlow { listState.isScrollInProgress }"))
+        assertTrue(episodeList.contains("currentOnSelect(episode.contentId)"))
+        assertTrue(itemDetail.contains("onEpisodeDetailClick = { viewModel.selectSeriesEpisode(it) }"))
+        assertTrue(seriesDetail.contains("selectedEpisode?.let { \"Play \${episodeNumberText(it)}\" }"))
+        assertTrue(seriesDetail.contains("loadedSelectedEpisodeDetail.versions.getOrNull(selectedVersionIndex)"))
+    }
+
+    @Test
+    fun episodeLongPressOffersAndPersistsWatchedState() = runItemDetailTest {
+        assertTrue(episodeList.contains("Mark as Watched"))
+        assertTrue(episodeList.contains("Mark as Unwatched"))
+        assertTrue(episodeList.contains("onLongClick"))
+
+        val repository = RecordingPersonalDataRepository(
+            mutableListOf({ ApiResult.Success(Unit) }),
+        )
+        val viewModel = itemDetailViewModel(repository)
+        viewModel.seedSeriesDetail()
+
+        viewModel.setEpisodeWatched("season-1-episode-1", true)
+        advanceUntilIdle()
+
+        assertEquals(listOf(true), repository.watchedCalls)
+        assertEquals(true, viewModel.uiState.value.episodes.single().userData?.played)
+        assertEquals(
+            true,
+            viewModel.uiState.value.episodesBySeason.getValue(1).single().userData?.played,
+        )
+    }
+
+    @Test
+    fun tappedArtworkWarmsTheDetailBackgroundDuringMetadataLoad() {
+        assertTrue(sharedElementTransition.contains("pendingArtworkUrl"))
+        assertTrue(mediaRow.contains("item.backdropUrl ?: item.posterUrl"))
+        assertTrue(appNavigation.contains("openingArtworkUrl"))
+        assertTrue(itemDetail.contains("artworkUrl = openingArtworkUrl"))
+        assertTrue(detailShared.contains("DetailArtworkCrossfadeMs = 120"))
+    }
+
+    @Test
+    fun continueWatchingUsesConfiguredWideCardOverlays() {
+        assertTrue(mediaRow.contains("overlay = rowItem.overlay"))
+        assertTrue(backdropCard.contains("overlayState.enabled && overlay != null"))
+        assertTrue(backdropCard.contains("variant = CardOverlayVariant.Wide"))
+    }
+
+    @Test
+    fun selectingSeriesEpisodeImmediatelyResetsItsPlaybackOverrides() = runItemDetailTest {
+        val viewModel = itemDetailViewModel(
+            personalDataRepository = RecordingPersonalDataRepository(mutableListOf()),
+        )
+        viewModel.seedSeriesDetail()
+
+        viewModel.selectVersion(1)
+        viewModel.selectAudioTrack(2)
+        viewModel.selectSubtitle(3)
+        viewModel.selectSeriesEpisode("season-1-episode-1")
+
+        val state = viewModel.uiState.value
+        assertEquals("season-1-episode-1", state.selectedEpisodeContentId)
+        assertEquals(null, state.selectedEpisodeDetail)
+        assertTrue(state.isLoadingSelectedEpisodeDetail)
+        assertEquals(0, state.selectedVersionIndex)
+        assertEquals(0, state.selectedAudioIndex)
+        assertEquals(-1, state.selectedSubtitleIndex)
+        assertFalse(state.hasExplicitVersionSelection)
+        assertFalse(state.hasExplicitAudioSelection)
+        assertFalse(state.hasExplicitSubtitleSelection)
+    }
+
+    @Test
+    fun selectedEpisodeReplacesCompactSeriesEditorialAndRailKeepsCompactIdentity() {
+        assertTrue(seriesDetail.contains("} else if (usesEpisodeEditorial) {"))
+        assertTrue(seriesDetail.contains("selectedEpisodeOverview"))
+        assertTrue(seriesDetail.contains("belowOverview = if (isExpandedDetailLayout) null else playbackSelector"))
+        assertTrue(
+            seriesDetail.contains(
+                "directorText = fixedSeriesCredit",
+            ),
+        )
+        assertTrue(seriesDetail.contains("remember(detail.contentId, detail.cast) { seriesStarringCredit(detail) }"))
+        assertFalse(seriesDetail.contains("selectedEpisodeCredit"))
+        assertFalse(seriesDetail.contains("SelectedEpisodeInfo"))
+
+        val railCard = episodeList
+            .substringAfter("private fun EpisodeRailCard")
+            .substringBefore("internal fun episodeProgressFraction")
+        assertTrue(railCard.contains("EPISODE"))
+        assertTrue(railCard.contains("NOW VIEWING"))
+        assertTrue(episodeList.contains("showsEpisodeDetails: Boolean = false"))
+        assertTrue(railCard.contains("if (showsEpisodeDetails)"))
+        assertTrue(railCard.contains("episode.title"))
+        assertTrue(railCard.contains("episodeMetadataLine"))
+        assertTrue(railCard.contains("episode.overview"))
+    }
+
+    @Test
+    fun fixedSeriesCreditAndPlaybackSelectorKeepStableFootprints() {
+        assertTrue(seriesDetail.contains("PlaybackSelectorSkeleton()"))
+        assertFalse(seriesDetail.contains("\"Loading…\""))
+        assertTrue(seriesDetail.contains("reserveCreditSpace = !isExpandedDetailLayout && usesEpisodeEditorial"))
+        assertTrue(seriesDetail.contains("isCreditLoading = false"))
+        assertTrue(seriesDetail.contains("reserveOverviewSpace = !isExpandedDetailLayout && usesEpisodeEditorial"))
+        assertTrue(detailShared.contains(".height(38.dp)"))
+        assertTrue(detailShared.contains("minLines = if (reserveCollapsedSpace && !expanded) 3 else 1"))
+        assertTrue(mediaSelectors.contains("repeat(3)"))
+        assertTrue(mediaSelectors.contains(".height(44.dp)"))
+        assertTrue(mediaSelectors.contains(".height(133.dp)"))
+    }
+
+    @Test
+    fun tabletHeroKeepsActionsWithinPosterAndCentersEditorialBelowWithoutChangingPhoneOrder() {
+        val expandedHero = detailShared
+            .substringAfter("private fun ExpandedDetailHero")
+            .substringBefore("private fun ExpandedHeroTitle")
+        val tabletActions = expandedHero.indexOf("actions()")
+        val tabletOverview = expandedHero.indexOf("OverviewBlock(")
+        val tabletCredit = expandedHero.indexOf("DetailCreditBlock(")
+        val tabletSelector = expandedHero.indexOf("belowOverview?.invoke()")
+        assertTrue(expandedHero.contains("Modifier.height(posterHeight)"))
+        assertTrue(expandedHero.contains("contentAlignment = Alignment.TopCenter"))
+        assertTrue(expandedHero.contains("1.00f to pageSurface"))
+        assertTrue(expandedHero.contains(".padding(top = 24.dp, bottom = 40.dp)"))
+        assertTrue(tabletActions >= 0)
+        assertTrue(tabletOverview > tabletActions)
+        assertTrue(tabletCredit > tabletOverview)
+        assertTrue(tabletSelector > tabletCredit)
+
+        val phoneHero = detailShared
+            .substringAfter("fun DetailHero(")
+            .substringBefore("private fun DetailCreditBlock")
+        val phoneActions = phoneHero.indexOf("actions()")
+        val phoneOverview = phoneHero.indexOf("OverviewBlock(")
+        val phoneSelector = phoneHero.indexOf("belowOverview?.invoke()")
+        assertTrue(phoneActions >= 0)
+        assertTrue(phoneOverview > phoneActions)
+        assertTrue(phoneSelector > phoneOverview)
+    }
+
+    @Test
+    fun tabletSeriesUsesMainPlotAndMovesPlaybackSelectorsBelowEpisodes() {
+        assertTrue(seriesDetail.contains("val isExpandedDetailLayout = maxWidth >= ExpandedDetailBreakpoint"))
+        assertTrue(
+            seriesDetail.contains(
+                "overviewText = if (isExpandedDetailLayout) {\n                    detail.overview",
+            ),
+        )
+        assertTrue(seriesDetail.contains("belowOverview = if (isExpandedDetailLayout) null else playbackSelector"))
+        assertTrue(seriesDetail.contains("eyebrow = if (isExpandedDetailLayout) null else eyebrow"))
+        assertTrue(seriesDetail.contains("expandedBelowOverview = {"))
+        assertTrue(seriesDetail.contains("episodeSection(true)"))
+        assertTrue(seriesDetail.contains("episodeSection(false)"))
+
+        val expandedEpisodes = seriesDetail.indexOf("episodeSection(true)")
+        val expandedSelectors = seriesDetail.indexOf("playbackSelector()", startIndex = expandedEpisodes)
+        assertTrue(expandedEpisodes >= 0)
+        assertTrue(expandedSelectors > expandedEpisodes)
+        assertFalse(seriesDetail.contains("item(contentType = \"detail-playback-selectors\")"))
+
+        val expandedHero = detailShared
+            .substringAfter("private fun ExpandedDetailHero")
+            .substringBefore("private fun ExpandedHeroTitle")
+        assertTrue(expandedHero.contains("horizontalAlignment = Alignment.CenterHorizontally"))
+        assertTrue(expandedHero.contains("horizontalAlignment = Alignment.CenterHorizontally,"))
+        assertTrue(expandedHero.contains("contentAlignment = Alignment.TopCenter"))
+        assertTrue(expandedHero.contains("belowOverview?.invoke()"))
+
+        val phoneHero = detailShared
+            .substringAfter("fun DetailHero(")
+            .substringBefore("private fun DetailCreditBlock")
+        assertTrue(phoneHero.contains("belowOverview?.invoke()"))
+
+        val creditBlock = detailShared
+            .substringAfter("private fun DetailCreditBlock")
+            .substringBefore("private fun Backdrop")
+        assertTrue(creditBlock.contains("textAlign = TextAlign.Start"))
+    }
+
+    @Test
+    fun tabletEpisodeRailUsesTapFocusWithoutChangingMobileCentreSelection() {
+        assertTrue(seriesDetail.contains("selectsCenteredEpisode = !showsEpisodeDetails"))
+        assertTrue(seriesDetail.contains("tapToFocusEpisode = showsEpisodeDetails"))
+        assertTrue(seriesDetail.contains("text = \"Tap to focus\""))
+        assertTrue(episodeList.contains("tapToFocusEpisode: Boolean = false"))
+        assertTrue(episodeList.contains("if (tapToFocusEpisode)"))
+        assertTrue(episodeList.contains("contentPadding = PaddingValues(horizontal = SafePadding"))
+        assertFalse(episodeList.contains("((maxWidth - cardWidth) / 2)"))
+
+        val railCard = episodeList
+            .substringAfter("private fun EpisodeRailCard")
+            .substringBefore("internal fun episodeProgressFraction")
+        assertTrue(railCard.contains("onClick = onSelect"))
+        assertTrue(railCard.contains(".clickable(onClick = onPlayClick)"))
+        assertTrue(railCard.contains("vertical = if (showsEpisodeDetails) 1.dp else 2.dp"))
+    }
+
+    @Test
+    fun homeReselectOnlyExpandsChromeAndHomeChromeUsesDetailMaterial() {
+        assertFalse(mainScreen.contains("homeScrollToTopTick"))
+        assertFalse(homeScreen.contains("scrollToTopTick"))
+        assertTrue(mainScreen.contains("homeBottomNavMinimized = false"))
+        assertTrue(bottomNav.contains(".background(SiloDetailActionControlActive)"))
+        assertTrue(bottomNav.contains(".border(1.dp, Color.White.copy(alpha = 0.24f), CircleShape)"))
+        assertTrue(bottomNav.contains("Modifier.size(25.dp)"))
+        assertTrue(bottomNav.contains("Color.White.copy(alpha = 0.28f)"))
+        assertTrue(bottomNav.contains("Color.White.copy(alpha = 0.46f)"))
+        assertTrue(bottomNav.contains("PillExpandedMaxWidth = 380.dp"))
+        assertTrue(bottomNav.contains("PillExpandedWindowBreakpoint = 560.dp"))
+        assertTrue(bottomNav.contains("maxWidth.coerceAtMost(PillExpandedMaxWidth)"))
+        assertTrue(
+            bottomNav.contains(
+                ".align(if (isExpandedWindow) Alignment.Center else Alignment.CenterStart)",
+            ),
+        )
+        assertTrue(bottomNav.contains("Alignment.CenterStart"))
+        assertTrue(bottomNav.contains("Alignment.Center"))
+        assertTrue(topBarActions.contains("opaque -> SiloDetailActionControlActive"))
+        assertTrue(topBarActions.contains("contentColor = if (opaque) Color.White"))
+    }
+
+    @Test
+    fun detailChromeStaysFixedAndAllClosePathsUseSmoothDownwardDismissal() {
+        assertTrue(itemDetail.contains("rememberSwipeDownDismissState()"))
+        assertTrue(itemDetail.contains("BackHandler { requestDismiss() }"))
+        assertTrue(itemDetail.contains("onClick = requestDismiss"))
+        assertFalse(itemDetail.contains("topControlTranslationY"))
+        assertTrue(itemDetail.contains(".statusBarsPadding()"))
+        assertTrue(itemDetail.contains("SiloDetailActionControlActive.copy(alpha = 0.38f)"))
+        assertTrue(itemDetail.contains("Color.White.copy(alpha = 0.36f)"))
+        assertTrue(swipeBack.contains("class SwipeDownDismissState"))
+        assertTrue(swipeBack.contains("offset.animateTo("))
+        assertTrue(swipeBack.contains("dismissing = true"))
+        assertTrue(swipeBack.contains("state.dismiss(onDismiss = currentOnDismiss)"))
+        assertFalse(swipeBack.contains("initialVelocity = initialVelocity.coerceAtLeast(0f)"))
+        assertTrue(appNavigation.contains("DetailCardOpenDurationMs = 600"))
+        assertTrue(appNavigation.contains("DetailCardCloseDurationMs = 440"))
+        assertTrue(appNavigation.contains("CubicBezierEasing(0.32f, 0.00f, 0.20f, 1.00f)"))
+        assertTrue(appNavigation.contains("CubicBezierEasing(0.40f, 0.00f, 0.20f, 1.00f)"))
+        assertTrue(appNavigation.contains("slideOutVertically("))
+        assertTrue(appNavigation.contains("delayMillis = DetailCardOpenDurationMs - 180"))
+        assertFalse(appNavigation.contains("DetailCardCloseHoldDurationMs"))
+        assertTrue(swipeBack.contains("internal var offsetPx by mutableFloatStateOf(0f)"))
+        assertFalse(swipeBack.contains("scope.launch { state.offset.snapTo"))
+        assertFalse(appNavigation.contains("popExitTransition = { ExitTransition.None }"))
+    }
+
+    @Test
+    fun openingAndClosingDetailPreservesTheSourceRowPosition() {
+        assertFalse(mediaRow.contains("settledBrowseContentId"))
+        assertFalse(mediaRow.contains("animateScrollToItem(index)"))
+        assertFalse(appNavigation.contains("settledBrowseContentId"))
+        assertFalse(sharedElementTransition.contains("settledBrowseContentId"))
+    }
+
+    @Test
+    fun liveDetailRequestStartsBeforeDurableCacheRead() {
+        val liveRequest = viewModel.indexOf("val liveDetail = async")
+        val cacheRead = viewModel.indexOf("seedCachedDetail()", startIndex = liveRequest)
+        val liveAwait = viewModel.indexOf("liveDetail.await()", startIndex = cacheRead)
+        assertTrue(liveRequest >= 0)
+        assertTrue(cacheRead > liveRequest)
+        assertTrue(liveAwait > cacheRead)
     }
 
     private fun runItemDetailTest(block: suspend kotlinx.coroutines.test.TestScope.() -> Unit) = runTest {

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/PhoneDirectorCreditSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/PhoneDirectorCreditSourceTest.kt
@@ -19,10 +19,11 @@ class PhoneDirectorCreditSourceTest {
     }
 
     @Test
-    fun phoneCreditStaysBetweenTranslationAndFacts() {
-        val translation = hero.indexOf("translation?.invoke()")
-        val director = hero.indexOf("directorText?.takeIf")
-        val facts = hero.indexOf("if (factsLine.isNotEmpty())", startIndex = director)
-        assertTrue(translation >= 0 && translation < director && director < facts)
+    fun phoneCreditStaysBelowFactsAndAboveTranslationAndSelectors() {
+        val facts = hero.indexOf("val metadataTokens = (factsLine + sourceTokens).distinct()")
+        val director = hero.indexOf("DetailCreditBlock(", startIndex = facts)
+        val translation = hero.indexOf("translation?.invoke()", startIndex = director)
+        val selectors = hero.indexOf("belowOverview?.invoke()", startIndex = translation)
+        assertTrue(facts >= 0 && facts < director && director < translation && translation < selectors)
     }
 }

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/SeasonPresentationLabelTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/SeasonPresentationLabelTest.kt
@@ -30,6 +30,18 @@ class SeasonPresentationLabelTest {
             "Specials",
             seriesSeasonSectionLabel(Season(contentId = "specials", seasonNumber = 0)),
         )
+        assertEquals(
+            "Specials Episodes",
+            seriesSeasonSectionTitle(Season(contentId = "specials", seasonNumber = 0)),
+        )
+    }
+
+    @Test
+    fun regularSeasonUsesIosCombinedEpisodeHeading() {
+        assertEquals(
+            "Season 1 Episodes",
+            seriesSeasonSectionTitle(Season(contentId = "season-1", seasonNumber = 1)),
+        )
     }
 
     @Test

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/util/DominantColorTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/util/DominantColorTest.kt
@@ -1,0 +1,26 @@
+package org.siloserver.silo.android.ui.util
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DominantColorTest {
+    @Test
+    fun `valid thumbhash provides an opaque normalized tint`() {
+        val tint = assertNotNull(
+            averageTintFromThumbhash("1QcSHQRnh493V4dIh4eXh1h4kJUI"),
+        )
+
+        assertTrue(tint.alpha == 1f)
+        assertTrue(tint.red in 0f..1f)
+        assertTrue(tint.green in 0f..1f)
+        assertTrue(tint.blue in 0f..1f)
+    }
+
+    @Test
+    fun `missing or malformed thumbhash falls back safely`() {
+        assertNull(averageTintFromThumbhash(null))
+        assertNull(averageTintFromThumbhash("not a thumbhash"))
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/CatalogRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/CatalogRepository.kt
@@ -18,13 +18,43 @@ import org.siloserver.silo.repository.port.CatalogCachePort
 import org.siloserver.silo.repository.port.CatalogCacheWriteLease
 import org.siloserver.silo.repository.port.NoOpCatalogCachePort
 import org.siloserver.silo.repository.port.canServeCache
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class CatalogRepository(
     private val catalogApi: CatalogApi,
     /** Offline read cache for a library's default first page (Track B). No-op by default. */
     private val catalogCache: CatalogCachePort = NoOpCatalogCachePort,
     private val identityTransitions: IdentityTransitionBarrier = DefaultIdentityTransitionBarrier(),
+    requestDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
+    /**
+     * Home may warm a detail immediately before its destination requests the
+     * same data. Process-owned, identity-keyed single-flight requests keep that
+     * navigation from duplicating calls, and keep useful work alive when Home
+     * leaves composition.
+     */
+    private val detailRequestScope = CoroutineScope(SupervisorJob() + requestDispatcher)
+    private val detailRequestMutex = Mutex()
+    private val itemDetailInFlight =
+        mutableMapOf<Pair<Long, String>, Deferred<ApiResult<ItemDetail>>>()
+    private val seasonsInFlight =
+        mutableMapOf<Pair<Long, String>, Deferred<ApiResult<SeasonsResponse>>>()
+    private data class EpisodesRequestKey(
+        val identityGeneration: Long,
+        val seriesId: String,
+        val seasonNumber: Int,
+    )
+    private val episodesInFlight =
+        mutableMapOf<EpisodesRequestKey, Deferred<ApiResult<EpisodesResponse>>>()
+
     /** Browse the catalog with optional filters, sorting, and pagination. */
     suspend fun browse(
         source: String? = null,
@@ -124,17 +154,24 @@ class CatalogRepository(
     /** Fetches full metadata for a single catalog item (offline: last cached detail). */
     suspend fun getItemDetail(contentId: String): ApiResult<ItemDetail> {
         val requestIdentityGeneration = identityTransitions.generation.value
-        val result = catalogApi.getItemDetail(contentId)
-        if (result is ApiResult.Success) {
-            writeIfIdentityUnchanged(requestIdentityGeneration) { cacheWriteLease ->
-                catalogCache.cacheItemDetail(contentId, result.data, cacheWriteLease)
-            }
-            return result
+        val warmRequest = detailRequestMutex.withLock {
+            itemDetailInFlight[requestIdentityGeneration to contentId]
         }
-        if (result.canServeCache()) {
-            catalogCache.getCachedItemDetail(contentId)?.let { return ApiResult.Success(it) }
+        return warmRequest?.await() ?: fetchItemDetail(contentId, requestIdentityGeneration)
+    }
+
+    /**
+     * Starts a process-owned live detail warm-up. A destination calling
+     * [getItemDetail] while it is active joins this exact request.
+     */
+    suspend fun warmItemDetail(contentId: String): ApiResult<ItemDetail> {
+        val requestIdentityGeneration = identityTransitions.generation.value
+        return coalescedDetailRequest(
+            requests = itemDetailInFlight,
+            key = requestIdentityGeneration to contentId,
+        ) {
+            fetchItemDetail(contentId, requestIdentityGeneration)
         }
-        return result
     }
 
     /** Returns the last cached item detail without touching the network. */
@@ -157,33 +194,69 @@ class CatalogRepository(
     /** Lists seasons for a series (offline: last cached seasons). */
     suspend fun getSeasons(seriesId: String): ApiResult<SeasonsResponse> {
         val requestIdentityGeneration = identityTransitions.generation.value
-        val result = catalogApi.getSeasons(seriesId)
-        if (result is ApiResult.Success) {
-            writeIfIdentityUnchanged(requestIdentityGeneration) { cacheWriteLease ->
-                catalogCache.cacheSeasons(seriesId, result.data, cacheWriteLease)
-            }
-            return result
+        val warmRequest = detailRequestMutex.withLock {
+            seasonsInFlight[requestIdentityGeneration to seriesId]
         }
-        if (result.canServeCache()) {
-            catalogCache.getCachedSeasons(seriesId)?.let { return ApiResult.Success(it) }
+        return warmRequest?.await() ?: fetchSeasons(seriesId, requestIdentityGeneration)
+    }
+
+    /** Starts a process-owned live season-list warm-up for a pending detail route. */
+    suspend fun warmSeasons(seriesId: String): ApiResult<SeasonsResponse> {
+        val requestIdentityGeneration = identityTransitions.generation.value
+        return coalescedDetailRequest(
+            requests = seasonsInFlight,
+            key = requestIdentityGeneration to seriesId,
+        ) {
+            fetchSeasons(seriesId, requestIdentityGeneration)
         }
-        return result
+    }
+
+    /** Returns the last cached season list without touching the network. */
+    suspend fun getCachedSeasons(seriesId: String): SeasonsResponse? =
+        catalogCache.getCachedSeasons(seriesId)
+
+    /** Cache-first season list for speculative detail navigation. */
+    suspend fun getSeasonsForPrefetch(seriesId: String): ApiResult<SeasonsResponse> {
+        catalogCache.getCachedSeasons(seriesId)?.let { return ApiResult.Success(it) }
+        return getSeasons(seriesId)
     }
 
     /** Lists episodes for a specific season of a series (offline: last cached episodes). */
     suspend fun getEpisodes(seriesId: String, seasonNumber: Int): ApiResult<EpisodesResponse> {
         val requestIdentityGeneration = identityTransitions.generation.value
-        val result = catalogApi.getEpisodes(seriesId, seasonNumber)
-        if (result is ApiResult.Success) {
-            writeIfIdentityUnchanged(requestIdentityGeneration) { cacheWriteLease ->
-                catalogCache.cacheEpisodes(seriesId, seasonNumber, result.data, cacheWriteLease)
-            }
-            return result
+        val requestKey = EpisodesRequestKey(requestIdentityGeneration, seriesId, seasonNumber)
+        val warmRequest = detailRequestMutex.withLock { episodesInFlight[requestKey] }
+        return warmRequest?.await()
+            ?: fetchEpisodes(seriesId, seasonNumber, requestIdentityGeneration)
+    }
+
+    /** Starts a process-owned live episode-list warm-up for a pending detail route. */
+    suspend fun warmEpisodes(
+        seriesId: String,
+        seasonNumber: Int,
+    ): ApiResult<EpisodesResponse> {
+        val requestIdentityGeneration = identityTransitions.generation.value
+        return coalescedDetailRequest(
+            requests = episodesInFlight,
+            key = EpisodesRequestKey(requestIdentityGeneration, seriesId, seasonNumber),
+        ) {
+            fetchEpisodes(seriesId, seasonNumber, requestIdentityGeneration)
         }
-        if (result.canServeCache()) {
-            catalogCache.getCachedEpisodes(seriesId, seasonNumber)?.let { return ApiResult.Success(it) }
+    }
+
+    /** Returns one cached season's episodes without touching the network. */
+    suspend fun getCachedEpisodes(seriesId: String, seasonNumber: Int): EpisodesResponse? =
+        catalogCache.getCachedEpisodes(seriesId, seasonNumber)
+
+    /** Cache-first episode list for speculative detail navigation. */
+    suspend fun getEpisodesForPrefetch(
+        seriesId: String,
+        seasonNumber: Int,
+    ): ApiResult<EpisodesResponse> {
+        catalogCache.getCachedEpisodes(seriesId, seasonNumber)?.let {
+            return ApiResult.Success(it)
         }
-        return result
+        return getEpisodes(seriesId, seasonNumber)
     }
 
     /** Lists all episodes directly attached to an item (e.g. a season content ID). */
@@ -222,6 +295,65 @@ class CatalogRepository(
             snapshotAt = snapshotAt,
         )
 
+    private suspend fun fetchItemDetail(
+        contentId: String,
+        requestIdentityGeneration: Long,
+    ): ApiResult<ItemDetail> {
+        val result = catalogApi.getItemDetail(contentId)
+        if (result is ApiResult.Success) {
+            writeIfIdentityUnchanged(requestIdentityGeneration) { cacheWriteLease ->
+                catalogCache.cacheItemDetail(contentId, result.data, cacheWriteLease)
+            }
+            return result
+        }
+        if (result.canServeCache()) {
+            catalogCache.getCachedItemDetail(contentId)?.let { return ApiResult.Success(it) }
+        }
+        return result
+    }
+
+    private suspend fun fetchSeasons(
+        seriesId: String,
+        requestIdentityGeneration: Long,
+    ): ApiResult<SeasonsResponse> {
+        val result = catalogApi.getSeasons(seriesId)
+        if (result is ApiResult.Success) {
+            writeIfIdentityUnchanged(requestIdentityGeneration) { cacheWriteLease ->
+                catalogCache.cacheSeasons(seriesId, result.data, cacheWriteLease)
+            }
+            return result
+        }
+        if (result.canServeCache()) {
+            catalogCache.getCachedSeasons(seriesId)?.let { return ApiResult.Success(it) }
+        }
+        return result
+    }
+
+    private suspend fun fetchEpisodes(
+        seriesId: String,
+        seasonNumber: Int,
+        requestIdentityGeneration: Long,
+    ): ApiResult<EpisodesResponse> {
+        val result = catalogApi.getEpisodes(seriesId, seasonNumber)
+        if (result is ApiResult.Success) {
+            writeIfIdentityUnchanged(requestIdentityGeneration) { cacheWriteLease ->
+                catalogCache.cacheEpisodes(
+                    seriesId,
+                    seasonNumber,
+                    result.data,
+                    cacheWriteLease,
+                )
+            }
+            return result
+        }
+        if (result.canServeCache()) {
+            catalogCache.getCachedEpisodes(seriesId, seasonNumber)?.let {
+                return ApiResult.Success(it)
+            }
+        }
+        return result
+    }
+
     private suspend fun writeIfIdentityUnchanged(
         requestGeneration: Long,
         write: suspend (CatalogCacheWriteLease) -> Unit,
@@ -229,5 +361,30 @@ class CatalogRepository(
         if (requestGeneration == identityTransitions.generation.value) {
             write(CatalogCacheWriteLease(requestGeneration))
         }
+    }
+
+    private suspend fun <K, T> coalescedDetailRequest(
+        requests: MutableMap<K, Deferred<T>>,
+        key: K,
+        request: suspend () -> T,
+    ): T {
+        val deferred = detailRequestMutex.withLock {
+            requests[key] ?: run {
+                lateinit var created: Deferred<T>
+                created = detailRequestScope.async(start = CoroutineStart.LAZY) {
+                    try {
+                        request()
+                    } finally {
+                        detailRequestMutex.withLock {
+                            if (requests[key] === created) requests.remove(key)
+                        }
+                    }
+                }
+                requests[key] = created
+                created.start()
+                created
+            }
+        }
+        return deferred.await()
     }
 }

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/CatalogRepositoryDetailCacheTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/CatalogRepositoryDetailCacheTest.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.repository
 
+import org.siloserver.silo.model.catalog.EpisodesResponse
 import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.catalog.SeasonsResponse
 import org.siloserver.silo.network.ApiResult
@@ -18,9 +19,15 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -31,6 +38,7 @@ class CatalogRepositoryDetailCacheTest {
     private class FakeCache(
         val preset: ItemDetail? = null,
         val seasonsPreset: SeasonsResponse? = null,
+        val episodesPreset: EpisodesResponse? = null,
         val identityTransitions: IdentityTransitionBarrier? = null,
         val beforeItemCache: suspend () -> Unit = {},
     ) : CatalogCachePort {
@@ -50,6 +58,10 @@ class CatalogRepositoryDetailCacheTest {
         }
         override suspend fun getCachedItemDetail(contentId: String): ItemDetail? = preset
         override suspend fun getCachedSeasons(seriesId: String): SeasonsResponse? = seasonsPreset
+        override suspend fun getCachedEpisodes(
+            seriesId: String,
+            seasonNumber: Int,
+        ): EpisodesResponse? = episodesPreset
     }
 
     private fun repo(status: HttpStatusCode, body: String, cache: CatalogCachePort): CatalogRepository {
@@ -68,6 +80,32 @@ class CatalogRepositoryDetailCacheTest {
             install(ContentNegotiation) { json(SiloJson) }
         }
         return CatalogRepository(CatalogApi(client), cache)
+    }
+
+    private fun gatedRepository(
+        requestDispatcher: CoroutineDispatcher,
+        requestEntered: CompletableDeferred<Unit>,
+        releaseResponse: CompletableDeferred<Unit>,
+        onRequest: () -> Unit,
+    ): CatalogRepository {
+        val client = HttpClient(
+            MockEngine {
+                onRequest()
+                requestEntered.complete(Unit)
+                releaseResponse.await()
+                respond(
+                    """{"content_id":"c1","type":"movie","title":"A"}""",
+                    HttpStatusCode.OK,
+                    headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        ) {
+            install(ContentNegotiation) { json(SiloJson) }
+        }
+        return CatalogRepository(
+            catalogApi = CatalogApi(client),
+            requestDispatcher = requestDispatcher,
+        )
     }
 
     @Test
@@ -108,6 +146,65 @@ class CatalogRepositoryDetailCacheTest {
             .getItemDetailForPrefetch("c2")
         assertEquals("Fresh", (result as ApiResult.Success).data.title)
         assertEquals("c2", cache.cachedId)
+    }
+
+    @Test
+    fun seasonAndEpisodePrefetchUseCacheWithoutNetwork() = runTest {
+        val cache = FakeCache(
+            seasonsPreset = SeasonsResponse(),
+            episodesPreset = EpisodesResponse(),
+        )
+        val repository = repoThatFailsOnNetwork(cache)
+
+        assertTrue(repository.getSeasonsForPrefetch("series-1") is ApiResult.Success)
+        assertTrue(repository.getEpisodesForPrefetch("series-1", 3) is ApiResult.Success)
+    }
+
+    @Test
+    fun destinationJoinsActiveDetailWarmup() = runTest {
+        var calls = 0
+        val entered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        val repository = gatedRepository(
+            requestDispatcher = StandardTestDispatcher(testScheduler),
+            requestEntered = entered,
+            releaseResponse = release,
+            onRequest = { calls += 1 },
+        )
+
+        val requests = listOf(
+            async { repository.warmItemDetail("c1") },
+            async { repository.getItemDetail("c1") },
+        )
+        entered.await()
+        repeat(10) { yield() }
+        release.complete(Unit)
+        requests.awaitAll()
+
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun cancelingHomePrefetchDoesNotCancelDestinationDetailRequest() = runTest {
+        var calls = 0
+        val entered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        val repository = gatedRepository(
+            requestDispatcher = StandardTestDispatcher(testScheduler),
+            requestEntered = entered,
+            releaseResponse = release,
+            onRequest = { calls += 1 },
+        )
+
+        val homePrefetch = launch { repository.warmItemDetail("c1") }
+        entered.await()
+        val destination = async { repository.getItemDetail("c1") }
+        repeat(10) { yield() }
+        homePrefetch.cancelAndJoin()
+        release.complete(Unit)
+
+        assertTrue(destination.await() is ApiResult.Success)
+        assertEquals(1, calls)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Android phone, tablet and foldable had drifted away from the iOS mobile experience. Home chrome was hard to read, detail pages still behaved like full-screen routes instead of cards, series/episode selection was split across old pages, large-screen ordering and focus were inconsistent, and artwork could visibly restart loading during navigation.

## Solution

I redesigned the Android mobile experience against the current iOS implementation and brought the three adaptive layouts back into one coherent flow.

### Home

- Reworked the bottom tab bar and top controls into an iOS-inspired opaque blur treatment that keeps the current background tint without using Android liquid glass.
- Strengthened selected-tab contrast and icon legibility while keeping the phone tab bar compact on tablets and folds.
- Added the iOS-style phone collapse/reopen behaviour: scrolling down hides the bar, tapping Home reveals it without jumping to the top, and returning to the top restores it.
- Made Home section visibility update immediately and added drag-to-reorder controls with profile/server-scoped persistence.
- Added configured media overlays to Continue Watching and the other Home cards.

### Movie and series detail cards

- Rebuilt phone, tablet and fold detail presentation as a rounded card that enters from the bottom, preserves Home behind the dismissal transition, clears cutouts, and keeps its shape throughout open/close gestures.
- Replaced the glass pills with readable background-aware opaque controls while keeping Play white and the secondary action row subtly grey.
- Grouped Version, Audio and Subtitles into the iOS-style selector panel with working pickers, stable spacing and loading skeletons.
- Removed the floating TMDB/IMDb eyebrow above movie artwork and kept facts in the normal metadata row.
- Warmed artwork before navigation and derived background tint directly from ThumbHash where available, avoiding a second image request just to calculate colour.

### Series and episodes

- Unified Continue Watching with the main series detail page. Opening S3E1 now opens the series, selects Season 3 and focuses that exact episode instead of pushing an obsolete season/episode page.
- Made episode focus update the hero overview, Play target and media selectors while the series starring credit remains stable.
- Matched the iOS season ordering, tighter spacing, episode cards, Now Viewing treatment and swipe/tap-to-focus behaviour.
- Kept episode number + Now Viewing under each card, moved editorial episode information into the main detail area on phone, and retained per-episode information in the tablet/fold rail.
- Added long-press Mark watched / Mark unwatched actions and removed the per-episode download button from the rail.
- Added expanded tap-to-focus behaviour so the first and final tablet/fold episodes can both be selected without a permanent empty gutter.

### Adaptive tablet and fold layout

- Added a dedicated expanded hero composition while leaving the completed phone composition independent.
- Centred the logo/facts/play stack, capped the action row at the poster bottom, aligned plot/starring to a shared content column, and moved seasons/episodes ahead of the playback selector on large screens.
- Added expanded-only episode focus guidance and denser Now Viewing pills.

## Benchmarks and validation

- Continue Watching request benchmark: two overlapping consumers (Home warm-up + detail destination) resolve through **1 backend request instead of 2**; cancellation of the Home caller still leaves **1 successful shared request** for the destination. This is locked by deterministic coroutine/network tests.
- Dominant-colour path: ThumbHash-backed cards now need **0 extra artwork fetches** for colour extraction; the previous bitmap sampling path needed an independent image load when no decoded bitmap was already available.
- Warm-up runway: the first **4 unique** Continue Watching series destinations prefetch parent metadata, exact episode metadata, season/episode lists and the real parent backdrop in row order.
- The complete Android and shared unit-test suites passed, the full CI lint matrix passed, `git diff --check` passed, and `:androidApp:assembleDebug` passed.
- Manually validated on the Android emulator across phone, tablet and foldable layouts, including direct opens, Continue Watching deep selection, episode swiping/focus, Home section editing, and card dismissal/reopen.

## Screenshots

Click any screenshot for the full-size image.

<table>
  <tr>
    <th>Tablet/fold movie detail</th>
    <th>Tablet/fold Home</th>
  </tr>
  <tr>
    <td><a href="https://github.com/user-attachments/assets/f427aaee-2cf9-4df6-b67f-2f666b9345e2"><img width="400" alt="Android tablet movie detail" src="https://github.com/user-attachments/assets/f427aaee-2cf9-4df6-b67f-2f666b9345e2" /></a></td>
    <td><a href="https://github.com/user-attachments/assets/02b502ae-c4b7-4952-b272-64ff5d3aabb6"><img width="400" alt="Android tablet Home" src="https://github.com/user-attachments/assets/02b502ae-c4b7-4952-b272-64ff5d3aabb6" /></a></td>
  </tr>
</table>

<table>
  <tr>
    <th>Phone Home</th>
    <th>Phone series detail</th>
    <th>Episode focus, cast and details</th>
  </tr>
  <tr>
    <td><a href="https://github.com/user-attachments/assets/a35574c6-42c1-4c22-a208-2bd5465ed797"><img width="170" alt="Android phone Home" src="https://github.com/user-attachments/assets/a35574c6-42c1-4c22-a208-2bd5465ed797" /></a></td>
    <td><a href="https://github.com/user-attachments/assets/65cface7-cfff-40f4-bc70-39322720508b"><img width="170" alt="Android phone series detail" src="https://github.com/user-attachments/assets/65cface7-cfff-40f4-bc70-39322720508b" /></a></td>
    <td><a href="https://github.com/user-attachments/assets/7fe23742-c286-44ab-9e03-60f7486a5302"><img width="170" alt="Android phone episode focus, cast and details" src="https://github.com/user-attachments/assets/7fe23742-c286-44ab-9e03-60f7486a5302" /></a></td>
  </tr>
</table>

## Notes

- Android phone, tablet and foldable only. Android TV behaviour is not changed.
- No server, database or deployment changes.

AI disclosure: I designed the experience and directed every product/UI decision. OpenAI Codex (`gpt-5.6-sol`, ultra reasoning) in the Codex desktop agent harness assisted with implementation, testing, and PR preparation. No other AI tooling was used.

