### PR TITLE
fix(home): prevent crashes from duplicate media keys

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
@@ -84,7 +84,8 @@ fun MediaRow(
 ) {
     val context = LocalContext.current
     val heroHandoff = LocalHeroSourceHandoff.current
-    val browseContentIds = remember(items) { items.map { it.contentId } }
+    val uniqueItems = remember(items) { items.distinctBy { it.contentId } }
+    val browseContentIds = remember(uniqueItems) { uniqueItems.map { it.contentId } }
     val browseOrigin = remember(title, browseContentIds) { "media-row-$title-${browseContentIds.hashCode()}" }
     val diagnosticsKeySnapshot = remember(items) {
         DiagnosticsListSnapshot.fromKeys(items.map { it.contentId })
@@ -95,8 +96,8 @@ fun MediaRow(
             diagnosticsKeySnapshot,
         )
     }
-    val rowItems = remember(items, showProgress, cardStyle) {
-        items.distinctBy { it.contentId }.map { item ->
+    val rowItems = remember(uniqueItems, showProgress, cardStyle) {
+        uniqueItems.map { item ->
             val pos = item.positionSeconds
             val dur = item.durationSeconds
             val progress = if (showProgress && pos != null && dur != null && dur > 0) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/components/MediaRow.kt
@@ -96,7 +96,7 @@ fun MediaRow(
         )
     }
     val rowItems = remember(items, showProgress, cardStyle) {
-        items.map { item ->
+        items.distinctBy { it.contentId }.map { item ->
             val pos = item.positionSeconds
             val dur = item.durationSeconds
             val progress = if (showProgress && pos != null && dur != null && dur > 0) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/browse/CatalogGrid.kt
@@ -104,9 +104,10 @@ fun CatalogGrid(
 ) {
     val gridState = rememberLazyGridState()
     val heroHandoff = LocalHeroSourceHandoff.current
-    val browseContentIds = remember(items) { items.map { it.contentId } }
-    val browseOrigin = remember(items.firstOrNull()?.contentId) {
-        "catalog-${items.firstOrNull()?.contentId.orEmpty()}"
+    val uniqueItems = remember(items) { items.distinctBy { it.contentId } }
+    val browseContentIds = remember(uniqueItems) { uniqueItems.map { it.contentId } }
+    val browseOrigin = remember(uniqueItems.firstOrNull()?.contentId) {
+        "catalog-${uniqueItems.firstOrNull()?.contentId.orEmpty()}"
     }
     // The session density picks the base cell; the server-driven poster-size
     // preference multiplies it, shifting the adaptive column count.
@@ -164,7 +165,7 @@ fun CatalogGrid(
             }
 
             items(
-                items = items,
+                items = uniqueItems,
                 key = { it.contentId },
                 contentType = { item -> item.type },
             ) { item ->


### PR DESCRIPTION
## Problem

A server-supplied home section can contain the same `content_id` more than once. The phone `MediaRow` passed those IDs directly to a keyed Compose `LazyRow`, where keys must be unique. When layout reached both copies, Compose threw `IllegalArgumentException [duplicate_lazy_key]` on the main thread and terminated the app.

The same unsafe key assumption existed in the phone catalog grid. Fixing only the current server producer would leave self-hosted clients connected to older servers, cached duplicate responses, and future malformed payloads vulnerable to the same crash.

## Solution

Deduplicate each phone lazy layout by `contentId` immediately before rendering, retaining the first occurrence to match the existing Android TV behavior.

- `MediaRow` deduplicates inside its existing remembered row-model construction.
- `CatalogGrid` renders a remembered unique list and uses that same list for browse-navigation context.
- Both diagnostics snapshots continue to inspect the original input, so upstream duplicate responses remain observable.
- The shared `HomeViewModel` remains unchanged; the guard protects any caller of these UI components without hiding the raw server anomaly from diagnostics.

## Validation

- `./gradlew :androidApp:assembleDebug` — passed
- `./gradlew :androidApp:testDebugUnitTest` — passed
- `./gradlew test` — passed
- `git diff --check` — passed

The builds emitted existing deprecation and opt-in warnings but no failures. Live device validation against a duplicate-producing feed was not run.

## Risk

Low. `distinctBy` is stable, so the first item and its metadata are preserved. A later duplicate with different metadata is ignored, which matches the Android TV policy and is preferable to a fatal lazy-layout exception. Inputs without duplicate IDs render unchanged.

## UI evidence

Screenshots are not applicable to this change. The before state is a process crash during lazy layout, while the expected after state has no visual styling change and simply renders one copy of the repeated card. Private diagnostic imagery was not published.

## Follow-up

The server should still repair the producing section path and enforce unique IDs in its response contract: https://github.com/Silo-Server/silo-server/issues/927

Related issue: https://github.com/Silo-Server/silo-server/issues/927

## AI disclosure

- Harness: OpenAI Codex desktop app
- Tooling: OpenAI Codex; `@ponytail-review`
- Model: GPT-5; the harness did not expose a more specific runtime identifier
- Involvement: AI-assisted
- Review: `@ponytail-review` checked the complete two-file diff for unnecessary abstractions, dependencies, and dead flexibility. It found the change already minimal: “Lean already. Ship.” A separate correctness pass compared the behavior with the existing TV dedupe pattern and verified that raw diagnostic input remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate media and catalog entries from appearing in rows and browse grids.
  * Improved hero navigation handoff by using unique catalog items, while preserving diagnostic processing of the original data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->