### PR TITLE
fix(tv): remove the top navigation shadow

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -1419,15 +1419,7 @@ fun TvMainShell(
             }
         }
 
-        // Shared one-layer nav shadow. Root artwork no longer draws a second
-        // scrim, so Home and flat shell pages have identical chrome.
-        TvTopMenuDropShadow(
-            visibility = if (currentRoute == TvMainRoute.Settings.route) 0f else menuVisibility.value,
-            modifier = Modifier.align(Alignment.TopCenter),
-        )
-
-        // Menu overlay — content remains visible behind the transparent bar,
-        // matching tvOS without a heavy top-edge shadow.
+        // Menu overlay — content remains visible behind the transparent bar.
         TvTopMenuBar(
             selectedRoot = selectedRoot,
             destinations = visibleRoots,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.Key
@@ -112,36 +111,6 @@ object TvTopMenuLayout {
      * the menu band (bar top inset + bar height + breathing room).
      */
     val contentTopInset: Dp = 94.dp
-}
-
-/**
- * One shared, soft shadow behind the floating top navigation.
- *
- * Root artwork used to paint its own black top scrim while the shell painted a
- * second background-coloured gradient. Home therefore had a much heavier band
- * than flat pages, and the two different colours could expose a visible seam.
- * Keeping this layer beside the bar gives every route exactly one shadow and
- * lets it disappear with the bar on full-screen surfaces such as Settings.
- */
-@Composable
-internal fun TvTopMenuDropShadow(
-    visibility: Float,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(TvTopMenuLayout.contentTopInset)
-            .graphicsLayer { alpha = visibility.coerceIn(0f, 1f) }
-            .background(
-                Brush.verticalGradient(
-                    0.00f to Color.Black.copy(alpha = 0.58f),
-                    0.58f to Color.Black.copy(alpha = 0.42f),
-                    0.80f to Color.Black.copy(alpha = 0.14f),
-                    1.00f to Color.Transparent,
-                ),
-            ),
-    )
 }
 
 /**

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuFocusRequestTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuFocusRequestTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertTrue
 
 class TvTopMenuFocusRequestTest {
     @Test
-    fun shellPagesShareOneTopNavigationShadow() {
+    fun shellPagesDoNotDrawATopNavigationShadow() {
         val barSource = File(
             "src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt",
         ).readText()
@@ -20,9 +20,8 @@ class TvTopMenuFocusRequestTest {
             "src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvRootHeroBackdrop.kt",
         ).readText()
 
-        assertTrue(barSource.contains("internal fun TvTopMenuDropShadow("))
-        assertTrue(shellSource.contains("TvTopMenuDropShadow("))
-        assertTrue(shellSource.contains("visibility = if (currentRoute == TvMainRoute.Settings.route)"))
+        assertFalse(barSource.contains("internal fun TvTopMenuDropShadow("))
+        assertFalse(shellSource.contains("TvTopMenuDropShadow("))
         assertFalse(rootBackdropSource.contains("TopScrimHeight"))
     }
 


### PR DESCRIPTION
The Android TV shell rendered a shared black gradient behind the floating top navigation. On artwork-heavy pages this appeared as an unwanted dark band even after the older root-backdrop scrim had been removed.

This removes `TvTopMenuDropShadow` and its shell layer so page artwork can continue naturally behind the transparent menu. The source-wiring test now locks in the shadow-free contract.

## Evidence

| Before | After |
| --- | --- |
| ![Top navigation before](https://github.com/user-attachments/assets/a55cc69c-7b54-4188-ab8f-2b87d37a243a) | ![Top navigation after](https://github.com/user-attachments/assets/d572ffe0-6b00-46ef-a9bc-c0a03977ffd7) |

## Validation

- `./gradlew :androidTvApp:testDebugUnitTest --tests '*TvTopMenuFocusRequestTest' :androidTvApp:assembleDebug`
- Android TV 14 `SiloTV` emulator visual verification at 1920×1080

## Risk

Low. The change removes one decorative shell layer and leaves menu focus, spacing, and content insets unchanged.

## AI disclosure

Implemented with OpenAI `gpt-5.6-sol` through the Codex desktop agent harness. Independent simplicity and change-split reviews used Codex subagents running the same model; no other AI tooling was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the drop shadow beneath the Android TV top navigation menu for a cleaner appearance.
  * Updated navigation visuals consistently across the main TV shell and menu.

* **Tests**
  * Updated coverage to confirm that the top navigation no longer displays a drop shadow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->