### PR TITLE
fix(ui): stop truncating playback readouts, drop episode pills, and use the brand lockup

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/overlays/CardOverlays.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/overlays/CardOverlays.kt
@@ -55,6 +55,8 @@ enum class CardOverlayVariant {
  * ```
  *
  * @param scale optical multiplier for wide/hero cards; posters measure their actual width.
+ * @param bottomInset overrides the variant's bottom corner inset (unscaled)
+ *   for cards that draw nothing but a thin progress bar along the bottom edge.
  */
 @Composable
 fun CardOverlays(
@@ -64,6 +66,7 @@ fun CardOverlays(
     variant: CardOverlayVariant = CardOverlayVariant.Poster,
     scale: Float = 1f,
     forceOpaqueBackground: Boolean = false,
+    bottomInset: Dp? = null,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
         // The web Home carousel's 185-unit overlay layer is the cross-platform
@@ -89,6 +92,7 @@ fun CardOverlays(
                 variant = variant,
                 scale = resolvedScale,
                 forceOpaqueBackground = forceOpaqueBackground,
+                bottomInset = bottomInset,
             )
         }
     }
@@ -103,6 +107,7 @@ private fun androidx.compose.foundation.layout.BoxScope.CornerStack(
     variant: CardOverlayVariant,
     scale: Float,
     forceOpaqueBackground: Boolean,
+    bottomInset: Dp?,
 ) {
     // Resolved once per (item, prefs, preset): this runs for four corners of
     // every card on every card composition, and rails recompose a lot.
@@ -115,7 +120,7 @@ private fun androidx.compose.foundation.layout.BoxScope.CornerStack(
     Column(
         modifier = Modifier
             .align(anchor(position))
-            .padding(insets(position, variant, scale)),
+            .padding(insets(position, variant, scale, bottomInset)),
         horizontalAlignment = horizontalAlignment(position),
         verticalArrangement = Arrangement.spacedBy(preset.gap),
     ) {
@@ -148,13 +153,20 @@ private fun horizontalAlignment(position: OverlayPosition): Alignment.Horizontal
  * block / progress bar typically sits under the image. Mirrors Apple's
  * `insets(for:)`.
  */
-private fun insets(position: OverlayPosition, variant: CardOverlayVariant, scale: Float): PaddingValues {
+private fun insets(
+    position: OverlayPosition,
+    variant: CardOverlayVariant,
+    scale: Float,
+    bottomInsetOverride: Dp?,
+): PaddingValues {
     val safeScale = scale.coerceAtLeast(0.1f)
-    val bottomInset: Dp = when (variant) {
-        CardOverlayVariant.Poster -> 8.dp
-        CardOverlayVariant.Wide -> 24.dp
-        CardOverlayVariant.Hero -> 16.dp
-    } * safeScale
+    val bottomInset: Dp = (
+        bottomInsetOverride ?: when (variant) {
+            CardOverlayVariant.Poster -> 8.dp
+            CardOverlayVariant.Wide -> 24.dp
+            CardOverlayVariant.Hero -> 16.dp
+        }
+    ) * safeScale
     val sideInset: Dp = (if (variant == CardOverlayVariant.Hero) 16.dp else 8.dp) * safeScale
     val topInset: Dp = (if (variant == CardOverlayVariant.Hero) 16.dp else 8.dp) * safeScale
     return when (position) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MediaSelectors.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MediaSelectors.kt
@@ -77,8 +77,8 @@ fun TrackSelectorRow(
         modifier = modifier
             .fillMaxWidth()
             .then(if (interactive) Modifier.clickable(onClick = onClick) else Modifier)
-            .height(44.dp)
-            .padding(horizontal = 14.dp),
+            .heightIn(min = 44.dp)
+            .padding(horizontal = 14.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
@@ -100,8 +100,6 @@ fun TrackSelectorRow(
             text = value,
             fontSize = 14.sp,
             color = Color.White,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
             fontWeight = FontWeight.SemiBold,
             textAlign = TextAlign.End,
             modifier = Modifier.weight(1f),
@@ -129,7 +127,7 @@ fun PlaybackSelectorCard(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .height(133.dp)
+            .heightIn(min = 133.dp)
             .clip(RoundedCornerShape(12.dp))
             .background(Color.White.copy(alpha = 0.05f))
             .border(0.5.dp, Color.White.copy(alpha = 0.10f), RoundedCornerShape(12.dp)),

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/home/HomeScreen.kt
@@ -52,11 +52,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil3.imageLoader
 import coil3.request.ImageRequest
+import org.siloserver.silo.android.ui.components.SiloWordmark
 import org.siloserver.silo.android.ui.components.TabTopBarActions
 import org.siloserver.silo.android.ui.components.TopBarIconButton
 import kotlinx.coroutines.async
@@ -445,14 +444,7 @@ fun HomeScreen(
                                     .padding(horizontal = 16.dp),
                                 verticalAlignment = Alignment.Top,
                             ) {
-                                Text(
-                                    text = "SILO",
-                                    color = Color.White,
-                                    fontSize = 26.sp,
-                                    lineHeight = 31.sp,
-                                    fontWeight = FontWeight.Black,
-                                    letterSpacing = (26f * 0.34f).sp,
-                                )
+                                SiloWordmark()
                             }
                         }
 

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/MobileDetailActionsSourceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/detail/MobileDetailActionsSourceTest.kt
@@ -309,8 +309,11 @@ class MobileDetailActionsSourceTest {
         assertTrue(detailShared.contains(".height(38.dp)"))
         assertTrue(detailShared.contains("minLines = if (reserveCollapsedSpace && !expanded) 3 else 1"))
         assertTrue(mediaSelectors.contains("repeat(3)"))
-        assertTrue(mediaSelectors.contains(".height(44.dp)"))
-        assertTrue(mediaSelectors.contains(".height(133.dp)"))
+        // Rows and the card keep their loading footprint as a floor but grow
+        // when a Version / Audio / Subtitles value wraps instead of truncating.
+        assertTrue(mediaSelectors.contains(".heightIn(min = 44.dp)"))
+        assertTrue(mediaSelectors.contains(".heightIn(min = 133.dp)"))
+        assertFalse(mediaSelectors.contains("overflow = TextOverflow.Ellipsis,\n            fontWeight = FontWeight.SemiBold"))
     }
 
     @Test

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvEpisodeCard.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvEpisodeCard.kt
@@ -84,7 +84,6 @@ fun TvEpisodeCard(
 
     val cardShape = TvEpisodeCardShape
     val cardFocus = siloCardDefaults(shape = cardShape, focusedScale = 1.04f)
-    val episodeBadge = formatEpisodeTag(seasonNumber, episodeNumber)
 
     var menuExpanded by remember { mutableStateOf(false) }
 
@@ -136,6 +135,8 @@ fun TvEpisodeCard(
 
                 // Card-overlay badge layer. Over the still + scrim, under the
                 // play affordance + progress bar. Never intercepts focus.
+                // The bottom inset matches the side inset plus the 3dp progress
+                // bar so the lower badges sit in the corner like the upper ones.
                 if (overlayState.enabled && overlay != null) {
                     CardOverlays(
                         data = overlay,
@@ -143,6 +144,7 @@ fun TvEpisodeCard(
                         variant = CardOverlayVariant.Wide,
                         scale = TvCardOverlayScale,
                         forceOpaqueBackground = false,
+                        bottomInset = TvEpisodeCardOverlayBottomInset,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
@@ -162,22 +164,6 @@ fun TvEpisodeCard(
                                 .background(ProgressFill),
                         )
                     }
-                }
-
-                if (episodeBadge != null) {
-                    Text(
-                        text = episodeBadge,
-                        style = MaterialTheme.typography.labelMedium.copy(fontSize = 14.sp),
-                        color = Color.White,
-                        modifier = Modifier
-                            .align(Alignment.BottomStart)
-                            .padding(7.dp)
-                            .background(
-                                Color.Black.copy(alpha = 0.65f),
-                                RoundedCornerShape(percent = 50),
-                            )
-                            .padding(horizontal = 7.dp, vertical = 3.5.dp),
-                    )
                 }
             }
         }
@@ -222,13 +208,6 @@ fun TvEpisodeCard(
     }
 }
 
-private fun formatEpisodeTag(season: Int?, episode: Int?): String? {
-    if (season == null && episode == null) return null
-    val s = season?.let { "S$it" }
-    val e = episode?.let { "E$it" }
-    return listOfNotNull(s, e).joinToString(" · ")
-}
-
 /**
  * Default width for episode / next-up cards. tvOS uses 360×200pt; Skyline maps
  * that to Android TV as 180×100dp.
@@ -241,3 +220,6 @@ fun tvEpisodeCardWidth(): Dp = TvEpisodeCardWidth.cardScaled()
 
 /** Hoisted so every card shares one instance instead of allocating a shape per composition. */
 private val TvEpisodeCardShape = RoundedCornerShape(8.dp)
+
+/** Unscaled: 8dp side inset + 3dp progress bar, scaled by [TvCardOverlayScale]. */
+private val TvEpisodeCardOverlayBottomInset = 12.dp

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -1375,8 +1375,11 @@ private fun TvPlaybackSummaryItem(
     value: String?,
     itemWidth: androidx.compose.ui.unit.Dp,
 ) {
+    // Items size to their text instead of a fixed width so long audio or
+    // subtitle labels are never cut off. The skeleton keeps a fixed width so
+    // the loading row stays stable until the values arrive.
     Row(
-        modifier = Modifier.width(itemWidth),
+        modifier = if (value == null) Modifier.width(itemWidth) else Modifier,
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
@@ -1393,12 +1396,10 @@ private fun TvPlaybackSummaryItem(
         } else {
             Text(
                 text = value,
-                modifier = Modifier.weight(1f),
                 fontWeight = FontWeight.Medium,
                 fontSize = 11.5.sp,
                 color = Color.White.copy(alpha = 0.82f),
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
             )
         }
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/shell/TvTopMenuBar.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -44,6 +46,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.layout.onGloballyPositioned
 import kotlinx.coroutines.delay
 import androidx.compose.ui.text.font.FontWeight
@@ -59,6 +62,7 @@ import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 import org.siloserver.silo.tv.ui.focus.claimFocusOrReport
 import org.siloserver.silo.common.ui.components.ThumbhashImage
+import org.siloserver.silo.tv.R
 import org.siloserver.silo.common.ui.components.ProfileAvatarRef
 import org.siloserver.silo.common.ui.components.profileAvatarDisplayText
 import org.siloserver.silo.common.ui.components.rememberProfileAvatarImage
@@ -131,7 +135,7 @@ private sealed class TvTopMenuFocus {
  * The custom top menu bar — the Skyline grammar from tvOS `TVTopMenuBar.swift`.
  *
  * Layout (three zones):
- * - Leading: the tracked SILO wordmark used by tvOS (see [TvSiloWordmark]).
+ * - Leading: the Silo brand lockup image (see [TvSiloWordmark]).
  * - Center: Search icon · `Home` · one inverted-capsule tab per visible
  *   library-type · `Calendar`, derived from [destinations] (the shell's
  *   `visibleRoots`), with an invisible search-size twin trailing the tabs so
@@ -671,22 +675,22 @@ data class TvAccountState(
     val serverName: String = "",
 )
 
-/**
- * The approved Apple TV bar deliberately uses a heavy text mark rather than
- * the multicolour image lockup: 26pt with 0.34-em tracking. Android's TV canvas
- * is half scale, with a 14sp floor for ten-foot readability.
- */
+/** The Silo brand lockup image, sized to the bar. */
 @Composable
 private fun TvSiloWordmark() {
-    Text(
-        text = "SILO",
-        color = Color.White,
-        fontSize = 14.sp,
-        fontWeight = FontWeight.ExtraBold,
-        letterSpacing = 4.42.sp,
-        maxLines = 1,
+    Image(
+        painter = painterResource(id = R.drawable.silo_wordmark),
+        contentDescription = "Silo",
+        contentScale = ContentScale.Fit,
+        modifier = Modifier
+            .height(TvSiloWordmarkHeight)
+            .width(TvSiloWordmarkHeight * TvSiloWordmarkAspect),
     )
 }
+
+/** Brand lockup height inside the 32dp bar; the PNG is 764×400. */
+private val TvSiloWordmarkHeight = 26.dp
+private const val TvSiloWordmarkAspect = 764f / 400f
 
 /**
  * A center-cluster type tab with inverted-capsule chrome (§5.1):

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
@@ -135,7 +135,10 @@ class TvDetailFocusPolicyTest {
         assertTrue(playbackReadout.contains("Arrangement.spacedBy(6.dp)"))
         assertTrue(playbackReadout.contains("Modifier.height(TV_PLAYBACK_SUMMARY_HEIGHT)"))
         assertTrue(playbackReadout.contains("TvPlaybackSummarySkeleton(modifier = Modifier.weight(1f))"))
-        assertTrue(playbackReadout.contains("modifier = Modifier.width(itemWidth)"))
+        // Loaded values size to their text so long audio / subtitle labels never
+        // truncate; only the skeleton keeps the fixed per-item width.
+        assertTrue(playbackReadout.contains("modifier = if (value == null) Modifier.width(itemWidth) else Modifier"))
+        assertFalse(playbackReadout.contains("overflow = TextOverflow.Ellipsis"))
         assertTrue(playbackReadout.contains("TV_PLAYBACK_VERSION_ITEM_WIDTH = 120.dp"))
         assertTrue(playbackReadout.contains("TV_PLAYBACK_AUDIO_ITEM_WIDTH = 160.dp"))
         assertTrue(playbackReadout.contains("TV_PLAYBACK_SUBTITLE_ITEM_WIDTH = 130.dp"))


### PR DESCRIPTION
## Problem

The Version / Audio / Subtitles readout on the detail page cut off long values with an ellipsis on both the phone and Android TV. On Android TV, episode cards also drew a redundant "S3 · E1" pill in the bottom-left corner of the artwork, which pushed the REMUX / WEB-DL overlay badges up out of the corner. Both clients rendered the brand as tracked "SILO" text instead of the Silo lockup.

## Solution

- **Phone detail page**: the Version / Audio / Subtitles selector rows let the value wrap and grow from a 44dp floor. The selector card height is now a 133dp minimum instead of fixed.
- **TV detail page**: the readout items size to their text instead of a fixed width, so long labels render in full. The loading skeleton keeps its fixed width so the row stays stable while values hydrate.
- **TV episode cards**: the S·E pill is removed. `CardOverlays` gains an optional `bottomInset` override, and the TV episode card uses it so the lower badges sit in the corner just above the progress bar. The phone backdrop card keeps its existing inset.
- **Brand**: the TV top bar and the phone Home header show the existing `silo_wordmark` drawable instead of text.

Source-assertion tests that pinned the old fixed heights and widths are updated to match.

This bundles three small UI fixes into one PR at the developer's request.

## Validation

- `./gradlew :androidApp:assembleDebug :androidTvApp:assembleDebug` build clean.
- `./gradlew :androidApp:testDebugUnitTest :androidTvApp:testDebugUnitTest :android-shared:testDebugUnitTest` pass after rebasing on main.
- Installed the TV debug build on a Google TV Streamer and confirmed the full "Auto · English · SRT" readout on a movie detail page, episode cards without the pill and with badges in the corner, and the lockup in the top bar.
- Phone changes compile but were not run on a device.

## Risks

- A very long TV readout value could extend past the hero text column, since values still render on one line.
- The phone Home header row is 64dp; the lockup image is shorter than the old 26sp text, so the header may read slightly lighter.

## AI disclosure

Written with Claude Fable 5.1 (`claude-fable-5-1`) via the Claude Code agent harness. No other AI tooling was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Media selector and playback details now expand to display longer values instead of truncating them.
  * Improved spacing and minimum-height behavior for selector controls.
  * Updated Android and TV navigation areas to use the Silo wordmark.
  * Refined TV card overlay positioning for more consistent episode artwork presentation.

* **Bug Fixes**
  * Added support for customized card overlay spacing where needed.
  * Updated TV and mobile UI tests to verify wrapped text and loading-state layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->