### PR TITLE
fix(player): stop showing raw terminal reason slugs to end users

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResult.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResult.kt
@@ -74,6 +74,15 @@ sealed interface VideoPlaybackStartResult {
     ) : VideoPlaybackStartResult
 }
 
+/**
+ * The user-visible text for a server playback terminal. `terminal.message` is
+ * written by the server for end users and can stand alone; the terminal reason
+ * slug (e.g. "transcode_start_failed") belongs in diagnostics/telemetry only,
+ * never in the on-screen sentence.
+ */
+fun serverTerminalUserMessage(message: String): String =
+    message.trim().ifEmpty { "Playback is unavailable right now." }
+
 @JvmInline
 value class PlaybackDiagnosticsCode private constructor(val wireValue: String) {
     companion object {

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResultTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/VideoPlaybackStartResultTest.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.common.player.video
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -15,5 +16,19 @@ class VideoPlaybackStartResultTest {
     @Test
     fun serverTerminalReturnsNullForUnknownReason() {
         assertNull(PlaybackDiagnosticsCode.serverTerminal("some_unlisted_reason"))
+    }
+
+    @Test
+    fun serverTerminalUserMessageReturnsTrimmedMessage() {
+        assertEquals(
+            "A lower-resolution source is required.",
+            serverTerminalUserMessage("  A lower-resolution source is required.  "),
+        )
+    }
+
+    @Test
+    fun serverTerminalUserMessageFallsBackWhenBlank() {
+        assertEquals("Playback is unavailable right now.", serverTerminalUserMessage(""))
+        assertEquals("Playback is unavailable right now.", serverTerminalUserMessage("   "))
     }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileVideoPlaybackStarter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileVideoPlaybackStarter.kt
@@ -13,6 +13,7 @@ import org.siloserver.silo.common.player.video.VideoPlaybackStartResult
 import org.siloserver.silo.common.player.video.VideoPlaybackStarter
 import org.siloserver.silo.common.player.video.PlaybackDiagnosticsCode
 import org.siloserver.silo.common.player.video.resolvedPlaybackDelivery
+import org.siloserver.silo.common.player.video.serverTerminalUserMessage
 import org.siloserver.silo.common.player.video.shouldReachServerForPlayback
 import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.common.settings.dolbyVisionPolicySnapshot
@@ -305,7 +306,7 @@ internal class MobileVideoPlaybackStarter(
                 is VideoSessionStartV3.Ready -> v3Start
                 is VideoSessionStartV3.Terminal -> return failure(
                     request.contentId,
-                    "Playback unavailable (${v3Start.reason}): ${v3Start.message}",
+                    serverTerminalUserMessage(v3Start.message),
                     diagnosticsCode = PlaybackDiagnosticsCode.serverTerminal(v3Start.reason),
                 )
                 VideoSessionStartV3.ServerUpgradeRequired -> return failure(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -48,6 +48,7 @@ import org.siloserver.silo.common.player.video.VideoPlayerRouteArgs
 import org.siloserver.silo.common.player.video.VideoPlayerUiState
 import org.siloserver.silo.common.player.video.canPlayResolvedStreamDirectly
 import org.siloserver.silo.common.player.video.resolvedPlaybackDelivery
+import org.siloserver.silo.common.player.video.serverTerminalUserMessage
 import org.siloserver.silo.common.settings.LetterboxExpansion
 import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.common.settings.dolbyVisionPolicySnapshot
@@ -1899,8 +1900,7 @@ class PlayerViewModel(
                     }
                     is VideoSessionStartV3.Terminal -> {
                         val failedSessionId = state.sessionId ?: return@launch
-                        val terminalMessage =
-                            "Playback unavailable (${decision.reason}): ${decision.message}"
+                        val terminalMessage = serverTerminalUserMessage(decision.message)
                         val terminalStillCurrent = sessionLifecycle.stopTerminalSessionIfCurrent(
                             expectedSessionId = failedSessionId,
                             isCurrent = {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -68,6 +68,7 @@ import org.siloserver.silo.common.player.video.resolveAudioSelectionAcrossVersio
 import org.siloserver.silo.common.player.normalizedSubtitleCodecFamily
 import org.siloserver.silo.common.player.video.VideoPlayerUiState
 import org.siloserver.silo.common.player.video.resolvedPlaybackDelivery
+import org.siloserver.silo.common.player.video.serverTerminalUserMessage
 import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.common.settings.dolbyVisionPolicySnapshot
 import org.siloserver.silo.domain.player.IntroAutoSkipController
@@ -2603,8 +2604,7 @@ class TvPlayerViewModel(
                     }
                     is VideoSessionStartV3.Terminal -> {
                         val failedSessionId = state.sessionId ?: return@launch
-                        val terminalMessage =
-                            "Playback unavailable (${decision.reason}): ${decision.message}"
+                        val terminalMessage = serverTerminalUserMessage(decision.message)
                         cancelPendingCatalogSubtitle()
                         val terminalStillCurrent = sessionLifecycle.stopTerminalSessionIfCurrent(
                             expectedSessionId = failedSessionId,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -23,6 +23,7 @@ import org.siloserver.silo.common.player.video.EpisodeAudioMode
 import org.siloserver.silo.common.player.video.resolveEpisodeAudioIntent
 import org.siloserver.silo.common.player.video.resolveEpisodeSubtitleIntent
 import org.siloserver.silo.common.player.video.resolvedPlaybackDelivery
+import org.siloserver.silo.common.player.video.serverTerminalUserMessage
 import org.siloserver.silo.common.player.video.shouldReachServerForPlayback
 import org.siloserver.silo.common.settings.PlayerSettingsStore
 import org.siloserver.silo.common.settings.dolbyVisionPolicySnapshot
@@ -227,7 +228,7 @@ class TvVideoPlaybackStarter(
                 is VideoSessionStartV3.Ready -> v3Start
                 is VideoSessionStartV3.Terminal -> return failure(
                     request.contentId,
-                    "Playback unavailable (${v3Start.reason}): ${v3Start.message}",
+                    serverTerminalUserMessage(v3Start.message),
                     diagnosticsCode = PlaybackDiagnosticsCode.serverTerminal(v3Start.reason),
                 )
                 VideoSessionStartV3.ServerUpgradeRequired -> return failure(


### PR DESCRIPTION
## What this fixes

When playback can't continue — the server refuses to start or replan a stream — the app shows the viewer an error message. Right now that message looks like this:

> Playback unavailable (transcode_start_failed): Failed to start the playback transport.

That `(transcode_start_failed)` part is an internal protocol code, not something a viewer should ever see. The server already sends a plain-English explanation alongside it (the part after the colon), which is meant to stand on its own — something like "A lower-resolution source is required because 4K transcoding is disabled." Four places in the app (phone start, phone replan, TV start, TV replan) were all gluing the internal code onto the front of that message before showing it. Neither the web player nor the iOS/tvOS/macOS apps do this — they just show the plain-English part.

## The fix

Added one small helper, `serverTerminalUserMessage`, that takes the server's message, trims it, and falls back to a generic "Playback is unavailable right now." if the server didn't send one. All four places now use that instead of building the "(code): message" string. The internal code hasn't been thrown away — it still flows into diagnostics and telemetry, just not onto the screen.

## How I checked it

- Added a test covering the trimming behavior and the fallback when the server message is blank.
- Ran that test — passes.
- Compiled both the phone and TV apps — clean.

Related issue: #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback error messages across mobile and TV apps.
  - Server-provided messages are now displayed without surrounding whitespace.
  - A clear fallback message—“Playback is unavailable right now.”—appears when no useful server message is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->