### PR TITLE
fix(playback): add the missing transcode-failure reasons to the diagnostics allowlist

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResult.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResult.kt
@@ -104,6 +104,9 @@ value class PlaybackDiagnosticsCode private constructor(val wireValue: String) {
             "source_metadata_incomplete",
             "source_unavailable",
             "transcoding_disabled",
+            "transcode_start_failed",
+            "transcode_node_unavailable",
+            "transcode_node_capability_unavailable",
         )
     }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResultTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResultTest.kt
@@ -1,0 +1,19 @@
+package org.siloserver.silo.common.player.video
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class VideoPlaybackStartResultTest {
+    @Test
+    fun serverTerminalRecognizesTranscodeFailureReasons() {
+        assertNotNull(PlaybackDiagnosticsCode.serverTerminal("transcode_start_failed"))
+        assertNotNull(PlaybackDiagnosticsCode.serverTerminal("transcode_node_unavailable"))
+        assertNotNull(PlaybackDiagnosticsCode.serverTerminal("transcode_node_capability_unavailable"))
+    }
+
+    @Test
+    fun serverTerminalReturnsNullForUnknownReason() {
+        assertNull(PlaybackDiagnosticsCode.serverTerminal("some_unlisted_reason"))
+    }
+}


### PR DESCRIPTION
## What this fixes

When Silo can't play something — say a transcode fails to start, or every transcode node is busy or missing the right capability — the app is supposed to log a diagnostics code so we can tell these failure types apart later. For three fairly common failure reasons, that code lookup was silently returning nothing instead of a real code:

- a transcode failing to start
- no transcode node being available
- no transcode node having the needed capability

Because the lookup is a fixed allowlist and these three reasons were missing from it, every one of these failures showed up in diagnostics as an unclassified "unknown reason" — indistinguishable from something we'd never seen before, even though these are common, well-understood failures.

## The fix

Added the three missing reasons to the allowlist (`SAFE_SERVER_TERMINAL_REASONS` in `VideoPlaybackStartResult.kt`), matching the names the server already uses for them. Nothing else changes — this only affects whether these failures get a proper diagnostics code, not how playback itself behaves.

I kept this narrow on purpose: the server's full list of possible failure reasons is much longer, covering things like subtitle or HDR conversion problems. Auditing that whole list for gaps is worth doing separately, not folded into this fix.

## How I checked it

- Added a test that feeds all three new reasons through the lookup and confirms each now returns a real diagnostics code, and that a made-up reason still correctly returns nothing.
- Ran that test — passes.
- Compiled both the phone and TV apps — clean.

Related issue: #247