### PR TITLE
fix(playback): own the display binding, name the base range, scope quarantine to video

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionTransformQuarantine.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionTransformQuarantine.kt
@@ -65,12 +65,22 @@ class DolbyVisionTransformQuarantine internal constructor(
 
     /**
      * Withdraws every [activeTransformations] entry when [classification]
-     * describes a fault in the local recipe rather than in the source or the
-     * transport. Returns the names that were withdrawn.
+     * describes a fault in the local recipe rather than in the source, the
+     * transport, or another renderer. Returns the names that were withdrawn.
+     *
+     * @param failedTrackType the Media3 track type of the renderer that
+     * raised the error, when the failure came from a player exception. A
+     * generic decoder classification only counts against the video recipe
+     * when the video renderer raised it; an audio decoder failing under a
+     * transformed plan says nothing about the transformation.
      */
-    fun noteFailure(classification: String, activeTransformations: Collection<String>): List<String> {
+    fun noteFailure(
+        classification: String,
+        activeTransformations: Collection<String>,
+        failedTrackType: Int? = null,
+    ): List<String> {
         if (activeTransformations.isEmpty()) return emptyList()
-        if (!isDeviceFault(classification)) return emptyList()
+        if (!isDeviceFault(classification, failedTrackType)) return emptyList()
         val withdrawn = activeTransformations.filter { it in KNOWN_TRANSFORMATIONS }
         withdrawn.forEach { name ->
             Log.w(TAG, "Quarantining client transformation $name after $classification")
@@ -88,25 +98,55 @@ class DolbyVisionTransformQuarantine internal constructor(
         internal val KNOWN_TRANSFORMATIONS: Set<String> = setOf(CLIENT_DV7_TO_DV81, CLIENT_DV7_TO_HDR10)
 
         /**
-         * Classifications that mean the local recipe failed on this hardware.
-         * A source that is not what the plan described, an encrypted sample,
-         * or a network stall is not evidence against the device.
+         * Classifications raised by the transformation itself, which name the
+         * local recipe as the fault regardless of which renderer surfaced
+         * them. A source that is not what the plan described, an encrypted
+         * sample, or a network stall is not evidence against the device.
          */
-        private val DEVICE_FAULT_PREFIXES = listOf(
+        private val TRANSFORM_FAULT_PREFIXES = listOf(
             "dv7_transform_stall",
             "dv7_transform_unavailable",
             "dv7_transform_oversized",
             "dv7_transform_failed",
             "dv7_rpu_conversion_failed",
         )
-        private val DEVICE_FAULT_DECODER_CLASSIFICATIONS = setOf(
+
+        /**
+         * Video-progress classifications from the stall detector. They watch
+         * the video decoder counters, so no renderer type is needed.
+         */
+        private val VIDEO_STALL_CLASSIFICATIONS = setOf(
             "decoder_no_output",
             "render_startup_failure",
-            "decoder_failure",
         )
 
-        internal fun isDeviceFault(classification: String): Boolean =
-            DEVICE_FAULT_PREFIXES.any(classification::startsWith) ||
-                classification in DEVICE_FAULT_DECODER_CLASSIFICATIONS
+        /**
+         * Generic player-exception classifications. Media3 raises the same
+         * codes for every renderer, so these count only when the exception
+         * came from the video renderer.
+         */
+        private val RENDERER_DECODER_CLASSIFICATIONS = setOf("decoder_failure")
+
+        /** Media3's `C.TRACK_TYPE_VIDEO`, restated so this file stays free of Media3 types. */
+        internal const val TRACK_TYPE_VIDEO = 2
+
+        internal fun isDeviceFault(classification: String, failedTrackType: Int? = null): Boolean = when {
+            TRANSFORM_FAULT_PREFIXES.any(classification::startsWith) -> true
+            classification in VIDEO_STALL_CLASSIFICATIONS -> true
+            classification in RENDERER_DECODER_CLASSIFICATIONS -> failedTrackType == TRACK_TYPE_VIDEO
+            else -> false
+        }
     }
+}
+
+/**
+ * The track type of the renderer that raised this exception, or null when
+ * the error did not come from a renderer (source, remote, unexpected).
+ */
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+fun androidx.media3.common.PlaybackException.failedRendererTrackType(): Int? {
+    val exo = this as? androidx.media3.exoplayer.ExoPlaybackException ?: return null
+    if (exo.type != androidx.media3.exoplayer.ExoPlaybackException.TYPE_RENDERER) return null
+    val mime = exo.rendererFormat?.sampleMimeType ?: return null
+    return androidx.media3.common.MimeTypes.getTrackType(mime)
 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionTransformQuarantine.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionTransformQuarantine.kt
@@ -142,10 +142,23 @@ class DolbyVisionTransformQuarantine internal constructor(
 /**
  * The track type of the renderer that raised this exception, or null when
  * the error did not come from a renderer (source, remote, unexpected).
+ *
+ * The screens receive errors through a MediaController, and MediaSession
+ * rebuilds the error as a base [androidx.media3.common.PlaybackException]
+ * on the way across, so the renderer attribution is gone by then. Pass the
+ * in-process [servicePlayer] when one is available: its own
+ * [androidx.media3.exoplayer.ExoPlayer.getPlayerError] still carries the
+ * typed exception for the same failure, matched here by error code and
+ * timestamp so a stale error from an earlier item is never attributed.
  */
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-fun androidx.media3.common.PlaybackException.failedRendererTrackType(): Int? {
-    val exo = this as? androidx.media3.exoplayer.ExoPlaybackException ?: return null
+fun androidx.media3.common.PlaybackException.failedRendererTrackType(
+    servicePlayer: androidx.media3.common.Player? = null,
+): Int? {
+    val exo = this as? androidx.media3.exoplayer.ExoPlaybackException
+        ?: (servicePlayer as? androidx.media3.exoplayer.ExoPlayer)?.playerError
+            ?.takeIf { it.errorCode == errorCode && it.timestampMs == timestampMs }
+        ?: return null
     if (exo.type != androidx.media3.exoplayer.ExoPlaybackException.TYPE_RENDERER) return null
     val mime = exo.rendererFormat?.sampleMimeType ?: return null
     return androidx.media3.common.MimeTypes.getTrackType(mime)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -97,11 +97,50 @@ class PlaybackCapabilityDetector(
      */
     @Volatile
     var playbackDisplayId: Int? = null
-        set(value) {
+        private set(value) {
             field = value
             // The audio-route manager owns the display-change listener that
             // rotates the output context; it must watch the same panel.
             audioCapabilityManager.playbackDisplayId = value
+        }
+
+    /** The binding that currently owns [playbackDisplayId]; null when unbound. */
+    @Volatile
+    private var playbackDisplayOwner: PlaybackDisplayBinding? = null
+
+    /**
+     * A claim on the playback display. Two players overlap during a
+     * player-to-player transition, so the display id is owned rather than
+     * assigned: the incoming player binds while the outgoing one is still
+     * composed, and the outgoing player's release must not clear the newer
+     * binding. Each binding releases only itself.
+     */
+    inner class PlaybackDisplayBinding internal constructor(val displayId: Int?) {
+        val isActive: Boolean get() = playbackDisplayOwner === this
+
+        /** Clears the display id only while this binding still owns it. */
+        fun release() {
+            synchronized(this@PlaybackCapabilityDetector) {
+                if (playbackDisplayOwner !== this) return
+                playbackDisplayOwner = null
+                playbackDisplayId = null
+            }
+        }
+    }
+
+    /**
+     * Binds the display that owns the playback surface and returns the
+     * binding that must be released when that player leaves. Binding always
+     * takes the id, even when another binding is active: the newest player
+     * is the one about to render, and the older binding becomes a no-op on
+     * release.
+     */
+    fun bindPlaybackDisplay(displayId: Int?): PlaybackDisplayBinding =
+        synchronized(this) {
+            PlaybackDisplayBinding(displayId).also {
+                playbackDisplayOwner = it
+                playbackDisplayId = displayId
+            }
         }
 
     /** Decoder-only HDR facts from the most recent [detect], for diagnostics. */
@@ -863,11 +902,18 @@ internal fun evaluateDolbyVisionRoute(
         }
 }
 
+/**
+ * Whether the active output carries the base range a Profile 8 base-layer
+ * plan promised. The range must be named: the renderer forces the stream
+ * through an ordinary HEVC decoder on this route and the colour repair keys
+ * off the promised range, so a plan that omitted it cannot be verified and
+ * must not be read as SDR.
+ */
 private fun baseRangeSupported(baseRange: String, nativeHdr: HdrCapabilities): Boolean =
     when (baseRange.trim().lowercase()) {
         "hdr10" -> nativeHdr.hdr10
         "hlg" -> nativeHdr.hlg
-        "sdr", "" -> true
+        "sdr" -> true
         else -> false
     }
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/DolbyVisionTransformQuarantineTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/DolbyVisionTransformQuarantineTest.kt
@@ -51,6 +51,43 @@ class DolbyVisionTransformQuarantineTest {
     }
 
     @Test
+    fun genericDecoderFailureCountsOnlyWhenTheVideoRendererRaisedIt() {
+        val store = MemoryStore()
+        val quarantine = DolbyVisionTransformQuarantine(store, fingerprint = "build-a", nowMs = { 1_000L })
+
+        assertTrue(
+            quarantine.noteFailure("decoder_failure", listOf(CLIENT_DV7_TO_DV81), failedTrackType = 1).isEmpty(),
+            "an audio renderer failing under a transformed plan says nothing about the video recipe",
+        )
+        assertTrue(
+            quarantine.noteFailure("decoder_failure", listOf(CLIENT_DV7_TO_DV81), failedTrackType = null).isEmpty(),
+            "a decoder failure with no renderer attribution must not quarantine",
+        )
+        assertFalse(quarantine.isQuarantined(CLIENT_DV7_TO_DV81))
+
+        assertEquals(
+            listOf(CLIENT_DV7_TO_DV81),
+            quarantine.noteFailure(
+                "decoder_failure",
+                listOf(CLIENT_DV7_TO_DV81),
+                failedTrackType = DolbyVisionTransformQuarantine.TRACK_TYPE_VIDEO,
+            ),
+        )
+        assertTrue(quarantine.isQuarantined(CLIENT_DV7_TO_DV81))
+    }
+
+    @Test
+    fun videoStallClassificationsNeedNoRendererAttribution() {
+        val quarantine = DolbyVisionTransformQuarantine(MemoryStore(), fingerprint = "build-a", nowMs = { 1_000L })
+
+        assertEquals(
+            listOf(CLIENT_DV7_TO_DV81),
+            quarantine.noteFailure("decoder_no_output", listOf(CLIENT_DV7_TO_DV81)),
+            "the stall detector watches the video decoder counters, so its verdict is already video-scoped",
+        )
+    }
+
+    @Test
     fun aFailureWithoutAnActiveTransformationIsIgnored() {
         val quarantine = DolbyVisionTransformQuarantine(MemoryStore(), fingerprint = "build-a", nowMs = { 1_000L })
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/FailedRendererTrackTypeTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/FailedRendererTrackTypeTest.kt
@@ -1,0 +1,89 @@
+package org.siloserver.silo.common.player
+
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.PlaybackException
+import androidx.media3.exoplayer.ExoPlaybackException
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.test.utils.StubExoPlayer
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(RobolectricTestRunner::class)
+class FailedRendererTrackTypeTest {
+
+    private fun rendererError(
+        mime: String,
+        errorCode: Int = PlaybackException.ERROR_CODE_DECODING_FAILED,
+    ): ExoPlaybackException =
+        ExoPlaybackException.createForRenderer(
+            RuntimeException("decode failed"),
+            "renderer",
+            0,
+            Format.Builder().setSampleMimeType(mime).build(),
+            C.FORMAT_HANDLED,
+            false,
+            errorCode,
+        )
+
+    /**
+     * What MediaSession delivers to the controller. The session bundles the
+     * error and the controller rebuilds a base exception from it, so the
+     * renderer attribution does not survive the crossing.
+     */
+    private fun controllerCopy(source: PlaybackException): PlaybackException =
+        PlaybackException.fromBundle(source.toBundle())
+
+    private fun serviceWithError(error: ExoPlaybackException): ExoPlayer = object : StubExoPlayer() {
+        override fun getPlayerError(): ExoPlaybackException = error
+    }
+
+    @Test
+    fun typedRendererErrorReportsItsOwnTrackType() {
+        assertEquals(C.TRACK_TYPE_VIDEO, rendererError(MimeTypes.VIDEO_DOLBY_VISION).failedRendererTrackType())
+        assertEquals(C.TRACK_TYPE_AUDIO, rendererError(MimeTypes.AUDIO_TRUEHD).failedRendererTrackType())
+    }
+
+    @Test
+    fun controllerCopyRecoversTheTrackTypeFromTheServicePlayer() {
+        val typed = rendererError(MimeTypes.VIDEO_DOLBY_VISION)
+        val delivered = controllerCopy(typed)
+
+        assertNull(delivered.failedRendererTrackType(), "the controller-side copy carries no renderer attribution")
+        assertEquals(
+            C.TRACK_TYPE_VIDEO,
+            delivered.failedRendererTrackType(serviceWithError(typed)),
+            "the in-process player still holds the typed exception for the same failure",
+        )
+    }
+
+    @Test
+    fun aStaleServiceErrorIsNotAttributedToANewFailure() {
+        // Robolectric's clock is frozen, so the timestamps match; the error
+        // code is the other half of the identity check and differs here.
+        val earlier = rendererError(MimeTypes.VIDEO_DOLBY_VISION, PlaybackException.ERROR_CODE_DECODING_FAILED)
+        val later = controllerCopy(
+            rendererError(MimeTypes.AUDIO_AAC, PlaybackException.ERROR_CODE_DECODER_INIT_FAILED),
+        )
+
+        assertNull(
+            later.failedRendererTrackType(serviceWithError(earlier)),
+            "a service error that does not match the delivered failure must not be reused",
+        )
+    }
+
+    @Test
+    fun nonRendererErrorsHaveNoTrackType() {
+        val source = ExoPlaybackException.createForSource(
+            java.io.IOException("gone"),
+            PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+        )
+        assertNull(source.failedRendererTrackType())
+        assertNull(controllerCopy(source).failedRendererTrackType(serviceWithError(source)))
+        assertNull(controllerCopy(source).failedRendererTrackType(null))
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -444,4 +444,70 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
             "no 10-bit hardware HEVC decoder, no claim",
         )
     }
+
+    @Test
+    fun baseLayerPlanRejectsAMissingBaseRangeInsteadOfAssumingSdr() {
+        val route = plannedVideoRouteFor(
+            decisionReason = org.siloserver.silo.model.playback.DECISION_REASON_CLIENT_DV8_BASE_LAYER,
+            effectiveDynamicRange = null,
+            clientTransformations = emptyList(),
+        )
+        assertEquals(PlannedVideoRoute.DolbyVisionProfile8BaseLayer(""), route)
+
+        val verdict = evaluateDolbyVisionRoute(
+            profile = 8,
+            route = route,
+            nativeHdr = HdrCapabilities(hdr10 = true, hlg = true),
+        )
+        assertEquals(
+            Playability.DvBaseLayerOutputMismatch(profile = 8, baseRange = ""),
+            verdict,
+            "a base-layer plan that names no range cannot be verified and must not be read as SDR",
+        )
+        assertEquals(
+            Playability.Supported,
+            evaluateDolbyVisionRoute(
+                profile = 8,
+                route = PlannedVideoRoute.DolbyVisionProfile8BaseLayer("sdr"),
+                nativeHdr = HdrCapabilities(),
+            ),
+            "an explicit SDR base needs no HDR output",
+        )
+    }
+
+    @Test
+    fun playbackDisplayBindingReleasesOnlyItsOwnClaim() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val detector = PlaybackCapabilityDetector(
+            context = context,
+            audioCapabilityManager = AudioCapabilityManager(context),
+            libassBridge = LibassBridge(false),
+            buildIdentity = SiloClientBuildIdentity(buildNumber = "test", channel = "test"),
+        )
+
+        // Player-to-player navigation: the incoming player binds while the
+        // outgoing player is still composed, then the outgoing one disposes.
+        val outgoing = detector.bindPlaybackDisplay(1)
+        assertEquals(1, detector.playbackDisplayId)
+        val incoming = detector.bindPlaybackDisplay(2)
+        assertEquals(2, detector.playbackDisplayId)
+        assertFalse(outgoing.isActive)
+        assertTrue(incoming.isActive)
+
+        outgoing.release()
+        assertEquals(2, detector.playbackDisplayId, "the stale player must not clear the newer binding")
+        assertTrue(incoming.isActive)
+
+        incoming.release()
+        assertEquals(null, detector.playbackDisplayId)
+        assertFalse(incoming.isActive)
+
+        // Releasing twice, or releasing after a later rebind, stays a no-op.
+        val rebound = detector.bindPlaybackDisplay(3)
+        incoming.release()
+        outgoing.release()
+        assertEquals(3, detector.playbackDisplayId)
+        rebound.release()
+        assertEquals(null, detector.playbackDisplayId)
+    }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -510,4 +510,26 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
         rebound.release()
         assertEquals(null, detector.playbackDisplayId)
     }
+
+    @Test
+    fun rebindingOnADisplayChangeMovesTheIdAndRetiresTheOldBinding() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val detector = PlaybackCapabilityDetector(
+            context = context,
+            audioCapabilityManager = AudioCapabilityManager(context),
+            libassBridge = LibassBridge(false),
+            buildIdentity = SiloClientBuildIdentity(buildNumber = "test", channel = "test"),
+        )
+
+        // The screens key their binding on the display id, so an Activity
+        // that moves to another display produces a fresh binding and the
+        // old one's release must not clear it.
+        val onFirstDisplay = detector.bindPlaybackDisplay(0)
+        val onSecondDisplay = detector.bindPlaybackDisplay(5)
+        assertEquals(5, detector.playbackDisplayId)
+
+        onFirstDisplay.release()
+        assertEquals(5, detector.playbackDisplayId, "the retired binding must not undo the move")
+        assertTrue(onSecondDisplay.isActive)
+    }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileVideoPlaybackStarter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileVideoPlaybackStarter.kt
@@ -79,6 +79,7 @@ internal data class MobileInitialTrackSelection(
  * Local/downloaded subtitle identities deliberately resolve to null and stay
  * on the Media3-only restore path after the server plan is mounted.
  */
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 internal fun resolveMobileInitialTrackSelection(
     explicitAudioTrackIndex: Int?,
     explicitSubtitleTrackIndex: Int?,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -226,8 +227,11 @@ fun PlayerScreen(
     // The binding is owned: during a player-to-player transition the incoming
     // screen binds while the outgoing one is still composed, and the outgoing
     // screen's release only clears its own claim.
-    val playbackDisplayBinding = remember(context, capabilityDetector) {
-        capabilityDetector.bindPlaybackDisplay(context.playbackDisplayId())
+    // Keyed on the display id itself so an Activity that moves to another
+    // display rebinds and the next plan describes the new panel.
+    val currentPlaybackDisplayId = context.playbackDisplayId()
+    val playbackDisplayBinding = remember(currentPlaybackDisplayId, capabilityDetector) {
+        capabilityDetector.bindPlaybackDisplay(currentPlaybackDisplayId)
     }
     // Re-probe whenever the output route generation moves, so track
     // selection sees the same display facts as capability detection.
@@ -850,6 +854,9 @@ fun PlayerScreen(
     // Preflight listener: evaluates the resolved Tracks and triggers the
     // transcode fallback when the selected track combo can't actually be
     // played on this device.
+    // The preflight listener is keyed on the controller and outlives engine
+    // swaps; read the service player at error time, not at registration.
+    val latestServicePlayerForErrors = rememberUpdatedState(sessionPlayer)
     DisposableEffect(mediaController) {
         val controller = mediaController
         if (controller == null) {
@@ -862,7 +869,7 @@ fun PlayerScreen(
                 // same recovery ladder as preflight failures — previously the
                 // mobile player dropped these on the floor and the screen sat
                 // on a stale frame.
-                onError = { error -> viewModel.onPlayerError(error) },
+                onError = { error -> viewModel.onPlayerError(error, servicePlayer = latestServicePlayerForErrors.value) },
                 plannedRoute = {
                     val plan = viewModel.uiState.value.playbackPlan
                     plannedVideoRouteFor(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -223,9 +223,11 @@ fun PlayerScreen(
     // Bind the playback display before anything plans: the ViewModel's
     // initializer starts loading as soon as it exists, so the binding has to
     // happen during composition, not in a later effect.
-    remember(context, capabilityDetector) {
-        capabilityDetector.playbackDisplayId = context.playbackDisplayId()
-        true
+    // The binding is owned: during a player-to-player transition the incoming
+    // screen binds while the outgoing one is still composed, and the outgoing
+    // screen's release only clears its own claim.
+    val playbackDisplayBinding = remember(context, capabilityDetector) {
+        capabilityDetector.bindPlaybackDisplay(context.playbackDisplayId())
     }
     // Re-probe whenever the output route generation moves, so track
     // selection sees the same display facts as capability detection.
@@ -839,9 +841,10 @@ fun PlayerScreen(
         }
     }
 
-    // Release the playback display binding when this player leaves.
-    DisposableEffect(capabilityDetector) {
-        onDispose { capabilityDetector.playbackDisplayId = null }
+    // Release this player's own display binding when it leaves. A newer
+    // player that has already bound keeps its claim.
+    DisposableEffect(playbackDisplayBinding) {
+        onDispose { playbackDisplayBinding.release() }
     }
 
     // Preflight listener: evaluates the resolved Tracks and triggers the

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -1501,7 +1501,15 @@ class PlayerViewModel(
      * Previously the mobile player had no error handling at all: a decoder or
      * IO failure left the screen on a stale frame/spinner forever.
      */
-    fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+    /**
+     * @param servicePlayer the in-process player the error came from, when the
+     * screen has it. The controller-side [error] has lost its renderer
+     * attribution; the service player still knows which renderer failed.
+     */
+    fun onPlayerError(
+        error: androidx.media3.common.PlaybackException,
+        servicePlayer: androidx.media3.common.Player? = null,
+    ) {
         val state = _uiState.value
         val message = error.localizedMessage?.takeIf { msg -> msg.isNotBlank() }
             ?: "Playback failed. Please try again."
@@ -1640,7 +1648,7 @@ class PlayerViewModel(
                     message,
                     state,
                     diagnostics = diagnostics,
-                    failedTrackType = error.failedRendererTrackType(),
+                    failedTrackType = error.failedRendererTrackType(servicePlayer),
                 )
             }
             return

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.android.ui.screens.player
 
 import org.siloserver.silo.common.player.dolbyVisionTransformClassification
+import org.siloserver.silo.common.player.failedRendererTrackType
 import org.siloserver.silo.common.player.failureDiagnostics
 import org.siloserver.silo.common.player.failureClassification
 
@@ -1639,6 +1640,7 @@ class PlayerViewModel(
                     message,
                     state,
                     diagnostics = diagnostics,
+                    failedTrackType = error.failedRendererTrackType(),
                 )
             }
             return
@@ -1658,6 +1660,7 @@ class PlayerViewModel(
         notice: String,
         state: PlayerUiState,
         diagnostics: Map<String, String> = emptyMap(),
+        failedTrackType: Int? = null,
         audioTrackIndexOverride: Int? = null,
     ) {
         if (recoveryJob?.isActive == true || serverSeekRecoveryInFlight) {
@@ -1698,6 +1701,7 @@ class PlayerViewModel(
                 activeTransformations = state.playbackPlan
                     ?.executableMedia3ClientTransformations()
                     .orEmpty(),
+                failedTrackType = failedTrackType,
             )
             val capabilities = capabilityDetector.detect(dolbyVision = dolbyVision)
             val playbackContext = capabilityDetector.detectPlaybackContext(

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
@@ -10,6 +10,7 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -52,9 +53,12 @@ class ProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        // The mock HTTP calls complete on Ktor's own dispatcher, not the test
+        // scheduler, so advanceUntilIdle() can return before the load lands.
+        // Wait for the load itself to finish instead of the scheduler.
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertTrue(viewModel.uiState.value.canManageProfiles)
+        assertTrue(loaded.canManageProfiles)
     }
 
     @Test

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionAdminGateTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -54,7 +53,7 @@ class ProfileSelectionAdminGateTest {
             authRepository = authRepo,
         )
         // The mock HTTP calls complete on Ktor's own dispatcher, not the test
-        // scheduler, so advanceUntilIdle() can return before the load lands.
+        // scheduler, so advancing the test scheduler can return before the load lands.
         // Wait for the load itself to finish instead of the scheduler.
         val loaded = viewModel.uiState.first { !it.isLoading }
 
@@ -71,9 +70,9 @@ class ProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -87,9 +86,9 @@ class ProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -99,9 +98,9 @@ class ProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = null,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -115,7 +114,7 @@ class ProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        viewModel.uiState.first { !it.isLoading }
 
         viewModel.toggleManageMode()
         assertFalse(viewModel.uiState.value.isManageMode)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -1175,9 +1175,11 @@ fun TvAppNavigation(
             // describes the panel that will show the video.
             val playerContext = androidx.compose.ui.platform.LocalContext.current
             val capabilityDetector = koinInject<org.siloserver.silo.common.player.PlaybackCapabilityDetector>()
+            // This early binding is superseded when TvPlayerScreen binds its
+            // own during composition; the screen's release then leaves the
+            // display bound to whichever player claimed it last.
             remember(playerContext, capabilityDetector) {
-                capabilityDetector.playbackDisplayId = playerContext.playbackDisplayId()
-                true
+                capabilityDetector.bindPlaybackDisplay(playerContext.playbackDisplayId())
             }
             TvPlayerScreen(
                 contentId = contentId,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/navigation/TvAppNavigation.kt
@@ -1178,8 +1178,9 @@ fun TvAppNavigation(
             // This early binding is superseded when TvPlayerScreen binds its
             // own during composition; the screen's release then leaves the
             // display bound to whichever player claimed it last.
-            remember(playerContext, capabilityDetector) {
-                capabilityDetector.bindPlaybackDisplay(playerContext.playbackDisplayId())
+            val earlyPlaybackDisplayId = playerContext.playbackDisplayId()
+            remember(earlyPlaybackDisplayId, capabilityDetector) {
+                capabilityDetector.bindPlaybackDisplay(earlyPlaybackDisplayId)
             }
             TvPlayerScreen(
                 contentId = contentId,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -370,8 +370,11 @@ fun TvPlayerScreen(
     // The binding is owned: during a player-to-player transition the incoming
     // screen binds while the outgoing one is still composed, and the outgoing
     // screen's release only clears its own claim.
-    val playbackDisplayBinding = remember(context, capabilityDetector) {
-        capabilityDetector.bindPlaybackDisplay(context.playbackDisplayId())
+    // Keyed on the display id itself so an Activity that moves to another
+    // display rebinds and the next plan describes the new panel.
+    val currentPlaybackDisplayId = context.playbackDisplayId()
+    val playbackDisplayBinding = remember(currentPlaybackDisplayId, capabilityDetector) {
+        capabilityDetector.bindPlaybackDisplay(currentPlaybackDisplayId)
     }
     // Re-probe whenever the output route generation moves, so track
     // selection sees the same display facts as capability detection.
@@ -1449,6 +1452,9 @@ fun TvPlayerScreen(
 
     // Preflight listener — falls back to a transcoded stream if the selected
     // Tracks can't be direct-played (DV P7, TrueHD without passthrough, …).
+    // The preflight listener is keyed on the controller and outlives engine
+    // swaps; read the service player at error time, not at registration.
+    val latestServicePlayerForErrors = rememberUpdatedState(sessionPlayer)
     DisposableEffect(mediaController) {
         val controller = mediaController
         if (controller == null) {
@@ -1457,7 +1463,7 @@ fun TvPlayerScreen(
             val preflight = PlaybackPreflightListener(
                 detector = capabilityDetector,
                 onUnsupported = { verdict -> viewModel.onUnsupportedPlayback(verdict) },
-                onError = { error -> viewModel.onPlayerError(error) },
+                onError = { error -> viewModel.onPlayerError(error, servicePlayer = latestServicePlayerForErrors.value) },
                 plannedRoute = {
                     val plan = viewModel.uiState.value.playbackPlan
                     org.siloserver.silo.common.player.plannedVideoRouteFor(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -367,9 +367,11 @@ fun TvPlayerScreen(
     // Bind the playback display before anything plans: the ViewModel's
     // initializer starts loading as soon as it exists, so the binding has to
     // happen during composition, not in a later effect.
-    remember(context, capabilityDetector) {
-        capabilityDetector.playbackDisplayId = context.playbackDisplayId()
-        true
+    // The binding is owned: during a player-to-player transition the incoming
+    // screen binds while the outgoing one is still composed, and the outgoing
+    // screen's release only clears its own claim.
+    val playbackDisplayBinding = remember(context, capabilityDetector) {
+        capabilityDetector.bindPlaybackDisplay(context.playbackDisplayId())
     }
     // Re-probe whenever the output route generation moves, so track
     // selection sees the same display facts as capability detection.
@@ -1439,9 +1441,10 @@ fun TvPlayerScreen(
         }
     }
 
-    // Release the playback display binding when this player leaves.
-    DisposableEffect(capabilityDetector) {
-        onDispose { capabilityDetector.playbackDisplayId = null }
+    // Release this player's own display binding when it leaves. A newer
+    // player that has already bound keeps its claim.
+    DisposableEffect(playbackDisplayBinding) {
+        onDispose { playbackDisplayBinding.release() }
     }
 
     // Preflight listener — falls back to a transcoded stream if the selected

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -5276,7 +5276,15 @@ class TvPlayerViewModel(
      * prepare). Without this the screen can sit on a stale spinner instead of
      * an actionable error. The error UI offers [retry].
      */
-    fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+    /**
+     * @param servicePlayer the in-process player the error came from, when the
+     * screen has it. The controller-side [error] has lost its renderer
+     * attribution; the service player still knows which renderer failed.
+     */
+    fun onPlayerError(
+        error: androidx.media3.common.PlaybackException,
+        servicePlayer: androidx.media3.common.Player? = null,
+    ) {
         val state = _uiState.value
         val message = error.localizedMessage?.takeIf { msg -> msg.isNotBlank() }
             ?: "Playback failed. Please try again."
@@ -5411,7 +5419,7 @@ class TvPlayerViewModel(
                     message,
                     state,
                     diagnostics = diagnostics,
-                    failedTrackType = error.failedRendererTrackType(),
+                    failedTrackType = error.failedRendererTrackType(servicePlayer),
                 )
             }
             return

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -3,6 +3,7 @@
 package org.siloserver.silo.tv.ui.screens.player
 
 import org.siloserver.silo.common.player.dolbyVisionTransformClassification
+import org.siloserver.silo.common.player.failedRendererTrackType
 import org.siloserver.silo.common.player.failureDiagnostics
 import org.siloserver.silo.common.player.failureClassification
 
@@ -2397,6 +2398,7 @@ class TvPlayerViewModel(
         state: UiState,
         qualityPreference: String? = null,
         diagnostics: Map<String, String> = emptyMap(),
+        failedTrackType: Int? = null,
         subtitleTrackIndexOverride: Int? = null,
     ) {
         if (recoveryJob?.isActive == true) {
@@ -2437,6 +2439,7 @@ class TvPlayerViewModel(
                 activeTransformations = state.playbackPlan
                     ?.executableMedia3ClientTransformations()
                     .orEmpty(),
+                failedTrackType = failedTrackType,
             )
             val capabilities = capabilityDetector.detect(dolbyVision = dolbyVision)
             val playbackContext = capabilityDetector.detectPlaybackContext(
@@ -5408,6 +5411,7 @@ class TvPlayerViewModel(
                     message,
                     state,
                     diagnostics = diagnostics,
+                    failedTrackType = error.failedRendererTrackType(),
                 )
             }
             return

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvVideoPlaybackStarter.kt
@@ -379,6 +379,7 @@ class TvVideoPlaybackStarter(
     }
 }
 
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 internal fun resolveTvInitialAudioTrackIndex(
     requestedAudioIndex: Int?,
     carriedAudioIndex: Int?,

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -54,7 +53,7 @@ class TvProfileSelectionAdminGateTest {
             authRepository = authRepo,
         )
         // The mock HTTP calls complete on Ktor's own dispatcher, not the test
-        // scheduler, so advanceUntilIdle() can return before the load lands.
+        // scheduler, so advancing the test scheduler can return before the load lands.
         val loaded = viewModel.uiState.first { !it.isLoading }
 
         assertTrue(loaded.canManageProfiles)
@@ -70,9 +69,9 @@ class TvProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -86,9 +85,9 @@ class TvProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -98,9 +97,9 @@ class TvProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = null,
         )
-        advanceUntilIdle()
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertFalse(viewModel.uiState.value.canManageProfiles)
+        assertFalse(loaded.canManageProfiles)
     }
 
     @Test
@@ -114,7 +113,7 @@ class TvProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        viewModel.uiState.first { !it.isLoading }
 
         viewModel.toggleManageMode()
         assertFalse(viewModel.uiState.value.isManageMode)

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionAdminGateTest.kt
@@ -10,6 +10,7 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -52,9 +53,11 @@ class TvProfileSelectionAdminGateTest {
             profileRepository = profileRepo,
             authRepository = authRepo,
         )
-        advanceUntilIdle()
+        // The mock HTTP calls complete on Ktor's own dispatcher, not the test
+        // scheduler, so advanceUntilIdle() can return before the load lands.
+        val loaded = viewModel.uiState.first { !it.isLoading }
 
-        assertTrue(viewModel.uiState.value.canManageProfiles)
+        assertTrue(loaded.canManageProfiles)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Three review findings landed on #275 after it was merged, so the fixes need their own PR.

- The playback display id was a bare setter on a process singleton. During a player-to-player transition the outgoing player's dispose could clear the binding the incoming player had just made, and a later replan would probe the default display and pick the wrong HDR or Dolby Vision route.
- A `client_dv8_base_layer` plan that omitted `effective_recipe.dynamic_range` was read as an SDR base and accepted. The renderer forces that route through an ordinary HEVC decoder and the colour repair keys off the promised range, so an unnamed range cannot be verified.
- The Dolby Vision transform quarantine treated the generic `decoder_failure` classification as evidence against the video recipe even when the audio renderer raised it. One audio decoder error under a transformed Profile 7 plan would have withdrawn the transformation for every title on the device for 14 days.

## Solution

- `PlaybackCapabilityDetector.bindPlaybackDisplay()` returns an owned `PlaybackDisplayBinding`; `release()` clears the id only while that binding still owns it. All three call sites (TV screen bind and dispose, TV navigation early bind, phone screen) use it.
- `baseRangeSupported` rejects an empty range. Preflight returns `DvBaseLayerOutputMismatch` so the replan asks the server for a plan that names the base. Explicit `sdr` still needs no HDR output.
- `noteFailure` takes the failed renderer's track type, derived from `ExoPlaybackException.rendererFormat` in both ViewModels. `decoder_failure` quarantines only when the video renderer raised it. Transform-raised classifications and the stall detector's video-counter verdicts already identify the video path and still count on their own.

## Validation

- `:android-shared:testDebugUnitTest` for the Dolby Vision detector, quarantine, and colour-info suites: 44 tests, 0 failures, including new tests for player-to-player binding overlap, the unnamed base range, and renderer-scoped quarantine.
- `:androidApp:lintDebug` and `:androidTvApp:lintDebug` clean after adding the `UnstableApi` opt-in on the new `ExoPlaybackException` helper.

## Risks

Low. The binding API is additive; the old setter is now private so no caller can bypass ownership. The base-range change only affects plans that omit the range, which the server's planner always sets.

## AI disclosure

Written with Claude Code (claude-fable-5-1) in the Claude desktop app, reviewing findings from CodeRabbit and Codex on #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback recovery by distinguishing audio and video decoder failures, helping avoid unnecessary Dolby Vision-related quarantines.
  * Prevented stale player errors from being attributed to new playback failures.
  * Fixed player transitions so changing or closing overlapping playback screens no longer disrupts the active display.
  * Dolby Vision Profile 8 playback now requires explicit SDR metadata for base-layer content, improving compatibility decisions.
  * Improved playback error handling across mobile and TV experiences.

* **Tests**
  * Added coverage for renderer-specific failures, display binding lifecycles, stale errors, and Dolby Vision profile validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->