### PR TITLE
fix(ci): opt into UnstableApi in the mobile track resolver and stop a flaky admin-gate test

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileVideoPlaybackStarter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileVideoPlaybackStarter.kt
@@ -79,6 +79,7 @@ internal data class MobileInitialTrackSelection(
  * Local/downloaded subtitle identities deliberately resolve to null and stay
  * on the Media3-only restore path after the server plan is mounted.
  */
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 internal fun resolveMobileInitialTrackSelection(
     explicitAudioTrackIndex: Int?,
     explicitSubtitleTrackIndex: Int?,

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
@@ -10,6 +10,7 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -52,9 +53,12 @@ class ProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        // The mock HTTP calls complete on Ktor's own dispatcher, not the test
+        // scheduler, so advanceUntilIdle() can return before the load lands.
+        // Wait for the load itself to finish instead of the scheduler.
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertTrue(viewModel.uiState.value.canManageProfiles)
+        assertTrue(loaded.canManageProfiles)
     }
 
     @Test

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -54,7 +53,7 @@ class ProfileSelectionAdminGateTest {
             authRepository = authRepo,
         )
         // The mock HTTP calls complete on Ktor's own dispatcher, not the test
-        // scheduler, so advanceUntilIdle() can return before the load lands.
+        // scheduler, so advancing the test scheduler can return before the load lands.
         // Wait for the load itself to finish instead of the scheduler.
         val loaded = viewModel.uiState.first { !it.isLoading }
 
@@ -71,9 +70,9 @@ class ProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -87,9 +86,9 @@ class ProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -99,9 +98,9 @@ class ProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = null,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -115,7 +114,7 @@ class ProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        viewModel.uiState.first { !it.isLoading }
 
         viewModel.toggleManageMode()
         assertFalse(viewModel.uiState.value.isManageMode)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -379,6 +379,7 @@ class TvVideoPlaybackStarter(
     }
 }
 
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 internal fun resolveTvInitialAudioTrackIndex(
     requestedAudioIndex: Int?,
     carriedAudioIndex: Int?,

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -54,7 +53,7 @@ class TvProfileSelectionAdminGateTest {
             authRepository = authRepo,
         )
         // The mock HTTP calls complete on Ktor's own dispatcher, not the test
-        // scheduler, so advanceUntilIdle() can return before the load lands.
+        // scheduler, so advancing the test scheduler can return before the load lands.
         val loaded = viewModel.uiState.first { !it.isLoading }
 
         assertTrue(loaded.canManageProfiles)
@@ -70,9 +69,9 @@ class TvProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -86,9 +85,9 @@ class TvProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -98,9 +97,9 @@ class TvProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = null,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -114,7 +113,7 @@ class TvProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        viewModel.uiState.first { !it.isLoading }
 
         viewModel.toggleManageMode()
         assertFalse(viewModel.uiState.value.isManageMode)

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
@@ -10,6 +10,7 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -52,9 +53,11 @@ class TvProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        // The mock HTTP calls complete on Ktor's own dispatcher, not the test
+        // scheduler, so advanceUntilIdle() can return before the load lands.
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertTrue(viewModel.uiState.value.canManageProfiles)
+        assertTrue(loaded.canManageProfiles)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Main's CI has been red since `9554331d` (Lint) and `c275d8a6` (Unit tests):

- `MobileVideoPlaybackStarter.resolveMobileInitialTrackSelection` calls the `@UnstableApi` `TrackSelectionPresets.selectBestCompatibleAudioTrackOrdinal` without an opt-in, so `:androidApp:lintDebug` reports `UnsafeOptInUsageError`.
- `ProfileSelectionAdminGateTest."admin user has canManageProfiles set to true"` fails intermittently. The mocked Ktor calls complete on Ktor's own dispatcher, so `advanceUntilIdle()` can return before the profile load has written `canManageProfiles`.

## Solution

- Add `@androidx.annotation.OptIn(UnstableApi::class)` on the resolver, matching the convention used elsewhere in the module.
- In the test, wait for `uiState.first { !it.isLoading }` instead of the test scheduler.

## Validation

- `:androidApp:lintDebug` passes locally (was 1 error).
- `ProfileSelectionAdminGateTest` passes on three forced reruns (was failing 1 of 5 locally and in CI).

## AI disclosure

Written with Claude Code using model `claude-fable-5-1` (Claude Fable 5.1). No other AI tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading the profile-selection screen by ensuring profile management is evaluated only after loading completes.
  - Improved handling of profile-selection states for administrators, non-administrators, failed profile requests, and unavailable authentication.

- **Tests**
  - Updated automated coverage to verify the loaded profile-selection state more consistently.
  - Expanded synchronization checks across mobile and TV profile-selection flows, including management actions and loading completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->