### PR TITLE
feat(playback): plan Dolby Vision Profile 8 base-layer playback on non-DV outputs

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
@@ -154,8 +154,23 @@ class AudioCapabilityManager(
     // and triggers the bounded output_change replan.
     private var lastDisplayHdr = DisplayHdrProbe.probeDetailed(appContext)
 
+    /**
+     * The display that owns the playback surface, mirrored from
+     * [PlaybackCapabilityDetector.playbackDisplayId]. The change detector
+     * below must watch the same panel the capability probe describes, or a
+     * mode change on a secondary display never rotates the output context.
+     * Setting it re-probes immediately so a switch of owning display is itself
+     * an output change.
+     */
+    @Volatile
+    var playbackDisplayId: Int? = null
+        set(value) {
+            field = value
+            publishDisplayCapabilitiesIfChanged()
+        }
+
     private fun publishDisplayCapabilitiesIfChanged() {
-        val next = DisplayHdrProbe.probeDetailed(appContext)
+        val next = DisplayHdrProbe.probeDetailed(appContext, playbackDisplayId)
         if (next == lastDisplayHdr) return
         lastDisplayHdr = next
         bumpOutputRouteGeneration()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/AudioCapabilityManager.kt
@@ -148,10 +148,14 @@ class AudioCapabilityManager(
         _outputRouteGeneration.value = generation
     }
 
-    private var lastDisplayHdr = DisplayHdrProbe.probe(appContext)
+    // Compared as the detailed result so an evidence-tier change (a probe
+    // that went from unknown to a confirmed SDR panel, or a display hot-plug
+    // that swapped the owning display) also rotates the output context id
+    // and triggers the bounded output_change replan.
+    private var lastDisplayHdr = DisplayHdrProbe.probeDetailed(appContext)
 
     private fun publishDisplayCapabilitiesIfChanged() {
-        val next = DisplayHdrProbe.probe(appContext)
+        val next = DisplayHdrProbe.probeDetailed(appContext)
         if (next == lastDisplayHdr) return
         lastDisplayHdr = next
         bumpOutputRouteGeneration()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/ContextActivity.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/ContextActivity.kt
@@ -3,6 +3,7 @@ package org.siloserver.silo.common.player
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.os.Build
 
 /** The Activity that owns this context, or null for an application/service context. */
 fun Context.findActivity(): Activity? {
@@ -12,4 +13,14 @@ fun Context.findActivity(): Activity? {
         current = current.baseContext
     }
     return null
+}
+
+/**
+ * The id of the display owning this context's Activity, or null when the
+ * context has no Activity or the platform predates per-context displays.
+ */
+fun Context.playbackDisplayId(): Int? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return null
+    val activity = findActivity() ?: return null
+    return runCatching { activity.display?.displayId }.getOrNull()
 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/ContextActivity.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/ContextActivity.kt
@@ -1,0 +1,15 @@
+package org.siloserver.silo.common.player
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+
+/** The Activity that owns this context, or null for an application/service context. */
+fun Context.findActivity(): Activity? {
+    var current: Context? = this
+    while (current is ContextWrapper) {
+        if (current is Activity) return current
+        current = current.baseContext
+    }
+    return null
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt
@@ -1,10 +1,15 @@
 package org.siloserver.silo.common.player
 
 import android.content.Context
+import android.content.ContextWrapper
 import android.hardware.display.DisplayManager
+import android.hardware.display.HdrConversionMode
 import android.os.Build
 import android.view.Display
 import org.siloserver.silo.model.playback.HdrCapabilities
+import org.siloserver.silo.model.playback.OUTPUT_HDR_EVIDENCE_EXACT
+import org.siloserver.silo.model.playback.OUTPUT_HDR_EVIDENCE_UNKNOWN
+import org.siloserver.silo.model.playback.PlaybackOutputDisplay
 
 data class DisplayDiagnosticsSnapshot(
     val widthPx: Int,
@@ -17,19 +22,47 @@ data class DisplayDiagnosticsSnapshot(
 )
 
 /**
- * Reports the default display's HDR support. Used to narrow the codec-level
- * HDR claim so we don't advertise HDR direct-play on a panel that would
- * tone-map it back to SDR anyway.
+ * What the active display reported, with the evidence tier attached.
  *
- * Callers surface `codecHdr AND displayHdr` to the server. Decoder support
- * alone is insufficient when the active HDMI/display path cannot carry the
- * same transfer function.
+ * [Exact] is a successful probe, including a confirmed SDR panel (empty
+ * [Exact.hdr]). [Unknown] means the platform gave no answer: no display, a
+ * pre-API-24 device, a null capability object, or a probe exception. The two
+ * must stay distinct because the server treats "confirmed SDR" as a fact and
+ * "unknown" as a reason to fail closed on native HDR output.
+ */
+sealed class DisplayHdrProbeResult {
+    abstract val hdr: HdrCapabilities
+    abstract val displayId: Int?
+
+    data class Exact(override val hdr: HdrCapabilities, override val displayId: Int?) : DisplayHdrProbeResult()
+
+    data class Unknown(override val displayId: Int?, val reason: String) : DisplayHdrProbeResult() {
+        override val hdr: HdrCapabilities get() = HdrCapabilities()
+    }
+
+    val isExact: Boolean get() = this is Exact
+
+    fun toOutputDisplay(): PlaybackOutputDisplay = PlaybackOutputDisplay(
+        hdrEvidence = if (isExact) OUTPUT_HDR_EVIDENCE_EXACT else OUTPUT_HDR_EVIDENCE_UNKNOWN,
+        hdrTypes = hdr,
+        displayId = displayId?.toString(),
+    )
+}
+
+/**
+ * Reports the HDR support of the display that owns the playback surface.
+ *
+ * The result narrows the codec-level HDR claim so we don't advertise native
+ * HDR direct-play on a panel that would tone-map it back to SDR. Callers
+ * surface `codecHdr AND displayHdr` to the server as the native-output
+ * capability; the raw display facts travel separately with their evidence
+ * tier so the server can tell a confirmed SDR panel from a failed probe.
  */
 object DisplayHdrProbe {
 
     /** Immutable, read-only evidence for diagnostics; never changes display state. */
     fun diagnosticsSnapshot(context: Context): DisplayDiagnosticsSnapshot? {
-        val display = defaultDisplay(context) ?: return null
+        val display = resolveDisplay(context) ?: return null
         val mode = display.mode
         return DisplayDiagnosticsSnapshot(
             widthPx = mode.physicalWidth,
@@ -45,31 +78,58 @@ object DisplayHdrProbe {
             } else {
                 null
             },
-            hdr = hdrCapabilities(display),
+            hdr = probeDetailed(context).hdr,
         )
     }
 
-    /** Returns the default display's HDR support, restricted to standards we model. */
-    fun probe(context: Context): HdrCapabilities {
-        val display = defaultDisplay(context) ?: return HdrCapabilities()
+    /**
+     * The active display's HDR support restricted to standards we model. An
+     * unknown probe collapses to the empty capability so native-output gates
+     * fail closed; use [probeDetailed] when the evidence tier matters.
+     */
+    fun probe(context: Context): HdrCapabilities = probeDetailed(context).hdr
 
-        return runCatching { hdrCapabilities(display) }.getOrDefault(HdrCapabilities())
+    /** The active display's HDR support with its evidence tier. */
+    fun probeDetailed(context: Context): DisplayHdrProbeResult {
+        val display = resolveDisplay(context)
+            ?: return DisplayHdrProbeResult.Unknown(displayId = null, reason = "no_display")
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return DisplayHdrProbeResult.Unknown(displayId = display.displayId, reason = "api_below_24")
+        }
+        return runCatching { hdrCapabilities(context, display) }
+            .getOrElse { DisplayHdrProbeResult.Unknown(displayId = display.displayId, reason = "probe_failed") }
     }
 
-    private fun hdrCapabilities(display: Display): HdrCapabilities {
+    private fun hdrCapabilities(context: Context, display: Display): DisplayHdrProbeResult {
+        val displayId = display.displayId
+        // Android 14 lets the user force the system HDR conversion to SDR. The
+        // legacy per-display capability object still lists the panel's HDR
+        // types then, so a plan promising native HDR would be tone-mapped by
+        // the compositor. Treat forced-SDR as a confirmed SDR output.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && systemForcesSdr(context)) {
+            return DisplayHdrProbeResult.Exact(HdrCapabilities(), displayId)
+        }
 
-        // HdrCapabilities is available from API 24+. On older API levels the
-        // display effectively has no HDR — return the empty capability.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return HdrCapabilities()
-
-        // Display.HdrCapabilities.supportedHdrTypes is deprecated in API 34 in
-        // favor of Display.Mode.getSupportedHdrTypes(); the per-display getter
-        // is still the right source pre-34 and is still functional, so we
-        // suppress the warning rather than branching on API level.
-        @Suppress("DEPRECATION")
-        val types = display.hdrCapabilities?.supportedHdrTypes
-            ?.toSet()
-            .orEmpty()
+        val types: Set<Int>? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            // Per-mode HDR types are the current API; a panel can carry HDR10
+            // at 4K60 but not at 4K120. Report the union so a later mode switch
+            // can only narrow, never surprise, the plan.
+            val perMode = display.supportedModes.flatMap { it.supportedHdrTypes.toList() }
+            if (perMode.isNotEmpty()) {
+                perMode.toSet()
+            } else {
+                @Suppress("DEPRECATION")
+                display.hdrCapabilities?.supportedHdrTypes?.toSet()
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            display.hdrCapabilities?.supportedHdrTypes?.toSet()
+        }
+        // The platform is documented to return an empty (not null) capability
+        // for an SDR panel; a null object means the display could not answer.
+        if (types == null) {
+            return DisplayHdrProbeResult.Unknown(displayId, reason = "null_capabilities")
+        }
 
         val hdr10 = Display.HdrCapabilities.HDR_TYPE_HDR10 in types
         val hdr10p = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 &&
@@ -85,18 +145,30 @@ object DisplayHdrProbe {
         // silently drops legitimate decoder claims — listing only [5, 8]
         // here is what previously made native P7 support undetectable even
         // on dual-layer-capable hardware.
-        return HdrCapabilities(
-            hdr10 = hdr10,
-            hdr10Plus = hdr10p,
-            hlg = hlg,
-            dolbyVisionProfiles = if (dv) listOf(5, 7, 8) else emptyList(),
+        return DisplayHdrProbeResult.Exact(
+            HdrCapabilities(
+                hdr10 = hdr10,
+                hdr10Plus = hdr10p,
+                hlg = hlg,
+                dolbyVisionProfiles = if (dv) listOf(5, 7, 8) else emptyList(),
+            ),
+            displayId,
         )
+    }
+
+    private fun systemForcesSdr(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false
+        val dm = context.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager ?: return false
+        val mode = runCatching { dm.hdrConversionMode }.getOrNull() ?: return false
+        return mode.conversionMode == HdrConversionMode.HDR_CONVERSION_FORCE &&
+            mode.preferredHdrOutputType == Display.HdrCapabilities.HDR_TYPE_INVALID
     }
 
     /**
      * Combines codec-reported HDR profiles with display-reported HDR types.
      * A profile is advertised to the server only when *both* the decoder and
-     * the panel can handle it.
+     * the panel can handle it. Decoder-side profile bounds survive for the
+     * profiles that remain.
      */
     fun intersect(codec: HdrCapabilities, display: HdrCapabilities): HdrCapabilities {
         val dvIntersection = codec.dolbyVisionProfiles
@@ -106,11 +178,30 @@ object DisplayHdrProbe {
             hdr10Plus = codec.hdr10Plus && display.hdr10Plus,
             hlg = codec.hlg && display.hlg,
             dolbyVisionProfiles = dvIntersection,
+            dolbyVisionProfileLevels = codec.dolbyVisionProfileLevels
+                .filter { it.profile in dvIntersection },
         )
     }
 
-    private fun defaultDisplay(context: Context): Display? {
+    /**
+     * The display that owns [context]'s window when [context] is (or wraps) an
+     * Activity, as Kodi does; otherwise the default display. Media3's own
+     * Dolby Vision display check reads the default display, so a playback
+     * Activity on a secondary display is reported here but should be treated
+     * as a device-class quirk rather than assumed to match Media3.
+     */
+    private fun resolveDisplay(context: Context): Display? {
         val dm = context.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager ?: return null
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            var current: Context? = context
+            while (current is ContextWrapper) {
+                if (current is android.app.Activity) {
+                    runCatching { current.display }.getOrNull()?.let { return it }
+                    break
+                }
+                current = current.baseContext
+            }
+        }
         return dm.getDisplay(Display.DEFAULT_DISPLAY)
     }
 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt
@@ -1,7 +1,6 @@
 package org.siloserver.silo.common.player
 
 import android.content.Context
-import android.content.ContextWrapper
 import android.hardware.display.DisplayManager
 import android.hardware.display.HdrConversionMode
 import android.os.Build
@@ -67,8 +66,8 @@ object DisplayHdrProbe {
     internal val PANEL_DOLBY_VISION_PROFILES: List<Int> = (0..10).toList()
 
     /** Immutable, read-only evidence for diagnostics; never changes display state. */
-    fun diagnosticsSnapshot(context: Context): DisplayDiagnosticsSnapshot? {
-        val display = resolveDisplay(context) ?: return null
+    fun diagnosticsSnapshot(context: Context, displayId: Int? = null): DisplayDiagnosticsSnapshot? {
+        val display = resolveDisplay(context, displayId) ?: return null
         val mode = display.mode
         return DisplayDiagnosticsSnapshot(
             widthPx = mode.physicalWidth,
@@ -84,7 +83,7 @@ object DisplayHdrProbe {
             } else {
                 null
             },
-            hdr = probeDetailed(context).hdr,
+            hdr = probeDetailed(context, displayId).hdr,
         )
     }
 
@@ -93,12 +92,18 @@ object DisplayHdrProbe {
      * unknown probe collapses to the empty capability so native-output gates
      * fail closed; use [probeDetailed] when the evidence tier matters.
      */
-    fun probe(context: Context): HdrCapabilities = probeDetailed(context).hdr
+    fun probe(context: Context, displayId: Int? = null): HdrCapabilities = probeDetailed(context, displayId).hdr
 
-    /** The active display's HDR support with its evidence tier. */
-    fun probeDetailed(context: Context): DisplayHdrProbeResult {
-        val display = resolveDisplay(context)
-            ?: return DisplayHdrProbeResult.Unknown(displayId = null, reason = "no_display")
+    /**
+     * The active display's HDR support with its evidence tier.
+     *
+     * @param displayId the display that owns the playback surface, when the
+     * caller knows it. Without it an Activity context resolves its own
+     * display and any other context resolves the default display.
+     */
+    fun probeDetailed(context: Context, displayId: Int? = null): DisplayHdrProbeResult {
+        val display = resolveDisplay(context, displayId)
+            ?: return DisplayHdrProbeResult.Unknown(displayId = displayId, reason = "no_display")
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             return DisplayHdrProbeResult.Unknown(displayId = display.displayId, reason = "api_below_24")
         }
@@ -200,16 +205,14 @@ object DisplayHdrProbe {
      * Activity on a secondary display is reported here but should be treated
      * as a device-class quirk rather than assumed to match Media3.
      */
-    private fun resolveDisplay(context: Context): Display? {
+    private fun resolveDisplay(context: Context, displayId: Int?): Display? {
         val dm = context.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager ?: return null
+        if (displayId != null) {
+            return dm.getDisplay(displayId) ?: dm.getDisplay(Display.DEFAULT_DISPLAY)
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            var current: Context? = context
-            while (current is ContextWrapper) {
-                if (current is android.app.Activity) {
-                    runCatching { current.display }.getOrNull()?.let { return it }
-                    break
-                }
-                current = current.baseContext
+            context.findActivity()?.let { activity ->
+                runCatching { activity.display }.getOrNull()?.let { return it }
             }
         }
         return dm.getDisplay(Display.DEFAULT_DISPLAY)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DisplayHdrProbe.kt
@@ -60,6 +60,12 @@ sealed class DisplayHdrProbeResult {
  */
 object DisplayHdrProbe {
 
+    /**
+     * Every Dolby Vision profile the codec probe can report. The panel flag is
+     * generic, so it must not exclude a profile the decoder supports.
+     */
+    internal val PANEL_DOLBY_VISION_PROFILES: List<Int> = (0..10).toList()
+
     /** Immutable, read-only evidence for diagnostics; never changes display state. */
     fun diagnosticsSnapshot(context: Context): DisplayDiagnosticsSnapshot? {
         val display = resolveDisplay(context) ?: return null
@@ -112,11 +118,15 @@ object DisplayHdrProbe {
 
         val types: Set<Int>? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             // Per-mode HDR types are the current API; a panel can carry HDR10
-            // at 4K60 but not at 4K120. Report the union so a later mode switch
-            // can only narrow, never surprise, the plan.
-            val perMode = display.supportedModes.flatMap { it.supportedHdrTypes.toList() }
-            if (perMode.isNotEmpty()) {
-                perMode.toSet()
+            // at 4K60 but not at 4K120. Report the *active* mode only: the
+            // refresh-rate matcher switches modes by resolution and rate, and
+            // the display listener re-probes on every change, so a switch
+            // onto a mode without HDR rotates the output context and replans
+            // instead of leaving a stale union in place.
+            val activeMode = runCatching { display.mode }.getOrNull()
+            val anyModeDeclares = display.supportedModes.any { it.supportedHdrTypes.isNotEmpty() }
+            if (activeMode != null && anyModeDeclares) {
+                activeMode.supportedHdrTypes.toSet()
             } else {
                 @Suppress("DEPRECATION")
                 display.hdrCapabilities?.supportedHdrTypes?.toSet()
@@ -141,16 +151,16 @@ object DisplayHdrProbe {
         // only reports whether the link/panel carries DV at all. The codec
         // probe (MediaCodecCapabilitiesProbe) enumerates actual profile
         // support (and already strips P7 without multi-instance HEVC), so
-        // this layer must list every profile we model or the intersection
-        // silently drops legitimate decoder claims — listing only [5, 8]
-        // here is what previously made native P7 support undetectable even
-        // on dual-layer-capable hardware.
+        // this layer lists every profile the codec probe can emit or the
+        // intersection silently drops legitimate decoder claims — listing
+        // only [5, 8] here is what previously made native P7 support
+        // undetectable even on dual-layer-capable hardware.
         return DisplayHdrProbeResult.Exact(
             HdrCapabilities(
                 hdr10 = hdr10,
                 hdr10Plus = hdr10p,
                 hlg = hlg,
-                dolbyVisionProfiles = if (dv) listOf(5, 7, 8) else emptyList(),
+                dolbyVisionProfiles = if (dv) PANEL_DOLBY_VISION_PROFILES else emptyList(),
             ),
             displayId,
         )

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionColorInfoExtractorsFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionColorInfoExtractorsFactory.kt
@@ -37,6 +37,12 @@ internal class DolbyVisionColorInfoExtractorsFactory(
     private val converter: DolbyVisionRpuConverter = NativeDolbyVisionRpuConverter,
     private val expectedDynamicRange: String? = null,
     private val expectedColorRange: String? = null,
+    /**
+     * The plan authorised the Profile 8 base-layer route. The Dolby Vision
+     * colour repair then follows [expectedDynamicRange] (the promised base
+     * range) instead of assuming a PQ base layer.
+     */
+    private val dolbyVisionBaseLayerRoute: Boolean = false,
 ) : ExtractorsFactory {
     override fun createExtractors(): Array<Extractor> =
         delegate.createExtractors().map(::wrap).toTypedArray()
@@ -55,6 +61,7 @@ internal class DolbyVisionColorInfoExtractorsFactory(
             converter,
             expectedDynamicRange,
             expectedColorRange,
+            dolbyVisionBaseLayerRoute,
         )
 
     private class ColorInfoExtractor(
@@ -63,6 +70,7 @@ internal class DolbyVisionColorInfoExtractorsFactory(
         private val converter: DolbyVisionRpuConverter,
         private val expectedDynamicRange: String?,
         private val expectedColorRange: String?,
+        private val dolbyVisionBaseLayerRoute: Boolean,
     ) : Extractor by delegate {
         private var output: ColorInfoExtractorOutput? = null
 
@@ -73,6 +81,7 @@ internal class DolbyVisionColorInfoExtractorsFactory(
                 converter,
                 expectedDynamicRange,
                 expectedColorRange,
+                dolbyVisionBaseLayerRoute,
             )
             this.output = wrapped
             delegate.init(wrapped)
@@ -96,6 +105,7 @@ internal class DolbyVisionColorInfoExtractorsFactory(
         private val converter: DolbyVisionRpuConverter,
         private val expectedDynamicRange: String?,
         private val expectedColorRange: String?,
+        private val dolbyVisionBaseLayerRoute: Boolean,
     ) : ExtractorOutput {
         private val tracks = mutableMapOf<Int, TrackOutput>()
 
@@ -106,6 +116,7 @@ internal class DolbyVisionColorInfoExtractorsFactory(
                     output,
                     expectedDynamicRange,
                     expectedColorRange,
+                    dolbyVisionBaseLayerRoute,
                 )
                 if (transformMode != DolbyVisionTransformMode.DISABLED) {
                     DolbyVisionTransformingTrackOutput(colorInfoOutput, transformMode, converter)
@@ -130,6 +141,7 @@ internal class DolbyVisionColorInfoExtractorsFactory(
         private val delegate: TrackOutput,
         private val expectedDynamicRange: String?,
         private val expectedColorRange: String?,
+        private val dolbyVisionBaseLayerRoute: Boolean,
     ) : TrackOutput {
         override fun durationUs(durationUs: Long) = delegate.durationUs(durationUs)
 
@@ -138,7 +150,9 @@ internal class DolbyVisionColorInfoExtractorsFactory(
                 format
                     .withValidatedColorRange(expectedColorRange)
                     .withValidatedDynamicRangeColorInfo(expectedDynamicRange)
-                    .withDolbyVisionHdrColorInfo(),
+                    .withDolbyVisionHdrColorInfo(
+                        baseLayerRange = expectedDynamicRange.takeIf { dolbyVisionBaseLayerRoute },
+                    ),
             )
         }
 
@@ -218,9 +232,16 @@ internal fun Format.withValidatedDynamicRangeColorInfo(expectedDynamicRange: Str
     return buildUpon().setColorInfo(repaired).build()
 }
 
+/**
+ * @param baseLayerRange when the plan authorised the Profile 8 base-layer
+ * route, the promised base range (`hdr10`, `hlg`, `sdr`). A PQ repair is then
+ * applied only for `hdr10`; an HLG or SDR base layer is left to the HLG
+ * repair above or to the container's own signalling, never rewritten to PQ.
+ */
 @UnstableApi
-internal fun Format.withDolbyVisionHdrColorInfo(): Format {
+internal fun Format.withDolbyVisionHdrColorInfo(baseLayerRange: String? = null): Format {
     if (sampleMimeType != MimeTypes.VIDEO_DOLBY_VISION) return this
+    if (baseLayerRange != null && !baseLayerRange.equals("hdr10", ignoreCase = true)) return this
     val current = colorInfo
     // Do not rewrite a valid non-PQ base layer (notably Profile 8.4 HLG).
     // This repair exists only for containers where Media3 emitted no usable

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt
@@ -25,6 +25,12 @@ internal data class SiloMediaTransformTag(
     val dolbyVisionMode: DolbyVisionTransformMode,
     val expectedDynamicRange: String? = null,
     val expectedColorRange: String? = null,
+    /**
+     * The plan authorised the Profile 8 base-layer fallback: the extractor
+     * repairs colour info from the base layer's compatibility id rather than
+     * assuming PQ, and [expectedDynamicRange] names the promised base range.
+     */
+    val dolbyVisionBaseLayerRoute: Boolean = false,
 )
 
 internal class DolbyVisionTransformException(

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionTransformQuarantine.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionTransformQuarantine.kt
@@ -1,0 +1,112 @@
+package org.siloserver.silo.common.player
+
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import org.siloserver.silo.model.playback.CLIENT_DV7_TO_DV81
+import org.siloserver.silo.model.playback.CLIENT_DV7_TO_HDR10
+
+/**
+ * Remembers client Dolby Vision transformations that failed on this device.
+ *
+ * The transformations are advertised from runtime evidence (a packaged RPU
+ * converter, a hardware Profile 8 decoder, a panel that carries Dolby
+ * Vision). That evidence is necessary but not sufficient: the SM-F976U1 met
+ * all of it and still wedged after one frame. Advertising the route again on
+ * the next session would make every fresh start pick the same doomed plan, so
+ * a device-level failure withdraws the advertisement here and the next plan
+ * request asks the server for its own recipe instead.
+ *
+ * Keyed by transformation name and the build fingerprint, so an OS update
+ * earns a fresh attempt, and expiring after [TTL_MS] so a transient fault
+ * does not permanently cost the device its best route.
+ */
+class DolbyVisionTransformQuarantine internal constructor(
+    private val store: Store,
+    private val fingerprint: String = Build.FINGERPRINT.orEmpty(),
+    private val nowMs: () -> Long = System::currentTimeMillis,
+) {
+    constructor(context: Context) : this(PrefsStore(context))
+
+    internal interface Store {
+        fun get(key: String): Long?
+        fun put(key: String, value: Long)
+        fun remove(key: String)
+    }
+
+    private class PrefsStore(context: Context) : Store {
+        private val prefs = context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+        override fun get(key: String): Long? =
+            if (prefs.contains(key)) prefs.getLong(key, 0L) else null
+
+        override fun put(key: String, value: Long) {
+            prefs.edit().putLong(key, value).apply()
+        }
+
+        override fun remove(key: String) {
+            prefs.edit().remove(key).apply()
+        }
+    }
+
+    /** Transformation names withdrawn on this device build right now. */
+    fun quarantined(): Set<String> = KNOWN_TRANSFORMATIONS.filterTo(mutableSetOf(), ::isQuarantined)
+
+    fun isQuarantined(transformation: String): Boolean {
+        val key = key(transformation)
+        val recordedAt = store.get(key) ?: return false
+        if (nowMs() - recordedAt > TTL_MS) {
+            store.remove(key)
+            return false
+        }
+        return true
+    }
+
+    /**
+     * Withdraws every [activeTransformations] entry when [classification]
+     * describes a fault in the local recipe rather than in the source or the
+     * transport. Returns the names that were withdrawn.
+     */
+    fun noteFailure(classification: String, activeTransformations: Collection<String>): List<String> {
+        if (activeTransformations.isEmpty()) return emptyList()
+        if (!isDeviceFault(classification)) return emptyList()
+        val withdrawn = activeTransformations.filter { it in KNOWN_TRANSFORMATIONS }
+        withdrawn.forEach { name ->
+            Log.w(TAG, "Quarantining client transformation $name after $classification")
+            store.put(key(name), nowMs())
+        }
+        return withdrawn
+    }
+
+    private fun key(transformation: String): String = "$transformation:$fingerprint"
+
+    companion object {
+        private const val TAG = "SiloDovi"
+        private const val PREFS_NAME = "silo_dv_transform_quarantine"
+        internal const val TTL_MS: Long = 14L * 24 * 60 * 60 * 1000
+        internal val KNOWN_TRANSFORMATIONS: Set<String> = setOf(CLIENT_DV7_TO_DV81, CLIENT_DV7_TO_HDR10)
+
+        /**
+         * Classifications that mean the local recipe failed on this hardware.
+         * A source that is not what the plan described, an encrypted sample,
+         * or a network stall is not evidence against the device.
+         */
+        private val DEVICE_FAULT_PREFIXES = listOf(
+            "dv7_transform_stall",
+            "dv7_transform_unavailable",
+            "dv7_transform_oversized",
+            "dv7_transform_failed",
+            "dv7_rpu_conversion_failed",
+        )
+        private val DEVICE_FAULT_DECODER_CLASSIFICATIONS = setOf(
+            "decoder_no_output",
+            "render_startup_failure",
+            "decoder_failure",
+        )
+
+        internal fun isDeviceFault(classification: String): Boolean =
+            DEVICE_FAULT_PREFIXES.any(classification::startsWith) ||
+                classification in DEVICE_FAULT_DECODER_CLASSIFICATIONS
+    }
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt
@@ -4,6 +4,7 @@ import android.media.MediaCodecInfo.CodecProfileLevel
 import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
+import org.siloserver.silo.model.playback.DolbyVisionProfileCapability
 import org.siloserver.silo.model.playback.HdrCapabilities
 import org.siloserver.silo.model.playback.VideoDecodeCapability
 
@@ -48,7 +49,10 @@ object MediaCodecCapabilitiesProbe {
                     bitDepths = capability.bitDepths.toList(),
                 )
             },
-            hdr = result.hdr.copy(dolbyVisionProfiles = result.hdr.dolbyVisionProfiles.toList()),
+            hdr = result.hdr.copy(
+                dolbyVisionProfiles = result.hdr.dolbyVisionProfiles.toList(),
+                dolbyVisionProfileLevels = result.hdr.dolbyVisionProfileLevels.toList(),
+            ),
         )
     }
 
@@ -64,6 +68,10 @@ object MediaCodecCapabilitiesProbe {
         var hdr10p = false
         var hlg = false
         val dv = sortedSetOf<Int>()
+        // Highest Dolby Vision level any decoder reports per profile. Sent as
+        // dolby_vision_profile_levels so the server can refuse a level-9
+        // stream on a level-6 decoder instead of assuming unbounded support.
+        val dvMaxLevels = mutableMapOf<Int, Int>()
         var dvP7DecoderMultiInstance = false
         var hevcMultiInstance = false
         var hevcHdrCapable = false
@@ -105,15 +113,13 @@ object MediaCodecCapabilitiesProbe {
                         val multiInstance = runCatching { caps.maxSupportedInstances >= 2 }
                             .getOrDefault(false)
                         for (pl in caps.profileLevels) {
-                            when (pl.profile) {
-                                CodecProfileLevel.DolbyVisionProfileDvheStn -> dv += 5
-                                CodecProfileLevel.DolbyVisionProfileDvheDtr -> dv += 4
-                                CodecProfileLevel.DolbyVisionProfileDvheDth -> dv += 6
-                                CodecProfileLevel.DolbyVisionProfileDvheDtb -> {
-                                    dv += 7
-                                    dvP7DecoderMultiInstance = dvP7DecoderMultiInstance || multiInstance
-                                }
-                                CodecProfileLevel.DolbyVisionProfileDvheSt -> dv += 8
+                            val profile = dolbyVisionProfileNumber(pl.profile) ?: continue
+                            dv += profile
+                            if (profile == 7) {
+                                dvP7DecoderMultiInstance = dvP7DecoderMultiInstance || multiInstance
+                            }
+                            dolbyVisionLevelNumber(pl.level)?.let { level ->
+                                dvMaxLevels[profile] = maxOf(dvMaxLevels[profile] ?: 0, level)
                             }
                         }
                     }
@@ -150,6 +156,16 @@ object MediaCodecCapabilitiesProbe {
         val dvP7Supported = dvP7DecoderMultiInstance && hevcMultiInstance
         val dvProfiles = if (dvP7Supported || !dv.contains(7)) dv.toList()
         else dv.filterNot { it == 7 }
+        // The server requires bounds for every advertised profile once any
+        // are present. A profile whose decoder reported no recognizable level
+        // therefore keeps the legacy unbounded contract for the whole list.
+        val dvProfileLevels = if (dvProfiles.all { it in dvMaxLevels }) {
+            dvProfiles.map { profile ->
+                DolbyVisionProfileCapability(profile = profile, maxLevel = dvMaxLevels.getValue(profile))
+            }
+        } else {
+            emptyList()
+        }
 
         val overallMaxH = videoMaxHeights.values.maxOrNull() ?: 0
         val claimedBucket = resolutionBucket(overallMaxH)
@@ -174,6 +190,7 @@ object MediaCodecCapabilitiesProbe {
                 hdr10Plus = effectiveHdr10p,
                 hlg = effectiveHlg,
                 dolbyVisionProfiles = dvProfiles,
+                dolbyVisionProfileLevels = dvProfileLevels,
             ),
             maxResolution = claimedBucket,
             supportsDvProfile7 = dvP7Supported,
@@ -186,6 +203,7 @@ object MediaCodecCapabilitiesProbe {
         mimeType.equals(MediaFormat.MIMETYPE_VIDEO_VP9, ignoreCase = true) -> "vp9"
         mimeType.equals(MediaFormat.MIMETYPE_VIDEO_VP8, ignoreCase = true) -> "vp8"
         mimeType.equals(MediaFormat.MIMETYPE_VIDEO_AV1, ignoreCase = true) -> "av1"
+        mimeType.equals(MediaFormat.MIMETYPE_VIDEO_DOLBY_VISION, ignoreCase = true) -> "dolby_vision"
         mimeType.equals(MediaFormat.MIMETYPE_VIDEO_MPEG2, ignoreCase = true) -> "mpeg2video"
         mimeType.equals(MediaFormat.MIMETYPE_VIDEO_MPEG4, ignoreCase = true) -> "mpeg4"
         mimeType.equals(MediaFormat.MIMETYPE_VIDEO_H263, ignoreCase = true) -> "h263"
@@ -325,6 +343,7 @@ object MediaCodecCapabilitiesProbe {
             -> "main 10"
             else -> null
         }
+        "dolby_vision" -> dolbyVisionProfileNumber(profile)?.let { "profile $it" }
         "vp9" -> when (profile) {
             CodecProfileLevel.VP9Profile0 -> "profile 0"
             CodecProfileLevel.VP9Profile1 -> "profile 1"
@@ -467,12 +486,50 @@ object MediaCodecCapabilitiesProbe {
         }
         "vp8" -> if (profile == CodecProfileLevel.VP8ProfileMain) 8 else null
         "h263" -> if (profileName("h263", profile) != null) 8 else null
+        "dolby_vision" -> if (dolbyVisionProfileNumber(profile) != null) 10 else null
         else -> null
+    }
+
+    /** MediaCodec Dolby Vision profile constant → Dolby profile number. */
+    internal fun dolbyVisionProfileNumber(profile: Int): Int? = when (profile) {
+        CodecProfileLevel.DolbyVisionProfileDvavPer -> 0
+        CodecProfileLevel.DolbyVisionProfileDvavPen -> 1
+        CodecProfileLevel.DolbyVisionProfileDvheDer -> 2
+        CodecProfileLevel.DolbyVisionProfileDvheDen -> 3
+        CodecProfileLevel.DolbyVisionProfileDvheDtr -> 4
+        CodecProfileLevel.DolbyVisionProfileDvheStn -> 5
+        CodecProfileLevel.DolbyVisionProfileDvheDth -> 6
+        CodecProfileLevel.DolbyVisionProfileDvheDtb -> 7
+        CodecProfileLevel.DolbyVisionProfileDvheSt -> 8
+        CodecProfileLevel.DolbyVisionProfileDvavSe -> 9
+        else -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            profile == CodecProfileLevel.DolbyVisionProfileDvav110
+        ) 10 else null
+    }
+
+    /** MediaCodec Dolby Vision level bit → Dolby level number (1..13). */
+    internal fun dolbyVisionLevelNumber(level: Int): Int? = when (level) {
+        CodecProfileLevel.DolbyVisionLevelHd24 -> 1
+        CodecProfileLevel.DolbyVisionLevelHd30 -> 2
+        CodecProfileLevel.DolbyVisionLevelFhd24 -> 3
+        CodecProfileLevel.DolbyVisionLevelFhd30 -> 4
+        CodecProfileLevel.DolbyVisionLevelFhd60 -> 5
+        CodecProfileLevel.DolbyVisionLevelUhd24 -> 6
+        CodecProfileLevel.DolbyVisionLevelUhd30 -> 7
+        CodecProfileLevel.DolbyVisionLevelUhd48 -> 8
+        CodecProfileLevel.DolbyVisionLevelUhd60 -> 9
+        else -> when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && level == CodecProfileLevel.DolbyVisionLevelUhd120 -> 10
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && level == CodecProfileLevel.DolbyVisionLevel8k30 -> 11
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && level == CodecProfileLevel.DolbyVisionLevel8k60 -> 12
+            else -> null
+        }
     }
 
     internal fun normalizedLevel(codec: String, level: Int): Int? = when (codec) {
         "h264" -> AVC_LEVELS[level]
         "hevc" -> HEVC_LEVELS[level]
+        "dolby_vision" -> dolbyVisionLevelNumber(level)
         else -> null
     }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/Playability.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/Playability.kt
@@ -12,6 +12,15 @@ package org.siloserver.silo.common.player
 sealed class Playability {
     object Supported : Playability()
     data class UnsupportedDvProfile(val profile: Int) : Playability()
+
+    /** The plan promised a Profile 8 base-layer route but the track is not Profile 8. */
+    data class DvBaseLayerMetadataMismatch(val profile: Int, val baseRange: String) : Playability()
+
+    /** The plan promised a base range the active output no longer supports. */
+    data class DvBaseLayerOutputMismatch(val profile: Int, val baseRange: String) : Playability()
+
+    /** The plan promised a base-layer route but the renderer opened a decoder that cannot produce it. */
+    data class DvBaseLayerDecoderUnavailable(val decoderName: String, val baseRange: String) : Playability()
     data class UnsupportedAudioCodec(val mimeType: String) : Playability()
     data class UnsupportedChannelCount(val codec: String, val channels: Int) : Playability()
     data class StartupStalled(
@@ -26,5 +35,29 @@ fun Playability.failureDiagnostics(): Map<String, String> = when (this) {
         "buffered_ahead_ms" to bufferedAheadMs.toString(),
         "stalled_for_ms" to stalledForMs.toString(),
     )
+    is Playability.DvBaseLayerMetadataMismatch -> mapOf(
+        "dolby_vision_profile" to profile.toString(),
+        "promised_base_range" to baseRange,
+    )
+    is Playability.DvBaseLayerOutputMismatch -> mapOf(
+        "dolby_vision_profile" to profile.toString(),
+        "promised_base_range" to baseRange,
+    )
+    is Playability.DvBaseLayerDecoderUnavailable -> mapOf(
+        "decoder_name" to decoderName,
+        "promised_base_range" to baseRange,
+    )
     else -> emptyMap()
+}
+
+/** Server-facing failure classification for a typed v3 replan. */
+fun Playability.failureClassification(): String = when (this) {
+    is Playability.UnsupportedDvProfile -> "unsupported_dolby_vision_profile"
+    is Playability.DvBaseLayerMetadataMismatch -> "dv8_base_layer_metadata_mismatch"
+    is Playability.DvBaseLayerOutputMismatch -> "dv8_base_layer_output_mismatch"
+    is Playability.DvBaseLayerDecoderUnavailable -> "dv8_base_layer_decoder_unavailable"
+    is Playability.UnsupportedAudioCodec -> "unsupported_audio_encoding"
+    is Playability.UnsupportedChannelCount -> "unsupported_audio_layout"
+    is Playability.StartupStalled -> classification
+    Playability.Supported -> "none"
 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -81,6 +81,17 @@ class PlaybackCapabilityDetector(
     @Volatile
     private var lastDisplayProbe: DisplayHdrProbeResult? = null
 
+    /**
+     * The display that owns the playback surface. The detector is a process
+     * singleton built on the application context, which can only ever resolve
+     * the default display; the player screens set this when they attach to
+     * their Activity so capability planning, preflight, and the output
+     * context all describe the panel actually showing the video. Null means
+     * "no player attached", which falls back to the default display.
+     */
+    @Volatile
+    var playbackDisplayId: Int? = null
+
     /** Decoder-only HDR facts from the most recent [detect], for diagnostics. */
     @Volatile
     private var lastDecoderHdr: HdrCapabilities? = null
@@ -127,7 +138,7 @@ class PlaybackCapabilityDetector(
                 val profile = dvMatch.groupValues[2].toIntOrNull()
                 if (profile != null) {
                     val codecProbe = MediaCodecCapabilitiesProbe.probe()
-                    val displayHdr = DisplayHdrProbe.probe(context)
+                    val displayHdr = DisplayHdrProbe.probe(context, playbackDisplayId)
                     val supportedHdr = TvPlaybackOutputPolicy.effectiveHdrCapabilities(
                         codec = codecProbe.hdr,
                         display = displayHdr,
@@ -246,7 +257,7 @@ class PlaybackCapabilityDetector(
     ): ClientCodecCapabilities {
         val audioRoute = audioCapabilityManager.playbackRouteSnapshot()
         val codecProbe = MediaCodecCapabilitiesProbe.probe()
-        val displayProbe = DisplayHdrProbe.probeDetailed(context)
+        val displayProbe = DisplayHdrProbe.probeDetailed(context, playbackDisplayId)
         // With Dolby Vision off, stop advertising DV profiles (except 5,
         // which has no watchable base layer) so the server plans base-layer /
         // HDR10 delivery and local direct-play checks agree. Single decision
@@ -370,7 +381,7 @@ class PlaybackCapabilityDetector(
                 outputContextId = audioRoute.routeGeneration.toString(),
                 // Raw display facts with their evidence tier so a new server
                 // can distinguish a confirmed SDR panel from a failed probe.
-                display = (lastDisplayProbe ?: DisplayHdrProbe.probeDetailed(context)).toOutputDisplay(),
+                display = (lastDisplayProbe ?: DisplayHdrProbe.probeDetailed(context, playbackDisplayId)).toOutputDisplay(),
             ),
             deliveries = mapOf(
                 DELIVERY_CLASS_ORIGINAL_HTTP to DeliveryCapability(

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -31,6 +31,8 @@ import org.siloserver.silo.model.playback.CLIENT_DV7_TO_HDR10
 import org.siloserver.silo.model.playback.CLIENT_DV_TRANSFORM_RECIPE_VERSION
 import org.siloserver.silo.model.playback.NATIVE_HLS_PLAYBACK_V1_FEATURE
 import org.siloserver.silo.model.playback.CLIENT_SELECTED_AUDIO_TRACK_V1_CLAIM
+import org.siloserver.silo.model.playback.CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM
+import org.siloserver.silo.model.playback.HdrCapabilities
 import org.siloserver.silo.model.playback.PlaybackDeviceContext
 import org.siloserver.silo.model.playback.PlaybackTransformationExecutor
 import org.siloserver.silo.model.playback.PlaybackTransformationV3
@@ -74,6 +76,18 @@ class PlaybackCapabilityDetector(
     // MediaCodecList enumeration for callers that need a fresh snapshot later.
     @Volatile
     private var cachedPlatformSoftwareAudioProbe: PlatformSoftwareAudioProbe? = null
+
+    /** Display probe from the most recent [detect], for the output context. */
+    @Volatile
+    private var lastDisplayProbe: DisplayHdrProbeResult? = null
+
+    /** Decoder-only HDR facts from the most recent [detect], for diagnostics. */
+    @Volatile
+    private var lastDecoderHdr: HdrCapabilities? = null
+
+    /** Decoder-only HDR support independent of the attached display. */
+    val decoderHdrCapabilities: HdrCapabilities?
+        get() = lastDecoderHdr
     /**
      * Inspect the resolved [Tracks] object (emitted by `Player.Listener.onTracksChanged`)
      * and declare whether direct play can proceed. Looks at the selected video
@@ -86,7 +100,10 @@ class PlaybackCapabilityDetector(
      * tracks can be ignored.
      */
     @UnstableApi
-    fun evaluateTracks(tracks: Tracks): Playability {
+    fun evaluateTracks(
+        tracks: Tracks,
+        route: PlannedVideoRoute = PlannedVideoRoute.Unspecified,
+    ): Playability {
         // Video — look for DV profile claims in Format.codecs.
         val selectedVideo = tracks.groups.firstOrNull {
             it.type == C.TRACK_TYPE_VIDEO && it.isSelected
@@ -115,8 +132,18 @@ class PlaybackCapabilityDetector(
                         codec = codecProbe.hdr,
                         display = displayHdr,
                     )
-                    val supported = isDirectPlayableDolbyVisionProfile(profile, supportedHdr)
-                    if (!supported) return Playability.UnsupportedDvProfile(profile)
+                    // Preflight validates the plan the server actually
+                    // issued, not the source's native format. A plan that
+                    // promised a Profile 8 base-layer route is checked
+                    // against that base range; only a plan promising native
+                    // Dolby Vision (or no plan at all) requires the decoder
+                    // and the active output to carry the DV profile.
+                    val verdict = evaluateDolbyVisionRoute(
+                        profile = profile,
+                        route = route,
+                        nativeHdr = supportedHdr,
+                    )
+                    if (verdict != Playability.Supported) return verdict
                 }
             }
         }
@@ -219,22 +246,17 @@ class PlaybackCapabilityDetector(
     ): ClientCodecCapabilities {
         val audioRoute = audioCapabilityManager.playbackRouteSnapshot()
         val codecProbe = MediaCodecCapabilitiesProbe.probe()
-        val displayHdr = DisplayHdrProbe.probe(context)
+        val displayProbe = DisplayHdrProbe.probeDetailed(context)
         // With Dolby Vision off, stop advertising DV profiles (except 5,
         // which has no watchable base layer) so the server plans base-layer /
         // HDR10 delivery and local direct-play checks agree. Single decision
         // source: DolbyVisionPolicy (Apple parity, silo-apple e9bd775).
         val intersectedHdr = TvPlaybackOutputPolicy.effectiveHdrCapabilities(
             codec = codecProbe.hdr,
-            display = displayHdr,
-        ).let { hdr ->
-            hdr.copy(
-                dolbyVisionProfiles = DolbyVisionPolicy.advertisableProfiles(
-                    hdr.dolbyVisionProfiles,
-                    dolbyVision,
-                ),
-            )
-        }
+            display = displayProbe.hdr,
+        ).withDolbyVisionPolicy(dolbyVision)
+        lastDisplayProbe = displayProbe
+        lastDecoderHdr = codecProbe.hdr.withDolbyVisionPolicy(dolbyVision)
 
         val platformAudio = detectPlatformSoftwareAudioCodecs()
         val ffmpegAudio = if (ffmpegAvailable) {
@@ -335,14 +357,20 @@ class PlaybackCapabilityDetector(
                 platformDetails = androidPlatformDetails(),
             ),
             output = PlaybackOutputContext(
+                // Native-output authority: decoder ∩ active display, with the
+                // decoder's per-profile bounds. Stays the intersection so an
+                // older server keeps reading the same meaning it always has.
                 hdrDetails = caps.hdrDetails,
                 audioPassthrough = passthrough,
                 currentSink = if (passthrough?.passthroughCodecs?.isNotEmpty() == true) "passthrough_sink" else "local_output",
                 sinkType = audioRoute.sinkType,
                 // Opaque to the server, which only ever compares it for
-                // equality. Android's route generation counter is exactly that:
-                // it changes when the audio route changes and nothing else.
+                // equality. Android's route generation counter changes when
+                // the audio route or the display's HDR capabilities change.
                 outputContextId = audioRoute.routeGeneration.toString(),
+                // Raw display facts with their evidence tier so a new server
+                // can distinguish a confirmed SDR panel from a failed probe.
+                display = (lastDisplayProbe ?: DisplayHdrProbe.probeDetailed(context)).toOutputDisplay(),
             ),
             deliveries = mapOf(
                 DELIVERY_CLASS_ORIGINAL_HTTP to DeliveryCapability(
@@ -381,7 +409,19 @@ class PlaybackCapabilityDetector(
                     // the mounted Media3 inventory and verifies the resulting
                     // selection. A bounded typed failure-recovery replan is
                     // emitted if the untouched file cannot honor the mapping.
-                    validatedClaims = listOf(CLIENT_SELECTED_AUDIO_TRACK_V1_CLAIM),
+                    validatedClaims = buildList {
+                        add(CLIENT_SELECTED_AUDIO_TRACK_V1_CLAIM)
+                        // Profile 8 base-layer fallback: the renderer routes a
+                        // single-layer DV stream to an ordinary HEVC decoder
+                        // when the plan names a base range, and preflight
+                        // verifies the decoder and output before playback.
+                        // Only meaningful when an HDR-capable HEVC decoder
+                        // exists; the server further gates on the source's
+                        // compatibility id and the active output.
+                        if (caps.videoDecode.any { it.codec == "hevc" && 10 in it.bitDepths && it.hardware }) {
+                            add(CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM)
+                        }
+                    },
                 ),
                 DELIVERY_CLASS_PROGRESSIVE to DeliveryCapability(
                     enabled = false,
@@ -677,6 +717,89 @@ internal fun isDirectPlayableDolbyVisionProfile(
     profile: Int,
     supportedHdr: org.siloserver.silo.model.playback.HdrCapabilities,
 ): Boolean = supportedHdr.dolbyVisionProfiles.contains(profile)
+
+private fun HdrCapabilities.withDolbyVisionPolicy(dolbyVision: DolbyVisionPolicy.Snapshot): HdrCapabilities {
+    val profiles = DolbyVisionPolicy.advertisableProfiles(dolbyVisionProfiles, dolbyVision)
+    return copy(
+        dolbyVisionProfiles = profiles,
+        dolbyVisionProfileLevels = dolbyVisionProfileLevels.filter { it.profile in profiles },
+    )
+}
+
+/**
+ * The video presentation the active plan promised, as far as preflight needs
+ * to know. [Unspecified] keeps the historical behaviour: a Dolby Vision track
+ * must be natively supported by decoder and display.
+ */
+sealed class PlannedVideoRoute {
+    /** No plan context (local file, legacy session); require native support. */
+    data object Unspecified : PlannedVideoRoute()
+
+    /** The plan promises native Dolby Vision output. */
+    data object NativeDolbyVision : PlannedVideoRoute()
+
+    /**
+     * The plan authorised the client Profile 8 base-layer fallback and
+     * promised [baseRange] (`hdr10`, `hlg`, or `sdr`) on the output.
+     */
+    data class DolbyVisionProfile8BaseLayer(val baseRange: String) : PlannedVideoRoute()
+
+    /**
+     * The plan expects a non-DV presentation of the same file (for example a
+     * client Profile 7 transformation); Dolby Vision in the track is expected
+     * and validated elsewhere.
+     */
+    data object ClientTransformed : PlannedVideoRoute()
+}
+
+/**
+ * Preflight verdict for a selected Dolby Vision track under [route].
+ *
+ * A base-layer plan is valid only for Profile 8 and only while the active
+ * output still supports the promised base range; otherwise it reports a typed
+ * failure that the replan ladder can act on. A native plan requires the
+ * decoder ∩ display intersection to carry the profile.
+ */
+internal fun evaluateDolbyVisionRoute(
+    profile: Int,
+    route: PlannedVideoRoute,
+    nativeHdr: HdrCapabilities,
+): Playability = when (route) {
+    is PlannedVideoRoute.DolbyVisionProfile8BaseLayer -> when {
+        profile != 8 -> Playability.DvBaseLayerMetadataMismatch(profile, route.baseRange)
+        !baseRangeSupported(route.baseRange, nativeHdr) ->
+            Playability.DvBaseLayerOutputMismatch(profile, route.baseRange)
+        else -> Playability.Supported
+    }
+    PlannedVideoRoute.ClientTransformed -> Playability.Supported
+    PlannedVideoRoute.NativeDolbyVision, PlannedVideoRoute.Unspecified ->
+        if (isDirectPlayableDolbyVisionProfile(profile, nativeHdr)) {
+            Playability.Supported
+        } else {
+            Playability.UnsupportedDvProfile(profile)
+        }
+}
+
+private fun baseRangeSupported(baseRange: String, nativeHdr: HdrCapabilities): Boolean =
+    when (baseRange.trim().lowercase()) {
+        "hdr10" -> nativeHdr.hdr10
+        "hlg" -> nativeHdr.hlg
+        "sdr", "" -> true
+        else -> false
+    }
+
+/** Derives the preflight route from the plan the client is executing. */
+fun plannedVideoRouteFor(
+    decisionReason: String?,
+    effectiveDynamicRange: String?,
+    clientTransformations: List<String>,
+): PlannedVideoRoute = when {
+    clientTransformations.isNotEmpty() -> PlannedVideoRoute.ClientTransformed
+    decisionReason == org.siloserver.silo.model.playback.DECISION_REASON_CLIENT_DV8_BASE_LAYER ->
+        PlannedVideoRoute.DolbyVisionProfile8BaseLayer(effectiveDynamicRange.orEmpty().lowercase())
+    effectiveDynamicRange.equals("dolby_vision", ignoreCase = true) -> PlannedVideoRoute.NativeDolbyVision
+    else -> PlannedVideoRoute.Unspecified
+}
 
 /**
  * Whether the connected sink will carry [codec] as an encoded stream at

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -91,6 +91,12 @@ class PlaybackCapabilityDetector(
      */
     @Volatile
     var playbackDisplayId: Int? = null
+        set(value) {
+            field = value
+            // The audio-route manager owns the display-change listener that
+            // rotates the output context; it must watch the same panel.
+            audioCapabilityManager.playbackDisplayId = value
+        }
 
     /** Decoder-only HDR facts from the most recent [detect], for diagnostics. */
     @Volatile

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -415,10 +415,11 @@ class PlaybackCapabilityDetector(
                         // single-layer DV stream to an ordinary HEVC decoder
                         // when the plan names a base range, and preflight
                         // verifies the decoder and output before playback.
-                        // Only meaningful when an HDR-capable HEVC decoder
-                        // exists; the server further gates on the source's
-                        // compatibility id and the active output.
-                        if (caps.videoDecode.any { it.codec == "hevc" && 10 in it.bitDepths && it.hardware }) {
+                        // Gated on the same decoder ∩ display facts preflight
+                        // uses (an HDR10 or HLG range the HEVC path can carry
+                        // on this output), so a claim can never be issued
+                        // that preflight would immediately refuse.
+                        if (canAdvertiseDv8BaseLayerFallback(caps)) {
                             add(CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM)
                         }
                     },
@@ -717,6 +718,21 @@ internal fun isDirectPlayableDolbyVisionProfile(
     profile: Int,
     supportedHdr: org.siloserver.silo.model.playback.HdrCapabilities,
 ): Boolean = supportedHdr.dolbyVisionProfiles.contains(profile)
+
+/**
+ * The base-layer claim is only truthful when preflight would accept the plan
+ * it produces: an HDR-capable hardware HEVC decoder plus at least one base
+ * range (HDR10 or HLG) present in the decoder ∩ display intersection that
+ * [PlaybackCapabilityDetector.evaluateTracks] checks. A decoder that reports
+ * only the plain Main10 profile earns no HDR range from the codec probe and
+ * therefore no claim, instead of a claim that fails on the first track change.
+ * An SDR-base (compat 2) source is still served by the server's own gate.
+ */
+internal fun canAdvertiseDv8BaseLayerFallback(caps: ClientCodecCapabilities): Boolean {
+    val hevc10 = caps.videoDecode.any { it.codec == "hevc" && 10 in it.bitDepths && it.hardware }
+    val hdr = caps.hdrDetails ?: return false
+    return hevc10 && (hdr.hdr10 || hdr.hlg)
+}
 
 private fun HdrCapabilities.withDolbyVisionPolicy(dolbyVision: DolbyVisionPolicy.Snapshot): HdrCapabilities {
     val profiles = DolbyVisionPolicy.advertisableProfiles(dolbyVisionProfiles, dolbyVision)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -419,7 +419,7 @@ class PlaybackCapabilityDetector(
                         // uses (an HDR10 or HLG range the HEVC path can carry
                         // on this output), so a claim can never be issued
                         // that preflight would immediately refuse.
-                        if (canAdvertiseDv8BaseLayerFallback(caps)) {
+                        if (canAdvertiseDv8BaseLayerFallback(caps, lastDisplayProbe)) {
                             add(CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM)
                         }
                     },
@@ -721,17 +721,29 @@ internal fun isDirectPlayableDolbyVisionProfile(
 
 /**
  * The base-layer claim is only truthful when preflight would accept the plan
- * it produces: an HDR-capable hardware HEVC decoder plus at least one base
- * range (HDR10 or HLG) present in the decoder ∩ display intersection that
- * [PlaybackCapabilityDetector.evaluateTracks] checks. A decoder that reports
- * only the plain Main10 profile earns no HDR range from the codec probe and
- * therefore no claim, instead of a claim that fails on the first track change.
- * An SDR-base (compat 2) source is still served by the server's own gate.
+ * it produces, using the same decoder ∩ display facts that
+ * [PlaybackCapabilityDetector.evaluateTracks] checks:
+ *
+ * - a 10-bit hardware HEVC decoder, and
+ * - either an HDR10 or HLG range in the intersection (for compat 1/4/6
+ *   bases), or a confirmed SDR display (for a compat 2 SDR base, which the
+ *   Main10 path presents without any HDR signalling).
+ *
+ * A decoder that reports only the plain Main10 profile on an HDR panel earns
+ * no HDR range from the codec probe and therefore no claim, instead of a
+ * claim that fails on the first track change. An unknown display probe never
+ * earns the claim: the server would fail closed on it anyway.
  */
-internal fun canAdvertiseDv8BaseLayerFallback(caps: ClientCodecCapabilities): Boolean {
+internal fun canAdvertiseDv8BaseLayerFallback(
+    caps: ClientCodecCapabilities,
+    display: DisplayHdrProbeResult?,
+): Boolean {
     val hevc10 = caps.videoDecode.any { it.codec == "hevc" && 10 in it.bitDepths && it.hardware }
-    val hdr = caps.hdrDetails ?: return false
-    return hevc10 && (hdr.hdr10 || hdr.hlg)
+    if (!hevc10) return false
+    val hdr = caps.hdrDetails ?: HdrCapabilities()
+    if (hdr.hdr10 || hdr.hlg) return true
+    val panel = display as? DisplayHdrProbeResult.Exact ?: return false
+    return !panel.hdr.hdr10 && !panel.hdr.hlg && panel.hdr.dolbyVisionProfiles.isEmpty()
 }
 
 private fun HdrCapabilities.withDolbyVisionPolicy(dolbyVision: DolbyVisionPolicy.Snapshot): HdrCapabilities {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -67,6 +67,12 @@ class PlaybackCapabilityDetector(
      * phone driving the cast, not the receiver.
      */
     val buildIdentity: SiloClientBuildIdentity,
+    /**
+     * Device-level memory of client Dolby Vision transformations that failed
+     * here, consulted before one is advertised again. The player ViewModels
+     * feed it from the failure classification that drove a replan.
+     */
+    val transformQuarantine: DolbyVisionTransformQuarantine = DolbyVisionTransformQuarantine(context),
 ) {
     val outputRouteGeneration: StateFlow<Long> = audioCapabilityManager.outputRouteGeneration
     private val planningSnapshots = PlaybackPlanningSnapshotRegistry(
@@ -353,6 +359,9 @@ class PlaybackCapabilityDetector(
         val clientVideoTransformations = advertisedClientDolbyVisionTransformations(
             hdrDetails = caps.hdrDetails,
             nativeRpuConverterAvailable = NativeDolbyVisionRpuConverter.isAvailable,
+            hardwareProfile8Decoder = hasHardwareDolbyVisionProfile8Decoder(caps),
+            displayConfirmsDolbyVision = displayConfirmsDolbyVision(lastDisplayProbe),
+            quarantined = transformQuarantine.quarantined(),
         )
         return ClientPlaybackContext(
             formFactor = formFactor,
@@ -671,26 +680,37 @@ internal fun advertisedAudioDecodeCodecs(
 /**
  * Client-side Dolby Vision transformations safe to expose to the v3 planner.
  *
- * A packaged converter and a compatible output range are prerequisites, not
- * end-to-end evidence. In particular, the SM-F976U1 can decode HDR10 and run
- * the packaged RPU bridge, yet a transformed Profile 7 stream renders one
- * frame and then makes no forward progress. Advertising the transformation in
- * that state makes every fresh session select the same unusable route before
- * runtime recovery can ask the server for its validated transformation.
+ * Profile 7 to Profile 8.1 is advertised from runtime evidence that names the
+ * whole path the transformed stream takes: the packaged RPU converter, a
+ * hardware `video/dolby-vision` decoder that lists Profile 8, and a panel
+ * that confirmed Dolby Vision with exact evidence. The decoder ∩ display
+ * intersection in [hdrDetails] carries the last two, but on its own it is not
+ * enough: a device can meet it and still fail. The SM-F976U1 decoded HDR10,
+ * ran the RPU bridge, rendered one frame of a transformed stream, and then
+ * made no forward progress, and while the transformation stayed advertised
+ * every fresh session picked the same route. The startup stall detector now
+ * classifies that wedge as `dv7_transform_stall`, the replan asks the server
+ * for its own recipe, and [DolbyVisionTransformQuarantine] withdraws the
+ * advertisement on this device build so the next session never tries it.
  *
- * Keep the default evidence set empty. A transformation may be added only
- * after the playback fixture matrix validates the complete extractor,
- * transformation, decoder, and display path for the Android device class.
+ * Profile 7 to HDR10 stays behind [fixtureValidatedTransformations]: the
+ * server's own RPU strip covers that case, so the client recipe only earns a
+ * place once the fixture matrix validates it for a device class.
  */
 internal fun advertisedClientDolbyVisionTransformations(
     hdrDetails: org.siloserver.silo.model.playback.HdrCapabilities?,
     nativeRpuConverterAvailable: Boolean,
     fixtureValidatedTransformations: Set<String> = emptySet(),
+    hardwareProfile8Decoder: Boolean = false,
+    displayConfirmsDolbyVision: Boolean = false,
+    quarantined: Set<String> = emptySet(),
 ): List<PlaybackTransformationV3> = buildList {
     if (
-        CLIENT_DV7_TO_DV81 in fixtureValidatedTransformations &&
+        CLIENT_DV7_TO_DV81 !in quarantined &&
         8 in hdrDetails?.dolbyVisionProfiles.orEmpty() &&
-        nativeRpuConverterAvailable
+        nativeRpuConverterAvailable &&
+        (CLIENT_DV7_TO_DV81 in fixtureValidatedTransformations ||
+            (hardwareProfile8Decoder && displayConfirmsDolbyVision))
     ) {
         add(
             PlaybackTransformationV3(
@@ -706,6 +726,7 @@ internal fun advertisedClientDolbyVisionTransformations(
         )
     }
     if (
+        CLIENT_DV7_TO_HDR10 !in quarantined &&
         CLIENT_DV7_TO_HDR10 in fixtureValidatedTransformations &&
         hdrDetails?.hdr10 == true
     ) {
@@ -762,6 +783,23 @@ internal fun canAdvertiseDv8BaseLayerFallback(
     val panel = display as? DisplayHdrProbeResult.Exact ?: return false
     return !panel.hdr.hdr10 && !panel.hdr.hlg && panel.hdr.dolbyVisionProfiles.isEmpty()
 }
+
+/**
+ * A hardware `video/dolby-vision` decoder that lists Profile 8. The Profile 7
+ * to 8.1 recipe hands the converted stream to this decoder under a `dvhe.08`
+ * codec string, so the software fallbacks Media3 would otherwise pick are not
+ * evidence the route can render.
+ */
+internal fun hasHardwareDolbyVisionProfile8Decoder(caps: ClientCodecCapabilities): Boolean =
+    caps.videoDecode.any { it.codec == "dolby_vision" && it.hardware && "profile 8" in it.profiles }
+
+/**
+ * The panel itself reported Dolby Vision with exact evidence. An unknown probe
+ * or a panel that reports only HDR10 cannot carry a Profile 8.1 presentation
+ * however capable the decoder is.
+ */
+internal fun displayConfirmsDolbyVision(display: DisplayHdrProbeResult?): Boolean =
+    (display as? DisplayHdrProbeResult.Exact)?.hdr?.dolbyVisionProfiles?.contains(8) == true
 
 private fun HdrCapabilities.withDolbyVisionPolicy(dolbyVision: DolbyVisionPolicy.Snapshot): HdrCapabilities {
     val profiles = DolbyVisionPolicy.advertisableProfiles(dolbyVisionProfiles, dolbyVision)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackPreflightListener.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackPreflightListener.kt
@@ -21,12 +21,18 @@ class PlaybackPreflightListener(
     private val detector: PlaybackCapabilityDetector,
     private val onUnsupported: (Playability) -> Unit,
     private val onError: (PlaybackException) -> Unit = {},
+    /**
+     * The video route the active plan promised. Read on every track change so
+     * a replan that swaps a native Dolby Vision plan for a base-layer plan is
+     * validated against the new promise, not the old one.
+     */
+    private val plannedRoute: () -> PlannedVideoRoute = { PlannedVideoRoute.Unspecified },
 ) : Player.Listener {
 
     private var lastSignaled: Playability? = null
 
     override fun onTracksChanged(tracks: Tracks) {
-        val verdict = detector.evaluateTracks(tracks)
+        val verdict = detector.evaluateTracks(tracks, plannedRoute())
         if (verdict != Playability.Supported && verdict != lastSignaled) {
             lastSignaled = verdict
             onUnsupported(verdict)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
@@ -95,6 +95,14 @@ class SiloPlayerFactory(
     @Volatile private var resumableDirectPlayUri: android.net.Uri? = null
     private val runtimeCorrectionState = PlaybackRuntimeCorrectionState()
 
+    /**
+     * Name of the decoder the renderer opened for a plan that promised the
+     * Profile 8 base-layer route but which cannot produce it (a native Dolby
+     * Vision decoder, or a non-HEVC decoder). Null while the promise holds.
+     * Observed by the player screens, which turn it into a typed replan.
+     */
+    val baseLayerDecoderMismatch = kotlinx.coroutines.flow.MutableStateFlow<String?>(null)
+
     private val dataSourceFactory = AuthenticatedDataSourceFactory(
         context = context,
         httpDataSourceFactory = httpDataSourceFactory,
@@ -238,6 +246,9 @@ class SiloPlayerFactory(
                     eventHandler = eventHandler,
                     eventListener = eventListener,
                     runtimeCorrectionEnabled = runtimeCorrectionState::isEnabled,
+                    onBaseLayerDecoderMismatch = { decoderName ->
+                        baseLayerDecoderMismatch.value = decoderName
+                    },
                 )
             }
         }.apply {
@@ -287,6 +298,7 @@ class SiloPlayerFactory(
             mode: DolbyVisionTransformMode,
             expectedDynamicRange: String? = null,
             expectedColorRange: String? = null,
+            dolbyVisionBaseLayerRoute: Boolean = false,
         ) =
             DefaultMediaSourceFactory(
                 context,
@@ -295,6 +307,7 @@ class SiloPlayerFactory(
                     mode,
                     expectedDynamicRange = expectedDynamicRange,
                     expectedColorRange = expectedColorRange,
+                    dolbyVisionBaseLayerRoute = dolbyVisionBaseLayerRoute,
                 ),
             )
             .setDataSourceFactory(dataSourceFactory)
@@ -462,9 +475,13 @@ class SiloPlayerFactory(
         expectedColorRange: String? = null,
         transformations: List<String> = emptyList(),
         runtimeCorrections: List<String> = emptyList(),
+        activeClaims: List<String> = emptyList(),
     ): MediaItem {
         this.serverUrl = serverUrl
-        runtimeCorrectionState.activate(runtimeCorrections)
+        // Runtime corrections and plan-scoped claims share one activation
+        // set: both are per-mount switches the renderer consults by name.
+        runtimeCorrectionState.activate(runtimeCorrections + activeClaims)
+        baseLayerDecoderMismatch.value = null
         subtitleOffsetHolder.setTimelineOffsetSeconds(timelineOffsetSeconds)
         val absoluteUrl = buildAbsoluteUrl(serverUrl, streamUrl)
         resumableDirectPlayUri = if (delivery == PlaybackDelivery.ORIGINAL_HTTP) {
@@ -493,6 +510,8 @@ class SiloPlayerFactory(
                     },
                     expectedDynamicRange = expectedDynamicRange,
                     expectedColorRange = expectedColorRange,
+                    dolbyVisionBaseLayerRoute =
+                        org.siloserver.silo.model.playback.CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM in activeClaims,
                 ),
             )
 
@@ -555,6 +574,7 @@ class SiloPlayerFactory(
             DolbyVisionTransformMode,
             String?,
             String?,
+            Boolean,
         ) -> MediaSource.Factory,
         private val hlsFactory: MediaSource.Factory,
         private val dataSourceFactory: DataSource.Factory,
@@ -620,6 +640,7 @@ class SiloPlayerFactory(
                 tag?.dolbyVisionMode ?: DolbyVisionTransformMode.DISABLED,
                 tag?.expectedDynamicRange,
                 tag?.expectedColorRange,
+                tag?.dolbyVisionBaseLayerRoute ?: false,
             ).also { factory ->
                 drmSessionManagerProvider?.let(factory::setDrmSessionManagerProvider)
                 factory.setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/VideoPlayerMediaMounter.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/VideoPlayerMediaMounter.kt
@@ -30,6 +30,7 @@ fun mountVideoMedia(
         expectedColorRange = spec.expectedColorRange,
         transformations = spec.transformations,
         runtimeCorrections = spec.runtimeCorrections,
+        activeClaims = spec.activeClaims,
     )
     player.setMediaItem(mediaItem, startPositionMs.coerceAtLeast(0L))
     player.prepare()
@@ -62,6 +63,7 @@ fun refreshMountedVideoMedia(
         expectedColorRange = spec.expectedColorRange,
         transformations = spec.transformations,
         runtimeCorrections = spec.runtimeCorrections,
+        activeClaims = spec.activeClaims,
     )
     player.setMediaItem(mediaItem, resumePositionMs)
     player.prepare()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/VideoPlayerMediaSpec.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/VideoPlayerMediaSpec.kt
@@ -161,6 +161,12 @@ data class VideoPlayerMediaSpec(
     val expectedColorRange: String? = null,
     val transformations: List<String> = emptyList(),
     val runtimeCorrections: List<String> = emptyList(),
+    /**
+     * Delivery-scoped validated claims the plan relies on
+     * (for example [org.siloserver.silo.model.playback.CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM]),
+     * derived from the plan's decision reason. Drives renderer decoder routing.
+     */
+    val activeClaims: List<String> = emptyList(),
 ) {
     val startPositionMs: Long
         get() {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/backend/Media3VideoPlaybackBackend.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/backend/Media3VideoPlaybackBackend.kt
@@ -26,6 +26,9 @@ class Media3VideoPlaybackBackend(
 
     private var mountedSpec: VideoPlayerMediaSpec? = null
 
+    override val baseLayerDecoderMismatch: kotlinx.coroutines.flow.StateFlow<String?>
+        get() = playerFactory.baseLayerDecoderMismatch
+
     override fun mount(
         spec: VideoPlayerMediaSpec,
         startPositionMs: Long,

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackend.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/backend/VideoPlaybackBackend.kt
@@ -24,6 +24,15 @@ interface VideoPlaybackBackend {
 
     fun refresh(spec: VideoPlayerMediaSpec)
 
+    /**
+     * Emits the decoder name when the mounted plan promised a Dolby Vision
+     * Profile 8 base-layer route and the engine opened a decoder that cannot
+     * honour it. Null while the promise holds or when the backend has no such
+     * check. Reset on every mount.
+     */
+    val baseLayerDecoderMismatch: kotlinx.coroutines.flow.StateFlow<String?>
+        get() = kotlinx.coroutines.flow.MutableStateFlow(null)
+
     fun selectSubtitle(track: VideoPlayerTrackEntry?): Boolean
 
     fun selectMountedSubtitle(

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/SiloMediaCodecVideoRenderer.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/SiloMediaCodecVideoRenderer.kt
@@ -9,15 +9,18 @@ import androidx.media3.decoder.DecoderInputBuffer
 import androidx.media3.exoplayer.DecoderReuseEvaluation
 import androidx.media3.exoplayer.FormatHolder
 import androidx.media3.exoplayer.mediacodec.MediaCodecAdapter
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.mediacodec.MediaCodecUtil
 import androidx.media3.exoplayer.video.MediaCodecVideoRenderer
 import androidx.media3.exoplayer.video.VideoRendererEventListener
+import org.siloserver.silo.model.playback.CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM
 import org.siloserver.silo.model.playback.CLIENT_DV8_HDR10_PLUS_SANITIZER
 
 /** Media3 video renderer with narrowly gated, independently tested fixes. */
 @UnstableApi
 internal class SiloMediaCodecVideoRenderer(
-    context: Context,
+    private val context: Context,
     codecAdapterFactory: MediaCodecAdapter.Factory,
     mediaCodecSelector: MediaCodecSelector,
     allowedJoiningTimeMs: Long,
@@ -25,6 +28,13 @@ internal class SiloMediaCodecVideoRenderer(
     eventHandler: Handler,
     eventListener: VideoRendererEventListener,
     runtimeCorrectionEnabled: (String) -> Boolean,
+    /**
+     * Invoked with the decoder name when a plan that promised the Profile 8
+     * base-layer route ended up on a decoder that cannot honour it. The
+     * player turns this into a typed `dv8_base_layer_decoder_unavailable`
+     * replan instead of playing with an unverified presentation.
+     */
+    private val onBaseLayerDecoderMismatch: (String) -> Unit = {},
 ) : MediaCodecVideoRenderer(
     MediaCodecVideoRenderer.Builder(context)
         .setCodecAdapterFactory(codecAdapterFactory)
@@ -39,6 +49,37 @@ internal class SiloMediaCodecVideoRenderer(
     private var nativeDolbyVisionDecoder = false
     private var profile8Input = false
 
+    private val baseLayerRouteActive: Boolean
+        get() = runtimeCorrectionEnabled(CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM)
+
+    /**
+     * Media3 only swaps a Dolby Vision format onto an ordinary HEVC/AVC
+     * decoder when the *default* display lacks Dolby Vision. That private
+     * decision is what the server's base-layer plan depends on, so when the
+     * plan named that route the renderer makes the choice explicitly: for a
+     * single-layer Profile 8 stream the alternative (base-layer) decoders are
+     * offered first, and the Dolby Vision decoder is not offered at all. The
+     * bytes are untouched; only the decoder that reads them changes.
+     */
+    override fun getDecoderInfos(
+        mediaCodecSelector: MediaCodecSelector,
+        format: Format,
+        requiresSecureDecoder: Boolean,
+    ): List<MediaCodecInfo> {
+        if (baseLayerRouteActive && isDolbyVisionProfile8(format)) {
+            val alternatives = MediaCodecUtil.getAlternativeDecoderInfos(
+                mediaCodecSelector,
+                format,
+                requiresSecureDecoder,
+                /* requiresTunnelingDecoder = */ false,
+            ).filter { it.hardwareAccelerated }
+            if (alternatives.isNotEmpty()) {
+                return MediaCodecUtil.getDecoderInfosSortedByFormatSupport(context, alternatives, format)
+            }
+        }
+        return super.getDecoderInfos(mediaCodecSelector, format, requiresSecureDecoder)
+    }
+
     override fun onCodecInitialized(
         name: String,
         configuration: MediaCodecAdapter.Configuration,
@@ -50,6 +91,13 @@ internal class SiloMediaCodecVideoRenderer(
             ignoreCase = true,
         ) && configuration.codecInfo.hardwareAccelerated
         profile8Input = isDolbyVisionProfile8(configuration.format)
+        if (baseLayerRouteActive && profile8Input) {
+            val honoursBaseLayer = configuration.codecInfo.codecMimeType.equals(
+                MimeTypes.VIDEO_H265,
+                ignoreCase = true,
+            ) && configuration.codecInfo.hardwareAccelerated
+            if (!honoursBaseLayer) onBaseLayerDecoderMismatch(name)
+        }
         super.onCodecInitialized(name, configuration, initializedTimestampMs, initializationDurationMs)
     }
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/DolbyVisionTransformQuarantineTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/DolbyVisionTransformQuarantineTest.kt
@@ -1,0 +1,77 @@
+package org.siloserver.silo.common.player
+
+import org.siloserver.silo.model.playback.CLIENT_DV7_TO_DV81
+import org.siloserver.silo.model.playback.CLIENT_DV7_TO_HDR10
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DolbyVisionTransformQuarantineTest {
+
+    private class MemoryStore : DolbyVisionTransformQuarantine.Store {
+        val values = mutableMapOf<String, Long>()
+        override fun get(key: String): Long? = values[key]
+        override fun put(key: String, value: Long) { values[key] = value }
+        override fun remove(key: String) { values.remove(key) }
+    }
+
+    @Test
+    fun deviceFaultWithdrawsTheActiveTransformation() {
+        val store = MemoryStore()
+        val quarantine = DolbyVisionTransformQuarantine(store, fingerprint = "build-a", nowMs = { 1_000L })
+
+        val withdrawn = quarantine.noteFailure("dv7_transform_stall", listOf(CLIENT_DV7_TO_DV81))
+
+        assertEquals(listOf(CLIENT_DV7_TO_DV81), withdrawn)
+        assertTrue(quarantine.isQuarantined(CLIENT_DV7_TO_DV81))
+        assertEquals(setOf(CLIENT_DV7_TO_DV81), quarantine.quarantined())
+        assertFalse(quarantine.isQuarantined(CLIENT_DV7_TO_HDR10))
+    }
+
+    @Test
+    fun sourceAndTransportFaultsDoNotBlameTheDevice() {
+        val quarantine = DolbyVisionTransformQuarantine(MemoryStore(), fingerprint = "build-a", nowMs = { 1_000L })
+
+        listOf(
+            "dv7_transform_source_mismatch",
+            "dv7_transform_encrypted",
+            "dv7_transform_malformed",
+            "dv7_transform_supplemental_unsupported",
+            "transport_stall",
+            "http_failure",
+            "audio_track_changed",
+        ).forEach { classification ->
+            assertTrue(
+                quarantine.noteFailure(classification, listOf(CLIENT_DV7_TO_DV81)).isEmpty(),
+                "$classification must not quarantine the recipe",
+            )
+        }
+        assertFalse(quarantine.isQuarantined(CLIENT_DV7_TO_DV81))
+    }
+
+    @Test
+    fun aFailureWithoutAnActiveTransformationIsIgnored() {
+        val quarantine = DolbyVisionTransformQuarantine(MemoryStore(), fingerprint = "build-a", nowMs = { 1_000L })
+
+        assertTrue(quarantine.noteFailure("decoder_no_output", emptyList()).isEmpty())
+        assertFalse(quarantine.isQuarantined(CLIENT_DV7_TO_DV81))
+    }
+
+    @Test
+    fun quarantineIsScopedToTheBuildFingerprintAndExpires() {
+        val store = MemoryStore()
+        var now = 1_000L
+        val onBuildA = DolbyVisionTransformQuarantine(store, fingerprint = "build-a", nowMs = { now })
+        val onBuildB = DolbyVisionTransformQuarantine(store, fingerprint = "build-b", nowMs = { now })
+
+        onBuildA.noteFailure("decoder_no_output", listOf(CLIENT_DV7_TO_DV81))
+
+        assertTrue(onBuildA.isQuarantined(CLIENT_DV7_TO_DV81))
+        assertFalse(onBuildB.isQuarantined(CLIENT_DV7_TO_DV81), "an OS update earns a fresh attempt")
+
+        now += DolbyVisionTransformQuarantine.TTL_MS + 1
+        assertFalse(onBuildA.isQuarantined(CLIENT_DV7_TO_DV81), "the quarantine expires")
+        assertTrue(store.values.isEmpty(), "an expired entry is dropped from the store")
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbeTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbeTest.kt
@@ -167,4 +167,21 @@ class MediaCodecCapabilitiesProbeTest {
         assertFalse(MediaCodecCapabilitiesProbe.isLikelySoftwareDecoderName("OMX.Nvidia.mpeg2v.decode"))
         assertFalse(MediaCodecCapabilitiesProbe.isLikelySoftwareDecoderName("c2.amlogic.hevc.decoder"))
     }
+
+    @Test
+    fun `Dolby Vision decoders are listed with profile and level bounds`() {
+        assertEquals("dolby_vision", MediaCodecCapabilitiesProbe.codecName("video/dolby-vision"))
+        assertEquals(
+            "profile 8",
+            MediaCodecCapabilitiesProbe.profileName("dolby_vision", CodecProfileLevel.DolbyVisionProfileDvheSt),
+        )
+        assertEquals(
+            10,
+            MediaCodecCapabilitiesProbe.profileBitDepth("dolby_vision", CodecProfileLevel.DolbyVisionProfileDvheSt),
+        )
+        assertEquals(7, MediaCodecCapabilitiesProbe.dolbyVisionProfileNumber(CodecProfileLevel.DolbyVisionProfileDvheDtb))
+        assertEquals(9, MediaCodecCapabilitiesProbe.dolbyVisionLevelNumber(CodecProfileLevel.DolbyVisionLevelUhd60))
+        assertEquals(6, MediaCodecCapabilitiesProbe.normalizedLevel("dolby_vision", CodecProfileLevel.DolbyVisionLevelUhd24))
+        assertNull(MediaCodecCapabilitiesProbe.dolbyVisionLevelNumber(0))
+    }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -15,6 +15,7 @@ import org.siloserver.silo.model.playback.DELIVERY_CLASS_ORIGINAL_HTTP
 import org.siloserver.silo.model.playback.DELIVERY_CLASS_PROGRESSIVE
 import org.siloserver.silo.model.playback.NATIVE_HLS_PLAYBACK_V1_FEATURE
 import org.siloserver.silo.model.playback.CLIENT_SELECTED_AUDIO_TRACK_V1_CLAIM
+import org.siloserver.silo.model.playback.CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -167,6 +168,119 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
         assertEquals(
             listOf(CLIENT_DV7_TO_DV81, CLIENT_DV7_TO_HDR10),
             transformations.map { it.name },
+        )
+    }
+
+    @Test
+    fun baseLayerPlanAcceptsProfile8WhenOutputCarriesPromisedRange() {
+        val verdict = evaluateDolbyVisionRoute(
+            profile = 8,
+            route = PlannedVideoRoute.DolbyVisionProfile8BaseLayer(baseRange = "hdr10"),
+            nativeHdr = HdrCapabilities(hdr10 = true),
+        )
+
+        assertEquals(Playability.Supported, verdict)
+    }
+
+    @Test
+    fun baseLayerPlanRejectsProfile8WhenOutputLostPromisedRange() {
+        val verdict = evaluateDolbyVisionRoute(
+            profile = 8,
+            route = PlannedVideoRoute.DolbyVisionProfile8BaseLayer(baseRange = "hlg"),
+            nativeHdr = HdrCapabilities(hdr10 = true),
+        )
+
+        assertEquals(Playability.DvBaseLayerOutputMismatch(profile = 8, baseRange = "hlg"), verdict)
+        assertEquals("dv8_base_layer_output_mismatch", verdict.failureClassification())
+    }
+
+    @Test
+    fun baseLayerPlanRejectsTrackThatIsNotProfile8() {
+        val verdict = evaluateDolbyVisionRoute(
+            profile = 5,
+            route = PlannedVideoRoute.DolbyVisionProfile8BaseLayer(baseRange = "hdr10"),
+            nativeHdr = HdrCapabilities(hdr10 = true),
+        )
+
+        assertEquals(Playability.DvBaseLayerMetadataMismatch(profile = 5, baseRange = "hdr10"), verdict)
+    }
+
+    @Test
+    fun nativeOrUnspecifiedPlanStillRequiresDecoderAndDisplayProfile() {
+        listOf(PlannedVideoRoute.NativeDolbyVision, PlannedVideoRoute.Unspecified).forEach { route ->
+            assertEquals(
+                Playability.UnsupportedDvProfile(8),
+                evaluateDolbyVisionRoute(profile = 8, route = route, nativeHdr = HdrCapabilities(hdr10 = true)),
+                "$route must not admit Dolby Vision on an output without native DV",
+            )
+        }
+    }
+
+    @Test
+    fun plannedRouteIsDerivedFromDecisionReasonAndRecipe() {
+        assertEquals(
+            PlannedVideoRoute.DolbyVisionProfile8BaseLayer("hdr10"),
+            plannedVideoRouteFor(
+                decisionReason = org.siloserver.silo.model.playback.DECISION_REASON_CLIENT_DV8_BASE_LAYER,
+                effectiveDynamicRange = "HDR10",
+                clientTransformations = emptyList(),
+            ),
+        )
+        assertEquals(
+            PlannedVideoRoute.NativeDolbyVision,
+            plannedVideoRouteFor("validated_original_playback", "dolby_vision", emptyList()),
+        )
+        assertEquals(
+            PlannedVideoRoute.ClientTransformed,
+            plannedVideoRouteFor("client_dv7_to_hdr10", "hdr10", listOf(CLIENT_DV7_TO_HDR10)),
+        )
+        assertEquals(PlannedVideoRoute.Unspecified, plannedVideoRouteFor(null, null, emptyList()))
+    }
+
+    @Test
+    fun originalHttpAdvertisesBaseLayerClaimOnlyWithTenBitHardwareHevc() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val detector = PlaybackCapabilityDetector(
+            context = context,
+            audioCapabilityManager = AudioCapabilityManager(context),
+            libassBridge = LibassBridge(false),
+            buildIdentity = SiloClientBuildIdentity(buildNumber = "test", channel = "test"),
+        )
+        val withHevc = detector.detectPlaybackContext(
+            formFactor = "tv",
+            appVersion = "test",
+            capabilities = ClientCodecCapabilities(
+                videoDecode = listOf(
+                    org.siloserver.silo.model.playback.VideoDecodeCapability(
+                        codec = "hevc",
+                        bitDepths = listOf(8, 10),
+                        hardware = true,
+                    ),
+                ),
+            ),
+        )
+        val without = detector.detectPlaybackContext(
+            formFactor = "tv",
+            appVersion = "test",
+            capabilities = ClientCodecCapabilities(),
+        )
+
+        assertTrue(
+            CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM in withHevc.deliveries.getValue(DELIVERY_CLASS_ORIGINAL_HTTP).validatedClaims,
+        )
+        assertFalse(
+            CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM in without.deliveries.getValue(DELIVERY_CLASS_ORIGINAL_HTTP).validatedClaims,
+        )
+        assertFalse(
+            CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM in withHevc.deliveries.getValue(DELIVERY_CLASS_HLS).validatedClaims,
+            "the base-layer claim is scoped to original_http",
+        )
+        assertTrue(
+            withHevc.output.display?.hdrEvidence in setOf(
+                org.siloserver.silo.model.playback.OUTPUT_HDR_EVIDENCE_EXACT,
+                org.siloserver.silo.model.playback.OUTPUT_HDR_EVIDENCE_UNKNOWN,
+            ),
+            "the output context must carry the display evidence tier",
         )
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -278,7 +278,7 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
         )
         assertFalse(
             CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM in hevcWithoutRange.deliveries.getValue(DELIVERY_CLASS_ORIGINAL_HTTP).validatedClaims,
-            "a Main10-only decoder with no HDR range in the intersection must not claim a route preflight would refuse",
+            "a Main10-only decoder with an unprobed display must not claim a route preflight would refuse",
         )
         assertFalse(
             CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM in withHevc.deliveries.getValue(DELIVERY_CLASS_HLS).validatedClaims,
@@ -290,6 +290,38 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
                 org.siloserver.silo.model.playback.OUTPUT_HDR_EVIDENCE_UNKNOWN,
             ),
             "the output context must carry the display evidence tier",
+        )
+    }
+
+    @Test
+    fun baseLayerClaimGateAcceptsConfirmedSdrPanelForSdrBases() {
+        val hevc10 = ClientCodecCapabilities(
+            videoDecode = listOf(
+                org.siloserver.silo.model.playback.VideoDecodeCapability(
+                    codec = "hevc",
+                    bitDepths = listOf(8, 10),
+                    hardware = true,
+                ),
+            ),
+        )
+        assertTrue(
+            canAdvertiseDv8BaseLayerFallback(hevc10, DisplayHdrProbeResult.Exact(HdrCapabilities(), displayId = 0)),
+            "a confirmed SDR panel can present a compat-2 SDR base through the Main10 path",
+        )
+        assertFalse(
+            canAdvertiseDv8BaseLayerFallback(hevc10, DisplayHdrProbeResult.Unknown(displayId = null, reason = "probe_failed")),
+            "an unknown display never earns the claim",
+        )
+        assertFalse(
+            canAdvertiseDv8BaseLayerFallback(
+                hevc10,
+                DisplayHdrProbeResult.Exact(HdrCapabilities(hdr10 = true), displayId = 0),
+            ),
+            "an HDR panel with no HDR range in the intersection means the decoder cannot signal it; no claim",
+        )
+        assertFalse(
+            canAdvertiseDv8BaseLayerFallback(ClientCodecCapabilities(), DisplayHdrProbeResult.Exact(HdrCapabilities(), displayId = 0)),
+            "no 10-bit hardware HEVC decoder, no claim",
         )
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -147,8 +147,128 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
 
         assertTrue(
             transformations.isEmpty(),
-            "Runtime prerequisites cannot be promoted to validated v3 capability claims.",
+            "An intersection alone is not evidence the transformed stream can render.",
         )
+    }
+
+    @Test
+    fun profile7ToProfile81IsAdvertisedFromHardwareDecoderAndConfirmedDolbyVisionPanel() {
+        val hdr = HdrCapabilities(hdr10 = true, dolbyVisionProfiles = listOf(5, 8))
+        val advertised = advertisedClientDolbyVisionTransformations(
+            hdrDetails = hdr,
+            nativeRpuConverterAvailable = true,
+            hardwareProfile8Decoder = true,
+            displayConfirmsDolbyVision = true,
+        )
+        assertEquals(listOf(CLIENT_DV7_TO_DV81), advertised.map { it.name })
+        assertFalse(
+            CLIENT_DV7_TO_HDR10 in advertised.map { it.name },
+            "the HDR10 recipe stays behind fixture validation; the server strip covers it",
+        )
+
+        assertTrue(
+            advertisedClientDolbyVisionTransformations(
+                hdrDetails = hdr,
+                nativeRpuConverterAvailable = true,
+                hardwareProfile8Decoder = false,
+                displayConfirmsDolbyVision = true,
+            ).isEmpty(),
+            "a software Profile 8 decoder is not a route",
+        )
+        assertTrue(
+            advertisedClientDolbyVisionTransformations(
+                hdrDetails = hdr,
+                nativeRpuConverterAvailable = true,
+                hardwareProfile8Decoder = true,
+                displayConfirmsDolbyVision = false,
+            ).isEmpty(),
+            "an unknown or HDR10-only panel cannot carry Profile 8.1",
+        )
+        assertTrue(
+            advertisedClientDolbyVisionTransformations(
+                hdrDetails = hdr,
+                nativeRpuConverterAvailable = false,
+                hardwareProfile8Decoder = true,
+                displayConfirmsDolbyVision = true,
+            ).isEmpty(),
+            "no packaged converter, no recipe",
+        )
+        assertTrue(
+            advertisedClientDolbyVisionTransformations(
+                hdrDetails = HdrCapabilities(hdr10 = true, dolbyVisionProfiles = listOf(5)),
+                nativeRpuConverterAvailable = true,
+                hardwareProfile8Decoder = true,
+                displayConfirmsDolbyVision = true,
+            ).isEmpty(),
+            "the Dolby Vision policy can still withdraw Profile 8 from the intersection",
+        )
+    }
+
+    @Test
+    fun aQuarantinedTransformationIsNotAdvertisedEvenWithFullEvidence() {
+        val advertised = advertisedClientDolbyVisionTransformations(
+            hdrDetails = HdrCapabilities(hdr10 = true, dolbyVisionProfiles = listOf(8)),
+            nativeRpuConverterAvailable = true,
+            fixtureValidatedTransformations = setOf(CLIENT_DV7_TO_DV81, CLIENT_DV7_TO_HDR10),
+            hardwareProfile8Decoder = true,
+            displayConfirmsDolbyVision = true,
+            quarantined = setOf(CLIENT_DV7_TO_DV81),
+        )
+
+        assertEquals(listOf(CLIENT_DV7_TO_HDR10), advertised.map { it.name })
+    }
+
+    @Test
+    fun profile8DecoderAndDolbyVisionPanelEvidenceReadTheProbeShapes() {
+        val hardwareP8 = ClientCodecCapabilities(
+            videoDecode = listOf(
+                org.siloserver.silo.model.playback.VideoDecodeCapability(
+                    codec = "dolby_vision",
+                    decoderName = "c2.mtk.dvhe.sth.decoder",
+                    profiles = listOf("profile 8"),
+                    hardware = true,
+                ),
+            ),
+        )
+        val softwareP8 = ClientCodecCapabilities(
+            videoDecode = listOf(
+                org.siloserver.silo.model.playback.VideoDecodeCapability(
+                    codec = "dolby_vision",
+                    profiles = listOf("profile 8"),
+                    hardware = false,
+                ),
+            ),
+        )
+        val hardwareP5Only = ClientCodecCapabilities(
+            videoDecode = listOf(
+                org.siloserver.silo.model.playback.VideoDecodeCapability(
+                    codec = "dolby_vision",
+                    profiles = listOf("profile 5"),
+                    hardware = true,
+                ),
+            ),
+        )
+        assertTrue(hasHardwareDolbyVisionProfile8Decoder(hardwareP8))
+        assertFalse(hasHardwareDolbyVisionProfile8Decoder(softwareP8))
+        assertFalse(hasHardwareDolbyVisionProfile8Decoder(hardwareP5Only))
+
+        assertTrue(
+            displayConfirmsDolbyVision(
+                DisplayHdrProbeResult.Exact(
+                    HdrCapabilities(dolbyVisionProfiles = DisplayHdrProbe.PANEL_DOLBY_VISION_PROFILES),
+                    displayId = 0,
+                ),
+            ),
+        )
+        assertFalse(
+            displayConfirmsDolbyVision(DisplayHdrProbeResult.Exact(HdrCapabilities(hdr10 = true), displayId = 0)),
+            "an HDR10-only panel is not a Dolby Vision panel",
+        )
+        assertFalse(
+            displayConfirmsDolbyVision(DisplayHdrProbeResult.Unknown(displayId = null, reason = "probe_failed")),
+            "unknown evidence never confirms the panel",
+        )
+        assertFalse(displayConfirmsDolbyVision(null))
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -246,18 +246,23 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
             libassBridge = LibassBridge(false),
             buildIdentity = SiloClientBuildIdentity(buildNumber = "test", channel = "test"),
         )
+        val hevc10 = org.siloserver.silo.model.playback.VideoDecodeCapability(
+            codec = "hevc",
+            bitDepths = listOf(8, 10),
+            hardware = true,
+        )
         val withHevc = detector.detectPlaybackContext(
             formFactor = "tv",
             appVersion = "test",
             capabilities = ClientCodecCapabilities(
-                videoDecode = listOf(
-                    org.siloserver.silo.model.playback.VideoDecodeCapability(
-                        codec = "hevc",
-                        bitDepths = listOf(8, 10),
-                        hardware = true,
-                    ),
-                ),
+                videoDecode = listOf(hevc10),
+                hdrDetails = HdrCapabilities(hdr10 = true),
             ),
+        )
+        val hevcWithoutRange = detector.detectPlaybackContext(
+            formFactor = "tv",
+            appVersion = "test",
+            capabilities = ClientCodecCapabilities(videoDecode = listOf(hevc10)),
         )
         val without = detector.detectPlaybackContext(
             formFactor = "tv",
@@ -270,6 +275,10 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
         )
         assertFalse(
             CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM in without.deliveries.getValue(DELIVERY_CLASS_ORIGINAL_HTTP).validatedClaims,
+        )
+        assertFalse(
+            CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM in hevcWithoutRange.deliveries.getValue(DELIVERY_CLASS_ORIGINAL_HTTP).validatedClaims,
+            "a Main10-only decoder with no HDR range in the intersection must not claim a route preflight would refuse",
         )
         assertFalse(
             CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM in withHevc.deliveries.getValue(DELIVERY_CLASS_HLS).validatedClaims,

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/TvPlaybackOutputPolicyTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/TvPlaybackOutputPolicyTest.kt
@@ -83,4 +83,22 @@ class TvPlaybackOutputPolicyTest {
             ),
         )
     }
+
+    @Test
+    fun `intersection keeps decoder profile bounds only for surviving profiles`() {
+        val effective = TvPlaybackOutputPolicy.effectiveHdrCapabilities(
+            codec = HdrCapabilities(
+                hdr10 = true,
+                dolbyVisionProfiles = listOf(5, 8),
+                dolbyVisionProfileLevels = listOf(
+                    org.siloserver.silo.model.playback.DolbyVisionProfileCapability(5, 9),
+                    org.siloserver.silo.model.playback.DolbyVisionProfileCapability(8, 9),
+                ),
+            ),
+            display = HdrCapabilities(hdr10 = true, dolbyVisionProfiles = listOf(8)),
+        )
+
+        assertEquals(listOf(8), effective.dolbyVisionProfiles)
+        assertEquals(listOf(8), effective.dolbyVisionProfileLevels.map { it.profile })
+    }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -70,6 +70,7 @@ import org.siloserver.silo.common.player.ActivePlayerHolder
 import org.siloserver.silo.common.player.AudioCapabilityManager
 import org.siloserver.silo.common.player.SiloPlaybackService
 import org.siloserver.silo.common.player.DisplayHdrProbe
+import org.siloserver.silo.common.player.findActivity
 import org.siloserver.silo.common.player.plannedVideoRouteFor
 import org.siloserver.silo.common.player.PlaybackCapabilityDetector
 import org.siloserver.silo.common.player.PlaybackPreflightListener
@@ -824,6 +825,21 @@ fun PlayerScreen(
                 controller.playWhenReady = desired
             }
         }
+    }
+
+    // Tell capability detection which display owns this player so the
+    // output context and preflight describe the panel showing the video
+    // rather than the default display.
+    DisposableEffect(context) {
+        val activity = context.findActivity()
+        capabilityDetector.playbackDisplayId = if (
+            activity != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R
+        ) {
+            runCatching { activity.display?.displayId }.getOrNull()
+        } else {
+            null
+        }
+        onDispose { capabilityDetector.playbackDisplayId = null }
     }
 
     // Preflight listener: evaluates the resolved Tracks and triggers the

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -70,7 +70,7 @@ import org.siloserver.silo.common.player.ActivePlayerHolder
 import org.siloserver.silo.common.player.AudioCapabilityManager
 import org.siloserver.silo.common.player.SiloPlaybackService
 import org.siloserver.silo.common.player.DisplayHdrProbe
-import org.siloserver.silo.common.player.findActivity
+import org.siloserver.silo.common.player.playbackDisplayId
 import org.siloserver.silo.common.player.plannedVideoRouteFor
 import org.siloserver.silo.common.player.PlaybackCapabilityDetector
 import org.siloserver.silo.common.player.PlaybackPreflightListener
@@ -220,7 +220,19 @@ fun PlayerScreen(
     val audioCapabilityManager: AudioCapabilityManager = koinInject()
     val capabilityDetector: PlaybackCapabilityDetector = koinInject()
     val subtitleManager: SubtitleManager = koinInject()
-    val displayHdr = remember { DisplayHdrProbe.probe(context) }
+    // Bind the playback display before anything plans: the ViewModel's
+    // initializer starts loading as soon as it exists, so the binding has to
+    // happen during composition, not in a later effect.
+    remember(context, capabilityDetector) {
+        capabilityDetector.playbackDisplayId = context.playbackDisplayId()
+        true
+    }
+    // Re-probe whenever the output route generation moves, so track
+    // selection sees the same display facts as capability detection.
+    val outputRouteGeneration by audioCapabilityManager.outputRouteGeneration.collectAsState()
+    val displayHdr = remember(outputRouteGeneration) {
+        DisplayHdrProbe.probe(context, capabilityDetector.playbackDisplayId)
+    }
     val refreshRateMatcher = remember { RefreshRateMatcher() }
     val audioCaps by audioCapabilityManager.capabilities.collectAsState()
     var exitRequested by remember { mutableStateOf(false) }
@@ -827,18 +839,8 @@ fun PlayerScreen(
         }
     }
 
-    // Tell capability detection which display owns this player so the
-    // output context and preflight describe the panel showing the video
-    // rather than the default display.
-    DisposableEffect(context) {
-        val activity = context.findActivity()
-        capabilityDetector.playbackDisplayId = if (
-            activity != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R
-        ) {
-            runCatching { activity.display?.displayId }.getOrNull()
-        } else {
-            null
-        }
+    // Release the playback display binding when this player leaves.
+    DisposableEffect(capabilityDetector) {
         onDispose { capabilityDetector.playbackDisplayId = null }
     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -70,6 +70,7 @@ import org.siloserver.silo.common.player.ActivePlayerHolder
 import org.siloserver.silo.common.player.AudioCapabilityManager
 import org.siloserver.silo.common.player.SiloPlaybackService
 import org.siloserver.silo.common.player.DisplayHdrProbe
+import org.siloserver.silo.common.player.plannedVideoRouteFor
 import org.siloserver.silo.common.player.PlaybackCapabilityDetector
 import org.siloserver.silo.common.player.PlaybackPreflightListener
 import org.siloserver.silo.common.player.RefreshRateMatcher
@@ -96,6 +97,7 @@ import org.siloserver.silo.model.playback.PlaybackExecutionPlan
 import org.siloserver.silo.model.playback.PlayerSubtitleInfo
 import org.siloserver.silo.model.playback.SubtitleIdentity
 import org.siloserver.silo.model.playback.executableMedia3ClientTransformations
+import org.siloserver.silo.model.playback.activeOriginalHttpClaims
 import org.siloserver.silo.model.watchtogether.RoomSnapshot
 import org.siloserver.silo.player.DolbyVisionDetection
 import com.google.common.util.concurrent.MoreExecutors
@@ -725,6 +727,7 @@ fun PlayerScreen(
             expectedColorRange = plan.validatedColorRangeFallback(),
             transformations = plan?.executableMedia3ClientTransformations().orEmpty(),
             runtimeCorrections = plan?.runtimeCorrections.orEmpty(),
+            activeClaims = plan?.activeOriginalHttpClaims().orEmpty(),
         )
         if (!isLocalMedia && uiState.sessionId != null) {
             PlaybackRuntimeCorrectionMetrics.reset()
@@ -806,6 +809,7 @@ fun PlayerScreen(
             expectedColorRange = plan.validatedColorRangeFallback(),
             transformations = plan?.executableMedia3ClientTransformations().orEmpty(),
             runtimeCorrections = plan?.runtimeCorrections.orEmpty(),
+            activeClaims = plan?.activeOriginalHttpClaims().orEmpty(),
         )
         backend.refresh(mediaSpec)
     }
@@ -838,6 +842,14 @@ fun PlayerScreen(
                 // mobile player dropped these on the floor and the screen sat
                 // on a stale frame.
                 onError = { error -> viewModel.onPlayerError(error) },
+                plannedRoute = {
+                    val plan = viewModel.uiState.value.playbackPlan
+                    plannedVideoRouteFor(
+                        decisionReason = plan?.decisionTrace?.firstOrNull(),
+                        effectiveDynamicRange = plan?.source?.hdrFormat,
+                        clientTransformations = plan?.executableMedia3ClientTransformations().orEmpty(),
+                    )
+                },
             )
             controller.addListener(preflight)
             onDispose { controller.removeListener(preflight) }
@@ -1092,6 +1104,24 @@ fun PlayerScreen(
                 }
                 delay(1_000)
             }
+        }
+    }
+
+    // A plan that promised the Dolby Vision Profile 8 base-layer route is
+    // only valid while an ordinary HEVC decoder is reading the stream. The
+    // renderer reports the decoder it actually opened; anything else becomes
+    // a typed replan rather than an unverified presentation.
+    LaunchedEffect(videoBackend) {
+        val backend = videoBackend ?: return@LaunchedEffect
+        backend.baseLayerDecoderMismatch.collect { decoderName ->
+            if (decoderName == null) return@collect
+            val plan = viewModel.uiState.value.playbackPlan
+            viewModel.onUnsupportedPlayback(
+                org.siloserver.silo.common.player.Playability.DvBaseLayerDecoderUnavailable(
+                    decoderName = decoderName,
+                    baseRange = plan?.source?.hdrFormat.orEmpty(),
+                ),
+            )
         }
     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -62,6 +62,7 @@ import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.model.playback.PlayMethod
 import org.siloserver.silo.model.playback.PlaybackDelivery
 import org.siloserver.silo.model.playback.PlaybackExecutionPlan
+import org.siloserver.silo.model.playback.executableMedia3ClientTransformations
 import org.siloserver.silo.model.playback.PlaybackRouteFamily
 import org.siloserver.silo.model.playback.PlaybackSessionResponse
 import org.siloserver.silo.model.playback.PlayerSubtitleInfo
@@ -1688,6 +1689,16 @@ class PlayerViewModel(
                     audioTracks = state.versions.getOrNull(state.selectedVersionIndex)?.audioTracks.orEmpty(),
                 )
             val dolbyVision = playerSettingsStore.dolbyVisionPolicySnapshot()
+            // A local Dolby Vision recipe that failed on this hardware is
+            // withdrawn before the replan context is built, so the server
+            // plans from what this device can still execute rather than
+            // handing back the route that just failed.
+            capabilityDetector.transformQuarantine.noteFailure(
+                classification = classification,
+                activeTransformations = state.playbackPlan
+                    ?.executableMedia3ClientTransformations()
+                    .orEmpty(),
+            )
             val capabilities = capabilityDetector.detect(dolbyVision = dolbyVision)
             val playbackContext = capabilityDetector.detectPlaybackContext(
                 formFactor = "mobile",

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -2,6 +2,7 @@ package org.siloserver.silo.android.ui.screens.player
 
 import org.siloserver.silo.common.player.dolbyVisionTransformClassification
 import org.siloserver.silo.common.player.failureDiagnostics
+import org.siloserver.silo.common.player.failureClassification
 
 import android.os.SystemClock
 import android.util.Log
@@ -1441,6 +1442,11 @@ class PlayerViewModel(
         val notice = when (reason) {
             is Playability.UnsupportedDvProfile ->
                 "This device cannot play Dolby Vision Profile ${reason.profile}. Falling back to transcoded stream."
+            is Playability.DvBaseLayerMetadataMismatch,
+            is Playability.DvBaseLayerOutputMismatch,
+            is Playability.DvBaseLayerDecoderUnavailable,
+            ->
+                "The Dolby Vision base-layer route could not be verified on this output. Requesting another route."
             is Playability.UnsupportedAudioCodec ->
                 "Lossless audio not supported on this output. Falling back to transcoded stream."
             is Playability.UnsupportedChannelCount ->
@@ -1947,14 +1953,6 @@ class PlayerViewModel(
                 )
             }
         }
-    }
-
-    private fun Playability.failureClassification(): String = when (this) {
-        is Playability.UnsupportedDvProfile -> "unsupported_dolby_vision_profile"
-        is Playability.UnsupportedAudioCodec -> "unsupported_audio_encoding"
-        is Playability.UnsupportedChannelCount -> "unsupported_audio_layout"
-        is Playability.StartupStalled -> classification
-        Playability.Supported -> "none"
     }
 
     private fun androidx.media3.common.PlaybackException.failureClassification(): String =

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -68,6 +68,7 @@ import org.siloserver.silo.tv.ui.screens.cast.TvSiloCastStandbyView
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.siloserver.silo.common.player.playbackDisplayId
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
 
@@ -1167,6 +1168,16 @@ fun TvAppNavigation(
                     nonce = episodeSelectionHandoffNonce,
                     targetContentId = contentId,
                 )
+            }
+            // TvPlayerViewModel starts loading in its initializer, which runs
+            // while TvPlayerScreen's default parameters are evaluated. Bind
+            // the playback display first so the very first capability probe
+            // describes the panel that will show the video.
+            val playerContext = androidx.compose.ui.platform.LocalContext.current
+            val capabilityDetector = koinInject<org.siloserver.silo.common.player.PlaybackCapabilityDetector>()
+            remember(playerContext, capabilityDetector) {
+                capabilityDetector.playbackDisplayId = playerContext.playbackDisplayId()
+                true
             }
             TvPlayerScreen(
                 contentId = contentId,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -107,6 +107,7 @@ import org.siloserver.silo.common.pip.SiloPictureInPictureSurface
 import org.siloserver.silo.common.player.ActivePlayerHolder
 import org.siloserver.silo.common.player.AudioCapabilityManager
 import org.siloserver.silo.common.player.DisplayHdrProbe
+import org.siloserver.silo.common.player.findActivity
 import org.siloserver.silo.common.player.HdrDisplayController
 import org.siloserver.silo.common.player.LetterboxInsets
 import org.siloserver.silo.common.player.PlayWhenReadyReconciliationGate
@@ -1424,6 +1425,21 @@ fun TvPlayerScreen(
         onDispose {
             lifecycleOwner.lifecycle.removeObserver(observer)
         }
+    }
+
+    // Tell capability detection which display owns this player so the
+    // output context and preflight describe the panel showing the video
+    // rather than the default display.
+    DisposableEffect(context) {
+        val activity = context.findActivity()
+        capabilityDetector.playbackDisplayId = if (
+            activity != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R
+        ) {
+            runCatching { activity.display?.displayId }.getOrNull()
+        } else {
+            null
+        }
+        onDispose { capabilityDetector.playbackDisplayId = null }
     }
 
     // Preflight listener — falls back to a transcoded stream if the selected

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -132,6 +132,7 @@ import org.siloserver.silo.model.playback.PlaybackExecutionPlan
 import org.siloserver.silo.model.playback.PlaybackSourceMetadata
 import org.siloserver.silo.model.playback.SubtitleIdentity
 import org.siloserver.silo.model.playback.executableMedia3ClientTransformations
+import org.siloserver.silo.model.playback.activeOriginalHttpClaims
 import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.model.settings.SubtitlePositionPreset
 import org.siloserver.silo.model.settings.legacyPosition
@@ -473,6 +474,23 @@ fun TvPlayerScreen(
     LaunchedEffect(videoBackend) {
         videoBackend?.let { backend ->
             viewModel.onBackendCapabilities(backend.capabilities)
+        }
+    }
+    // A plan that promised the Dolby Vision Profile 8 base-layer route is
+    // only valid while an ordinary HEVC decoder is reading the stream. The
+    // renderer reports the decoder it actually opened; anything else becomes
+    // a typed replan rather than an unverified presentation.
+    LaunchedEffect(videoBackend) {
+        val backend = videoBackend ?: return@LaunchedEffect
+        backend.baseLayerDecoderMismatch.collect { decoderName ->
+            if (decoderName == null) return@collect
+            val plan = viewModel.uiState.value.playbackPlan
+            viewModel.onUnsupportedPlayback(
+                org.siloserver.silo.common.player.Playability.DvBaseLayerDecoderUnavailable(
+                    decoderName = decoderName,
+                    baseRange = plan?.source?.hdrFormat.orEmpty(),
+                ),
+            )
         }
     }
     val latestSiloCastMediaController by rememberUpdatedState(mediaController)
@@ -1419,6 +1437,14 @@ fun TvPlayerScreen(
                 detector = capabilityDetector,
                 onUnsupported = { verdict -> viewModel.onUnsupportedPlayback(verdict) },
                 onError = { error -> viewModel.onPlayerError(error) },
+                plannedRoute = {
+                    val plan = viewModel.uiState.value.playbackPlan
+                    org.siloserver.silo.common.player.plannedVideoRouteFor(
+                        decisionReason = plan?.decisionTrace?.firstOrNull(),
+                        effectiveDynamicRange = plan?.source?.hdrFormat,
+                        clientTransformations = plan?.executableMedia3ClientTransformations().orEmpty(),
+                    )
+                },
             )
             controller.addListener(preflight)
             onDispose { controller.removeListener(preflight) }
@@ -1746,6 +1772,7 @@ fun TvPlayerScreen(
             expectedColorRange = plan.validatedColorRangeFallback(),
             transformations = plan?.executableMedia3ClientTransformations().orEmpty(),
             runtimeCorrections = plan?.runtimeCorrections.orEmpty(),
+            activeClaims = plan?.activeOriginalHttpClaims().orEmpty(),
         )
         state.sessionId?.let { sessionId ->
             PlaybackRuntimeCorrectionMetrics.reset()
@@ -1813,6 +1840,7 @@ fun TvPlayerScreen(
             expectedColorRange = plan.validatedColorRangeFallback(),
             transformations = plan?.executableMedia3ClientTransformations().orEmpty(),
             runtimeCorrections = plan?.runtimeCorrections.orEmpty(),
+            activeClaims = plan?.activeOriginalHttpClaims().orEmpty(),
         )
         backend.refresh(mediaSpec)
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -107,7 +107,7 @@ import org.siloserver.silo.common.pip.SiloPictureInPictureSurface
 import org.siloserver.silo.common.player.ActivePlayerHolder
 import org.siloserver.silo.common.player.AudioCapabilityManager
 import org.siloserver.silo.common.player.DisplayHdrProbe
-import org.siloserver.silo.common.player.findActivity
+import org.siloserver.silo.common.player.playbackDisplayId
 import org.siloserver.silo.common.player.HdrDisplayController
 import org.siloserver.silo.common.player.LetterboxInsets
 import org.siloserver.silo.common.player.PlayWhenReadyReconciliationGate
@@ -364,7 +364,19 @@ fun TvPlayerScreen(
     val latestSiloCastSubtitleAppearance by rememberUpdatedState(subtitleAppearance)
     val context = LocalContext.current
     val hdrDisplayController = remember { HdrDisplayController() }
-    val displayHdr = remember { DisplayHdrProbe.probe(context) }
+    // Bind the playback display before anything plans: the ViewModel's
+    // initializer starts loading as soon as it exists, so the binding has to
+    // happen during composition, not in a later effect.
+    remember(context, capabilityDetector) {
+        capabilityDetector.playbackDisplayId = context.playbackDisplayId()
+        true
+    }
+    // Re-probe whenever the output route generation moves, so track
+    // selection sees the same display facts as capability detection.
+    val outputRouteGeneration by audioCapabilityManager.outputRouteGeneration.collectAsState()
+    val displayHdr = remember(outputRouteGeneration) {
+        DisplayHdrProbe.probe(context, capabilityDetector.playbackDisplayId)
+    }
     val audioCaps by audioCapabilityManager.capabilities.collectAsState()
     val rootFocus = remember { FocusRequester() }
     var playerRootHasFocus by remember { mutableStateOf(false) }
@@ -1427,18 +1439,8 @@ fun TvPlayerScreen(
         }
     }
 
-    // Tell capability detection which display owns this player so the
-    // output context and preflight describe the panel showing the video
-    // rather than the default display.
-    DisposableEffect(context) {
-        val activity = context.findActivity()
-        capabilityDetector.playbackDisplayId = if (
-            activity != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R
-        ) {
-            runCatching { activity.display?.displayId }.getOrNull()
-        } else {
-            null
-        }
+    // Release the playback display binding when this player leaves.
+    DisposableEffect(capabilityDetector) {
         onDispose { capabilityDetector.playbackDisplayId = null }
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -79,6 +79,7 @@ import org.siloserver.silo.model.catalog.TimeRange
 import org.siloserver.silo.model.catalog.VersionChapter
 import org.siloserver.silo.model.settings.SubtitleAppearance
 import org.siloserver.silo.model.playback.AutoSubtitleCandidate
+import org.siloserver.silo.model.playback.executableMedia3ClientTransformations
 import org.siloserver.silo.model.playback.AutoSubtitleContext
 import org.siloserver.silo.model.playback.AutoSubtitleResolution
 import org.siloserver.silo.model.playback.inventoryAutoSubtitleCandidates
@@ -2427,6 +2428,16 @@ class TvPlayerViewModel(
             val dolbyVision = playerSettingsStore.dolbyVisionPolicySnapshot()
             coroutineContext.ensureActive()
             if (recoveryContentGeneration != contentLoadGeneration) return@launch
+            // A local Dolby Vision recipe that failed on this hardware is
+            // withdrawn before the replan context is built, so the server
+            // plans from what this device can still execute rather than
+            // handing back the route that just failed.
+            capabilityDetector.transformQuarantine.noteFailure(
+                classification = classification,
+                activeTransformations = state.playbackPlan
+                    ?.executableMedia3ClientTransformations()
+                    .orEmpty(),
+            )
             val capabilities = capabilityDetector.detect(dolbyVision = dolbyVision)
             val playbackContext = capabilityDetector.detectPlaybackContext(
                 formFactor = "tv",

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -4,6 +4,7 @@ package org.siloserver.silo.tv.ui.screens.player
 
 import org.siloserver.silo.common.player.dolbyVisionTransformClassification
 import org.siloserver.silo.common.player.failureDiagnostics
+import org.siloserver.silo.common.player.failureClassification
 
 import org.siloserver.silo.tv.BuildConfig
 
@@ -2339,6 +2340,11 @@ class TvPlayerViewModel(
         val notice = when (reason) {
             is org.siloserver.silo.common.player.Playability.UnsupportedDvProfile ->
                 "This device cannot play Dolby Vision Profile ${reason.profile}. Falling back to transcoded stream."
+            is org.siloserver.silo.common.player.Playability.DvBaseLayerMetadataMismatch,
+            is org.siloserver.silo.common.player.Playability.DvBaseLayerOutputMismatch,
+            is org.siloserver.silo.common.player.Playability.DvBaseLayerDecoderUnavailable,
+            ->
+                "The Dolby Vision base-layer route could not be verified on this output. Requesting another route."
             is org.siloserver.silo.common.player.Playability.UnsupportedAudioCodec ->
                 "Lossless audio not supported on this output. Falling back to transcoded stream."
             is org.siloserver.silo.common.player.Playability.UnsupportedChannelCount ->
@@ -2674,14 +2680,6 @@ class TvPlayerViewModel(
                 )
             }
         }
-    }
-
-    private fun org.siloserver.silo.common.player.Playability.failureClassification(): String = when (this) {
-        is org.siloserver.silo.common.player.Playability.UnsupportedDvProfile -> "unsupported_dolby_vision_profile"
-        is org.siloserver.silo.common.player.Playability.UnsupportedAudioCodec -> "unsupported_audio_encoding"
-        is org.siloserver.silo.common.player.Playability.UnsupportedChannelCount -> "unsupported_audio_layout"
-        is org.siloserver.silo.common.player.Playability.StartupStalled -> classification
-        org.siloserver.silo.common.player.Playability.Supported -> "none"
     }
 
     private fun androidx.media3.common.PlaybackException.failureClassification(): String =

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackModels.kt
@@ -100,6 +100,46 @@ data class HdrCapabilities(
     @SerialName("hdr10_plus") val hdr10Plus: Boolean = false,
     val hlg: Boolean = false,
     @SerialName("dolby_vision_profiles") val dolbyVisionProfiles: List<Int> = emptyList(),
+    /**
+     * Per-profile decoder bounds. Once any entry is present the server requires
+     * one for every profile in [dolbyVisionProfiles]; an advertised profile
+     * without bounds is then refused rather than assumed unbounded.
+     */
+    @SerialName("dolby_vision_profile_levels")
+    val dolbyVisionProfileLevels: List<DolbyVisionProfileCapability> = emptyList(),
+)
+
+/**
+ * Decoder bounds for one Dolby Vision profile. [maxLevel] is the Dolby Vision
+ * level (1..13). An empty [blCompatibilityIds] means every base-layer
+ * compatibility id is accepted for the profile.
+ */
+@Serializable
+data class DolbyVisionProfileCapability(
+    val profile: Int,
+    @SerialName("max_level") val maxLevel: Int,
+    @SerialName("bl_compatibility_ids") val blCompatibilityIds: List<Int> = emptyList(),
+)
+
+/** How the active display's HDR facts were obtained. */
+const val OUTPUT_HDR_EVIDENCE_EXACT = "exact"
+
+/** The display could not be probed; the server must not infer native output. */
+const val OUTPUT_HDR_EVIDENCE_UNKNOWN = "unknown"
+
+/**
+ * Raw facts about the display that currently owns the playback surface, kept
+ * separate from [PlaybackOutputContext.hdrDetails] (decoder ∩ display) so the
+ * server can distinguish "confirmed SDR" from "could not probe".
+ */
+@Serializable
+data class PlaybackOutputDisplay(
+    /** [OUTPUT_HDR_EVIDENCE_EXACT] or [OUTPUT_HDR_EVIDENCE_UNKNOWN]. */
+    @SerialName("hdr_evidence") val hdrEvidence: String,
+    /** Display-reported HDR types, independent of any decoder. */
+    @SerialName("hdr_types") val hdrTypes: HdrCapabilities = HdrCapabilities(),
+    /** Platform display identity (Android display id), for diagnostics. */
+    @SerialName("display_id") val displayId: String? = null,
 )
 
 /**
@@ -379,6 +419,11 @@ data class PlaybackOutputContext(
      * stringified, Apple a synthetic sink hash, web omits it.
      */
     @SerialName("output_context_id") val outputContextId: String? = null,
+    /**
+     * Raw active-display facts with an evidence marker. Additive: older servers
+     * ignore it and keep reading [hdrDetails].
+     */
+    val display: PlaybackOutputDisplay? = null,
 )
 
 /** What the client can do with one delivery class. */

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
@@ -31,6 +31,20 @@ const val NATIVE_HLS_PLAYBACK_V1_FEATURE = "native_hls_playback_v1"
 const val CLIENT_SELECTED_AUDIO_TRACK_V1_CLAIM = "client_selected_audio_track_v1"
 
 /**
+ * Delivery-scoped claim that the original-file player decodes a single-layer
+ * Dolby Vision Profile 8 stream through an ordinary HEVC decoder and presents
+ * its standards-compatible base layer (HDR10, HLG, or SDR by `dv_bl_compat_id`)
+ * when the active output lacks native Dolby Vision. The bytes are untouched;
+ * the plan's `effective_recipe.dynamic_range` names the base range and the
+ * plan never claims Dolby Vision output. Not a transformation and not the
+ * broad `client_managed_dynamic_range_v1` promise.
+ */
+const val CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM = "client_dv8_base_layer_fallback_v1"
+
+/** Server decision reason for a plan that used [CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM]. */
+const val DECISION_REASON_CLIENT_DV8_BASE_LAYER = "client_dv8_base_layer"
+
+/**
  * How a capability list was obtained. The server validates strictly against
  * [CAPABILITY_EVIDENCE_EXACT] and only grants audio passthrough at that tier;
  * weaker tiers exist so a platform that cannot enumerate decoders does not have
@@ -639,3 +653,21 @@ private fun List<PlaybackTransformationV3>.executableMedia3ClientTransformations
             it.name in setOf(CLIENT_DV7_TO_DV81, CLIENT_DV7_TO_HDR10)
     }
     .map { it.name }
+
+/**
+ * Delivery-scoped claims the plan's decision relies on, derived from the
+ * decision reason. The server does not echo claims back; the decision reason
+ * is the contract for which claim an original_http plan exercised.
+ */
+fun PlaybackExecutionPlan.activeOriginalHttpClaims(): List<String> =
+    activeOriginalHttpClaimsFor(delivery, decisionTrace.firstOrNull())
+
+fun PlaybackPlanV3.activeOriginalHttpClaims(): List<String> =
+    activeOriginalHttpClaimsFor(delivery, decisionReason)
+
+private fun activeOriginalHttpClaimsFor(delivery: PlaybackDelivery, decisionReason: String?): List<String> =
+    if (delivery == PlaybackDelivery.ORIGINAL_HTTP && decisionReason == DECISION_REASON_CLIENT_DV8_BASE_LAYER) {
+        listOf(CLIENT_DV8_BASE_LAYER_FALLBACK_V1_CLAIM)
+    } else {
+        emptyList()
+    }


### PR DESCRIPTION
## Problem

Android used the decoder ∩ display HDR intersection as a playability gate. A Dolby Vision Profile 8.1 file on an HDR10-only output was refused by preflight (`UnsupportedDvProfile`) and bounced to a transcode, even though Media3 decodes its HDR10 base layer through the ordinary HEVC decoder. Reports that "the same file plays in Jellyfin" were this: those clients silently play the base layer.

Related gaps: the display probe returned the same empty object for confirmed-SDR, missing display, old API, and probe failure; the detailed decoder list omitted the Dolby Vision MIME; no per-profile DV level bounds were sent; the DV colour repair assumed a PQ base for every profile; and a display capability change never rotated the output context id.

## Solution

Keep decoder, active-output, and per-delivery scopes separate, and validate the plan the server issued rather than the source's native format.

- `DisplayHdrProbe` returns `Exact` vs `Unknown`, probes the display owning the playback Activity, uses API 34 per-mode HDR types, and treats forced-SDR conversion as SDR. Display changes now bump the output route generation.
- `MediaCodecCapabilitiesProbe` lists the DV decoder and emits `dolby_vision_profile_levels`.
- Output context keeps `hdr_details` as the intersection and adds `display { hdr_evidence, hdr_types }`.
- `original_http` advertises `client_dv8_base_layer_fallback_v1` when a 10-bit hardware HEVC decoder exists.
- Preflight takes a `PlannedVideoRoute` derived from the plan; a base-layer plan is checked against its promised base range, with typed failures `dv8_base_layer_metadata_mismatch`, `dv8_base_layer_output_mismatch`, `dv8_base_layer_decoder_unavailable`.
- `SiloMediaCodecVideoRenderer` overrides `getDecoderInfos` to offer only base-layer decoders for a base-layer plan (Media3's own swap depends on the default display) and reports the opened decoder; both screens turn a mismatch into a replan.
- DV colour repair follows the promised base range instead of assuming PQ.

Server side: Silo-Server/silo-server#899.

## Validation

- `:android-shared` and `:shared` unit tests: 2537 passed, 0 failed (new tests for route evaluation, DV probe mapping, claim scoping, intersection bounds).
- Phone and TV modules compile; R8 release build of the TV app installed on an Onn 4K box (API 34, armeabi-v7a) with no crash.
- End-to-end against the dev server on PR 899: a 90 Mbps DV P8.1 remux planned as `client_dv8_base_layer` / `hdr10`, Media3 selected the `dvhe.08.06` track and opened `c2.realtek.video.hevc.main10.decoder`, mastering metadata came from the container, display switched to 2160p23.976 with HDR10, zero replans. No screenshots or recordings attached.

## Risks

- Needs a server with PR 899; older servers ignore the claim and `display` field and behave as before.
- Device matrix is one box so far; P8.2 (SDR base) and P8.4 (HLG base) are gated on but not device-validated.

## AI disclosure

Written with Claude Code using model `claude-fable-5-1` (Claude Fable 5.1). No other AI tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Dolby Vision Profile 8 base-layer fallback playback when supported by the device and display.
  - Added display-specific HDR and Dolby Vision capability detection, including decoder profile and level limits.
  - Playback can request alternate routes when metadata, display output, or decoder compatibility is insufficient.
  - Added reporting for decoder mismatches and improved handling of failed playback transformations.

- **Bug Fixes**
  - Improved HDR reporting across displays, including forced-SDR scenarios.
  - Ensured fallback routing uses compatible HDR signaling and hardware decoders.

- **Tests**
  - Added coverage for Dolby Vision capabilities, fallback validation, HDR intersections, and route selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->