### PR TITLE
fix(tv): route season and episode details through series

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -980,6 +980,24 @@ fun TvAppNavigation(
                         current?.let { popUpTo(it) { inclusive = true } }
                     }
                 },
+                onSeriesDetailReplace = canonicalizeSeries@{ seriesContentId, selectedSeason, episodeContentId ->
+                    // Parent resolution is asynchronous. If the viewer backed
+                    // out (or another destination won) while it was running,
+                    // this exiting detail must not replace the new top entry.
+                    if (navController.currentBackStackEntry?.id != backStack.id) {
+                        return@canonicalizeSeries
+                    }
+                    val current = backStack.destination.route
+                    navController.navigate(
+                        TvRoute.ItemDetail(
+                            contentId = seriesContentId,
+                            seasonNumber = selectedSeason,
+                            episodeContentId = episodeContentId,
+                        ).route,
+                    ) {
+                        current?.let { popUpTo(it) { inclusive = true } }
+                    }
+                },
                 onSeriesClick = { seriesId ->
                     navController.navigateToTvItemDetail(seriesId)
                 },

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarScreen.kt
@@ -141,10 +141,34 @@ import org.siloserver.silo.viewmodel.CalendarViewModel
  * Mirrors [org.siloserver.silo.tv.ui.screens.recommendations.TvRecommendationsScreen]
  * for the koinViewModel + initial-focus-once pattern.
  */
+internal data class TvCalendarDetailTarget(
+    val contentId: String,
+    val seasonNumber: Int? = null,
+    val episodeContentId: String? = null,
+)
+
+/** Carries an aired episode into the exact mode of the combined Series page. */
+internal fun tvCalendarDetailTarget(item: CalendarItem): TvCalendarDetailTarget {
+    val seriesContentId = item.seriesId?.trim()?.takeIf { it.isNotEmpty() }
+    if (item.isEpisode && seriesContentId != null && item.seasonNumber != null) {
+        return TvCalendarDetailTarget(
+            contentId = seriesContentId,
+            seasonNumber = item.seasonNumber,
+            episodeContentId = item.contentId,
+        )
+    }
+
+    return TvCalendarDetailTarget(contentId = item.contentId)
+}
+
 @OptIn(ExperimentalTvMaterial3Api::class, kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @Composable
 fun TvCalendarScreen(
-    onOpenItemDetail: (contentId: String) -> Unit,
+    onOpenItemDetailSelection: (
+        contentId: String,
+        seasonNumber: Int?,
+        episodeContentId: String?,
+    ) -> Unit,
     onInitialContentFocus: () -> Unit = {},
     onMoveUpToMenu: () -> Unit = {},
     focusRequest: Int = 0,
@@ -488,7 +512,7 @@ fun TvCalendarScreen(
                 onItemClicked = { date, item, index ->
                     recordReturnTarget(date, item, index)
                 },
-                onOpenItemDetail = onOpenItemDetail,
+                onOpenItemDetailSelection = onOpenItemDetailSelection,
             )
         }
     }
@@ -993,7 +1017,11 @@ private fun CalendarList(
     onShelfFocusConsumed: () -> Unit,
     onItemFocused: (date: String, item: CalendarItem, index: Int, focused: Boolean) -> Unit,
     onItemClicked: (date: String, item: CalendarItem, index: Int) -> Unit,
-    onOpenItemDetail: (contentId: String) -> Unit,
+    onOpenItemDetailSelection: (
+        contentId: String,
+        seasonNumber: Int?,
+        episodeContentId: String?,
+    ) -> Unit,
 ) {
     val snapScope = rememberCoroutineScope()
     val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
@@ -1187,7 +1215,7 @@ private fun CalendarList(
                         focusedShelfIndex = null
                     }
                 },
-                onOpenItemDetail = onOpenItemDetail,
+                onOpenItemDetailSelection = onOpenItemDetailSelection,
             )
         }
             }
@@ -1214,7 +1242,11 @@ private fun DayShelf(
     onItemClicked: (item: CalendarItem, index: Int) -> Unit = { _, _ -> },
     onShelfFocused: () -> Unit = {},
     onShelfFocusChanged: (Boolean) -> Unit = {},
-    onOpenItemDetail: (contentId: String) -> Unit,
+    onOpenItemDetailSelection: (
+        contentId: String,
+        seasonNumber: Int?,
+        episodeContentId: String?,
+    ) -> Unit,
 ) {
     val targetCardFocusRequester = remember { FocusRequester() }
     val rowState = rememberLazyListState()
@@ -1289,11 +1321,15 @@ private fun DayShelf(
                         onFocusChanged = { focused -> onItemFocusChanged(item, index, focused) },
                         onClick = {
                             onItemClicked(item, index)
-                            // detailContentId is where the card GOES; contentId
-                            // is what the card IS. Several episodes of one show
-                            // share a destination, so identity has to come from
-                            // the item, not from the route.
-                            onOpenItemDetail(item.detailContentId)
+                            // Identity still comes from the event contentId,
+                            // while the target carries its parent Series plus
+                            // the exact season/episode mode to restore.
+                            val target = tvCalendarDetailTarget(item)
+                            onOpenItemDetailSelection(
+                                target.contentId,
+                                target.seasonNumber,
+                                target.episodeContentId,
+                            )
                         },
                     )
                 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -143,6 +143,39 @@ import org.siloserver.silo.tv.ui.screens.watchtogether.TvWatchTogetherViewModel
 import org.siloserver.silo.tv.ui.theme.Spacing
 import org.siloserver.silo.tv.ui.theme.TvSmoothBringIntoViewSpec
 
+internal data class TvSeriesDetailRedirect(
+    val seriesContentId: String,
+    val seasonNumber: Int,
+    val episodeContentId: String?,
+)
+
+/**
+ * Maps a standalone season or episode detail onto the combined Series page.
+ * Incomplete hierarchy data deliberately returns null so the existing detail
+ * remains available as a resilient fallback.
+ */
+internal fun tvSeriesDetailRedirect(detail: ItemDetail): TvSeriesDetailRedirect? {
+    val type = detail.type.trim().lowercase()
+    if (type != "season" && type != "episode") return null
+
+    val seriesContentId = detail.seriesId
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() && it != detail.contentId }
+        ?: return null
+    val seasonNumber = detail.seasonNumber ?: return null
+
+    return TvSeriesDetailRedirect(
+        seriesContentId = seriesContentId,
+        seasonNumber = seasonNumber,
+        episodeContentId = detail.contentId.takeIf { type == "episode" },
+    )
+}
+
+internal fun ItemDetail?.isMatchingSeriesDetail(expectedContentId: String): Boolean =
+    this != null &&
+        type.equals("series", ignoreCase = true) &&
+        contentId == expectedContentId
+
 @Composable
 fun TvItemDetailScreen(
     contentId: String,
@@ -151,6 +184,11 @@ fun TvItemDetailScreen(
     onPlay: (contentId: String, fileId: Int?, audioTrackIndex: Int?, audioPickedThisSession: Boolean, subtitleSelection: TvSubtitleLaunchSelection?, itemType: String?, resumePositionSeconds: Double?) -> Unit,
     onItemDetail: (contentId: String) -> Unit,
     onItemDetailReplace: (contentId: String) -> Unit = onItemDetail,
+    onSeriesDetailReplace: (
+        seriesContentId: String,
+        seasonNumber: Int,
+        episodeContentId: String?,
+    ) -> Unit,
     onSeriesClick: (seriesId: String) -> Unit,
     onSeasonClick: (seriesId: String, seasonNumber: Int) -> Unit,
     onWatchTogether: (RoomSnapshot) -> Unit,
@@ -162,11 +200,39 @@ fun TvItemDetailScreen(
     ),
 ) {
     val state by viewModel.uiState.collectAsState()
+    val seriesRedirect = remember(state.detail) {
+        state.detail?.let(::tvSeriesDetailRedirect)
+    }
+    var seriesRedirectFailed by rememberSaveable(
+        contentId,
+        seriesRedirect?.seriesContentId,
+        seriesRedirect?.seasonNumber,
+        seriesRedirect?.episodeContentId,
+    ) {
+        mutableStateOf(false)
+    }
     var pendingEntrySeasonNumber by rememberSaveable(contentId, seasonNumber) {
         mutableStateOf(seasonNumber)
     }
 
     BackHandler(enabled = true) { onBack() }
+
+    LaunchedEffect(seriesRedirect, seriesRedirectFailed) {
+        val redirect = seriesRedirect ?: return@LaunchedEffect
+        if (seriesRedirectFailed) return@LaunchedEffect
+
+        if (viewModel.hasSeriesDetailForRedirect(redirect.seriesContentId)) {
+            onSeriesDetailReplace(
+                redirect.seriesContentId,
+                redirect.seasonNumber,
+                redirect.episodeContentId,
+            )
+        } else {
+            // Match tvOS's defensive behavior: if the parent is unavailable or
+            // does not resolve as a Series, keep the standalone page usable.
+            seriesRedirectFailed = true
+        }
+    }
 
     // Refresh on return (e.g. backing out of the player): the ViewModel loads
     // once in init, so without this the Play button keeps the resume label
@@ -233,9 +299,13 @@ fun TvItemDetailScreen(
             onRetry = viewModel::loadAll,
             modifier = Modifier.background(MaterialTheme.colorScheme.background),
         )
+        seriesRedirect != null && !seriesRedirectFailed -> TvLoadingScreen(
+            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+        )
         state.detail != null -> TvDetailContent(
             detail = state.detail!!,
             state = state,
+            initialSeasonNumber = seasonNumber,
             initialEpisodeContentId = initialEpisodeContentId,
             viewModel = viewModel,
             onPlay = onPlay,
@@ -254,6 +324,7 @@ fun TvItemDetailScreen(
 private fun TvDetailContent(
     detail: ItemDetail,
     state: TvItemDetailUiState,
+    initialSeasonNumber: Int?,
     initialEpisodeContentId: String?,
     viewModel: TvItemDetailViewModel,
     onPlay: (contentId: String, fileId: Int?, audioTrackIndex: Int?, audioPickedThisSession: Boolean, subtitleSelection: TvSubtitleLaunchSelection?, itemType: String?, resumePositionSeconds: Double?) -> Unit,
@@ -313,7 +384,30 @@ private fun TvDetailContent(
     val coroutineScope = rememberCoroutineScope()
     val isAudiobook = isAudiobookItemType(detail.type)
     val isSeriesDetail = detail.type == "series"
-    var isShowingSeriesOverview by rememberSaveable(detail.contentId) { mutableStateOf(true) }
+    var isShowingSeriesOverview by rememberSaveable(
+        detail.contentId,
+        initialSeasonNumber,
+        initialEpisodeContentId,
+    ) {
+        mutableStateOf(true)
+    }
+    LaunchedEffect(
+        initialSeasonNumber,
+        initialEpisodeContentId,
+        state.selectedSeason,
+        state.episodesLoading,
+        state.nextUpEpisode?.seasonNumber,
+    ) {
+        if (
+            initialSeasonNumber != null &&
+            initialEpisodeContentId == null &&
+            state.selectedSeason == initialSeasonNumber &&
+            !state.episodesLoading &&
+            (state.nextUpEpisode == null || state.nextUpEpisode.seasonNumber == initialSeasonNumber)
+        ) {
+            isShowingSeriesOverview = false
+        }
+    }
     LaunchedEffect(
         initialEpisodeContentId,
         state.entryEpisodeSelectionApplied,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -496,6 +496,23 @@ class TvItemDetailViewModel(
         }
     }
 
+    /**
+     * Resolves the parent before replacing a standalone season/episode route.
+     * A failed or malformed parent leaves the current detail on screen instead
+     * of turning incomplete hierarchy metadata into a dead-end Series page.
+     */
+    suspend fun hasSeriesDetailForRedirect(seriesContentId: String): Boolean {
+        val cached = catalogRepository.getCachedItemDetail(seriesContentId)
+        if (cached.isMatchingSeriesDetail(seriesContentId)) return true
+
+        return when (val resolved = catalogRepository.getItemDetail(seriesContentId)) {
+            is ApiResult.Success -> resolved.data.isMatchingSeriesDetail(seriesContentId)
+            is ApiResult.Error,
+            is ApiResult.NetworkError,
+            -> false
+        }
+    }
+
     fun loadAll() {
         viewModelScope.launch {
             runCatching { playerSettingsStore.refreshFromServer() }
@@ -606,7 +623,14 @@ class TvItemDetailViewModel(
                     // Restore a durably-persisted audio/subtitle override (TM4).
                     seedPersistedTrackSelection(detail)
                     when (detail.type.lowercase()) {
-                        "series" -> loadSeasons(seriesContentId = detail.contentId)
+                        "series" -> loadSeasons(
+                            seriesContentId = detail.contentId,
+                            // Cached navigation may already have applied an
+                            // entry-route season before this fresh detail
+                            // response arrives. Carry it into the refresh so
+                            // the default/in-progress season cannot replace it.
+                            preferredSeasonNumber = _uiState.value.selectedSeason,
+                        )
                         "season",
                         "episode",
                         -> detail.seriesId?.takeIf { it.isNotBlank() }?.let { seriesId ->
@@ -1067,6 +1091,7 @@ class TvItemDetailViewModel(
     }
 
     private var episodeLoadJob: kotlinx.coroutines.Job? = null
+    private var episodeLoadRequestGeneration: Long = 0
 
     /**
      * How far through [TvFavoriteRevalidationSession] this screen has caught up.
@@ -1129,14 +1154,30 @@ class TvItemDetailViewModel(
         // Cancel any in-flight episode load so a slower response for a
         // previously-selected season can't overwrite episodes/next-up for the
         // season the user is now on (rapid season switches / the initial
-        // selected-season load racing a route-driven season load).
+        // selected-season load racing a route-driven season load). Cancellation
+        // alone is insufficient because the network wrapper converts a caught
+        // CancellationException into an error result; the generation remains
+        // the authoritative owner of the network result publications below.
+        episodeLoadRequestGeneration += 1
+        val requestGeneration = episodeLoadRequestGeneration
         episodeLoadJob?.cancel()
         episodeLoadJob = viewModelScope.launch {
+            fun ownsRequest(): Boolean =
+                requestGeneration == episodeLoadRequestGeneration &&
+                    _uiState.value.selectedSeason == seasonNumber
+
+            if (!ownsRequest()) return@launch
             if (!quiet) _uiState.update { it.copy(episodesLoading = true) }
             seedCachedEpisodes(seriesContentId, seasonNumber)
-            when (val r = catalogRepository.getEpisodes(seriesContentId, seasonNumber)) {
+            if (!ownsRequest()) return@launch
+            val result = catalogRepository.getEpisodes(seriesContentId, seasonNumber)
+            if (!ownsRequest()) return@launch
+            when (result) {
                 is ApiResult.Success -> {
-                    val episodes = withLocalProgress(r.data.episodes.sortedBy { ep -> ep.episodeNumber })
+                    val episodes = withLocalProgress(
+                        result.data.episodes.sortedBy { episode -> episode.episodeNumber },
+                    )
+                    if (!ownsRequest()) return@launch
                     loadedSeason = seasonNumber
                     episodeListGeneration += 1
                     _uiState.update { it.copy(episodesLoading = false, episodes = episodes) }
@@ -1148,7 +1189,7 @@ class TvItemDetailViewModel(
                     // the signal when the reload failed; advancing after a
                     // FAILED probe would drop it just as permanently, leaving
                     // that one episode stale with nothing left to retry it.
-                    if (revalidationComplete) {
+                    if (revalidationComplete && ownsRequest()) {
                         favoritesVersion?.let { favoritesRevalidatedThrough = it }
                     }
                 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvMainShell.kt
@@ -1367,7 +1367,7 @@ fun TvMainShell(
                 }
                 shellComposable(TvMainRoute.Calendar.route) {
                     TvCalendarScreen(
-                        onOpenItemDetail = onOpenItemDetail,
+                        onOpenItemDetailSelection = onOpenItemDetailSelection,
                         onInitialContentFocus = {
                             focusState.closeProfileMenuForContent()
                             calendarFocusHandoffPending = false

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/navigation/TvItemDetailNavigationTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/navigation/TvItemDetailNavigationTest.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.tv.ui.navigation
 
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -112,6 +113,32 @@ class TvItemDetailNavigationTest {
                 episodeContentId = "episode/1",
             ).route,
         )
+    }
+
+    @Test
+    fun `season canonicalization route carries no episode selection`() {
+        assertEquals(
+            "item/series%2Fa?seasonNumber=3",
+            TvRoute.ItemDetail(
+                contentId = "series/a",
+                seasonNumber = 3,
+            ).route,
+        )
+    }
+
+    @Test
+    fun `canonical replacement is owned by the raw detail entry`() {
+        val source = File(
+            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt",
+        ).readText()
+        val replacement = source
+            .substringAfter("onSeriesDetailReplace = canonicalizeSeries@")
+            .substringBefore("onSeriesClick =")
+
+        assertTrue(replacement.contains("currentBackStackEntry?.id != backStack.id"))
+        assertTrue(replacement.contains("return@canonicalizeSeries"))
+        assertTrue(replacement.contains("episodeContentId = episodeContentId"))
+        assertTrue(replacement.contains("popUpTo(it) { inclusive = true }"))
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/calendar/TvCalendarFocusRoutingTest.kt
@@ -4,8 +4,54 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.siloserver.silo.model.calendar.CalendarItem
 
 class TvCalendarFocusRoutingTest {
+    @Test
+    fun episodeDetailTargetCarriesSeriesSeasonAndEpisode() {
+        assertEquals(
+            TvCalendarDetailTarget(
+                contentId = "series-1",
+                seasonNumber = 3,
+                episodeContentId = "episode-7",
+            ),
+            tvCalendarDetailTarget(
+                calendarItem(
+                    contentId = "episode-7",
+                    type = "episode",
+                    seriesId = "series-1",
+                    seasonNumber = 3,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun incompleteEpisodeHierarchyFallsBackToStandaloneDetail() {
+        assertEquals(
+            TvCalendarDetailTarget(contentId = "episode-7"),
+            tvCalendarDetailTarget(
+                calendarItem(
+                    contentId = "episode-7",
+                    type = "episode",
+                    seriesId = " ",
+                    seasonNumber = 3,
+                ),
+            ),
+        )
+        assertEquals(
+            TvCalendarDetailTarget(contentId = "episode-7"),
+            tvCalendarDetailTarget(
+                calendarItem(
+                    contentId = "episode-7",
+                    type = "episode",
+                    seriesId = "series-1",
+                    seasonNumber = null,
+                ),
+            ),
+        )
+    }
+
     @Test
     fun firstFocusableShelfReturnsToControls() {
         assertTrue(shouldReturnCalendarFocusToControls(2, 2, false))
@@ -119,4 +165,19 @@ class TvCalendarFocusRoutingTest {
             ),
         )
     }
+
+    private fun calendarItem(
+        contentId: String,
+        type: String,
+        seriesId: String? = null,
+        seasonNumber: Int? = null,
+    ) = CalendarItem(
+        contentId = contentId,
+        type = type,
+        title = contentId,
+        seriesId = seriesId,
+        seasonNumber = seasonNumber,
+        airDate = "2026-09-01",
+        localAirDate = "2026-09-01",
+    )
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
@@ -216,16 +216,21 @@ class TvDetailFocusPolicyTest {
         val source = File(
             "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
         ).readText()
-        val hydration = source
+        val routeSeasonState = source
             .substringAfter("var pendingEntrySeasonNumber")
-            .substringBefore("initialEpisodeContentId,")
-        val effectKeys = hydration
-            .substringAfter("LaunchedEffect(")
-            .substringBefore(") {")
+            .substringBefore("BackHandler(enabled = true)")
+        val hydration = source
+            .substringAfter(
+                "LaunchedEffect(state.detail?.contentId, pendingEntrySeasonNumber, state.seasons) {",
+            )
+            .substringBefore("\n    LaunchedEffect(\n        state.detail?.contentId,\n        seasonNumber,")
 
-        assertTrue(hydration.contains("rememberSaveable(contentId, seasonNumber)"))
-        assertTrue(effectKeys.contains("pendingEntrySeasonNumber"))
-        assertFalse(effectKeys.contains("state.selectedSeason"))
+        assertTrue(routeSeasonState.contains("rememberSaveable(contentId, seasonNumber)"))
+        assertTrue(
+            source.contains(
+                "LaunchedEffect(state.detail?.contentId, pendingEntrySeasonNumber, state.seasons) {",
+            ),
+        )
         assertTrue(hydration.contains("pendingEntrySeasonNumber = null"))
         assertTrue(
             hydration.indexOf("pendingEntrySeasonNumber = null") <

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
@@ -71,6 +71,60 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvNextUpSelectionHandoffTest {
     @Test
+    fun cancelledPriorSeasonCannotEndReplacementLoad() = runDetailTest {
+        val scenario = Scenario(suffix = "-cancelled-season-owner")
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+
+        scenario.seasonOneEpisodesGate = CompletableDeferred()
+        scenario.seasonTwoEpisodesGate = CompletableDeferred()
+        fixture.viewModel.onSeasonSelected(2)
+        awaitCondition {
+            fixture.viewModel.uiState.value.let { it.selectedSeason == 2 && it.episodesLoading }
+        }
+
+        fixture.viewModel.onSeasonSelected(1)
+        awaitCondition { fixture.viewModel.uiState.value.selectedSeason == 1 }
+        delay(20)
+
+        assertTrue(
+            fixture.viewModel.uiState.value.episodesLoading,
+            "a canceled season request must not end the replacement request's loading state",
+        )
+
+        scenario.seasonOneEpisodesGate?.complete(Unit)
+        scenario.seasonTwoEpisodesGate?.complete(Unit)
+        awaitCondition {
+            fixture.viewModel.uiState.value.let { state ->
+                !state.episodesLoading && state.episodes.all { it.seasonNumber == 1 }
+            }
+        }
+    }
+
+    @Test
+    fun seasonRefreshStartedAfterSelectionKeepsThatSelection() = runDetailTest {
+        val scenario = Scenario(suffix = "-season-refresh-after-selection")
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+
+        fixture.viewModel.onSeasonSelected(2)
+        awaitCondition {
+            fixture.viewModel.uiState.value.episodes.any { it.seasonNumber == 2 }
+        }
+
+        val seasonsBeforeRefresh = scenario.seasonsRequests.get()
+        scenario.seasonsGate = CompletableDeferred()
+        fixture.viewModel.loadAll()
+        awaitCondition { scenario.seasonsRequests.get() > seasonsBeforeRefresh }
+
+        scenario.seasonsGate?.complete(Unit)
+        awaitCondition { !fixture.viewModel.uiState.value.seasonsLoading }
+
+        assertEquals(2, fixture.viewModel.uiState.value.selectedSeason)
+        assertTrue(fixture.viewModel.uiState.value.episodes.all { it.seasonNumber == 2 })
+    }
+
+    @Test
     fun delayedSeasonRefreshPreservesNewerSelectionAndInvalidatesOldPlayTarget() = runDetailTest {
         val scenario = Scenario(suffix = "-season-refresh")
         val fixture = createFixture(scenario)
@@ -658,6 +712,7 @@ class TvNextUpSelectionHandoffTest {
         var episodeTwoGate: CompletableDeferred<Unit>? = null
         var episodeOneWatchGate: CompletableDeferred<Unit>? = null
         var seasonsGate: CompletableDeferred<Unit>? = null
+        var seasonOneEpisodesGate: CompletableDeferred<Unit>? = null
         var seasonTwoEpisodesGate: CompletableDeferred<Unit>? = null
         val seasonsRequests = AtomicInteger()
         val episodeTwoRequests = AtomicInteger()
@@ -686,7 +741,10 @@ class TvNextUpSelectionHandoffTest {
                             ]}""".trimIndent(),
                         )
                     }
-                    "/api/v1/catalog/series/$seriesId/seasons/1/episodes" -> json(episodesJson())
+                    "/api/v1/catalog/series/$seriesId/seasons/1/episodes" -> {
+                        seasonOneEpisodesGate?.await()
+                        json(episodesJson())
+                    }
                     "/api/v1/catalog/series/$seriesId/seasons/2/episodes" -> {
                         seasonTwoEpisodesGate?.await()
                         json(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeriesDetailRedirectTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeriesDetailRedirectTest.kt
@@ -1,0 +1,122 @@
+package org.siloserver.silo.tv.ui.screens.detail
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.siloserver.silo.model.catalog.ItemDetail
+
+class TvSeriesDetailRedirectTest {
+    @Test
+    fun `episode redirects to its parent series with exact selection`() {
+        assertEquals(
+            TvSeriesDetailRedirect(
+                seriesContentId = "series-a",
+                seasonNumber = 3,
+                episodeContentId = "episode-7",
+            ),
+            tvSeriesDetailRedirect(
+                detail(
+                    contentId = "episode-7",
+                    type = "episode",
+                    seriesId = "series-a",
+                    seasonNumber = 3,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `season redirects to its parent series without selecting an episode`() {
+        assertEquals(
+            TvSeriesDetailRedirect(
+                seriesContentId = "series-a",
+                seasonNumber = 2,
+                episodeContentId = null,
+            ),
+            tvSeriesDetailRedirect(
+                detail(
+                    contentId = "season-2",
+                    type = "season",
+                    seriesId = "series-a",
+                    seasonNumber = 2,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `specials season zero remains a valid selection`() {
+        assertEquals(
+            0,
+            tvSeriesDetailRedirect(
+                detail(
+                    contentId = "specials",
+                    type = "SEASON",
+                    seriesId = "series-a",
+                    seasonNumber = 0,
+                ),
+            )?.seasonNumber,
+        )
+    }
+
+    @Test
+    fun `incomplete or self-referential hierarchy keeps standalone fallback`() {
+        assertNull(
+            tvSeriesDetailRedirect(
+                detail(contentId = "episode-a", type = "episode", seasonNumber = 1),
+            ),
+        )
+        assertNull(
+            tvSeriesDetailRedirect(
+                detail(contentId = "episode-a", type = "episode", seriesId = "series-a"),
+            ),
+        )
+        assertNull(
+            tvSeriesDetailRedirect(
+                detail(
+                    contentId = "series-a",
+                    type = "episode",
+                    seriesId = "series-a",
+                    seasonNumber = 1,
+                ),
+            ),
+        )
+        assertNull(
+            tvSeriesDetailRedirect(
+                detail(contentId = "movie-a", type = "movie"),
+            ),
+        )
+    }
+
+    @Test
+    fun `redirect parent must resolve as the requested series`() {
+        assertTrue(
+            detail(contentId = "series-a", type = "Series")
+                .isMatchingSeriesDetail("series-a"),
+        )
+        assertFalse(
+            detail(contentId = "series-b", type = "series")
+                .isMatchingSeriesDetail("series-a"),
+        )
+        assertFalse(
+            detail(contentId = "series-a", type = "season")
+                .isMatchingSeriesDetail("series-a"),
+        )
+        assertFalse((null as ItemDetail?).isMatchingSeriesDetail("series-a"))
+    }
+
+    private fun detail(
+        contentId: String,
+        type: String,
+        seriesId: String? = null,
+        seasonNumber: Int? = null,
+    ) = ItemDetail(
+        contentId = contentId,
+        type = type,
+        title = contentId,
+        seriesId = seriesId,
+        seasonNumber = seasonNumber,
+    )
+}


### PR DESCRIPTION
Android TV could open raw season and episode IDs as standalone detail pages. That diverged from the streamlined tvOS flow, split one show across multiple nested screens, and made exact Calendar or deep-link context vulnerable to cached/fresh metadata races.

This canonicalizes loaded season and episode routes to a validated parent Series destination while preserving the requested season and episode. Calendar selections carry the same context, malformed hierarchy metadata retains the standalone fallback, route replacement keeps Back behavior shallow, and request ownership prevents a slower season hydration from overwriting the route-selected episode rail.

## Evidence

| Before | After |
| --- | --- |
| ![Standalone episode detail before](https://github.com/user-attachments/assets/c7810449-f3b2-4e38-aba4-23f08421d30c) | ![Unified Series detail after](https://github.com/user-attachments/assets/edc0cdc2-277a-4905-af48-93dd34b17a17) |

## Validation

- `./gradlew :androidTvApp:testDebugUnitTest :androidTvApp:assembleDebug`
- `ANDROID_SERIAL=emulator-5554 ./gradlew :androidTvApp:installDebug`
- Raw episode `episode-tvdb-275274-1-1` settled on the parent Series page with Season 1, Episode 1, and `Play S1:E1`
- Raw season navigation settled on the same Series page with its season preserved
- One Back press returned directly to Home after route replacement

## Risk

Moderate and scoped to TV detail routing and Series hydration. Invalid or unavailable parent metadata intentionally keeps the existing standalone detail fallback.

## AI disclosure

Implemented with OpenAI `gpt-5.6-sol` through the Codex desktop agent harness. Independent simplicity and change-split reviews used Codex subagents running the same model; no other AI tooling was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar entries now open the correct series, season, and episode when that information is available.
  * Season and episode selections are preserved when navigating from calendar items or “Next Up.”
* **Bug Fixes**
  * Improved navigation when opening episode details, including fallback handling for incomplete content information.
  * Prevented outdated loading results from overriding newer season selections.
  * Series detail pages now reliably switch to the selected season during navigation and refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->