### PR TITLE
fix(tv): match Apple's hold-to-seek speeds, show the bar's rate pill, and stop clipping it

### DIFF
--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -180,21 +180,13 @@ private data class TvIdleOverlayFocusRequest(
 )
 
 /**
- * Manual rate step for a hidden-controls hold-seek.
- *
- * Delegates to [TvSeekRateLadder] so this control and the focused scrubber's
- * hold-seek walk one ladder. They previously kept separate ones, and the
- * hidden path's was both dishonest about its multiples (see
- * [advanceCleanPlaybackSeekPreview]) and flipped direction when stepped below
- * 1× — so "slower" eventually meant "backwards".
+ * Manual rate step for a hidden-controls hold-seek. Delegates to
+ * [TvSeekRateLadder] so this control and the focused scrubber walk the same
+ * ladder as the Apple clients.
  */
-internal fun adjustedCleanPlaybackSeekRate(
-    currentRate: Int,
-    adjustment: Int,
-    durationSec: Double,
-): Int {
+internal fun adjustedCleanPlaybackSeekRate(currentRate: Int, adjustment: Int): Int {
     if (adjustment == 0) return currentRate
-    return TvSeekRateLadder.bumped(currentRate, adjustment, durationSec)
+    return TvSeekRateLadder.bumped(currentRate, adjustment)
 }
 
 /**
@@ -226,22 +218,17 @@ internal fun isCleanPlaybackSeekAdjustmentTap(
 ): Boolean = !repeated && pressDurationMs < CLEAN_SEEK_HOLD_THRESHOLD_MS
 
 /**
- * One hold-seek tick for the hidden-controls scan.
- *
- * Advances by [TvSeekRateLadder.tickSeconds], which is what makes the rate
- * chip mean what it says: rate × tick seconds per tick is exactly rate × real
- * time. This previously advanced a flat 2s per 100ms tick at 1×, so every
- * multiple on screen was a twentieth of the truth — a chip reading "8×" moved
- * at 160×, and the same gesture ran 20× faster with the chrome hidden than the
- * focused scrubber's hold-seek, which had already been corrected.
+ * One hold-seek tick for the hidden-controls scan. Advances by the ladder's
+ * content-per-elapsed-time so the speed matches tvOS `beginHoldSeek`.
  */
 internal fun advanceCleanPlaybackSeekPreview(
     previewSec: Double,
     durationSec: Double,
     rate: Int,
+    elapsedMillis: Long = TvSeekRateLadder.TICK_MILLIS,
 ): Double {
     val safePreview = previewSec.takeIf { it.isFinite() }?.coerceAtLeast(0.0) ?: 0.0
-    val next = (safePreview + TvSeekRateLadder.tickSeconds(rate)).coerceAtLeast(0.0)
+    val next = (safePreview + TvSeekRateLadder.elapsedSeconds(rate, elapsedMillis)).coerceAtLeast(0.0)
     return if (durationSec.isFinite() && durationSec > 0.0) {
         next.coerceAtMost(durationSec)
     } else {
@@ -802,35 +789,32 @@ fun TvPlayerScreen(
 
         cleanSeekTickJob?.cancel()
         cleanSeekTickJob = cleanPlaybackSeekScope.launch {
+            var lastTickAt = SystemClock.elapsedRealtime()
             while (isActive && cleanSeekRate != 0) {
+                val now = SystemClock.elapsedRealtime()
                 cleanSeekPreviewSec = advanceCleanPlaybackSeekPreview(
                     previewSec = cleanSeekPreviewSec,
                     durationSec = viewModel.uiState.value.duration,
                     rate = cleanSeekRate,
+                    elapsedMillis = now - lastTickAt,
                 )
+                lastTickAt = now
                 delay(TvSeekRateLadder.TICK_MILLIS)
             }
         }
 
-        // Ramp on the shared ladder rather than a fixed 2→4→8. Now that a tick
-        // covers rate × real time, a fixed ceiling cannot serve both ends: 8×
-        // would take over twenty minutes to cross a film. The ladder derives
-        // its top from the runtime so "hold until it arrives" costs about the
-        // same whatever you're watching.
+        // Sustained ramp, Apple `startHoldSeekAutoRamp`: 1 → 2 → 4 → 8 on a
+        // 1.2s beat, then the viewer taps to go faster. Each step only fires
+        // while the rate is still the one the previous step left, so a tap
+        // in the meantime (which is the viewer driving) wins.
         cleanSeekRampJob?.cancel()
         cleanSeekRampJob = cleanPlaybackSeekScope.launch {
-            val durationSec = viewModel.uiState.value.duration
             var previous = TvSeekRateLadder.BASE_RATE * sign
-            repeat(TvSeekRateLadder.rampSteps(durationSec)) { step ->
+            for (magnitude in TvSeekRateLadder.rampRates) {
                 delay(TvSeekRateLadder.RAMP_STEP_MILLIS)
-                // Only continue while the viewer is still holding at the rate
-                // the previous step left, so a release and a fresh press the
-                // other way isn't overwritten by this hold's timer.
                 if (cleanSeekRate != previous) return@launch
-                val next = TvSeekRateLadder.sustainedRate(step, sign, durationSec)
-                if (next == previous) return@launch
-                cleanSeekRate = next
-                previous = next
+                cleanSeekRate = magnitude * sign
+                previous = cleanSeekRate
             }
         }
     }
@@ -895,7 +879,6 @@ fun TvPlayerScreen(
         cleanSeekRate = adjustedCleanPlaybackSeekRate(
             currentRate = cleanSeekRate,
             adjustment = adjustment,
-            durationSec = viewModel.uiState.value.duration,
         )
     }
 
@@ -2550,7 +2533,6 @@ private fun TvPlayerIdleOverlay(
     // needed a Back (which hides the overlay, clearing the flag) before Down.
     var scrubberHasFocus by remember { mutableStateOf(false) }
     var transportHasFocus by remember { mutableStateOf(false) }
-    var currentRate by remember { mutableStateOf(0) }
     LaunchedEffect(focusRequest.nonce) {
         val overlayTarget = when (focusRequest.target) {
             TvIdleOverlayFocusTarget.Scrubber -> scrubberFocus
@@ -2682,7 +2664,6 @@ private fun TvPlayerIdleOverlay(
                     )
                 },
                 onExitWhenIdle = onClose,
-                onRateChanged = { currentRate = it },
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -2743,19 +2724,6 @@ private fun TvPlayerIdleOverlay(
             }
         }
 
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = 80.dp),
-            contentAlignment = Alignment.TopCenter,
-        ) {
-            TvHoldSeekIndicator(
-                isVisible = currentRate != 0,
-                rate = currentRate,
-                previewTimeSec = scrubPreviewSec,
-                durationSec = durationSec,
-            )
-        }
     }
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScrubber.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScrubber.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.tv.ui.screens.player
 
+import android.os.SystemClock
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -45,6 +47,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
@@ -56,6 +59,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
@@ -68,10 +72,8 @@ import kotlin.math.roundToInt
  *
  * - **Tap left/right** (idle): ±10 s quick skip via [onSkipBack] / [onSkipForward].
  * - **Tap left/right** (timeline scrub): ±10 s nudge of the in-flight preview.
- * - **Hold left/right**: enter timeline auto-seek at ±2x, doubling every
- *   900 ms up to a ceiling derived from the item's runtime — ±256x for a
- *   22-minute episode, ±1024x for a feature — or tap again to bump the rate
- *   by hand. See [TvSeekRateLadder.maxRateFor].
+ * - **Hold left/right**: enter timeline auto-seek at 1x on the shared
+ *   [TvSeekRateLadder]; tap again to step the rate, as on tvOS.
  * - **OK / Select**: commit an in-flight preview (or enter timeline scrub).
  * - **Back / Down**: cancel the preview / move focus to transport.
  *
@@ -129,7 +131,6 @@ fun TvPlayerScrubber(
     canToggleAfterCommit: Boolean = true,
     onMoveDownToTransport: () -> Unit,
     onExitWhenIdle: () -> Unit,
-    onRateChanged: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -147,20 +148,19 @@ fun TvPlayerScrubber(
     var autoSeekRate by remember { mutableStateOf(0) }
     val scope = rememberCoroutineScope()
     var autoSeekJob by remember { mutableStateOf<Job?>(null) }
-    // Speeds and ramp live in TvSeekRateLadder so the chip's number and the
-    // distance actually travelled cannot drift apart again.
-    var holdRampJob by remember { mutableStateOf<Job?>(null) }
+    // Direction of a Left/Right press whose tap action is waiting for KeyUp.
+    // tvOS classifies tap versus hold from the release (TVPressCaptureView),
+    // so a hold never fires the ±10/30s skip on its way into auto-seek. The
+    // first repeat clears this and starts the hold instead.
+    var pendingTapDirection by remember { mutableStateOf(0) }
 
     fun setRate(rate: Int) {
         autoSeekRate = rate
-        onRateChanged(rate)
     }
 
     fun stopAutoSeek() {
         autoSeekJob?.cancel()
         autoSeekJob = null
-        holdRampJob?.cancel()
-        holdRampJob = null
         setRate(0)
     }
 
@@ -171,46 +171,38 @@ fun TvPlayerScrubber(
         setRate(TvSeekRateLadder.BASE_RATE * sign)
         autoSeekJob?.cancel()
         autoSeekJob = scope.launch {
+            // Delay first so onBeginScrub's position seed lands in
+            // currentPreviewSec before the loop reads it (otherwise the first
+            // update would overwrite the seed and scanning starts at ~0).
+            delay(TvSeekRateLadder.TICK_MILLIS)
+            // The loop owns the running position. Pulling the preview back
+            // through recomposition each tick meant every tick advanced from
+            // whatever the UI had last managed to draw — under 4K decode load
+            // that lagged several ticks, so a chip reading 128× travelled at a
+            // fraction of it. Mirrors the hidden-controls path, which keeps
+            // its own counter for the same reason.
+            var previewSec = currentPreviewSec
+            var lastTickAt = SystemClock.elapsedRealtime()
             while (isActive) {
-                // Delay first so onBeginScrub's position seed lands in
-                // currentPreviewSec before the first tick reads it (otherwise the
-                // first update would overwrite the seed and scanning starts at ~0).
-                delay(TvSeekRateLadder.TICK_MILLIS)
                 val rate = autoSeekRate
                 if (rate == 0) break
-                val base = currentPreviewSec + TvSeekRateLadder.tickSeconds(rate)
-                onUpdateScrub(base)
+                val now = SystemClock.elapsedRealtime()
+                previewSec = clampTvScrubPreview(
+                    previewSec + TvSeekRateLadder.elapsedSeconds(rate, now - lastTickAt),
+                    durationSec,
+                )
+                lastTickAt = now
+                onUpdateScrub(previewSec)
+                delay(TvSeekRateLadder.TICK_MILLIS)
             }
         }
-        // Sustained progression through the ladder. Each step only fires if the
-        // viewer is still holding the same direction at the rate the previous
-        // step left — otherwise a release and a fresh press the other way would
-        // be overwritten by a timer from the abandoned hold.
-        holdRampJob?.cancel()
-        holdRampJob = scope.launch {
-            var previous = TvSeekRateLadder.BASE_RATE * sign
-            repeat(TvSeekRateLadder.rampSteps(durationSec)) { step ->
-                delay(TvSeekRateLadder.RAMP_STEP_MILLIS)
-                // Only continue while the viewer is still holding at the rate
-                // the previous step left; a release and a fresh press the other
-                // way must not be overwritten by this hold's timer.
-                if (autoSeekRate != previous) return@launch
-                val next = TvSeekRateLadder.sustainedRate(step, sign, durationSec)
-                if (next == previous) return@launch
-                setRate(next)
-                previous = next
-            }
-        }
+        // No sustained ramp on the focused bar: tvOS `beginTimelineAutoSeek`
+        // holds the rate the press started at and leaves speed to taps.
     }
 
     fun bumpRate(delta: Int) {
-        val next = TvSeekRateLadder.bumped(autoSeekRate, delta, durationSec)
-        if (next == autoSeekRate) return
-        // User-driven rate change cancels the time-based ramp so it doesn't
-        // overwrite the manual pick a beat later.
-        holdRampJob?.cancel()
-        holdRampJob = null
-        setRate(next)
+        val next = TvSeekRateLadder.bumped(autoSeekRate, delta)
+        if (next != autoSeekRate) setRate(next)
     }
 
     // Cancel any in-flight scrub on focus loss when the shell asks us to
@@ -280,15 +272,16 @@ fun TvPlayerScrubber(
         }
 
         Box(modifier = Modifier.weight(1f)) {
-            // Auto-seek visualization is owned by [TvHoldSeekIndicator] rendered
-            // by the parent overlay so it can float top-center above the
-            // transport instead of crowding the scrubber.
 
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.Center)
-                .height(28.dp)
+                // Required, not preferred: the column above hands this box
+                // ~14dp once the clock row has taken its share, and a plain
+                // height() is coerced to that, squashing the puck and
+                // clipping the auto-seek chip.
+                .requiredHeight(28.dp)
                 .focusRequester(onRequestFocus)
                 .onFocusChanged { /* state collected via interactionSource */ }
                 .focusable(interactionSource = interactionSource)
@@ -297,58 +290,40 @@ fun TvPlayerScrubber(
                     val isUp = event.type == KeyEventType.KeyUp
                     val nativeRepeat = event.nativeKeyEvent.repeatCount
                     when (event.key) {
-                        Key.DirectionLeft -> {
-                            // KeyUp cancels the time-based ramp coroutine —
-                            // user has released the D-pad, so further rate
-                            // climbs would be unsolicited. The auto-seek loop
-                            // itself stays alive until commit/cancel.
+                        Key.DirectionLeft, Key.DirectionRight -> {
+                            val direction = if (event.key == Key.DirectionLeft) -1 else 1
                             if (isUp) {
-                                holdRampJob?.cancel()
-                                holdRampJob = null
+                                // Release before the first repeat: this was a
+                                // tap. ±10s/30s skip in idle, a nudge of the
+                                // in-flight preview, or a rate bump in auto-seek.
+                                if (pendingTapDirection == direction) {
+                                    pendingTapDirection = 0
+                                    when {
+                                        autoSeekRate != 0 -> bumpRate(direction)
+                                        // Forward nudge matches the 30s transport
+                                        // skip (back stays 10s), mirroring tvOS
+                                        // scrubForwardStep/scrubBackwardStep.
+                                        isTimelineScrubbing -> onUpdateScrub(
+                                            scrubPreviewSec + if (direction < 0) -10.0 else 30.0,
+                                        )
+                                        direction < 0 -> onSkipBack()
+                                        else -> onSkipForward()
+                                    }
+                                    return@onPreviewKeyEvent true
+                                }
                                 return@onPreviewKeyEvent false
                             }
                             if (!isDown) return@onPreviewKeyEvent false
-                            // First repeat (count==1) marks "long-press" —
-                            // engage timeline auto-seek mode. Standalone
-                            // taps (repeat==0 followed by KeyUp) fall back
-                            // to ±10s skip in idle, or chip rate-bump in
-                            // auto-seek.
+                            // First repeat (count==1) marks "long-press": engage
+                            // timeline auto-seek and forget the pending tap so
+                            // the hold does not also skip on the way in.
                             if (nativeRepeat == 1) {
-                                if (autoSeekRate == 0) beginAutoSeek(-1)
+                                pendingTapDirection = 0
+                                if (autoSeekRate == 0) beginAutoSeek(direction)
                                 return@onPreviewKeyEvent true
                             }
                             if (nativeRepeat > 1) return@onPreviewKeyEvent true
-                            if (autoSeekRate != 0) {
-                                bumpRate(-1)
-                            } else if (isTimelineScrubbing) {
-                                onUpdateScrub(scrubPreviewSec - 10.0)
-                            } else {
-                                onSkipBack()
-                            }
-                            true
-                        }
-                        Key.DirectionRight -> {
-                            if (isUp) {
-                                holdRampJob?.cancel()
-                                holdRampJob = null
-                                return@onPreviewKeyEvent false
-                            }
-                            if (!isDown) return@onPreviewKeyEvent false
-                            if (nativeRepeat == 1) {
-                                if (autoSeekRate == 0) beginAutoSeek(1)
-                                return@onPreviewKeyEvent true
-                            }
-                            if (nativeRepeat > 1) return@onPreviewKeyEvent true
-                            if (autoSeekRate != 0) {
-                                bumpRate(1)
-                            } else if (isTimelineScrubbing) {
-                                // Forward nudge matches the 30s transport skip
-                                // (back nudge stays 10s), mirroring tvOS
-                                // scrubForwardStep/scrubBackwardStep.
-                                onUpdateScrub(scrubPreviewSec + 30.0)
-                            } else {
-                                onSkipForward()
-                            }
+                            pendingTapDirection = direction
                             true
                         }
                         Key.DirectionDown -> {
@@ -511,10 +486,62 @@ fun TvPlayerScrubber(
                         .background(Color.White),
                 )
             }
+
+            // Auto-seek chip, after tvOS `timelineAutoSeekChip`: a small white
+            // pill with the direction glyph and rate, riding above the puck so
+            // the eye stays on the playhead. Kept inside the bar's width so it
+            // never hangs off either end. The bar's puck and clocks already
+            // show where the preview is, so the full [TvHoldSeekIndicator]
+            // overlay stays reserved for the hidden-controls session where
+            // nothing else is on screen.
+            if (autoSeekRate != 0) {
+                var chipWidthPx by remember { mutableStateOf(0) }
+                val chipLiftPx = with(density) { 40.dp.roundToPx() }
+                TvScrubberAutoSeekChip(
+                    rate = autoSeekRate,
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        .onSizeChanged { chipWidthPx = it.width }
+                        .offset {
+                            val maxX = (barWidthPx - chipWidthPx).roundToInt().coerceAtLeast(0)
+                            val x = (barWidthPx * totalProgress - chipWidthPx / 2f)
+                                .roundToInt()
+                                .coerceIn(0, maxX)
+                            IntOffset(x, -chipLiftPx)
+                        },
+                )
+            }
         }
     }
 }
 
+}
+
+@Composable
+private fun TvScrubberAutoSeekChip(rate: Int, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .shadow(8.dp, RoundedCornerShape(percent = 50), clip = false)
+            .clip(RoundedCornerShape(percent = 50))
+            .background(Color.White)
+            .padding(horizontal = 9.dp, vertical = 3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        Icon(
+            imageVector = if (rate < 0) Icons.Filled.FastRewind else Icons.Filled.FastForward,
+            contentDescription = null,
+            tint = Color.Black,
+            modifier = Modifier.size(12.dp),
+        )
+        Text(
+            text = "${abs(rate)}x",
+            color = Color.Black,
+            maxLines = 1,
+            softWrap = false,
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+        )
+    }
 }
 
 private fun formatScrubberTime(seconds: Double): String = formatTimelineClock(seconds)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSeekRateLadder.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSeekRateLadder.kt
@@ -1,174 +1,69 @@
 package org.siloserver.silo.tv.ui.screens.player
 
-import kotlin.math.ceil
-import kotlin.math.max
-import kotlin.math.min
-
 /**
- * Speeds for hold-to-seek, and how a sustained press climbs through them.
+ * Speeds for hold-to-seek and how a sustained press climbs through them.
  *
- * The rate a viewer sees on the chip is a multiple of real time, and this is
- * the only place that decides what that multiple means. It previously did not
- * mean anything: the scrubber advanced `2.0 * rate` seconds on a 100ms tick, so
- * a chip reading "8×" moved at 160× real time. Every number on screen was a
- * twentieth of the truth, which is why the control felt ungovernable — you
- * aimed with the number and the number was wrong.
+ * Mirrors the Apple clients exactly (`PlayerViewModel.seekRates`,
+ * `TVPlayerScrubber.timelineAutoSeekRates`): a signed ladder of 1×…32×, a
+ * 100 ms tick, and [SECONDS_PER_TICK_AT_1X] seconds of content per tick per
+ * rate unit. The label is therefore a ladder position, not a literal multiple
+ * of real time — "8×" travels 160× real time — but it is the same number, at
+ * the same speed, the viewer sees on Apple TV.
  *
- * [SECONDS_PER_TICK] is what makes the label honest: rate × tick seconds per
- * tick is exactly rate × real time.
- *
- * A single fixed ceiling cannot serve both ends of this control. Nudging past
- * an intro wants single digits; reaching the end of a three-hour film at 32×
- * takes five and a half minutes of holding, which is not a seek, it is a
- * hostage situation. So the top of the ladder is derived from the runtime
- * instead of being a constant: [maxRateFor] targets [TRAVERSE_TARGET_SECONDS]
- * to cross the whole item, so "hold until it gets there" costs about the same
- * however long the thing is.
+ * A previous revision tried to make the label honest (rate × real time) and
+ * derived the ceiling from the runtime. That made every rung 20× slower than
+ * tvOS, which read as "the speeds are wrong" to anyone who uses both clients.
  */
 internal object TvSeekRateLadder {
 
-    /** Auto-seek tick cadence. Content advanced per tick is rate × this. */
+    /** Auto-seek tick cadence. */
     const val TICK_MILLIS = 100L
-    private const val SECONDS_PER_TICK = TICK_MILLIS / 1000.0
+
+    /** Content seconds covered per tick at 1×. Apple's `holdSeekBaseStep`. */
+    const val SECONDS_PER_TICK_AT_1X = 2.0
+
+    /** Where a hold starts. */
+    const val BASE_RATE = 1
+
+    /** Rate magnitudes, slowest to fastest. */
+    val rates: List<Int> = listOf(1, 2, 4, 8, 16, 32)
 
     /**
-     * Slowest speed. A press has to visibly move, so 1× — which scans at
-     * exactly playback speed — is not a useful first step.
+     * Rates a sustained hold climbs through after [BASE_RATE], one per
+     * [RAMP_STEP_MILLIS]. Apple's `startHoldSeekAutoRamp`: 1 → 2 → 4 → 8, then
+     * the viewer taps to go faster. Only the hidden-controls session ramps;
+     * the focused scrubber's hold holds its rate (tvOS `beginTimelineAutoSeek`).
      */
-    const val BASE_RATE = 2
+    val rampRates: List<Int> = listOf(2, 4, 8)
+
+    /** Cadence of the sustained ramp. */
+    const val RAMP_STEP_MILLIS = 1_200L
+
+    /** Content seconds to advance for one full tick at [rate]. */
+    fun tickSeconds(rate: Int): Double = rate * SECONDS_PER_TICK_AT_1X
 
     /**
-     * Steady-state crossing target: the ceiling is derived so that holding at
-     * it crosses the item in about this long.
+     * Content seconds covered by [rate] over [elapsedMillis] of wall-clock time.
      *
-     * NOT the end-to-end figure. A hold ramps up to the ceiling rather than
-     * starting there, and the early rungs cover almost nothing, so the real
-     * cost runs ~10.5s for a 22-minute episode to ~17.8s for a three-hour
-     * film. [traverseSeconds] computes the honest number; that spread is the
-     * thing being kept small, not the absolute value.
+     * The loops advance by measured elapsed time rather than by counting
+     * ticks: `delay` only promises to wait at least this long, and on a box
+     * busy decoding 4K a 100 ms tick can land 50 ms late. Counting ticks would
+     * make the same rate run slower on a busier box; measuring time keeps the
+     * speed the ladder promises.
      */
-    const val TRAVERSE_TARGET_SECONDS = 10.0
+    fun elapsedSeconds(rate: Int, elapsedMillis: Long): Double =
+        tickSeconds(rate) * elapsedMillis.coerceAtLeast(0L) / TICK_MILLIS
 
     /**
-     * Floor for the derived ceiling, so short content still gets a fast top
-     * gear, and cap, so a very long item does not produce a rate whose single
-     * tick skips minutes.
+     * Neighbouring rate after a tap while seeking, Apple `adjustHoldSeekRate`:
+     * step [delta] along the signed ladder …-32, …, -1, 1, …, 32 and clamp at
+     * the ends. Stepping past 1× in the opposite direction reverses, exactly
+     * as it does on tvOS.
      */
-    const val MIN_TOP_RATE = 32
-    const val MAX_TOP_RATE = 1024
-
-    /**
-     * The fastest aimable speed. Above this a hold is travelling rather than
-     * aiming, which is fine — but it should be reached deliberately, by
-     * continuing to hold, not stumbled into in the first second.
-     */
-    const val AIMABLE_MAX_RATE = 16
-
-    /** Doubling ladder; the reachable top is bounded by [maxRateFor]. */
-    val rates: List<Int> = listOf(2, 4, 8, 16, 32, 64, 128, 256, 512, 1024)
-
-    /**
-     * Cadence of the sustained ramp. The ramp keeps doubling on this beat until
-     * it reaches the item's ceiling, rather than walking a fixed number of
-     * steps — so a three-hour film goes on accelerating past the point where a
-     * twenty-minute episode has already topped out, which is the whole reason
-     * the ceiling is derived from runtime.
-     */
-    const val RAMP_STEP_MILLIS = 900L
-
-    /** Number of doublings needed to reach [durationSeconds]'s ceiling. */
-    fun rampSteps(durationSeconds: Double): Int {
-        val ceiling = maxRateFor(durationSeconds)
-        var rate = BASE_RATE
-        var steps = 0
-        while (rate < ceiling) {
-            rate *= 2
-            steps++
-        }
-        return steps
-    }
-
-    /**
-     * Wall-clock seconds a sustained hold needs to cross an item of
-     * [durationSeconds] — INCLUDING the ramp, which is the part
-     * [TRAVERSE_TARGET_SECONDS] does not describe.
-     *
-     * The ceiling is derived so the STEADY-STATE crossing is about
-     * [TRAVERSE_TARGET_SECONDS], but a hold does not start at the ceiling: it
-     * doubles every [RAMP_STEP_MILLIS] to get there, and those early rungs
-     * cover very little. A three-hour item spends 8.1s ramping and covers only
-     * ~920s of it, so the honest end-to-end figure is ~17.8s, not ~10.5s.
-     *
-     * Exposed so the tests can assert what a viewer actually experiences
-     * rather than re-deriving `duration / topRate`, which is the arithmetic the
-     * implementation does NOT perform.
-     */
-    fun traverseSeconds(durationSeconds: Double): Double {
-        if (!durationSeconds.isFinite() || durationSeconds <= 0.0) return 0.0
-        val ceiling = maxRateFor(durationSeconds)
-        val rampStepSeconds = RAMP_STEP_MILLIS / 1000.0
-        var covered = 0.0
-        var elapsed = 0.0
-        var rate = BASE_RATE
-        while (rate < ceiling && covered < durationSeconds) {
-            covered += rate * rampStepSeconds
-            elapsed += rampStepSeconds
-            rate *= 2
-        }
-        if (covered >= durationSeconds) return elapsed
-        return elapsed + (durationSeconds - covered) / ceiling
-    }
-
-    /** Content seconds to advance for one tick at [rate]. */
-    fun tickSeconds(rate: Int): Double = rate * SECONDS_PER_TICK
-
-    /**
-     * Fastest rate offered for an item of [durationSeconds].
-     *
-     * Derived so a sustained hold crosses the item in about
-     * [TRAVERSE_TARGET_SECONDS], then rounded up to the next ladder rung so the
-     * chip still shows a familiar number. Unknown or nonsensical durations fall
-     * back to [MIN_TOP_RATE] rather than guessing.
-     */
-    fun maxRateFor(durationSeconds: Double): Int {
-        if (!durationSeconds.isFinite() || durationSeconds <= 0.0) return MIN_TOP_RATE
-        val needed = ceil(durationSeconds / TRAVERSE_TARGET_SECONDS).toInt()
-        val bounded = min(max(needed, MIN_TOP_RATE), MAX_TOP_RATE)
-        return rates.firstOrNull { it >= bounded } ?: MAX_TOP_RATE
-    }
-
-    /**
-     * The rate a sustained hold reaches at ramp [step] (0-based) in
-     * [direction], for an item of [durationSeconds].
-     *
-     * Doubles from [BASE_RATE] and stops at whatever that item's ceiling is, so
-     * a long film keeps accelerating past the point where a short episode has
-     * already topped out. Step 0 is the first change, [RAMP_STEP_MILLIS] in.
-     */
-    fun sustainedRate(step: Int, direction: Int, durationSeconds: Double): Int {
-        val sign = if (direction < 0) -1 else 1
-        val ceiling = maxRateFor(durationSeconds)
-        var rate = BASE_RATE
-        repeat(step + 1) { rate = min(rate * 2, ceiling) }
-        return rate * sign
-    }
-
-    /**
-     * Neighbouring rate after a repeat-press bump, clamped to this item's range.
-     *
-     * [delta] is a direction along the signed ladder as the key handlers see it,
-     * not "faster": +1 is rightwards (faster forwards, or slower backwards) and
-     * -1 is leftwards. A bump therefore never flips direction — it stops at the
-     * base rate on the way in.
-     */
-    fun bumped(current: Int, delta: Int, durationSeconds: Double): Int {
-        val ceiling = maxRateFor(durationSeconds)
-        val usable = rates.filter { it <= ceiling }
-        val magnitude = if (current < 0) -current else current
-        val sign = if (current < 0) -1 else 1
-        val index = usable.indexOf(magnitude)
+    fun bumped(current: Int, delta: Int): Int {
+        val signed = rates.asReversed().map { -it } + rates
+        val index = signed.indexOf(current)
         if (index < 0) return current
-        val next = usable[(index + delta * sign).coerceIn(0, usable.lastIndex)]
-        return next * sign
+        return signed[(index + delta).coerceIn(0, signed.lastIndex)]
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvCleanPlaybackSeekTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvCleanPlaybackSeekTest.kt
@@ -24,71 +24,66 @@ class TvCleanPlaybackSeekTest {
 
     @Test
     fun manualTapsWalkTheSignedRateLadder() {
-        // A 90-minute item; its ladder ceiling is well above these rungs.
-        val durationSec = 5_400.0
-        assertEquals(4, adjustedCleanPlaybackSeekRate(2, adjustment = 1, durationSec = durationSec))
-        assertEquals(2, adjustedCleanPlaybackSeekRate(4, adjustment = -1, durationSec = durationSec))
-        assertEquals(-4, adjustedCleanPlaybackSeekRate(-2, adjustment = -1, durationSec = durationSec))
-        assertEquals(-2, adjustedCleanPlaybackSeekRate(-4, adjustment = 1, durationSec = durationSec))
-        assertEquals(32, adjustedCleanPlaybackSeekRate(16, adjustment = 1, durationSec = durationSec))
+        assertEquals(2, adjustedCleanPlaybackSeekRate(1, adjustment = 1))
+        assertEquals(1, adjustedCleanPlaybackSeekRate(2, adjustment = -1))
+        assertEquals(-2, adjustedCleanPlaybackSeekRate(-1, adjustment = -1))
+        assertEquals(-1, adjustedCleanPlaybackSeekRate(-2, adjustment = 1))
+        assertEquals(32, adjustedCleanPlaybackSeekRate(16, adjustment = 1))
+        assertEquals(32, adjustedCleanPlaybackSeekRate(32, adjustment = 1))
+        assertEquals(-32, adjustedCleanPlaybackSeekRate(-32, adjustment = -1))
+    }
+
+    /** Apple parity: the ladder is signed end to end, so 1× → -1× reverses. */
+    @Test
+    fun steppingPastOneReversesDirectionLikeApple() {
+        assertEquals(-1, adjustedCleanPlaybackSeekRate(1, adjustment = -1))
+        assertEquals(1, adjustedCleanPlaybackSeekRate(-1, adjustment = 1))
     }
 
     @Test
-    fun steppingBelowTheBaseRateStopsRatherThanReversingDirection() {
-        // The old signed ladder ran ... -1, 1 ... so stepping "slower" past the
-        // bottom silently flipped a forward scan into a backward one.
-        val durationSec = 5_400.0
-        assertEquals(2, adjustedCleanPlaybackSeekRate(2, adjustment = -1, durationSec = durationSec))
-        assertEquals(-2, adjustedCleanPlaybackSeekRate(-2, adjustment = 1, durationSec = durationSec))
-    }
-
-    @Test
-    fun rateAdjustmentClampsAtTheItemsDerivedCeiling() {
-        // 90 minutes needs ceil(5400 / 10) = 540x to cross in the target time,
-        // which rounds up to the 1024 rung.
-        val durationSec = 5_400.0
-        assertEquals(1024, adjustedCleanPlaybackSeekRate(1024, adjustment = 1, durationSec = durationSec))
-        assertEquals(-1024, adjustedCleanPlaybackSeekRate(-1024, adjustment = -1, durationSec = durationSec))
-    }
-
-    @Test
-    fun shortContentGetsALowerCeilingThanAFeature() {
-        // A 22-minute episode: ceil(1320 / 10) = 132x, rounded up to 256.
-        val episodeSec = 1_320.0
-        assertEquals(256, adjustedCleanPlaybackSeekRate(256, adjustment = 1, durationSec = episodeSec))
-    }
-
-    @Test
-    fun previewAdvancesByExactlyRateTimesRealTime() {
-        // 100ms tick, so one tick at 8x covers 0.8s of content — not the 16s
-        // the old flat 2s-per-tick base step produced for the same "8x" chip.
+    fun previewAdvancesByAppleBaseStepTimesRatePerTick() {
+        // 2s per 100ms tick at 1×, so one tick at 8× covers 16s of content.
         assertEquals(
-            100.8,
+            116.0,
             advanceCleanPlaybackSeekPreview(previewSec = 100.0, durationSec = 500.0, rate = 8),
         )
         assertEquals(
-            99.6,
+            92.0,
             advanceCleanPlaybackSeekPreview(previewSec = 100.0, durationSec = 500.0, rate = -4),
         )
     }
 
     @Test
+    fun previewScalesWithMeasuredElapsedTime() {
+        // A tick that lands late covers proportionally more, so a busy box
+        // still travels at the ladder's speed.
+        assertEquals(
+            124.0,
+            advanceCleanPlaybackSeekPreview(
+                previewSec = 100.0,
+                durationSec = 500.0,
+                rate = 8,
+                elapsedMillis = 150L,
+            ),
+        )
+    }
+
+    @Test
     fun previewClampsToKnownTimelineBounds() {
-        // Rates large enough that a single tick overshoots each end.
         assertEquals(
             0.0,
-            advanceCleanPlaybackSeekPreview(previewSec = 1.0, durationSec = 500.0, rate = -64),
+            advanceCleanPlaybackSeekPreview(previewSec = 1.0, durationSec = 500.0, rate = -32),
         )
         assertEquals(
             500.0,
-            advanceCleanPlaybackSeekPreview(previewSec = 499.0, durationSec = 500.0, rate = 64),
+            advanceCleanPlaybackSeekPreview(previewSec = 499.0, durationSec = 500.0, rate = 32),
         )
     }
 
     @Test
     fun unknownDurationStillAllowsForwardPreview() {
         assertEquals(
-            10.2,
+            14.0,
             advanceCleanPlaybackSeekPreview(previewSec = 10.0, durationSec = 0.0, rate = 2),
         )
     }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSeekRateLadderTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSeekRateLadderTest.kt
@@ -4,176 +4,62 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+/**
+ * The ladder mirrors the Apple clients (`PlayerViewModel.seekRates`,
+ * `TVPlayerScrubber.timelineAutoSeekRates`, `startHoldSeekAutoRamp`), so these
+ * pin the numbers a viewer who uses both would notice drifting apart.
+ */
 class TvSeekRateLadderTest {
 
-    private companion object {
-        const val EPISODE = 2_700.0      // 45 min
-        const val SHORT_EPISODE = 1_320.0 // 22 min
-        const val LONG_FILM = 10_800.0    // 3 h
+    @Test
+    fun ladderMatchesApple() {
+        assertEquals(listOf(1, 2, 4, 8, 16, 32), TvSeekRateLadder.rates)
+        assertEquals(1, TvSeekRateLadder.BASE_RATE)
+        assertEquals(listOf(2, 4, 8), TvSeekRateLadder.rampRates)
+        assertEquals(1_200L, TvSeekRateLadder.RAMP_STEP_MILLIS)
+        assertEquals(100L, TvSeekRateLadder.TICK_MILLIS)
+        assertEquals(2.0, TvSeekRateLadder.SECONDS_PER_TICK_AT_1X)
+    }
+
+    /** Apple's `holdSeekBaseStep * rate` per 100ms tick: 8× covers 16s a tick. */
+    @Test
+    fun aTickCoversAppleBaseStepTimesRate() {
+        assertEquals(2.0, TvSeekRateLadder.tickSeconds(1), 0.0001)
+        assertEquals(16.0, TvSeekRateLadder.tickSeconds(8), 0.0001)
+        assertEquals(-64.0, TvSeekRateLadder.tickSeconds(-32), 0.0001)
     }
 
     /**
-     * The defect this ladder exists to prevent: the chip said "8×" while the
-     * scrubber advanced 2.0s every 100ms, which is 160× real time. A rate must
-     * mean its own multiple of real time and nothing else.
+     * Advancing by measured elapsed time is what keeps a busy box honest: a
+     * tick that lands 50ms late covers 50% more, not the same amount.
      */
     @Test
-    fun aRateAdvancesExactlyThatMultipleOfRealTime() {
-        val tickSeconds = TvSeekRateLadder.TICK_MILLIS / 1000.0
-        TvSeekRateLadder.rates.forEach { rate ->
-            val advancedPerSecond = TvSeekRateLadder.tickSeconds(rate) / tickSeconds
-            assertEquals(rate.toDouble(), advancedPerSecond, 0.0001, "rate ${rate}x")
-        }
+    fun elapsedSecondsScalesWithWallClock() {
+        assertEquals(TvSeekRateLadder.tickSeconds(8), TvSeekRateLadder.elapsedSeconds(8, 100L), 0.0001)
+        assertEquals(TvSeekRateLadder.tickSeconds(8) * 1.5, TvSeekRateLadder.elapsedSeconds(8, 150L), 0.0001)
+        assertEquals(0.0, TvSeekRateLadder.elapsedSeconds(8, -20L), 0.0001)
     }
 
     @Test
-    fun reverseRatesMirrorForwardOnes() {
-        TvSeekRateLadder.rates.forEach { rate ->
-            assertEquals(
-                -TvSeekRateLadder.tickSeconds(rate),
-                TvSeekRateLadder.tickSeconds(-rate),
-                0.0001,
-            )
-        }
+    fun bumpsWalkTheSignedLadderAndClampAtTheEnds() {
+        assertEquals(2, TvSeekRateLadder.bumped(1, 1))
+        assertEquals(1, TvSeekRateLadder.bumped(2, -1))
+        assertEquals(32, TvSeekRateLadder.bumped(32, 1))
+        assertEquals(-32, TvSeekRateLadder.bumped(-32, -1))
+        assertEquals(-4, TvSeekRateLadder.bumped(-2, -1))
+        assertEquals(-2, TvSeekRateLadder.bumped(-4, 1))
     }
 
-    /**
-     * The point of deriving the ceiling from runtime: holding to the end costs
-     * roughly the same whether the item is twenty minutes or three hours. A
-     * fixed 32x ceiling took 41s for a short episode and 338s for a long film.
-     *
-     * Asserted against [TvSeekRateLadder.traverseSeconds], which models the
-     * ramp the implementation actually performs. The previous version computed
-     * `duration / topRate` — steady-state arithmetic the code never does — and
-     * so reported 10.55s for a three-hour film that really takes 17.75s,
-     * passing a 15s tolerance it should have failed.
-     */
+    /** As on tvOS: stepping past 1× in the opposite direction reverses. */
     @Test
-    fun holdingToTheEndCostsAboutTheSameAtAnyRuntime() {
-        val durations = listOf(SHORT_EPISODE, EPISODE, 5_400.0, LONG_FILM)
-        val costs = durations.map { TvSeekRateLadder.traverseSeconds(it) }
-
-        costs.forEachIndexed { index, seconds ->
-            assertTrue(
-                seconds <= 20.0,
-                "a ${durations[index]}s item takes ${seconds}s to cross",
-            )
-        }
-        assertTrue(
-            costs.max() / costs.min() <= 2.0,
-            "runtimes should cost within 2x of each other, got $costs",
-        )
-    }
-
-    /**
-     * The honest envelope, pinned. If a ladder or cadence change moves these,
-     * the numbers in TRAVERSE_TARGET_SECONDS' documentation are wrong too.
-     */
-    @Test
-    fun traversalCostIncludesTheRampNotJustTheCeiling() {
-        assertEquals(10.56, TvSeekRateLadder.traverseSeconds(SHORT_EPISODE), 0.01)
-        assertEquals(17.75, TvSeekRateLadder.traverseSeconds(LONG_FILM), 0.01)
-        assertTrue(
-            TvSeekRateLadder.traverseSeconds(LONG_FILM) >
-                LONG_FILM / TvSeekRateLadder.maxRateFor(LONG_FILM),
-            "the ramp must cost something; steady-state division understates it",
-        )
-    }
-
-    /**
-     * Protocol v3 declares duration server-side and deliberately does not fall
-     * back to Media3/catalog, so an omitted duration reaches the ladder as 0.
-     * That lands on the MIN_TOP_RATE floor rather than a derived ceiling —
-     * slow for a long item, but the alternative is guessing a ceiling for
-     * content of unknown length.
-     */
-    @Test
-    fun anUnknownDurationFallsBackToTheFloorRatherThanGuessing() {
-        assertEquals(TvSeekRateLadder.MIN_TOP_RATE, TvSeekRateLadder.maxRateFor(0.0))
-        assertEquals(TvSeekRateLadder.MIN_TOP_RATE, TvSeekRateLadder.maxRateFor(Double.NaN))
+    fun steppingPastOneReversesLikeApple() {
+        assertEquals(-1, TvSeekRateLadder.bumped(1, -1))
+        assertEquals(1, TvSeekRateLadder.bumped(-1, 1))
     }
 
     @Test
-    fun aLongerItemGetsAFasterTopGear() {
-        assertTrue(
-            TvSeekRateLadder.maxRateFor(LONG_FILM) > TvSeekRateLadder.maxRateFor(SHORT_EPISODE),
-            "a three-hour film must reach further than a twenty-minute episode",
-        )
-    }
-
-    /**
-     * An unknown runtime must not produce a guessed ceiling; live content and
-     * un-probed files both arrive as zero.
-     */
-    @Test
-    fun anUnknownRuntimeFallsBackRatherThanGuessing() {
-        listOf(0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY).forEach { bad ->
-            assertEquals(TvSeekRateLadder.MIN_TOP_RATE, TvSeekRateLadder.maxRateFor(bad))
-        }
-    }
-
-    /**
-     * The first second of holding stays slow enough to aim with — that is the
-     * half of the control used to skip an intro, and the half the old ramp
-     * destroyed by reaching its top speed in three seconds.
-     */
-    @Test
-    fun theFirstSecondOfHoldingStaysAimable() {
-        assertEquals(TvSeekRateLadder.BASE_RATE, 2)
-        assertTrue(TvSeekRateLadder.RAMP_STEP_MILLIS >= 750L)
-        val afterFirstStep = TvSeekRateLadder.sustainedRate(0, 1, EPISODE)
-        assertTrue(
-            afterFirstStep <= TvSeekRateLadder.AIMABLE_MAX_RATE,
-            "one second of holding jumped to ${afterFirstStep}x",
-        )
-    }
-
-    @Test
-    fun aSustainedHoldClimbsToTheItemsCeilingAndStops() {
-        val ceiling = TvSeekRateLadder.maxRateFor(EPISODE)
-        val reached = (0 until TvSeekRateLadder.rampSteps(EPISODE)).map {
-            TvSeekRateLadder.sustainedRate(it, 1, EPISODE)
-        }
-        assertEquals(ceiling, reached.last())
-        assertTrue(reached.zipWithNext().all { (a, b) -> b >= a }, "the ramp must not go backwards")
-    }
-
-    @Test
-    fun sustainedRateFollowsTheHeldDirection() {
-        (0 until TvSeekRateLadder.rampSteps(EPISODE)).forEach { step ->
-            assertEquals(
-                -TvSeekRateLadder.sustainedRate(step, 1, EPISODE),
-                TvSeekRateLadder.sustainedRate(step, -1, EPISODE),
-            )
-        }
-    }
-
-    @Test
-    fun bumpsWalkTheLadderAndClampToTheItemsCeiling() {
-        assertEquals(4, TvSeekRateLadder.bumped(2, 1, EPISODE))
-        assertEquals(2, TvSeekRateLadder.bumped(4, -1, EPISODE))
-
-        val ceiling = TvSeekRateLadder.maxRateFor(EPISODE)
-        assertEquals(ceiling, TvSeekRateLadder.bumped(ceiling, 1, EPISODE))
-    }
-
-    /**
-     * delta is a direction along the signed ladder as the key handlers use it,
-     * so -1 is leftwards: faster when already seeking backwards. The property
-     * that matters is that a bump never crosses zero and flips direction.
-     */
-    @Test
-    fun bumpingWhileSeekingBackwardsKeepsTheDirection() {
-        assertEquals(-4, TvSeekRateLadder.bumped(-2, -1, EPISODE))
-        assertEquals(-2, TvSeekRateLadder.bumped(-4, 1, EPISODE))
-        assertEquals(-2, TvSeekRateLadder.bumped(-2, 1, EPISODE))
-        listOf(-2, -4, -32).forEach { rate ->
-            listOf(-1, 1).forEach { delta ->
-                assertTrue(
-                    TvSeekRateLadder.bumped(rate, delta, EPISODE) < 0,
-                    "bumping $rate by $delta flipped direction",
-                )
-            }
-        }
+    fun anUnknownRateIsLeftAlone() {
+        assertEquals(3, TvSeekRateLadder.bumped(3, 1))
+        assertTrue(TvSeekRateLadder.rates.none { it == 3 })
     }
 }


### PR DESCRIPTION
## Problem

Hold-to-seek on Android TV ran far slower than the label said. The rate ladder had been rewritten so a rate meant a literal multiple of real time, which made every rung twenty times slower than the Apple clients. A chip reading 128x felt like 8x to anyone who uses both.

With the progress bar focused, a held Left/Right also had three smaller problems. It rendered through the full-screen hold-seek overlay instead of on the bar. Its rate pill was cut in half. And the hold fired the 30 second tap skip on the way into auto-seek.

## Solution

- `TvSeekRateLadder` now mirrors Apple exactly (`PlayerViewModel.seekRates`, `TVPlayerScrubber.timelineAutoSeekRates`, `startHoldSeekAutoRamp`): a signed 1x to 32x ladder, 2 seconds of content per 100 ms tick at 1x, and the hidden-controls hold ramps 1 → 2 → 4 → 8 on a 1.2 second beat. The focused bar holds its starting rate and taps step it, as on tvOS.
- Both seek loops advance by measured elapsed time instead of counting ticks, so a box busy decoding 4K still travels at the ladder's speed.
- The focused bar shows a small rate pill above the puck, after tvOS `timelineAutoSeekChip`, and no longer drives the full-screen `TvHoldSeekIndicator`. That overlay stays for the hidden-controls session only.
- The bar's box uses a required height. The surrounding column only had 14dp left for it, so the preferred 28dp was coerced and the pill was clipped.
- Bar taps fire on release, so a hold no longer skips on entry.

The ladder and clean-seek unit tests are rewritten for the Apple model.

## Validation

- `./gradlew :androidTvApp:assembleDebug :androidTvApp:testDebugUnitTest` pass on this branch rebased on current main.
- Measured on a Google TV Streamer via a `silo://play` deep link from position 0, reading the landed position from the player's `seek_commit` log:

| Path | Hold | Landed | Apple model predicts |
|---|---|---|---|
| Controls hidden | 6 s, ramped to 8x | 633 s | ~630 s |
| Bar, 1x | 6 s | 131 s | ~130 s |
| Bar, tapped to 8x | 4 s at 8x | 997 s | ~1000 s |

- The minified release build (`assembleRelease` with debug signing, 6 GiB Gradle heap) installs and launches on the Streamer.

## Risks

- Backward auto-seek on the bar and Watch Together rooms share these paths but were not exercised on a device.
- Stepping past 1x now reverses direction, matching tvOS. The previous Android ladder clamped at the base rate instead.

## AI disclosure

Written with Claude Fable 5.1 (`claude-fable-5-1`) via the Claude Code agent harness. No other AI tooling was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TV playback seeking with elapsed-time-based preview movement.
  * Added automatic seek-rate progression from 1× to 2×, 4×, and 8× during sustained holds.
  * Added an inline scrubber indicator showing seek direction and speed.
  * Added direction reversal at 1× and clamping through the supported seek-rate range.

* **Bug Fixes**
  * Improved tap-versus-hold detection to prevent held remote buttons from triggering unintended skip actions.
  * Improved timeline-boundary handling during preview seeking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->