### PR TITLE
fix(tv): direct-play Dolby Vision Profile 7 on HDR10 outputs so TrueHD passthrough survives

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7Transformer.kt
@@ -246,6 +246,14 @@ internal class DolbyVisionTransformingTrackOutput(
                     filteredInitializationData + buildDolbyVisionProfile81Config(dolbyVisionLevel(format.codecs)),
                 )
                 .build()
+            // The base layer is ordinary HEVC Main 10 under PQ signalling. The
+            // codec string is deliberately left null rather than derived from
+            // the SPS: Media3 reads it only for profile/level capability
+            // matching, and the player's HEVC selector already hands these
+            // streams to the hardware decoder regardless of what its
+            // capability table claims (odd-resolution Main 10 titles are
+            // rejected by the table and decode fine). A null string means
+            // "assume supported", which is the same intent.
             DolbyVisionTransformMode.PROFILE7_TO_HDR10 -> format.buildUpon()
                 .setSampleMimeType(MimeTypes.VIDEO_H265)
                 .setCodecs(null)

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt
@@ -26,6 +26,13 @@ object MediaCodecCapabilitiesProbe {
         val hdr: HdrCapabilities,
         val maxResolution: String,
         val supportsDvProfile7: Boolean,
+        /**
+         * A hardware HEVC decoder reported `HEVCProfileMain10HDR10` (or
+         * HDR10+). [hdr] aggregates HDR10 across HEVC and AV1, so a route that
+         * hands a PQ HEVC base layer to the HEVC decoder must check this
+         * rather than the aggregate.
+         */
+        val hevcHdr10Decoder: Boolean = false,
     )
 
     // Decoder/HDR support is static for the process lifetime; the MediaCodecList
@@ -194,6 +201,7 @@ object MediaCodecCapabilitiesProbe {
             ),
             maxResolution = claimedBucket,
             supportsDvProfile7 = dvP7Supported,
+            hevcHdr10Decoder = hevcHdrCapable && "hevc" in advertisedVideo,
         )
     }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/MediaCodecCapabilitiesProbe.kt
@@ -44,6 +44,11 @@ object MediaCodecCapabilitiesProbe {
     fun probe(): ProbeResult =
         cached ?: synchronized(this) { cached ?: computeProbe().also { cached = it } }
 
+    /** Drops the cached probe so a test can re-run it against a shadowed codec list. */
+    internal fun resetCacheForTest() {
+        synchronized(this) { cached = null }
+    }
+
     /** Returns an immutable copy for diagnostics without reconfiguring or opening any codec. */
     fun diagnosticsSnapshot(): ProbeResult {
         val result = probe()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -176,6 +176,10 @@ class PlaybackCapabilityDetector(
     @Volatile
     private var lastDecoderHdr: HdrCapabilities? = null
 
+    /** Whether the most recent [detect] found a hardware HEVC decoder with an HDR10 profile. */
+    @Volatile
+    private var lastHevcHdr10Decoder: Boolean = false
+
     /** Decoder-only HDR support independent of the attached display. */
     val decoderHdrCapabilities: HdrCapabilities?
         get() = lastDecoderHdr
@@ -348,6 +352,7 @@ class PlaybackCapabilityDetector(
         ).withDolbyVisionPolicy(dolbyVision)
         lastDisplayProbe = displayProbe
         lastDecoderHdr = codecProbe.hdr.withDolbyVisionPolicy(dolbyVision)
+        lastHevcHdr10Decoder = codecProbe.hevcHdr10Decoder
 
         val platformAudio = detectPlatformSoftwareAudioCodecs()
         val ffmpegAudio = if (ffmpegAvailable) {
@@ -413,6 +418,12 @@ class PlaybackCapabilityDetector(
         ffmpegAvailable: Boolean = FfmpegAudioSupport.isAvailable(),
         dolbyVision: DolbyVisionPolicy.Snapshot = DolbyVisionPolicy.Snapshot(),
         capabilities: ClientCodecCapabilities? = null,
+        /**
+         * Whether a hardware HEVC decoder reports an HDR10 profile. Defaults
+         * to the last [detect] probe; injectable because [capabilities] can
+         * be supplied without a probe having run in this process.
+         */
+        hardwareHevcHdr10Decoder: Boolean = lastHevcHdr10Decoder,
     ): ClientPlaybackContext {
         val caps = capabilities ?: detect(ffmpegAvailable, dolbyVision)
         val audioRoute = planningSnapshots.resolve(
@@ -429,6 +440,8 @@ class PlaybackCapabilityDetector(
             nativeRpuConverterAvailable = NativeDolbyVisionRpuConverter.isAvailable,
             hardwareProfile8Decoder = hasHardwareDolbyVisionProfile8Decoder(caps),
             displayConfirmsDolbyVision = displayConfirmsDolbyVision(lastDisplayProbe),
+            hardwareHevcHdr10Decoder = hardwareHevcHdr10Decoder && hasHardwareHevcMain10Decoder(caps),
+            hdr10TransformRouteEnabled = clientDv7ToHdr10RouteEnabled(formFactor),
             quarantined = transformQuarantine.quarantined(),
         )
         return ClientPlaybackContext(
@@ -761,24 +774,35 @@ internal fun advertisedAudioDecodeCodecs(
  * for its own recipe, and [DolbyVisionTransformQuarantine] withdraws the
  * advertisement on this device build so the next session never tries it.
  *
- * Profile 7 to HDR10 stays behind [fixtureValidatedTransformations]: the
- * server's own RPU strip covers that case, so the client recipe only earns a
- * place once the fixture matrix validates it for a device class.
+ * Profile 7 to HDR10 needs no RPU conversion: the transformer drops the
+ * enhancement layer and RPU and hands the untouched HDR10 base layer to an
+ * ordinary HEVC decoder under PQ signalling. It is advertised when the
+ * decoder ∩ display intersection carries HDR10 (which requires exact display
+ * evidence), a hardware HEVC decoder itself reports an HDR10 profile (the
+ * intersection's HDR10 flag is aggregated across HEVC and AV1, so it alone
+ * could be vouched for by an AV1 decoder the route never uses), and
+ * [hdr10TransformRouteEnabled] says the device class runs the recipe. Without
+ * this route, a Profile 7 title on a non-DV output is forced onto a server HLS
+ * remux, and HLS cannot carry TrueHD or DTS: the viewer loses lossless audio
+ * and Atmos to a server AAC conversion even though the HDMI sink accepts the
+ * bitstream. The same [DolbyVisionTransformQuarantine] and stall detector
+ * cover this recipe, so a device that wedges falls back to the server strip.
  */
 internal fun advertisedClientDolbyVisionTransformations(
     hdrDetails: org.siloserver.silo.model.playback.HdrCapabilities?,
     nativeRpuConverterAvailable: Boolean,
-    fixtureValidatedTransformations: Set<String> = emptySet(),
     hardwareProfile8Decoder: Boolean = false,
     displayConfirmsDolbyVision: Boolean = false,
+    hardwareHevcHdr10Decoder: Boolean = false,
+    hdr10TransformRouteEnabled: Boolean = false,
     quarantined: Set<String> = emptySet(),
 ): List<PlaybackTransformationV3> = buildList {
     if (
         CLIENT_DV7_TO_DV81 !in quarantined &&
         8 in hdrDetails?.dolbyVisionProfiles.orEmpty() &&
         nativeRpuConverterAvailable &&
-        (CLIENT_DV7_TO_DV81 in fixtureValidatedTransformations ||
-            (hardwareProfile8Decoder && displayConfirmsDolbyVision))
+        hardwareProfile8Decoder &&
+        displayConfirmsDolbyVision
     ) {
         add(
             PlaybackTransformationV3(
@@ -795,7 +819,8 @@ internal fun advertisedClientDolbyVisionTransformations(
     }
     if (
         CLIENT_DV7_TO_HDR10 !in quarantined &&
-        CLIENT_DV7_TO_HDR10 in fixtureValidatedTransformations &&
+        hdr10TransformRouteEnabled &&
+        hardwareHevcHdr10Decoder &&
         hdrDetails?.hdr10 == true
     ) {
         add(
@@ -844,13 +869,34 @@ internal fun canAdvertiseDv8BaseLayerFallback(
     caps: ClientCodecCapabilities,
     display: DisplayHdrProbeResult?,
 ): Boolean {
-    val hevc10 = caps.videoDecode.any { it.codec == "hevc" && 10 in it.bitDepths && it.hardware }
-    if (!hevc10) return false
+    if (!hasHardwareHevcMain10Decoder(caps)) return false
     val hdr = caps.hdrDetails ?: HdrCapabilities()
     if (hdr.hdr10 || hdr.hlg) return true
     val panel = display as? DisplayHdrProbeResult.Exact ?: return false
     return !panel.hdr.hdr10 && !panel.hdr.hlg && panel.hdr.dolbyVisionProfiles.isEmpty()
 }
+
+/**
+ * A hardware HEVC decoder that accepts 10-bit input. Both base-layer routes
+ * (the Profile 8 fallback and the Profile 7 to HDR10 transform) hand a
+ * Main 10 PQ stream to this decoder, so a software or 8-bit-only decoder is
+ * not evidence the route can render.
+ */
+internal fun hasHardwareHevcMain10Decoder(caps: ClientCodecCapabilities): Boolean =
+    caps.videoDecode.any { it.codec == "hevc" && 10 in it.bitDepths && it.hardware }
+
+/**
+ * Whether this form factor runs the client Profile 7 to HDR10 recipe.
+ *
+ * TV is the population that pays for the missing route: it sits behind an
+ * HDMI sink that accepts TrueHD and DTS bitstreams, and the alternative HLS
+ * remux converts that audio to AAC. Phones and tablets have no passthrough
+ * sink, so the server strip costs them nothing but a remux, and the one
+ * device that wedged on a client Dolby Vision transform (SM-F976U1) was a
+ * phone. They stay on the server recipe until the fixture matrix covers them.
+ */
+internal fun clientDv7ToHdr10RouteEnabled(formFactor: String): Boolean =
+    formFactor.equals("tv", ignoreCase = true)
 
 /**
  * A hardware `video/dolby-vision` decoder that lists Profile 8. The Profile 7

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -176,10 +176,6 @@ class PlaybackCapabilityDetector(
     @Volatile
     private var lastDecoderHdr: HdrCapabilities? = null
 
-    /** Whether the most recent [detect] found a hardware HEVC decoder with an HDR10 profile. */
-    @Volatile
-    private var lastHevcHdr10Decoder: Boolean = false
-
     /** Decoder-only HDR support independent of the attached display. */
     val decoderHdrCapabilities: HdrCapabilities?
         get() = lastDecoderHdr
@@ -352,7 +348,6 @@ class PlaybackCapabilityDetector(
         ).withDolbyVisionPolicy(dolbyVision)
         lastDisplayProbe = displayProbe
         lastDecoderHdr = codecProbe.hdr.withDolbyVisionPolicy(dolbyVision)
-        lastHevcHdr10Decoder = codecProbe.hevcHdr10Decoder
 
         val platformAudio = detectPlatformSoftwareAudioCodecs()
         val ffmpegAudio = if (ffmpegAvailable) {
@@ -419,13 +414,19 @@ class PlaybackCapabilityDetector(
         dolbyVision: DolbyVisionPolicy.Snapshot = DolbyVisionPolicy.Snapshot(),
         capabilities: ClientCodecCapabilities? = null,
         /**
-         * Whether a hardware HEVC decoder reports an HDR10 profile. Defaults
-         * to the last [detect] probe; injectable because [capabilities] can
-         * be supplied without a probe having run in this process.
+         * Whether a hardware HEVC decoder reports an HDR10 profile. Null
+         * resolves it from the process-cached codec probe after [capabilities]
+         * is settled, so a fresh detector and injected capabilities both read
+         * the same evidence. Tests inject a value to bypass the probe.
          */
-        hardwareHevcHdr10Decoder: Boolean = lastHevcHdr10Decoder,
+        hardwareHevcHdr10Decoder: Boolean? = null,
     ): ClientPlaybackContext {
         val caps = capabilities ?: detect(ffmpegAvailable, dolbyVision)
+        // Resolved after capability selection: the probe is static for the
+        // process, so this cannot go stale against injected capabilities the
+        // way a per-detector field populated only by detect() could.
+        val hevcHdr10Decoder = hardwareHevcHdr10Decoder
+            ?: MediaCodecCapabilitiesProbe.probe().hevcHdr10Decoder
         val audioRoute = planningSnapshots.resolve(
             capabilities = caps,
             currentRoute = audioCapabilityManager.playbackRouteSnapshot(),
@@ -440,7 +441,7 @@ class PlaybackCapabilityDetector(
             nativeRpuConverterAvailable = NativeDolbyVisionRpuConverter.isAvailable,
             hardwareProfile8Decoder = hasHardwareDolbyVisionProfile8Decoder(caps),
             displayConfirmsDolbyVision = displayConfirmsDolbyVision(lastDisplayProbe),
-            hardwareHevcHdr10Decoder = hardwareHevcHdr10Decoder && hasHardwareHevcMain10Decoder(caps),
+            hardwareHevcHdr10Decoder = hevcHdr10Decoder && hasHardwareHevcMain10Decoder(caps),
             hdr10TransformRouteEnabled = clientDv7ToHdr10RouteEnabled(formFactor),
             quarantined = transformQuarantine.quarantined(),
         )

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
@@ -18,6 +18,7 @@ class PlaybackStartupStallDetector(
     private val startupGraceMs: Long = DEFAULT_STARTUP_GRACE_MS,
     private val midStreamGraceMs: Long = DEFAULT_MID_STREAM_GRACE_MS,
     private val clientTransformGraceMs: Long = DEFAULT_CLIENT_TRANSFORM_GRACE_MS,
+    private val clientTransformMinBufferedAheadMs: Long = DEFAULT_CLIENT_TRANSFORM_MIN_BUFFERED_AHEAD_MS,
     private val startedProgressMs: Long = DEFAULT_STARTED_PROGRESS_MS,
     private val bufferedProgressMs: Long = DEFAULT_BUFFERED_PROGRESS_MS,
 ) {
@@ -177,13 +178,30 @@ class PlaybackStartupStallDetector(
         // bounded progress deadline and identify the failed local recipe. This
         // deliberately does not cover a route with zero decoder evidence: a
         // genuine no-input network stall keeps the normal transport retry.
+        //
+        // A network rebuffer is not a wedged transform either: 4K Profile 7
+        // remuxes run at 70-110 Mbps, and a Shield on Wi-Fi drains its buffer
+        // and sits in BUFFERING with the decoder idle because it has nothing
+        // to decode. While BUFFERING, only call the recipe wedged when the
+        // player is holding enough media to have fed the decoder; otherwise
+        // the generic transport clock keeps ownership. A player that is
+        // PLAYING is a different case: audio is advancing from the same
+        // muxed source, so input is arriving and a silent video decoder is
+        // the recipe's fault however little is buffered. That is the shape
+        // of the SM-F976U1 wedge and must keep its dedicated deadline.
+        // Misclassifying a bandwidth stall as a recipe fault quarantines the
+        // route for 14 days and hands the title back to the server's
+        // AAC-converting HLS remux.
+        val bufferedAheadMs = (bufferedPositionMs - currentPositionMs).coerceAtLeast(0L)
+        val transformOwnsStall = isPlaying ||
+            (isBuffering && bufferedAheadMs >= clientTransformMinBufferedAheadMs)
         if (!signaled && hasClientTransformDecodeEvidence &&
-            (isBuffering || isPlaying) &&
+            transformOwnsStall &&
             nowMs - clientTransformProgressAtMs > clientTransformGraceMs
         ) {
             signaled = true
             return Playability.StartupStalled(
-                bufferedAheadMs = (bufferedPositionMs - currentPositionMs).coerceAtLeast(0L),
+                bufferedAheadMs = bufferedAheadMs,
                 stalledForMs = nowMs - clientTransformProgressAtMs,
                 classification = DV7_TRANSFORM_STALL_CLASSIFICATION,
             )
@@ -257,6 +275,14 @@ class PlaybackStartupStallDetector(
         const val DEFAULT_STARTUP_GRACE_MS: Long = 20_000L
         const val DEFAULT_MID_STREAM_GRACE_MS: Long = 20_000L
         const val DEFAULT_CLIENT_TRANSFORM_GRACE_MS: Long = 10_000L
+
+        /**
+         * Media the player must be holding before a stalled client transform
+         * is blamed on the recipe. Matches the load control's post-rebuffer
+         * restart threshold: below it Media3 is legitimately waiting on the
+         * network and the decoder is idle for want of input.
+         */
+        const val DEFAULT_CLIENT_TRANSFORM_MIN_BUFFERED_AHEAD_MS: Long = 5_000L
         const val DEFAULT_STARTED_PROGRESS_MS: Long = 1_500L
         const val DEFAULT_BUFFERED_PROGRESS_MS: Long = 250L
         const val DV7_TRANSFORM_STALL_CLASSIFICATION = "dv7_transform_stall"

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
@@ -33,6 +33,7 @@ class PlaybackStartupStallDetector(
     private var clientTransformPositionMs: Long = 0L
     private var clientTransformDecoderOutputCount: Int = 0
     private var clientTransformProgressAtMs: Long = 0L
+    private var clientTransformOwnedLastSample = true
     private var paused = false
     // Last time playback made forward progress (or the mount time before it
     // starts). The stall is measured from here, so the same logic covers a
@@ -73,6 +74,7 @@ class PlaybackStartupStallDetector(
         this.clientTransformPositionMs = this.startPositionMs
         this.clientTransformDecoderOutputCount = 0
         this.clientTransformProgressAtMs = nowMs
+        this.clientTransformOwnedLastSample = true
         this.paused = false
         this.lastProgressPositionMs = this.startPositionMs
         this.lastBufferedPositionMs = this.startPositionMs
@@ -195,16 +197,19 @@ class PlaybackStartupStallDetector(
         val bufferedAheadMs = (bufferedPositionMs - currentPositionMs).coerceAtLeast(0L)
         val transformOwnsStall = isPlaying ||
             (isBuffering && bufferedAheadMs >= clientTransformMinBufferedAheadMs)
-        if (!transformOwnsStall) {
+        if (!transformOwnsStall || !clientTransformOwnedLastSample) {
             // While transport owns the stall the decoder is idle for want of
             // input, so its silence is not evidence against the recipe. Keep
             // the transform clock anchored here; otherwise a rebuffer longer
             // than the transform grace would blame the recipe on the first
             // sample after the buffer refilled, before the decoder had a
             // chance to emit another frame. The deadline restarts from the
-            // moment ownership returns to the transform.
+            // sample on which ownership returns to the transform, so a gap
+            // between polls (a lifecycle pause, say) spanning the whole
+            // refill cannot leave the clock pointing into the rebuffer.
             clientTransformProgressAtMs = nowMs
         }
+        clientTransformOwnedLastSample = transformOwnsStall
         if (!signaled && hasClientTransformDecodeEvidence &&
             transformOwnsStall &&
             nowMs - clientTransformProgressAtMs > clientTransformGraceMs

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetector.kt
@@ -195,6 +195,16 @@ class PlaybackStartupStallDetector(
         val bufferedAheadMs = (bufferedPositionMs - currentPositionMs).coerceAtLeast(0L)
         val transformOwnsStall = isPlaying ||
             (isBuffering && bufferedAheadMs >= clientTransformMinBufferedAheadMs)
+        if (!transformOwnsStall) {
+            // While transport owns the stall the decoder is idle for want of
+            // input, so its silence is not evidence against the recipe. Keep
+            // the transform clock anchored here; otherwise a rebuffer longer
+            // than the transform grace would blame the recipe on the first
+            // sample after the buffer refilled, before the decoder had a
+            // chance to emit another frame. The deadline restarts from the
+            // moment ownership returns to the transform.
+            clientTransformProgressAtMs = nowMs
+        }
         if (!signaled && hasClientTransformDecodeEvidence &&
             transformOwnsStall &&
             nowMs - clientTransformProgressAtMs > clientTransformGraceMs

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7TransformerTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/DolbyVisionProfile7TransformerTest.kt
@@ -328,6 +328,47 @@ class DolbyVisionProfile7TransformerTest {
     }
 
     @Test
+    fun hdr10FormatRewriteHandsThePqBaseLayerToAPlainHevcDecoder() {
+        val delegate = RecordingTrackOutput()
+        val output = DolbyVisionTransformingTrackOutput(
+            delegate,
+            DolbyVisionTransformMode.PROFILE7_TO_HDR10,
+            DolbyVisionRpuConverter { error("the HDR10 recipe never converts an RPU") },
+        )
+        val sps = nal(33, payload = byteArrayOf(0x01, 0x02))
+        output.format(
+            Format.Builder()
+                .setSampleMimeType(MimeTypes.VIDEO_DOLBY_VISION)
+                .setCodecs("dvhe.07.06")
+                .setInitializationData(
+                    listOf(
+                        hvcC(sps, nal(63, payload = byteArrayOf(0x09)), nal(62)),
+                        dolbyVisionConfig(profile = 7, level = 6),
+                    ),
+                )
+                .build(),
+        )
+
+        val rewritten = delegate.format ?: error("no format forwarded")
+        assertEquals(MimeTypes.VIDEO_H265, rewritten.sampleMimeType)
+        assertEquals(null, rewritten.codecs, "no Dolby Vision codec string survives the rewrite")
+        assertEquals(C.COLOR_TRANSFER_ST2084, rewritten.colorInfo?.colorTransfer)
+        assertEquals(C.COLOR_SPACE_BT2020, rewritten.colorInfo?.colorSpace)
+        assertEquals(C.COLOR_RANGE_LIMITED, rewritten.colorInfo?.colorRange)
+        assertTrue(rewritten.colorInfo?.hdrStaticInfo?.isNotEmpty() == true, "PQ needs static metadata for codec setup")
+        assertEquals(1, rewritten.initializationData.size, "the dvcC record is dropped with the enhancement layer")
+        val keptRecord = rewritten.initializationData.single()
+        assertEquals(1, keptRecord[22].toInt(), "only the base-layer parameter-set array remains")
+        assertTrue(keptRecord.size < hvcC(sps, nal(63, payload = byteArrayOf(0x09)), nal(62)).size)
+
+        // Samples then flow through the same base-layer-only path.
+        val access = accessUnit(nal(19, payload = byteArrayOf(7, 7, 7)), nal(62), nal(63, layer = 1))
+        output.sampleData(ParsableByteArray(access), access.size, TrackOutput.SAMPLE_DATA_PART_MAIN)
+        output.sampleMetadata(0L, C.BUFFER_FLAG_KEY_FRAME, access.size, 0, null)
+        assertContentEquals(accessUnit(nal(19, payload = byteArrayOf(7, 7, 7))), delegate.samples.single())
+    }
+
+    @Test
     fun serverDirectedTransformRejectsUnverifiedHevcMime() {
         val output = DolbyVisionTransformingTrackOutput(
             RecordingTrackOutput(),

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -163,7 +163,7 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
         assertEquals(listOf(CLIENT_DV7_TO_DV81), advertised.map { it.name })
         assertFalse(
             CLIENT_DV7_TO_HDR10 in advertised.map { it.name },
-            "the HDR10 recipe stays behind fixture validation; the server strip covers it",
+            "the HDR10 recipe needs its own decoder and route evidence; a DV panel alone is not it",
         )
 
         assertTrue(
@@ -209,13 +209,145 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
         val advertised = advertisedClientDolbyVisionTransformations(
             hdrDetails = HdrCapabilities(hdr10 = true, dolbyVisionProfiles = listOf(8)),
             nativeRpuConverterAvailable = true,
-            fixtureValidatedTransformations = setOf(CLIENT_DV7_TO_DV81, CLIENT_DV7_TO_HDR10),
             hardwareProfile8Decoder = true,
             displayConfirmsDolbyVision = true,
+            hardwareHevcHdr10Decoder = true,
+            hdr10TransformRouteEnabled = true,
             quarantined = setOf(CLIENT_DV7_TO_DV81),
         )
 
         assertEquals(listOf(CLIENT_DV7_TO_HDR10), advertised.map { it.name })
+    }
+
+    @Test
+    fun profile7ToHdr10IsAdvertisedOnAnHdr10OutputWithATenBitHardwareHevcDecoder() {
+        // The Shield-class case from SILO-MT2PPCKZ: HDR10 panel, no Dolby
+        // Vision, hardware Main10 HEVC, HDMI sink that takes TrueHD. Without
+        // this route the server has to HLS-remux and convert the audio to AAC.
+        val hdr10Only = HdrCapabilities(hdr10 = true)
+        val advertised = advertisedClientDolbyVisionTransformations(
+            hdrDetails = hdr10Only,
+            nativeRpuConverterAvailable = false,
+            hardwareHevcHdr10Decoder = true,
+            hdr10TransformRouteEnabled = true,
+        )
+        assertEquals(
+            listOf(CLIENT_DV7_TO_HDR10),
+            advertised.map { it.name },
+            "the HDR10 recipe drops the RPU rather than converting it, so it needs no libdovi bridge",
+        )
+
+        assertTrue(
+            advertisedClientDolbyVisionTransformations(
+                hdrDetails = hdr10Only,
+                nativeRpuConverterAvailable = false,
+                hardwareHevcHdr10Decoder = false,
+                hdr10TransformRouteEnabled = true,
+            ).isEmpty(),
+            "a HEVC decoder without an HDR10 profile is not a route for a PQ base layer, whatever AV1 reports",
+        )
+        assertTrue(
+            advertisedClientDolbyVisionTransformations(
+                hdrDetails = HdrCapabilities(hdr10 = false),
+                nativeRpuConverterAvailable = false,
+                hardwareHevcHdr10Decoder = true,
+                hdr10TransformRouteEnabled = true,
+            ).isEmpty(),
+            "an SDR or unprobed output cannot carry the HDR10 base layer",
+        )
+        assertTrue(
+            advertisedClientDolbyVisionTransformations(
+                hdrDetails = hdr10Only,
+                nativeRpuConverterAvailable = false,
+                hardwareHevcHdr10Decoder = true,
+                hdr10TransformRouteEnabled = false,
+            ).isEmpty(),
+            "a form factor outside the enabled population stays on the server strip",
+        )
+        assertTrue(
+            advertisedClientDolbyVisionTransformations(
+                hdrDetails = hdr10Only,
+                nativeRpuConverterAvailable = false,
+                hardwareHevcHdr10Decoder = true,
+                hdr10TransformRouteEnabled = true,
+                quarantined = setOf(CLIENT_DV7_TO_HDR10),
+            ).isEmpty(),
+            "a device that wedged on the recipe stays quarantined",
+        )
+    }
+
+    @Test
+    fun profile7ToHdr10RouteIsScopedToTv() {
+        assertTrue(clientDv7ToHdr10RouteEnabled("tv"))
+        assertTrue(clientDv7ToHdr10RouteEnabled("TV"))
+        assertFalse(clientDv7ToHdr10RouteEnabled("mobile"))
+        assertFalse(clientDv7ToHdr10RouteEnabled("tablet"))
+        assertFalse(clientDv7ToHdr10RouteEnabled(""))
+    }
+
+    @Test
+    fun tvPlaybackContextAdvertisesProfile7ToHdr10OnlyWithHardwareHevcMain10AndHdr10Output() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val detector = PlaybackCapabilityDetector(
+            context = context,
+            audioCapabilityManager = AudioCapabilityManager(context),
+            libassBridge = LibassBridge(false),
+            buildIdentity = SiloClientBuildIdentity(buildNumber = "test", channel = "test"),
+        )
+        val hevc10 = org.siloserver.silo.model.playback.VideoDecodeCapability(
+            codec = "hevc",
+            bitDepths = listOf(8, 10),
+            hardware = true,
+        )
+        val shieldLike = ClientCodecCapabilities(
+            videoDecode = listOf(hevc10),
+            hdrDetails = HdrCapabilities(hdr10 = true),
+        )
+
+        fun transformationsFor(
+            formFactor: String,
+            caps: ClientCodecCapabilities,
+            hevcHdr10Decoder: Boolean = true,
+        ): List<String> =
+            detector.detectPlaybackContext(
+                formFactor = formFactor,
+                appVersion = "test",
+                capabilities = caps,
+                hardwareHevcHdr10Decoder = hevcHdr10Decoder,
+            )
+                .deliveries.getValue(DELIVERY_CLASS_ORIGINAL_HTTP)
+                .transformations
+                .map { it.name }
+
+        assertEquals(listOf(CLIENT_DV7_TO_HDR10), transformationsFor("tv", shieldLike))
+        assertTrue(
+            transformationsFor("mobile", shieldLike).isEmpty(),
+            "the phone stays on the server strip",
+        )
+        assertTrue(
+            transformationsFor("tv", ClientCodecCapabilities(hdrDetails = HdrCapabilities(hdr10 = true))).isEmpty(),
+            "no hardware Main10 decoder, no route",
+        )
+        assertTrue(
+            transformationsFor("tv", shieldLike, hevcHdr10Decoder = false).isEmpty(),
+            "an aggregate HDR10 flag earned by an AV1 decoder does not vouch for the HEVC path",
+        )
+        assertTrue(
+            transformationsFor("tv", ClientCodecCapabilities(videoDecode = listOf(hevc10))).isEmpty(),
+            "no HDR10 in the decoder ∩ display intersection, no route",
+        )
+        assertTrue(
+            detector.detectPlaybackContext(
+                formFactor = "tv",
+                appVersion = "test",
+                capabilities = shieldLike,
+                hardwareHevcHdr10Decoder = true,
+            )
+                .deliveries.getValue(DELIVERY_CLASS_HLS)
+                .transformations
+                .isEmpty(),
+            "client transformations are scoped to original_http",
+        )
     }
 
     @Test
@@ -272,22 +404,23 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
     }
 
     @Test
-    fun clientTransformationsRequireExactFixtureValidationAndRuntimePrerequisites() {
+    fun bothClientTransformationsAreAdvertisedWhenEveryRuntimePrerequisiteHolds() {
         val transformations = advertisedClientDolbyVisionTransformations(
             hdrDetails = HdrCapabilities(
                 hdr10 = true,
                 dolbyVisionProfiles = listOf(8),
             ),
             nativeRpuConverterAvailable = true,
-            fixtureValidatedTransformations = setOf(
-                CLIENT_DV7_TO_DV81,
-                CLIENT_DV7_TO_HDR10,
-            ),
+            hardwareProfile8Decoder = true,
+            displayConfirmsDolbyVision = true,
+            hardwareHevcHdr10Decoder = true,
+            hdr10TransformRouteEnabled = true,
         )
 
         assertEquals(
             listOf(CLIENT_DV7_TO_DV81, CLIENT_DV7_TO_HDR10),
             transformations.map { it.name },
+            "the server prefers 8.1 on a DV panel and keeps HDR10 as the second client route",
         )
     }
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetectorDolbyVisionTest.kt
@@ -1,9 +1,14 @@
 package org.siloserver.silo.common.player
 
 import android.content.Context
+import android.media.MediaCodecInfo.CodecCapabilities
+import android.media.MediaCodecInfo.CodecProfileLevel
+import android.media.MediaFormat
 import androidx.test.core.app.ApplicationProvider
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.MediaCodecInfoBuilder
+import org.robolectric.shadows.ShadowMediaCodecList
 import org.siloserver.silo.common.network.SiloClientBuildIdentity
 import org.siloserver.silo.libass.LibassBridge
 import org.siloserver.silo.model.playback.HdrCapabilities
@@ -348,6 +353,85 @@ class PlaybackCapabilityDetectorDolbyVisionTest {
                 .isEmpty(),
             "client transformations are scoped to original_http",
         )
+    }
+
+    @Test
+    fun freshDetectorResolvesHevcHdr10EvidenceFromTheCodecProbeWhenCapabilitiesAreInjected() {
+        // CodeRabbit on #289: the HEVC HDR10 flag used to default to a field
+        // that only detect() populated. Every production caller injects
+        // capabilities, so a detector that had never run detect() advertised
+        // no Profile 7 to HDR10 route however capable the decoder was.
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val hevc10 = org.siloserver.silo.model.playback.VideoDecodeCapability(
+            codec = "hevc",
+            bitDepths = listOf(8, 10),
+            hardware = true,
+        )
+        val shieldLike = ClientCodecCapabilities(
+            videoDecode = listOf(hevc10),
+            hdrDetails = HdrCapabilities(hdr10 = true),
+        )
+
+        fun freshDetector() = PlaybackCapabilityDetector(
+            context = context,
+            audioCapabilityManager = AudioCapabilityManager(context),
+            libassBridge = LibassBridge(false),
+            buildIdentity = SiloClientBuildIdentity(buildNumber = "test", channel = "test"),
+        )
+
+        fun transformationsFromProbe(): List<String> =
+            freshDetector().detectPlaybackContext(
+                formFactor = "tv",
+                appVersion = "test",
+                capabilities = shieldLike,
+            )
+                .deliveries.getValue(DELIVERY_CLASS_ORIGINAL_HTTP)
+                .transformations
+                .map { it.name }
+
+        fun hevcDecoder(vararg profiles: Int) = MediaCodecInfoBuilder.newBuilder()
+            .setName("c2.nvidia.hevc.decoder")
+            .setIsHardwareAccelerated(true)
+            .setIsSoftwareOnly(false)
+            .setCapabilities(
+                MediaCodecInfoBuilder.CodecCapabilitiesBuilder.newBuilder()
+                    .setMediaFormat(
+                        MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_HEVC, 3840, 2160),
+                    )
+                    .setColorFormats(intArrayOf(CodecCapabilities.COLOR_FormatYUV420Flexible))
+                    .setProfileLevels(
+                        profiles.map { profile ->
+                            CodecProfileLevel().apply {
+                                this.profile = profile
+                                level = CodecProfileLevel.HEVCMainTierLevel51
+                            }
+                        }.toTypedArray(),
+                    )
+                    .build(),
+            )
+            .build()
+
+        try {
+            ShadowMediaCodecList.reset()
+            ShadowMediaCodecList.addCodec(hevcDecoder(CodecProfileLevel.HEVCProfileMain10HDR10))
+            MediaCodecCapabilitiesProbe.resetCacheForTest()
+            assertEquals(
+                listOf(CLIENT_DV7_TO_HDR10),
+                transformationsFromProbe(),
+                "a detector that never ran detect() must still read the probe's HEVC HDR10 evidence",
+            )
+
+            ShadowMediaCodecList.reset()
+            ShadowMediaCodecList.addCodec(hevcDecoder(CodecProfileLevel.HEVCProfileMain10))
+            MediaCodecCapabilitiesProbe.resetCacheForTest()
+            assertTrue(
+                transformationsFromProbe().isEmpty(),
+                "a Main10 decoder without an HDR10 profile does not earn the route",
+            )
+        } finally {
+            ShadowMediaCodecList.reset()
+            MediaCodecCapabilitiesProbe.resetCacheForTest()
+        }
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
@@ -583,6 +583,46 @@ class PlaybackStartupStallDetectorTest {
     }
 
     @Test
+    fun dv7TransformDeadlineRestartsOnTheSampleThatReturnsOwnershipToTheTransform() {
+        // CodeRabbit on #289: if no poll lands while transport owns the stall
+        // (a lifecycle gap spanning the refill), the first transform-owned
+        // sample must not inherit a clock anchored at the last transport
+        // sample. The transition itself restarts the deadline.
+        val detector = PlaybackStartupStallDetector(
+            startupGraceMs = 30_000,
+            midStreamGraceMs = 20_000,
+            clientTransformGraceMs = 10_000,
+            clientTransformMinBufferedAheadMs = 5_000,
+        )
+        detector.onMounted(
+            sessionKey = "dv7-gap",
+            playMethod = PlayMethod.DIRECT,
+            startPositionMs = 0,
+            nowMs = 0,
+            clientTransformations = listOf(CLIENT_DV7_TO_HDR10),
+        )
+        detector.onFirstFrameRendered()
+
+        assertNull(detector.sample("dv7-gap", 5_000, true, true, false, 4_900, 6_000, 120, 120))
+        // One transport-owned sample as the buffer drains, then no polls at
+        // all until the buffer has refilled 11.5 s later.
+        assertNull(detector.sample("dv7-gap", 6_000, true, false, true, 6_000, 6_100, 145, 145))
+        assertNull(
+            detector.sample("dv7-gap", 17_500, true, false, true, 6_000, 12_000, 145, 145),
+            "the sample that hands ownership back to the transform must not be blamed on the recipe",
+        )
+        // Playback resumes on audio but the video decoder stays silent: the
+        // deadline that restarted at the hand-back trips ten seconds on.
+        assertNull(detector.sample("dv7-gap", 18_000, true, true, false, 6_100, 12_000, 145, 145))
+        assertNull(detector.sample("dv7-gap", 27_500, true, true, false, 15_000, 20_000, 145, 145))
+        assertEquals(
+            PlaybackStartupStallDetector.DV7_TRANSFORM_STALL_CLASSIFICATION,
+            detector.sample("dv7-gap", 27_501, true, true, false, 15_001, 20_000, 145, 145)
+                ?.classification,
+        )
+    }
+
+    @Test
     fun dv7RouteWithoutDecoderEvidenceKeepsTransportDeadline() {
         val detector = PlaybackStartupStallDetector(
             startupGraceMs = 20_000,

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
@@ -383,15 +383,15 @@ class PlaybackStartupStallDetectorTest {
                 isPlaying = false,
                 isBuffering = true,
                 currentPositionMs = 0,
-                bufferedPositionMs = 0,
+                bufferedPositionMs = 20_000,
                 decoderInputBufferCount = 1,
                 decoderRenderedOutputBufferCount = 1,
             ),
         )
-        assertNull(detector.sample("dv7", 10_100, true, false, true, 0, 0, 1, 1))
+        assertNull(detector.sample("dv7", 10_100, true, false, true, 0, 20_000, 1, 1))
         assertEquals(
             PlaybackStartupStallDetector.DV7_TRANSFORM_STALL_CLASSIFICATION,
-            detector.sample("dv7", 10_101, true, false, true, 0, 0, 1, 1)?.classification,
+            detector.sample("dv7", 10_101, true, false, true, 0, 20_000, 1, 1)?.classification,
         )
     }
 
@@ -410,12 +410,12 @@ class PlaybackStartupStallDetectorTest {
         )
         detector.onFirstFrameRendered()
 
-        assertNull(detector.sample("dv7-progress", 100, true, false, true, 0, 0, 1, 1))
-        assertNull(detector.sample("dv7-progress", 5_000, true, true, false, 1_600, 5_000, 5, 5))
-        assertNull(detector.sample("dv7-progress", 15_000, true, false, true, 1_600, 1_600, 5, 5))
+        assertNull(detector.sample("dv7-progress", 100, true, false, true, 0, 20_000, 1, 1))
+        assertNull(detector.sample("dv7-progress", 5_000, true, true, false, 1_600, 25_000, 5, 5))
+        assertNull(detector.sample("dv7-progress", 15_000, true, false, true, 1_600, 25_000, 5, 5))
         assertEquals(
             PlaybackStartupStallDetector.DV7_TRANSFORM_STALL_CLASSIFICATION,
-            detector.sample("dv7-progress", 15_001, true, false, true, 1_600, 1_600, 5, 5)
+            detector.sample("dv7-progress", 15_001, true, false, true, 1_600, 25_000, 5, 5)
                 ?.classification,
         )
     }
@@ -435,12 +435,12 @@ class PlaybackStartupStallDetectorTest {
         )
         detector.onFirstFrameRendered()
 
-        assertNull(detector.sample("dv7-audio-only", 100, true, true, false, 0, 5_000, 1, 1))
-        assertNull(detector.sample("dv7-audio-only", 5_000, true, true, false, 1_600, 6_000, 1, 1))
-        assertNull(detector.sample("dv7-audio-only", 10_100, true, true, false, 3_200, 7_000, 1, 1))
+        assertNull(detector.sample("dv7-audio-only", 100, true, true, false, 0, 20_000, 1, 1))
+        assertNull(detector.sample("dv7-audio-only", 5_000, true, true, false, 1_600, 21_000, 1, 1))
+        assertNull(detector.sample("dv7-audio-only", 10_100, true, true, false, 3_200, 22_000, 1, 1))
         assertEquals(
             PlaybackStartupStallDetector.DV7_TRANSFORM_STALL_CLASSIFICATION,
-            detector.sample("dv7-audio-only", 10_101, true, true, false, 4_800, 8_000, 1, 1)
+            detector.sample("dv7-audio-only", 10_101, true, true, false, 4_800, 23_000, 1, 1)
                 ?.classification,
         )
     }
@@ -460,13 +460,78 @@ class PlaybackStartupStallDetectorTest {
         )
         detector.onFirstFrameRendered()
 
-        assertNull(detector.sample("dv7-backward-seek", 100, true, true, false, 5_000, 8_000, 1, 1))
-        assertNull(detector.sample("dv7-backward-seek", 9_000, true, true, false, 10_000, 13_000, 1, 1))
-        assertNull(detector.sample("dv7-backward-seek", 9_001, true, true, false, 2_000, 5_000, 1, 1))
-        assertNull(detector.sample("dv7-backward-seek", 19_001, true, true, false, 2_000, 5_000, 1, 1))
+        assertNull(detector.sample("dv7-backward-seek", 100, true, true, false, 5_000, 25_000, 1, 1))
+        assertNull(detector.sample("dv7-backward-seek", 9_000, true, true, false, 10_000, 30_000, 1, 1))
+        assertNull(detector.sample("dv7-backward-seek", 9_001, true, true, false, 2_000, 22_000, 1, 1))
+        assertNull(detector.sample("dv7-backward-seek", 19_001, true, true, false, 2_000, 22_000, 1, 1))
         assertEquals(
             PlaybackStartupStallDetector.DV7_TRANSFORM_STALL_CLASSIFICATION,
-            detector.sample("dv7-backward-seek", 19_002, true, true, false, 2_000, 5_000, 1, 1)
+            detector.sample("dv7-backward-seek", 19_002, true, true, false, 2_000, 22_000, 1, 1)
+                ?.classification,
+        )
+    }
+
+    @Test
+    fun dv7WedgeWhileAudioPlaysIsBlamedOnTheRecipeHoweverLittleIsBuffered() {
+        // The SM-F976U1 shape: one frame, then the video decoder goes silent
+        // while TrueHD keeps the position moving. The player is PLAYING, so
+        // input is reaching the pipeline; a thin buffer is not an excuse.
+        val detector = PlaybackStartupStallDetector(
+            startupGraceMs = 30_000,
+            clientTransformGraceMs = 10_000,
+            clientTransformMinBufferedAheadMs = 5_000,
+        )
+        detector.onMounted(
+            sessionKey = "dv7-thin-buffer-wedge",
+            playMethod = PlayMethod.DIRECT,
+            startPositionMs = 0,
+            nowMs = 0,
+            clientTransformations = listOf(CLIENT_DV7_TO_HDR10),
+        )
+        detector.onFirstFrameRendered()
+
+        assertNull(detector.sample("dv7-thin-buffer-wedge", 100, true, true, false, 0, 1_500, 1, 1))
+        assertNull(detector.sample("dv7-thin-buffer-wedge", 5_000, true, true, false, 4_900, 6_000, 1, 1))
+        assertNull(detector.sample("dv7-thin-buffer-wedge", 10_100, true, true, false, 10_000, 11_000, 1, 1))
+        assertEquals(
+            PlaybackStartupStallDetector.DV7_TRANSFORM_STALL_CLASSIFICATION,
+            detector.sample("dv7-thin-buffer-wedge", 10_101, true, true, false, 10_001, 11_000, 1, 1)
+                ?.classification,
+        )
+    }
+
+    @Test
+    fun dv7DrainedBufferIsANetworkRebufferNotATransformStall() {
+        // A 4K Profile 7 remux on Wi-Fi: the transform decoded frames, then
+        // the buffer ran dry and the player sits in BUFFERING with the decoder
+        // idle for want of input. That is the transport clock's stall, not
+        // the recipe's; blaming the recipe would quarantine a working route.
+        val detector = PlaybackStartupStallDetector(
+            startupGraceMs = 30_000,
+            midStreamGraceMs = 20_000,
+            clientTransformGraceMs = 10_000,
+            clientTransformMinBufferedAheadMs = 5_000,
+        )
+        detector.onMounted(
+            sessionKey = "dv7-rebuffer",
+            playMethod = PlayMethod.DIRECT,
+            startPositionMs = 0,
+            nowMs = 0,
+            clientTransformations = listOf(CLIENT_DV7_TO_HDR10),
+        )
+        detector.onFirstFrameRendered()
+
+        assertNull(detector.sample("dv7-rebuffer", 100, true, true, false, 0, 6_000, 10, 10))
+        assertNull(detector.sample("dv7-rebuffer", 5_000, true, true, false, 4_900, 6_000, 120, 120))
+        // Buffer drained; the decoder has nothing to chew on.
+        assertNull(detector.sample("dv7-rebuffer", 6_000, true, false, true, 6_000, 6_100, 145, 145))
+        assertNull(detector.sample("dv7-rebuffer", 16_100, true, false, true, 6_000, 6_500, 145, 145))
+        assertNull(detector.sample("dv7-rebuffer", 20_000, true, false, true, 6_000, 8_000, 145, 145))
+        // Twenty seconds without playback progress is the mid-stream transport
+        // stall, which reopens the same route rather than withdrawing it.
+        assertEquals(
+            "transport_stall",
+            detector.sample("dv7-rebuffer", 26_001, true, false, true, 6_000, 8_000, 145, 145)
                 ?.classification,
         )
     }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/video/PlaybackStartupStallDetectorTest.kt
@@ -537,6 +537,52 @@ class PlaybackStartupStallDetectorTest {
     }
 
     @Test
+    fun dv7TransformDeadlineRestartsWhenTheBufferRefillsAfterALongRebuffer() {
+        // Codex review on #289: a rebuffer longer than the transform grace
+        // used to leave the transform clock pointing at the last frame before
+        // the network stall. The first sample after the buffer refilled then
+        // blamed the recipe before the decoder had a chance to emit a frame,
+        // and the working route was quarantined for 14 days.
+        val detector = PlaybackStartupStallDetector(
+            startupGraceMs = 30_000,
+            midStreamGraceMs = 20_000,
+            clientTransformGraceMs = 10_000,
+            clientTransformMinBufferedAheadMs = 5_000,
+        )
+        detector.onMounted(
+            sessionKey = "dv7-refill",
+            playMethod = PlayMethod.DIRECT,
+            startPositionMs = 0,
+            nowMs = 0,
+            clientTransformations = listOf(CLIENT_DV7_TO_HDR10),
+        )
+        detector.onFirstFrameRendered()
+
+        assertNull(detector.sample("dv7-refill", 100, true, true, false, 0, 6_000, 10, 10))
+        assertNull(detector.sample("dv7-refill", 5_000, true, true, false, 4_900, 6_000, 120, 120))
+        // Buffer drains; transport owns the stall for twelve seconds.
+        assertNull(detector.sample("dv7-refill", 6_000, true, false, true, 6_000, 6_100, 145, 145))
+        assertNull(detector.sample("dv7-refill", 17_000, true, false, true, 6_000, 6_500, 145, 145))
+        // Refilled past the threshold, still BUFFERING, decoder not yet fed.
+        assertNull(
+            detector.sample("dv7-refill", 17_500, true, false, true, 6_000, 12_000, 145, 145),
+            "the first sample after a refill must not blame the recipe",
+        )
+        // Playback resumes and the decoder keeps producing frames.
+        assertNull(detector.sample("dv7-refill", 18_000, true, true, false, 6_100, 12_000, 150, 150))
+        assertNull(detector.sample("dv7-refill", 27_000, true, true, false, 15_000, 20_000, 400, 400))
+
+        // The clock restarted from the refill rather than being disabled: a
+        // real wedge after the rebuffer still trips the transform deadline.
+        assertNull(detector.sample("dv7-refill", 37_000, true, true, false, 25_000, 30_000, 400, 400))
+        assertEquals(
+            PlaybackStartupStallDetector.DV7_TRANSFORM_STALL_CLASSIFICATION,
+            detector.sample("dv7-refill", 37_001, true, true, false, 25_001, 30_000, 400, 400)
+                ?.classification,
+        )
+    }
+
+    @Test
     fun dv7RouteWithoutDecoderEvidenceKeepsTransportDeadline() {
         val detector = PlaybackStartupStallDetector(
             startupGraceMs = 20_000,

--- a/docs/playback/04-implementation-status-and-dv-handoff.md
+++ b/docs/playback/04-implementation-status-and-dv-handoff.md
@@ -33,6 +33,16 @@ architecture or migration contract in documents 01 and 02.
 - MediaCodec and display probes are intersected. Dolby Vision profiles 4/6/7/8
   map to their Android constants; Profile 7 additionally requires concurrent
   DV and HEVC decoder capacity. Profile 8 is not assumed.
+- Android TV advertises the client `client_dv7_to_hdr10` transformation when
+  the decoder ∩ display intersection carries HDR10 and a hardware 10-bit HEVC
+  decoder exists. The extractor drops the enhancement layer, RPU, and dvcC
+  record and hands the untouched Main 10 PQ base layer to the HEVC decoder,
+  so a Profile 7 title on a non-DV output direct-plays with TrueHD/DTS
+  passthrough instead of taking the server HLS remux, which must convert
+  that audio to AAC. Phones stay on the server strip. A recipe wedge is
+  classified `dv7_transform_stall` only when the player holds at least the
+  rebuffer threshold of media, so a Wi-Fi rebuffer on a 70-110 Mbps remux
+  keeps the transport clock and does not quarantine the route.
 - Platform audio remains first and the Media3 1.11.0 FFmpeg extension is
   fallback-only. One sink failure may suppress the exact encoded MIME/layout
   and reprepare through PCM. Audio delay is labelled PCM-only and disabled


### PR DESCRIPTION
## Problem

A Dolby Vision Profile 7 title played on an Android TV device whose display has no Dolby Vision loses TrueHD, DTS-HD, and Atmos. Hosted diagnostics report SILO-MT2PPCKZ (Shield, Android 11, HDR10-only panel, build 16) shows the HDMI route advertising TrueHD at 8 channels, yet both playback attempts landed on `server_remux_hls` with `hls_audio_adaptation` and the audio converted to AAC 5.1. The viewer heard multichannel PCM instead of Atmos.

The cause is a missing route, not broken passthrough. The client advertised no Profile 7 transformation, so the server had to strip Dolby Vision itself. Progressive remux is disabled on the client, leaving HLS, and HLS cannot carry TrueHD. The client already has a `PROFILE7_TO_HDR10` transformer that drops the enhancement layer, RPU, and dvcC record and hands the untouched Main 10 PQ base layer to the HEVC decoder. It was gated behind a fixture-validation set that nothing ever populated.

## Solution

Advertise `client_dv7_to_hdr10` from runtime evidence instead of the empty fixture set:

- TV form factor only. Phones have no passthrough sink, so the server strip costs them nothing, and the one device that wedged on a client DV transform was a phone.
- A hardware HEVC decoder that itself reports an HDR10 profile. The probe's aggregate `hdr10` flag can be earned by an AV1 decoder the route never uses, so `MediaCodecCapabilitiesProbe` now exposes `hevcHdr10Decoder` separately.
- HDR10 in the decoder ∩ display intersection, which requires exact display evidence (an unknown probe contributes nothing).
- Not quarantined. The existing `DolbyVisionTransformQuarantine` and `dv7_transform_stall` detector cover this recipe unchanged.

The Profile 7 → 8.1 gate is unchanged in production behaviour; the removed `fixtureValidatedTransformations` OR branch was always empty.

The `dv7_transform_stall` classifier gained one guard. It blames the recipe only when the player is PLAYING (audio advancing proves input is arriving) or is BUFFERING with at least the 5 s rebuffer threshold held. Without that, a Wi-Fi rebuffer on a 70-110 Mbps 4K remux was classified as a recipe fault and quarantined a working route for 14 days. While transport owns the stall, the transform clock is re-anchored each sample, so the deadline restarts when ownership returns to the transform instead of counting from the last frame before the rebuffer.

The HEVC HDR10 decoder flag is resolved from the process-cached codec probe after capabilities are selected. Every production caller injects `capabilities`, so a per-detector field populated only by `detect()` left a fresh detector without the route.

Reviewed the transformer before enabling it: Annex-B framing, hvcC filtering, supplemental-data prefix rewrite, encrypted-sample refusal, and format rewrite all hold. One new test covers the HDR10 format rewrite end to end.

## Validation

- `./gradlew :android-shared:testDebugUnitTest`: 1468 tests, 0 failures.
- `./gradlew :androidTvApp:testDebugUnitTest :androidApp:testDebugUnitTest :shared:testDebugUnitTest`: 1115 / 644 / 1101 tests, 0 failures.
- `./gradlew :androidTvApp:assembleDebug :androidApp:assembleDebug`: both build.
- Codex adversarial review of the diff found two real issues (uncorrelated HEVC/AV1 HDR10 evidence in the gate; the buffered-ahead guard masking a wedge while audio plays). Both are fixed and each has a test.
- PR review found two more (Codex: transform deadline not re-anchored after a long rebuffer; CodeRabbit: HEVC HDR10 evidence read before capability selection). Both are fixed in `8d083bd` and each has a regression test. A follow-up CodeRabbit finding (deadline not restarted when the transform-owned sample arrives without an intermediate transport-owned poll) is fixed in `a2c1fb51` with its own test.

**Not yet validated on hardware.** The Shields were offline during this work. The runbook below is what closes the gap; the PR should not merge before it passes on an HDR10-only panel.

<details>
<summary>Shield runbook</summary>

Fixture: `movie-tmdb-300671` (13 Hours, DV P7 + TrueHD Atmos). Run on a Shield attached to an HDR10-only panel for the fix, and on mdarcy (DV panel) as the no-regression control (it should take the 8.1 route).

```bash
S=$HOME/.agents/skills/test-shield-playback/scripts/shield-test
$S doctor
$S install androidTvApp/build/outputs/apk/debug/androidTvApp-arm64-v8a-debug.apk
$S clear-logs
$S play movie-tmdb-300671 movie
# wait ~20 s for the HDMI handshake
$S snapshot movie-tmdb-300671; $S plan 1 movie-tmdb-300671; $S audio; $S display
```

Pass criteria:
1. Plan: `delivery=original_http`, `decision_reason=client_dv7_to_hdr10`, `claims.audio.passthrough=true`, recipe audio `truehd` 8ch, no `audio_to_aac`.
2. Logcat `Media3Analytics`: `video format changed fmt=video/hevc`, `audio format changed fmt=audio/true-hd`, no `dv7_transform_*`, no `client_pcm_retry`.
3. `audio`: non-standby `DIRECT` output, Processing format `AUDIO_FORMAT_DOLBY_TRUEHD` (or `0x0e000000`) on HDMI; receiver shows TrueHD/Atmos.
4. `display`: 3840x2160 mode with HDR10; panel shows HDR10, not SDR or DV.
5. Seek ±10 min; audio stays TrueHD.
6. 5 min soak; same plan id, no `plan_failed` / `plan_invalidated` in `events 10`.

Negative: `play movie-tmdb-919207` (DV P8 + TrueHD) must not select `client_dv7_to_hdr10`.
</details>

## Risks

- A device whose HEVC decoder reports `HEVCProfileMain10HDR10` but cannot actually render a de-layered Profile 7 base layer would stall. The stall detector classifies that as `dv7_transform_stall` and the quarantine withdraws the route for 14 days; the next plan takes the server strip.
- Sources whose RPU cannot be stripped, or DV8 with a compat id other than 1, still take the server HLS route and still lose TrueHD. A server-side change to convert to E-AC-3 instead of AAC on that path is a separate follow-up.
- The HUD's "Passthrough / Decoded to PCM" label still reflects the plan claim, not the sink. Separate follow-up.

## AI disclosure

Written by Claude Fable 5.1 (`claude-fable-5-1`) in Claude Code, with a read-only adversarial review pass from OpenAI Codex (GPT 5.6 Sol) via the `codex` Claude Code plugin. Diagnosis used the hosted diagnostics inbox and read-only production database queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android TV can play supported Dolby Vision Profile 7 content as HDR10 when compatible displays and 10-bit HEVC hardware are available.
  * HDR10 playback preserves the base-layer HDR picture and supports lossless audio passthrough.
* **Bug Fixes**
  * Improved playback-stall classification during buffering and transitions back to client-side processing, reducing false stall detection.
* **Documentation**
  * Updated playback documentation to describe Android TV’s HDR10 transformation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

