### PR TITLE
fix(player): select exact native subtitles and align Cast timing

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackCapabilityDetector.kt
@@ -477,6 +477,11 @@ class PlaybackCapabilityDetector(
                     maxChannels = passthrough?.maxChannels,
                     hdrDetails = caps.hdrDetails,
                     subtitles = DeliverySubtitleCapabilities(
+                        nativeEmbedded = listOf(org.siloserver.silo.model.playback.NativeEmbeddedSubtitleCapability(
+                            container = "mp4",
+                            codecs = listOf("mov_text"),
+                            trackIdentity = "container_track_id",
+                        )),
                         embeddedText = true,
                         sidecarText = true,
                         assStyling = libassDirectFidelity,

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionManager.kt
@@ -727,7 +727,9 @@ open class PlaybackSessionManager(
                 capabilities = capabilities,
                 clientPlaybackContext = clientPlaybackContext,
                 operation = replanOperationForClassification(classification),
-                preserveImmediateOutcomes = true,
+                // A rejected subtitle retry must not tear down healthy video.
+                // Reuse staged rejection cleanup while successful retries still commit.
+                preserveImmediateOutcomes = classification != "subtitle_embedded_failed",
             )
         ) {
             is ApiResult.Success -> when (val value = prepared.data) {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackSessionManager.kt
@@ -1780,6 +1780,9 @@ open class PlaybackSessionManager(
             PlaybackSubtitleModeV3.CONVERT,
             PlaybackSubtitleModeV3.RENDER,
             -> {
+                if (subtitle.embedded != null && candidate.delivery == org.siloserver.silo.model.playback.PlaybackDelivery.ORIGINAL_HTTP &&
+                    subtitle.embedded?.containerTrackId != null && subtitle.artifact == null
+                ) return null
                 val artifact = subtitle.artifact
                 if (artifact == null ||
                     artifact.url.isBlank() ||

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackV3Session.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackV3Session.kt
@@ -106,6 +106,9 @@ internal fun PlaybackPlanV3.toSessionResponse(
                 catalogLabel = item.label,
                 catalogSource = item.source,
                 isDefault = item.isDefault,
+                nativeContainerTrackId = subtitle.embedded?.containerTrackId.takeIf {
+                    item.trackId == subtitle.trackId && item.combinedIndex == selectedSubtitleIndex
+                },
                 serverTrackId = item.trackId,
                 serverDelivery = item.delivery.takeIf {
                     it == SUBTITLE_DELIVERY_SIDECAR ||

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleManager.kt
@@ -1705,6 +1705,13 @@ internal fun resolveSubtitleSelection(
     return candidates.firstOrNull { it.track.index == match.track.index }?.selection
 }
 
+/** Whether the exact resolved subtitle is selected in this published snapshot. */
+fun isSubtitleSelected(tracks: Tracks, identity: SubtitleIdentity): Boolean {
+    val selection = resolveSubtitleSelection(tracks, identity) ?: return false
+    return tracks.groups.firstOrNull { it.mediaTrackGroup == selection.mediaTrackGroup }
+        ?.isTrackSelected(selection.trackIndex) == true
+}
+
 private data class TextTrackCandidate(
     val selection: SubtitleSelection,
     val track: MountedSubtitleTrack,

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleMountResolver.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SubtitleMountResolver.kt
@@ -71,6 +71,10 @@ fun resolveMountedSubtitle(
     identity: SubtitleIdentity,
     tracks: List<MountedSubtitleTrack>,
 ): MountedSubtitleMatch? {
+    if (identity is SubtitleIdentity.Embedded && identity.containerTrackId != null) {
+        return tracks.filter { trackIdDenotes(it.trackId, requireNotNull(identity.containerTrackId)) }
+            .singleOrNull()?.let(::MountedSubtitleMatch)
+    }
     val expectedTrackId = identity.expectedMediaTrackId()
     if (expectedTrackId != null) {
         tracks.firstOrNull { trackIdDenotes(it.trackId, expectedTrackId) }
@@ -122,6 +126,9 @@ fun resolveMountedSubtitle(
     subtitle: PlayerSubtitleInfo,
     tracks: List<MountedSubtitleTrack>,
 ): MountedSubtitleMatch? {
+    if (subtitle.nativeContainerTrackId != null || subtitle.serverDelivery != null) {
+        return resolveMountedSubtitle(org.siloserver.silo.playback.playbackSubtitleIdentity(subtitle), tracks)
+    }
     val explicitSource = subtitle.effectiveSubtitleSource()
     val isEmbedded = when {
         subtitle.url.isNotBlank() -> false

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/VideoPlayerMediaSpec.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/VideoPlayerMediaSpec.kt
@@ -13,29 +13,7 @@ import org.siloserver.silo.playback.isBitmapSubtitleCodecFamily
 import org.siloserver.silo.playback.isClientMountableBitmapCodecFamily
 import org.siloserver.silo.playback.subtitleLabelIndicatesHearingImpaired
 
-/**
- * Subtitle artifacts attached to one Media3 media mount.
- *
- * Neutral v3 keeps the complete server inventory in UI state so the picker can
- * display every choice. That inventory is not a preload list: attaching every
- * inventory URL to the MediaItem makes Media3 open every sidecar eagerly and a
- * slow duplicate request can block video preparation. The active plan owns the
- * server artifact, while [subtitleIdentity] owns any client-local artifact.
- * Exactly one external artifact may be attached: preloading every downloaded
- * row recreates the same fan-out under different indexes.
- *
- * A missing plan is the legacy/offline path, where the supplied list remains
- * the media-mount contract.
- *
- * [preferMuxedTracks]: protocol v3 types EVERY non-burn-in inventory row
- * `delivery = sidecar`, including a row that merely describes a track muxed
- * into the direct-play stream. Attaching the server-extracted artifact for such
- * a row makes Media3 fetch and parse a whole SUP/SRT the stream already carries
- * — the player stalls in BUFFERING while the sidecar loads and the cue backlog
- * paints past the resume point. A caller whose selection path can resolve a
- * server-row identity onto the muxed Media3 track (the TV mount latch does)
- * passes true so that row mounts nothing and the in-stream track is used.
- */
+/** Mounts only the selected artifact. Explicit embedded decisions mount none. */
 fun subtitlesForVideoMediaMount(
     subtitles: List<PlayerSubtitleInfo>,
     playbackPlan: PlaybackExecutionPlan?,
@@ -84,6 +62,8 @@ fun subtitlesForVideoMediaMount(
  */
 internal fun PlayerSubtitleInfo.isMuxedInDirectPlayStream(plan: PlaybackExecutionPlan): Boolean {
     if (plan.delivery != PlaybackDelivery.ORIGINAL_HTTP) return false
+    // Explicit server sidecars remain sidecars; only a selected embedded decision bypasses extraction.
+    if (serverDelivery != null) return nativeContainerTrackId != null
     val embedded = catalogSource?.trim()?.equals("embedded", ignoreCase = true) == true ||
         (catalogSource == null && source?.trim()?.equals("embedded", ignoreCase = true) == true)
     if (!embedded) return false

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/cast/CastPlaybackPreparer.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/cast/CastPlaybackPreparer.kt
@@ -205,7 +205,7 @@ class CastPlaybackPreparer(
         // the account access token: the server stamps a session-scoped ?st= on
         // the stream URL only, and the subtitle route rejects anything else
         // (observed: all subtitle fetches 401'd with the access token).
-        val streamToken = STREAM_TOKEN_VALUE_REGEX.find(castUrl)?.groupValues?.get(1)
+        val streamToken = STREAM_TOKEN_VALUE_REGEX.find(castUrl.substringBefore('#'))?.groupValues?.get(1)
         val inventory = castSubtitleInventory(plan)
         val labels = castSubtitleLabels(inventory)
         val selectedIndex = plan.resolvedSelectedSubtitleIndex()
@@ -220,9 +220,8 @@ class CastPlaybackPreparer(
                 trackId = item.trackId,
                 combinedIndex = item.combinedIndex,
                 receiverUrl = receiverUrl?.let { base ->
-                    if (streamToken != null && !STREAM_TOKEN_REGEX.containsMatchIn(base)) {
-                        val sep = if (base.contains('?')) '&' else '?'
-                        "$base${sep}st=$streamToken"
+                    if (streamToken != null) {
+                        appendCastStreamToken(base, streamToken)
                     } else {
                         signStreamUrl(base, token)
                     }
@@ -260,10 +259,7 @@ class CastPlaybackPreparer(
      */
     private fun signStreamUrl(url: String, token: String?): String {
         if (token.isNullOrBlank()) return url
-        if (STREAM_TOKEN_REGEX.containsMatchIn(url)) return url
-        val separator = if (url.contains('?')) '&' else '?'
-        val encoded = URLEncoder.encode(token, "UTF-8")
-        return "$url${separator}st=$encoded"
+        return appendCastStreamToken(url, URLEncoder.encode(token, "UTF-8"))
     }
 
     /**
@@ -320,7 +316,6 @@ class CastPlaybackPreparer(
         private const val TAG = "CastPlaybackPreparer"
         private const val VTT_EXTENSION = ".vtt"
 
-        private val STREAM_TOKEN_REGEX = Regex("[?&]st=")
         private val STREAM_TOKEN_VALUE_REGEX = Regex("[?&]st=([^&]+)")
 
         /**
@@ -799,4 +794,13 @@ internal fun castSubtitleUrlForTimeline(url: String, timelineOffsetSeconds: Doub
         .plus("timestamp_offset=${-timelineOffsetSeconds}")
         .joinToString("&")
     return "$path?$query" + if ('#' in url) "#$fragment" else ""
+}
+
+/** Adds an already-encoded Cast token to the HTTP query, never to the fragment. */
+internal fun appendCastStreamToken(url: String, encodedToken: String): String {
+    val base = url.substringBefore('#')
+    if (Regex("[?&]st=").containsMatchIn(base)) return url
+    val fragment = url.substringAfter('#', "")
+    val separator = if ('?' in base) '&' else '?'
+    return "$base${separator}st=$encodedToken" + if ('#' in url) "#$fragment" else ""
 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/cast/CastPlaybackPreparer.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/cast/CastPlaybackPreparer.kt
@@ -211,7 +211,10 @@ class CastPlaybackPreparer(
         val selectedIndex = plan.resolvedSelectedSubtitleIndex()
         return inventory.mapIndexed { index, item ->
             val receiverUrl = item.takeIf { it.isCastableAsVtt() }?.let {
-                forceVttExtension(resolvePlaybackStreamUrl(serverUrl, it.url.orEmpty()))
+                castSubtitleUrlForTimeline(
+                    forceVttExtension(resolvePlaybackStreamUrl(serverUrl, it.url.orEmpty())),
+                    plan.timeline.timelineOffsetSeconds,
+                )
             }
             CastSubtitleTrack(
                 trackId = item.trackId,
@@ -783,3 +786,17 @@ fun chromecastPlaybackContext(
             ),
         ),
     )
+
+/** Cast renders VTT in the transport clock; canonical subtitle cues use source time. */
+internal fun castSubtitleUrlForTimeline(url: String, timelineOffsetSeconds: Double): String {
+    require(timelineOffsetSeconds.isFinite()) { "Subtitle timeline offset must be finite" }
+    if (timelineOffsetSeconds == 0.0) return url
+    val fragment = url.substringAfter('#', "")
+    val base = url.substringBefore('#')
+    val path = base.substringBefore('?')
+    val query = base.substringAfter('?', "").split('&')
+        .filter { it.isNotEmpty() && it.substringBefore('=') != "timestamp_offset" }
+        .plus("timestamp_offset=${-timelineOffsetSeconds}")
+        .joinToString("&")
+    return "$path?$query" + if ('#' in url) "#$fragment" else ""
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/NativeEmbeddedSubtitleTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/NativeEmbeddedSubtitleTest.kt
@@ -1,0 +1,54 @@
+package org.siloserver.silo.common.player
+
+import org.siloserver.silo.model.playback.*
+import org.siloserver.silo.playback.playbackSubtitleIdentity
+import kotlin.test.*
+
+class NativeEmbeddedSubtitleTest {
+    private val row = PlaybackSubtitleInventoryItemV3(
+        trackId = "file:42:subtitle:0", combinedIndex = 0, source = "embedded",
+        codec = "mov_text", language = "eng", label = "English", delivery = "sidecar",
+        url = "/stream/session/subtitles/0.vtt",
+    )
+    private val plan = PlaybackPlanV3(
+        planId = "native", planAttemptKey = "v3:native", sessionId = "session",
+        delivery = PlaybackDelivery.ORIGINAL_HTTP,
+        source = PlaybackSourceDescriptorV3(container = "mp4"),
+        stream = PlaybackStreamV3(url = "/stream/session", protocol = PlaybackStreamProtocol.HTTP_PROGRESSIVE, container = "mp4"),
+        selectedTracks = SelectedPlaybackTracksV3(subtitle = PlaybackTrackIdentityV3(row.trackId, 0)),
+        subtitle = PlaybackSubtitleDecisionV3(mode = PlaybackSubtitleModeV3.RENDER, trackId = row.trackId,
+            embedded = PlaybackEmbeddedSubtitleV3(streamIndex = 2, containerTrackId = "19"), inventory = listOf(row)),
+        decisionReason = "native",
+    )
+
+    @Test fun projectsExactContainerIdentityWithoutMountingFallbackUrl() {
+        val session = plan.toSessionResponse("session", "profile", 42)
+        val selected = session.subtitleUrls!!.single()
+        assertEquals(row.url, selected.url)
+        val identity = assertIs<SubtitleIdentity.Embedded>(playbackSubtitleIdentity(selected))
+        assertEquals("19", identity.containerTrackId)
+        assertTrue(subtitlesForVideoMediaMount(session.subtitleUrls!!, session.playbackPlan, identity).isEmpty())
+        val fallback = plan.copy(subtitle = plan.subtitle.copy(embedded = null,
+            artifact = PlaybackSubtitleArtifactV3(row.url!!, "text/vtt", "vtt")))
+            .toSessionResponse("session", "profile", 42)
+        assertIs<SubtitleIdentity.ServerSidecar>(playbackSubtitleIdentity(fallback.subtitleUrls!!.single()))
+    }
+
+    @Test fun exactNativeIdDoesNotUseStreamIndexOrMetadataFallback() {
+        val identity = SubtitleIdentity.Embedded(0, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+        fun track(id: String, index: Int) = MountedSubtitleTrack(index, id, "English", "eng", "application/x-quicktime-tx3g", false, false)
+        assertEquals(7, resolveMountedSubtitle(identity, listOf(track("2", 0), track("0:19", 7)))?.track?.index)
+        assertNull(resolveMountedSubtitle(identity, listOf(track("2", 0))))
+        assertNull(resolveMountedSubtitle(identity, listOf(track("19", 0), track("0:19", 1))))
+        assertNull(resolveMountedSubtitle(identity, listOf(track("1:silo-subtitle:0", 0))))
+    }
+
+    @Test fun declaredV3SidecarNeverSkipsMountForHeuristicMuxedMatch() {
+        val response = plan.copy(subtitle = plan.subtitle.copy(embedded = null,
+            artifact = PlaybackSubtitleArtifactV3(row.url!!, "text/vtt", "vtt")))
+            .toSessionResponse("session", "profile", 42)
+        val identity = playbackSubtitleIdentity(response.subtitleUrls!!.single())
+        assertEquals(listOf(row.url), subtitlesForVideoMediaMount(response.subtitleUrls!!,
+            response.playbackPlan, identity, preferMuxedTracks = true).map { it.url })
+    }
+}

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionManagerStagedReplanTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionManagerStagedReplanTest.kt
@@ -1366,6 +1366,45 @@ class PlaybackSessionManagerStagedReplanTest {
     }
 
     @Test
+    fun `native subtitle recovery rejection keeps the active session usable for another retry`() = runTest {
+        val rejectedResponses = listOf(
+            terminalResponse("s2", "adaptation_unavailable", "No subtitle route."),
+            response(sidecarPlan(sessionId = "s2")).copy(protocolVersion = 2),
+            response(sidecarPlan(sessionId = "s2").copy(runtimeCorrections = listOf("future_runtime_fix"))),
+        )
+        for (rejectedResponse in rejectedResponses) {
+            val harness = Harness(
+                replanResponse = { index, _ ->
+                    if (index == 0) rejectedResponse else response(sidecarPlan(sessionId = "s3"))
+                },
+            )
+            harness.start()
+
+            val rejected = harness.manager.replanActiveVideoSession(
+                classification = "subtitle_embedded_failed",
+                positionSeconds = 42.0,
+                audioTrackIndex = 0,
+                subtitleTrackIndex = 4,
+            )
+
+            assertIs<ApiResult.Error>(rejected)
+            assertEquals("s1", harness.manager.activeSessionIdForTest())
+            assertEquals(listOf("s2"), harness.stoppedSessions)
+
+            val retried = harness.manager.replanActiveVideoSession(
+                classification = "subtitle_embedded_failed",
+                positionSeconds = 43.0,
+                audioTrackIndex = 0,
+                subtitleTrackIndex = 4,
+            )
+            assertIs<VideoSessionStartV3.Ready>(assertIs<ApiResult.Success<VideoSessionStartV3>>(retried).data)
+            harness.awaitStopped("s1")
+            assertEquals("s3", harness.manager.activeSessionIdForTest())
+            assertEquals(mapOf("s1" to 1, "s2" to 1), harness.stoppedSessions.groupingBy { it }.eachCount())
+        }
+    }
+
+    @Test
     fun `immediate terminal response preserves typed outcome and teardown`() = runTest {
         val harness = Harness(
             replanResponse = { index, _ ->

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionManagerStagedReplanTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlaybackSessionManagerStagedReplanTest.kt
@@ -15,6 +15,7 @@ import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -39,6 +40,8 @@ import org.siloserver.silo.model.playback.NEUTRAL_PLAYBACK_V3_CONTRACT_FEATURE
 import org.siloserver.silo.model.playback.PlaybackDecisionOutcome
 import org.siloserver.silo.model.playback.PlaybackDecisionResponseV3
 import org.siloserver.silo.model.playback.PlaybackDelivery
+import org.siloserver.silo.model.playback.PlaybackEmbeddedSubtitleV3
+import org.siloserver.silo.model.playback.PlaybackSourceDescriptorV3
 import org.siloserver.silo.model.playback.PlaybackEffectiveRecipeV3
 import org.siloserver.silo.model.playback.PlaybackOutputContext
 import org.siloserver.silo.model.playback.PlaybackPlanV3
@@ -238,6 +241,62 @@ class PlaybackSessionManagerStagedReplanTest {
         assertEquals(409, assertIs<ApiResult.Error>(consumed).code)
         assertEquals("s2", harness.manager.activeSessionIdForTest())
         assertEquals(listOf("s1"), harness.stoppedSessions)
+    }
+
+    @Test
+    fun `native failure retry waits for publication rollback and preserves explicit subtitle index`() = runTest {
+        val native = sidecarPlan("s2").let { plan ->
+            plan.copy(
+                delivery = PlaybackDelivery.ORIGINAL_HTTP,
+                stream = PlaybackStreamV3(
+                    url = "/stream/s2",
+                    protocol = PlaybackStreamProtocol.HTTP_PROGRESSIVE,
+                    container = "mp4",
+                    mimeType = "video/mp4",
+                ),
+                source = PlaybackSourceDescriptorV3(mediaFileId = 42, container = "mp4"),
+                subtitle = plan.subtitle.copy(
+                    mode = PlaybackSubtitleModeV3.RENDER,
+                    artifact = null,
+                    embedded = PlaybackEmbeddedSubtitleV3(streamIndex = 7, containerTrackId = "19"),
+                    inventory = plan.subtitle.inventory.map { it.copy(codec = "mov_text") },
+                ),
+            )
+        }
+        val harness = Harness(
+            replanResponse = { index, _ ->
+                response(if (index == 0) native else sidecarPlan("s3"))
+            },
+        )
+        harness.start()
+        val stagedNative = harness.stageSidecar()
+        assertIs<ApiResult.Success<VideoSessionStartV3.Ready>>(
+            harness.manager.commitStagedVideoReplan(stagedNative, deferPublication = true),
+        )
+
+        // Enter the real publication barrier before checking the HTTP count.
+        // A TV callback that retries before settling its native owner waits here.
+        val retry = async(start = CoroutineStart.UNDISPATCHED) {
+            harness.manager.replanActiveVideoSession(
+                classification = "subtitle_embedded_failed",
+                positionSeconds = 43.0,
+                audioTrackIndex = 0,
+                subtitleTrackIndex = 4,
+            )
+        }
+        assertFalse(retry.isCompleted)
+        assertEquals(listOf("s1"), harness.replanBaseSessions)
+        assertTrue(harness.manager.rollbackUnpublishedVideoSession("s2"))
+
+        val recovered = assertIs<ApiResult.Success<VideoSessionStartV3>>(retry.await()).data
+        assertEquals("s3", assertIs<VideoSessionStartV3.Ready>(recovered).session.sessionId)
+        assertEquals(listOf("s1", "s1"), harness.replanBaseSessions)
+        val request = harness.replanBodies[1]
+        assertEquals("subtitle_embedded_failed", request["failure"]!!.jsonObject["classification"]!!.jsonPrimitive.content)
+        val subtitle = request["selected_tracks"]!!.jsonObject["subtitle"]!!.jsonObject
+        assertEquals(4, subtitle["index"]!!.jsonPrimitive.int)
+        assertEquals("file:42:subtitle:4", subtitle["id"]!!.jsonPrimitive.content)
+        assertEquals(1, harness.stoppedSessions.count { it == "s2" })
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerTrackSelectionTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleManagerTrackSelectionTest.kt
@@ -22,6 +22,19 @@ import kotlin.test.assertTrue
 class SubtitleManagerTrackSelectionTest {
 
     @Test
+    fun nativeConfirmationRequiresTheExactPublishedTrackToBeSelected() {
+        val identity = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "en"), "19")
+        fun group(id: String, selected: Boolean) = Tracks.Group(
+            TrackGroup(subtitle(label = "English", language = "en", sampleMimeType = MimeTypes.APPLICATION_TX3G, id = id)),
+            false, intArrayOf(C.FORMAT_HANDLED), booleanArrayOf(selected),
+        )
+        assertFalse(isSubtitleSelected(Tracks(listOf(group("19", false), group("20", true))), identity))
+        assertTrue(isSubtitleSelected(Tracks(listOf(group("19", true), group("20", false))), identity))
+        assertFalse(isSubtitleSelected(Tracks(listOf(group("20", true))), identity))
+        assertFalse(isSubtitleSelected(Tracks(listOf(group("19", true), group("0:19", true))), identity))
+    }
+
+    @Test
     fun typedLocalSelectionUsesExactMedia3IdAcrossDuplicateMetadata() {
         val first = TrackGroup(
             subtitle(

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleMountResolverTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/SubtitleMountResolverTest.kt
@@ -636,7 +636,7 @@ class SubtitleMountResolverTest {
     // (url present) but the direct-play stream carries the track, so it must
     // resolve onto the untitled Media3 track — not to nothing.
     @Test
-    fun untitledPlaceholderLabelledRowResolvesToTheUntitledSiblingNotSdhOrForced() {
+    fun v3SidecarRowDoesNotInferAnUntitledNativeSibling() {
         val tracks = listOf(
             track(index = 0, trackId = "2", label = "Forced", language = "en", codec = "application/x-subrip", forced = true, hearingImpaired = false),
             // The TV synthesises "EN" for a track Media3 exposes without a label.
@@ -655,7 +655,7 @@ class SubtitleMountResolverTest {
             url = "/stream/s/subtitles/8.srt",
         )
 
-        assertEquals(1, resolveMountedSubtitle(row, tracks)?.track?.index)
+        assertNull(resolveMountedSubtitle(row, tracks))
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/VideoPlayerSubtitleMountTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/VideoPlayerSubtitleMountTest.kt
@@ -92,13 +92,9 @@ class VideoPlayerSubtitleMountTest {
         )
     }
 
-    // Protocol v3 types a row describing a track MUXED into the file as
-    // `delivery = sidecar` too. On the untouched original that track is already
-    // in the stream, so a caller that can select it in place must not have the
-    // server-extracted duplicate attached (it stalls the mount and paints the
-    // cue backlog past the resume point).
+    // Sidecar inventory is fallback delivery, not permission to guess a native track.
     @Test
-    fun v3MuxedEmbeddedRowMountsNothingOnDirectPlayWhenMuxedTracksPreferred() {
+    fun v3SidecarRowMountsSidecarWithoutAnExplicitNativeDecision() {
         val rows = listOf(serverRow(index = 3), embeddedPgsRow(index = 8))
 
         val mounted = subtitlesForVideoMediaMount(
@@ -108,7 +104,7 @@ class VideoPlayerSubtitleMountTest {
             preferMuxedTracks = true,
         )
 
-        assertEquals(emptyList(), mounted)
+        assertEquals(listOf(8), mounted.map(PlayerSubtitleInfo::index))
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/cast/CastPlaybackPreparerTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/cast/CastPlaybackPreparerTest.kt
@@ -16,6 +16,21 @@ import kotlin.test.assertTrue
 
 class CastPlaybackPreparerTest {
     @Test
+    fun shiftedSubtitleAuthenticationPrecedesFragment() {
+        val shifted = castSubtitleUrlForTimeline("https://server/subtitles/2.vtt?file_id=42#cue", 90.5)
+        assertEquals(
+            "https://server/subtitles/2.vtt?file_id=42&timestamp_offset=-90.5&st=signed%2Btoken#cue",
+            appendCastStreamToken(shifted, "signed%2Btoken"),
+        )
+        assertEquals(
+            "https://server/subtitles/2.vtt?st=signed%2Btoken#cue&st=fragment-only",
+            appendCastStreamToken("https://server/subtitles/2.vtt#cue&st=fragment-only", "signed%2Btoken"),
+        )
+        val alreadySigned = "https://server/subtitles/2.vtt?st=existing%2Btoken#cue"
+        assertEquals(alreadySigned, appendCastStreamToken(alreadySigned, "replacement"))
+    }
+
+    @Test
     fun resumedCastSubtitlesShiftIntoTransportClockWithoutChangingIdentityPins() {
         val url = "https://server/subtitles/2.vtt?file_id=42&provider_id=a%2Fb&st=signed%2Btoken"
         assertEquals("$url&timestamp_offset=-90.5", castSubtitleUrlForTimeline(url, 90.5))

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/cast/CastPlaybackPreparerTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/cast/CastPlaybackPreparerTest.kt
@@ -16,6 +16,24 @@ import kotlin.test.assertTrue
 
 class CastPlaybackPreparerTest {
     @Test
+    fun resumedCastSubtitlesShiftIntoTransportClockWithoutChangingIdentityPins() {
+        val url = "https://server/subtitles/2.vtt?file_id=42&provider_id=a%2Fb&st=signed%2Btoken"
+        assertEquals("$url&timestamp_offset=-90.5", castSubtitleUrlForTimeline(url, 90.5))
+        assertEquals(url, castSubtitleUrlForTimeline(url, 0.0))
+        assertEquals(url, castSubtitleUrlForTimeline(url, -0.0))
+        assertEquals("$url&timestamp_offset=12.0", castSubtitleUrlForTimeline(url, -12.0))
+    }
+
+    @Test
+    fun castSubtitleShiftReplacesOldOffsetAndPreservesFragment() {
+        assertEquals(
+            "/subtitles/2.vtt?file_id=42&timestamp_offset=-120.0#cue",
+            castSubtitleUrlForTimeline("/subtitles/2.vtt?timestamp_offset=-60&file_id=42#cue", 120.0),
+        )
+        assertEquals("/subtitles/2.vtt?timestamp_offset=-15.0", castSubtitleUrlForTimeline("/subtitles/2.vtt", 15.0))
+    }
+
+    @Test
     fun castContextDoesNotAdvertiseThePreNeutralSidecarFeature() {
         assertFalse(
             "external_text_sidecar_set_v1" in

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplan.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplan.kt
@@ -1,0 +1,14 @@
+package org.siloserver.silo.android.ui.screens.player
+
+import org.siloserver.silo.common.player.PlaybackSessionManager
+
+/** A deferred replan keeps the selected subtitle ordinal until its recovery can run. */
+internal data class MobileRecoveryReplan(
+    val classification: String,
+    val notice: String,
+    val subtitleTrackIndexOverride: Int? = null,
+) {
+    val shouldQueue: Boolean
+        get() = classification in PlaybackSessionManager.USER_INVALIDATION_CLASSIFICATIONS ||
+            classification == "subtitle_embedded_failed"
+}

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplan.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplan.kt
@@ -16,5 +16,5 @@ internal data class MobileRecoveryReplan(
 
     fun isNonfatalFailure(result: ApiResult<VideoSessionStartV3>): Boolean =
         classification == "subtitle_embedded_failed" &&
-            !(result is ApiResult.Success && result.data is VideoSessionStartV3.Ready)
+            result !is ApiResult.Success
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplan.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplan.kt
@@ -1,6 +1,8 @@
 package org.siloserver.silo.android.ui.screens.player
 
 import org.siloserver.silo.common.player.PlaybackSessionManager
+import org.siloserver.silo.common.player.VideoSessionStartV3
+import org.siloserver.silo.network.ApiResult
 
 /** A deferred replan keeps the selected subtitle ordinal until its recovery can run. */
 internal data class MobileRecoveryReplan(
@@ -11,4 +13,8 @@ internal data class MobileRecoveryReplan(
     val shouldQueue: Boolean
         get() = classification in PlaybackSessionManager.USER_INVALIDATION_CLASSIFICATIONS ||
             classification == "subtitle_embedded_failed"
+
+    fun isNonfatalFailure(result: ApiResult<VideoSessionStartV3>): Boolean =
+        classification == "subtitle_embedded_failed" &&
+            !(result is ApiResult.Success && result.data is VideoSessionStartV3.Ready)
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleMount.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleMount.kt
@@ -1,0 +1,11 @@
+package org.siloserver.silo.android.ui.screens.player
+
+/** Both transport changes and subtitle refreshes replace Media3 track groups. */
+internal data class MobileSubtitleMount(val generation: Long, val refreshNonce: Int)
+
+internal fun isCurrentMobileSubtitleMount(
+    applied: MobileSubtitleMount?,
+    expected: MobileSubtitleMount,
+    awaitingGeneration: Long?,
+    loading: Boolean,
+): Boolean = applied == expected && awaitingGeneration == null && !loading

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapter.kt
@@ -1015,6 +1015,14 @@ internal class MobileSubtitleTransactionAdapter(
         val failedIdentity = (if (ownedSelection) pendingLocalSelection?.identity else pendingLocalRestore?.identity)
             as? SubtitleIdentity.Embedded
         if (failedIdentity?.containerTrackId != null) {
+            // An adopted native plan is not a mounted subtitle. Clear a failed
+            // restore now so a failed sidecar recovery cannot leave it selected.
+            // Keep the requested index for recovery and do not persist Off.
+            if (ownedRestore && transition.committed.identity == failedIdentity) {
+                transition = transition.copy(
+                    committed = transition.committed.copy(identity = SubtitleIdentity.Off),
+                )
+            }
             invalidateLocalMount()
             failureMessage = "Embedded subtitles couldn't load. Retrying with a sidecar."
             publish()

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapter.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapter.kt
@@ -171,6 +171,7 @@ internal class MobileSubtitleTransactionAdapter(
         MobileSubtitlePlaybackAdoption,
     ) -> MobileSubtitleAdoptionResult = { MobileSubtitleAdoptionResult.Adopted },
     private val onCommittedPlaybackFailure: suspend (String) -> Unit = {},
+    private val onEmbeddedSubtitleFailure: (Int) -> Unit = {},
 ) {
     private data class PendingLocalSelection(
         val generation: Long,
@@ -1011,6 +1012,15 @@ internal class MobileSubtitleTransactionAdapter(
         val ownedSelection = pendingLocalSelection?.generation == generation
         val ownedRestore = pendingLocalRestore?.generation == generation
         if (!ownedSelection && !ownedRestore) return
+        val failedIdentity = (if (ownedSelection) pendingLocalSelection?.identity else pendingLocalRestore?.identity)
+            as? SubtitleIdentity.Embedded
+        if (failedIdentity?.containerTrackId != null) {
+            invalidateLocalMount()
+            failureMessage = "Embedded subtitles couldn't load. Retrying with a sidecar."
+            publish()
+            onEmbeddedSubtitleFailure(failedIdentity.serverIndex)
+            return
+        }
         invalidateLocalMount()
         failureMessage = "The selected subtitle could not be mounted."
         publish()
@@ -1268,6 +1278,10 @@ private fun MobileStagedSubtitleCandidate.validationFailure(
             ?: return "The adapted candidate omitted its selected subtitle identity."
         return validationFailure(returnedIdentity)
     }
+    if (selectedSubtitleIdentity is SubtitleIdentity.Embedded &&
+        selectedSubtitleIdentity.containerTrackId != null &&
+        selectedSubtitleIndex == expectedSubtitleIndex && subtitleMode == PlaybackSubtitleModeV3.RENDER && !hasSidecar
+    ) return null
     return when (requested.identity) {
         is SubtitleIdentity.Embedded,
         is SubtitleIdentity.Downloaded,
@@ -1347,7 +1361,9 @@ private fun MobileStagedSubtitleCandidate.validationFailure(
             "The candidate did not burn in the requested subtitle."
         else -> null
     }
-    is SubtitleIdentity.Embedded,
+    is SubtitleIdentity.Embedded -> if (identity.containerTrackId != null &&
+        selectedSubtitleIndex == identity.serverIndex && subtitleMode == PlaybackSubtitleModeV3.RENDER && !hasSidecar
+    ) null else "The candidate omitted the exact embedded subtitle."
     is SubtitleIdentity.Downloaded,
     is SubtitleIdentity.LocalMedia3,
     -> "A local subtitle identity unexpectedly reached staged validation."

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -424,7 +424,7 @@ fun PlayerScreen(
     // A neutral-v3 replan publishes replacement route state before the
     // corresponding Compose mount effect runs. Subtitle restoration must wait
     // for that exact media generation rather than racing a newly mounted route.
-    var mountedSubtitleMount by remember(videoBackend) { mutableStateOf<MobileSubtitleMount?>(null) }
+    val mountedSubtitleMount by viewModel.mountedSubtitleMount.collectAsState()
     // False until presets have been applied once for the current backend, so
     // only later capability changes wait for the route to settle.
     var trackPresetsApplied by remember(videoBackend) { mutableStateOf(false) }
@@ -763,9 +763,9 @@ fun PlayerScreen(
                     "${plan?.decisionTrace?.size ?: 0}:${uiState.mediaMountGeneration}",
             )
         }
-        mountedSubtitleMount = null
+        viewModel.onSubtitleMediaMountChanging()
         backend.mount(mediaSpec, playWhenReady = !viewModel.uiState.value.isPaused)
-        mountedSubtitleMount = MobileSubtitleMount(uiState.mediaMountGeneration, uiState.subtitleRefreshNonce)
+        viewModel.onSubtitleMediaMountApplied(MobileSubtitleMount(uiState.mediaMountGeneration, uiState.subtitleRefreshNonce))
         viewModel.onMediaMountApplied(uiState.mediaMountGeneration)
     }
 
@@ -830,9 +830,9 @@ fun PlayerScreen(
             runtimeCorrections = plan?.runtimeCorrections.orEmpty(),
             activeClaims = plan?.activeOriginalHttpClaims().orEmpty(),
         )
-        mountedSubtitleMount = null
+        viewModel.onSubtitleMediaMountChanging()
         backend.refresh(mediaSpec)
-        mountedSubtitleMount = MobileSubtitleMount(uiState.mediaMountGeneration, uiState.subtitleRefreshNonce)
+        viewModel.onSubtitleMediaMountApplied(MobileSubtitleMount(uiState.mediaMountGeneration, uiState.subtitleRefreshNonce))
     }
 
     // Sync play/pause from ViewModel to player without reclassifying this
@@ -994,20 +994,21 @@ fun PlayerScreen(
                     // already fired (against the OLD tracks), so without this the
                     // auto-selected downloaded/AI track never engages. Reads the
                     // live VM state — `uiState` here can be a stale closure capture.
-                    val mount = mountedSubtitleMount
+                    val mount = viewModel.mountedSubtitleMount.value
                     val backend = videoBackend ?: return
-                    if (!viewModel.isCurrentSubtitleMount(mount) || tracks != backend.player.currentTracks) return
+                    if (!viewModel.isCurrentSubtitleMount(mount)) return
+                    val currentTracks = backend.player.currentTracks
                     val liveState = viewModel.uiState.value
                     val pendingIdentity = liveState.localSubtitleMountIdentity
                     val targetIdentity = pendingIdentity ?: liveState.committedSubtitleIdentity
                     val accepted = backend.selectMountedSubtitle(identity = targetIdentity)
-                    val selected = isSubtitleSelected(tracks, targetIdentity)
+                    val selected = isSubtitleSelected(currentTracks, targetIdentity)
                     if (pendingIdentity != null) {
                         viewModel.onPendingSubtitleMountResult(
                             mount = mount,
                             identity = pendingIdentity,
                             selected = selected,
-                            snapshotKey = media3TextTrackSnapshotKey(tracks),
+                            snapshotKey = media3TextTrackSnapshotKey(currentTracks),
                             settled = backend.player.playbackState == Player.STATE_READY && (selected || !accepted),
                         )
                     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerScreen.kt
@@ -91,6 +91,7 @@ import org.siloserver.silo.common.player.video.selectedMountedAudioOrdinal
 import org.siloserver.silo.common.player.video.PlaybackStartupStallDetector
 import org.siloserver.silo.common.player.video.PlaybackRuntimeCorrectionMetrics
 import org.siloserver.silo.common.player.video.PostResumeVideoStallDetector
+import org.siloserver.silo.common.player.isSubtitleSelected
 import org.siloserver.silo.common.player.video.VideoPlayerTrackEntry
 import org.siloserver.silo.model.playback.PlaybackExecutionPlan
 import org.siloserver.silo.model.playback.PlayerSubtitleInfo
@@ -423,7 +424,7 @@ fun PlayerScreen(
     // A neutral-v3 replan publishes replacement route state before the
     // corresponding Compose mount effect runs. Subtitle restoration must wait
     // for that exact media generation rather than racing a newly mounted route.
-    var mountedMediaGeneration by remember(videoBackend) { mutableStateOf<Long?>(null) }
+    var mountedSubtitleMount by remember(videoBackend) { mutableStateOf<MobileSubtitleMount?>(null) }
     // False until presets have been applied once for the current backend, so
     // only later capability changes wait for the route to settle.
     var trackPresetsApplied by remember(videoBackend) { mutableStateOf(false) }
@@ -762,8 +763,9 @@ fun PlayerScreen(
                     "${plan?.decisionTrace?.size ?: 0}:${uiState.mediaMountGeneration}",
             )
         }
+        mountedSubtitleMount = null
         backend.mount(mediaSpec, playWhenReady = !viewModel.uiState.value.isPaused)
-        mountedMediaGeneration = uiState.mediaMountGeneration
+        mountedSubtitleMount = MobileSubtitleMount(uiState.mediaMountGeneration, uiState.subtitleRefreshNonce)
         viewModel.onMediaMountApplied(uiState.mediaMountGeneration)
     }
 
@@ -828,7 +830,9 @@ fun PlayerScreen(
             runtimeCorrections = plan?.runtimeCorrections.orEmpty(),
             activeClaims = plan?.activeOriginalHttpClaims().orEmpty(),
         )
+        mountedSubtitleMount = null
         backend.refresh(mediaSpec)
+        mountedSubtitleMount = MobileSubtitleMount(uiState.mediaMountGeneration, uiState.subtitleRefreshNonce)
     }
 
     // Sync play/pause from ViewModel to player without reclassifying this
@@ -990,18 +994,21 @@ fun PlayerScreen(
                     // already fired (against the OLD tracks), so without this the
                     // auto-selected downloaded/AI track never engages. Reads the
                     // live VM state — `uiState` here can be a stale closure capture.
+                    val mount = mountedSubtitleMount
+                    val backend = videoBackend ?: return
+                    if (!viewModel.isCurrentSubtitleMount(mount) || tracks != backend.player.currentTracks) return
                     val liveState = viewModel.uiState.value
                     val pendingIdentity = liveState.localSubtitleMountIdentity
                     val targetIdentity = pendingIdentity ?: liveState.committedSubtitleIdentity
-                    val selected = videoBackend?.selectMountedSubtitle(
-                        identity = targetIdentity,
-                    ) == true
+                    val accepted = backend.selectMountedSubtitle(identity = targetIdentity)
+                    val selected = isSubtitleSelected(tracks, targetIdentity)
                     if (pendingIdentity != null) {
                         viewModel.onPendingSubtitleMountResult(
+                            mount = mount,
                             identity = pendingIdentity,
                             selected = selected,
                             snapshotKey = media3TextTrackSnapshotKey(tracks),
-                            settled = videoBackend?.player?.playbackState == Player.STATE_READY,
+                            settled = backend.player.playbackState == Player.STATE_READY && (selected || !accepted),
                         )
                     }
                 }
@@ -1172,10 +1179,11 @@ fun PlayerScreen(
         uiState.committedSubtitleIdentity,
         uiState.localSubtitleMountIdentity,
         uiState.mediaMountGeneration,
-        mountedMediaGeneration,
+        mountedSubtitleMount,
     ) {
         val backend = videoBackend ?: return@LaunchedEffect
-        if (mountedMediaGeneration != uiState.mediaMountGeneration) return@LaunchedEffect
+        val mount = mountedSubtitleMount
+        if (!viewModel.isCurrentSubtitleMount(mount)) return@LaunchedEffect
         val pendingIdentity = uiState.localSubtitleMountIdentity
         val targetIdentity = pendingIdentity ?: uiState.committedSubtitleIdentity
         val selectedIndex = resolveMobileSubtitleOrdinal(targetIdentity, uiState.subtitleTracks)
@@ -1186,11 +1194,12 @@ fun PlayerScreen(
             // an empty sidecar entry or refresh the mounted MediaItem.
             backend.selectMountedSubtitle(identity = SubtitleIdentity.Off)
         } else if (targetIdentity.requiresMountedMobileSelection()) {
-            val selected = backend.selectMountedSubtitle(identity = targetIdentity)
+            backend.selectMountedSubtitle(identity = targetIdentity)
             if (pendingIdentity != null) {
                 viewModel.onPendingSubtitleMountResult(
+                    mount = mount,
                     identity = pendingIdentity,
-                    selected = selected,
+                    selected = isSubtitleSelected(backend.player.currentTracks, targetIdentity),
                     snapshotKey = media3TextTrackSnapshotKey(backend.player.currentTracks),
                     // This composition-side attempt can race Media3's first
                     // text-track publication. Only onTracksChanged callbacks

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -3170,12 +3170,21 @@ class PlayerViewModel(
         mobileSubtitleTransactions.select(identity)
     }
 
-    fun onPendingSubtitleMountResult(
+    internal fun isCurrentSubtitleMount(mount: MobileSubtitleMount?): Boolean = isCurrentMobileSubtitleMount(
+        applied = mount,
+        expected = MobileSubtitleMount(_uiState.value.mediaMountGeneration, _uiState.value.subtitleRefreshNonce),
+        awaitingGeneration = awaitingMediaMountGeneration,
+        loading = positionReportsBlockedForPendingLoad,
+    )
+
+    internal fun onPendingSubtitleMountResult(
+        mount: MobileSubtitleMount?,
         identity: SubtitleIdentity,
         selected: Boolean,
         snapshotKey: String?,
         settled: Boolean,
     ) {
+        if (!isCurrentSubtitleMount(mount)) return
         mobileSubtitleTransactions.reportMountedSelection(
             identity = identity,
             selected = selected,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -1753,6 +1753,11 @@ class PlayerViewModel(
             }
             currentCoroutineContext().ensureActive()
             if (recoveryGeneration != playbackRecoveryGeneration) return@launch
+            if (queuedRequest.isNonfatalFailure(result)) {
+                showVersionSwitchMessage("Subtitles couldn't load — playback continues.")
+                _uiState.update { it.copy(isLoading = false, isBuffering = false) }
+                return@launch
+            }
             when (result) {
                 is ApiResult.Success -> when (val decision = result.data) {
                     is VideoSessionStartV3.Ready -> {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -674,6 +674,18 @@ class PlayerViewModel(
     private var serverSeekRecoveryInFlight = false
     private var queuedServerSeek: ServerSeekRecoveryRequest? = null
     private var playbackRecoveryGeneration = 0L
+    // The service and this ViewModel survive screen recreation; applied evidence must too.
+    private val _mountedSubtitleMount = MutableStateFlow<MobileSubtitleMount?>(null)
+    internal val mountedSubtitleMount: StateFlow<MobileSubtitleMount?> = _mountedSubtitleMount
+
+    internal fun onSubtitleMediaMountChanging() {
+        _mountedSubtitleMount.value = null
+    }
+
+    internal fun onSubtitleMediaMountApplied(mount: MobileSubtitleMount) {
+        _mountedSubtitleMount.value = mount
+    }
+
     private var mediaMountSequence = 0L
     private var awaitingMediaMountGeneration: Long? = null
     private val subtitleRefreshGate = SubtitleRefreshGate()
@@ -2038,6 +2050,7 @@ class PlayerViewModel(
         queuedServerSeek = null
         awaitingMediaMountGeneration = null
         positionReportsBlockedForPendingLoad = true
+        onSubtitleMediaMountChanging()
         seekRecoveryRollbackInvalidated = false
         clearBufferedSeekCommands()
         pendingNativeSeekAfterMount = null
@@ -3170,12 +3183,13 @@ class PlayerViewModel(
         mobileSubtitleTransactions.select(identity)
     }
 
-    internal fun isCurrentSubtitleMount(mount: MobileSubtitleMount?): Boolean = isCurrentMobileSubtitleMount(
-        applied = mount,
-        expected = MobileSubtitleMount(_uiState.value.mediaMountGeneration, _uiState.value.subtitleRefreshNonce),
-        awaitingGeneration = awaitingMediaMountGeneration,
-        loading = positionReportsBlockedForPendingLoad,
-    )
+    internal fun isCurrentSubtitleMount(mount: MobileSubtitleMount?): Boolean =
+        mount == _mountedSubtitleMount.value && isCurrentMobileSubtitleMount(
+            applied = mount,
+            expected = MobileSubtitleMount(_uiState.value.mediaMountGeneration, _uiState.value.subtitleRefreshNonce),
+            awaitingGeneration = awaitingMediaMountGeneration,
+            loading = positionReportsBlockedForPendingLoad,
+        )
 
     internal fun onPendingSubtitleMountResult(
         mount: MobileSubtitleMount?,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -507,6 +507,14 @@ class PlayerViewModel(
         },
         onSnapshotChanged = ::applyMobileSubtitleSnapshot,
         onCommittedPlayback = ::adoptMobileSubtitlePlayback,
+        onEmbeddedSubtitleFailure = { serverIndex ->
+            startProtocolV3Replan(
+                classification = "subtitle_embedded_failed",
+                notice = "Embedded subtitles couldn't load. Retrying with a sidecar.",
+                state = _uiState.value,
+                subtitleTrackIndexOverride = serverIndex,
+            )
+        },
         onCommittedPlaybackFailure = ::recoverFromSubtitleAdoptionFailure,
     )
 
@@ -1663,6 +1671,7 @@ class PlayerViewModel(
         diagnostics: Map<String, String> = emptyMap(),
         failedTrackType: Int? = null,
         audioTrackIndexOverride: Int? = null,
+        subtitleTrackIndexOverride: Int? = null,
     ) {
         if (recoveryJob?.isActive == true || serverSeekRecoveryInFlight) {
             // Never silently drop a user selection: queue it (newest wins) and
@@ -1683,7 +1692,7 @@ class PlayerViewModel(
         val fileId = state.versions.getOrNull(state.selectedVersionIndex)?.fileId ?: return
         val recoveryGeneration = playbackRecoveryGeneration
         recoveryJob = viewModelScope.launch {
-            val selectedSubtitleTrackIndex = selectedServerSubtitleTrackIndex(
+            val selectedSubtitleTrackIndex = subtitleTrackIndexOverride ?: selectedServerSubtitleTrackIndex(
                 selectedOrdinal = state.selectedSubtitleIndex,
                 subtitleTracks = state.subtitleTracks,
             )

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModel.kt
@@ -638,11 +638,11 @@ class PlayerViewModel(
     private var transientNetworkRetries = 0
     private var recoveryJob: Job? = null
 
-    // Latest user track/quality/route change (classification to notice) that
+    // Latest user change or embedded-subtitle failure that
     // arrived while a recovery held the replan single-flight guard. Re-driven
     // once that flight completes so the selection isn't silently dropped;
     // last-write-wins because only the newest selection matters.
-    private var queuedInvalidationReplan: Pair<String, String>? = null
+    private var queuedInvalidationReplan: MobileRecoveryReplan? = null
 
     private enum class ServerSeekRecoveryMode {
         REANCHOR,
@@ -1673,18 +1673,20 @@ class PlayerViewModel(
         audioTrackIndexOverride: Int? = null,
         subtitleTrackIndexOverride: Int? = null,
     ) {
+        val queuedRequest = MobileRecoveryReplan(classification, notice, subtitleTrackIndexOverride)
         if (recoveryJob?.isActive == true || serverSeekRecoveryInFlight) {
             // Never silently drop a user selection: queue it (newest wins) and
             // re-drive it when the in-flight recovery completes. Failure-driven
-            // replans stay dropped — onPlayerError re-raises those.
-            if (classification in PlaybackSessionManager.USER_INVALIDATION_CLASSIFICATIONS) {
-                queuedInvalidationReplan = classification to notice
+            // replans stay dropped — onPlayerError re-raises those. Native
+            // subtitle failures have no player-error retry, so retain them.
+            if (queuedRequest.shouldQueue) {
+                queuedInvalidationReplan = queuedRequest
             }
             return
         }
         if (mobileSubtitleTransactions.hasActiveTransaction) {
             if (classification in PlaybackSessionManager.USER_INVALIDATION_CLASSIFICATIONS) {
-                queuedInvalidationReplan = classification to notice
+                queuedInvalidationReplan = queuedRequest
                 return
             }
             mobileSubtitleTransactions.invalidate()
@@ -1950,11 +1952,16 @@ class PlayerViewModel(
     }
 
     private fun redriveQueuedInvalidationReplan() {
-        val (classification, notice) = queuedInvalidationReplan ?: return
+        val queued = queuedInvalidationReplan ?: return
         queuedInvalidationReplan = null
         // Current state, not the queuing-time state, so the replan carries the
         // latest committed track/quality selection.
-        startProtocolV3Replan(classification, notice, _uiState.value)
+        startProtocolV3Replan(
+            queued.classification,
+            queued.notice,
+            _uiState.value,
+            subtitleTrackIndexOverride = queued.subtitleTrackIndexOverride,
+        )
     }
 
     /**

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobilePlayerPresentationStateTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobilePlayerPresentationStateTest.kt
@@ -8,6 +8,14 @@ import kotlin.test.assertTrue
 
 class MobilePlayerPresentationStateTest {
     @Test
+    fun subtitleRefreshCannotAcceptThePreviousItemsTrackSnapshot() {
+        val refreshed = MobileSubtitleMount(2, 1)
+        assertFalse(isCurrentMobileSubtitleMount(MobileSubtitleMount(2, 0), refreshed, null, false))
+        assertFalse(isCurrentMobileSubtitleMount(null, refreshed, null, false))
+        assertTrue(isCurrentMobileSubtitleMount(refreshed, refreshed, null, false))
+    }
+
+    @Test
     fun clockOnlyUpdatesLeaveStructuralStateEqual() {
         val first = PlayerViewModel.PlayerUiState(
             contentId = "movie-1",

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplanTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplanTest.kt
@@ -1,0 +1,17 @@
+package org.siloserver.silo.android.ui.screens.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MobileRecoveryReplanTest {
+    @Test
+    fun nativeFailureQueuesTheUncommittedTrackInsteadOfReusingTheCurrentSelection() {
+        val failure = MobileRecoveryReplan("subtitle_embedded_failed", "Retrying", 4)
+        assertTrue(failure.shouldQueue)
+        assertEquals(4, failure.subtitleTrackIndexOverride)
+        assertEquals("subtitle_embedded_failed", failure.classification)
+        assertFalse(MobileRecoveryReplan("transport_stall", "Retrying").shouldQueue)
+    }
+}

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplanTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplanTest.kt
@@ -23,13 +23,18 @@ class MobileRecoveryReplanTest {
         val failures: List<ApiResult<VideoSessionStartV3>> = listOf(
             ApiResult.Error(code = 503, error = "unavailable", message = "Unavailable"),
             ApiResult.NetworkError(IllegalStateException("Offline")),
-            ApiResult.Success(VideoSessionStartV3.Terminal("unsupported", "No subtitles", false)),
-            ApiResult.Success(VideoSessionStartV3.ServerUpgradeRequired),
         )
         failures.forEach { failure ->
             assertTrue(native.isNonfatalFailure(failure), "$failure")
             assertFalse(transport.isNonfatalFailure(failure), "$failure")
         }
+    }
+
+    @Test
+    fun terminalAndUpgradeOutcomesAreNeverMistakenForAStillActiveSession() {
+        val native = MobileRecoveryReplan("subtitle_embedded_failed", "Retrying", 4)
+        assertFalse(native.isNonfatalFailure(ApiResult.Success(VideoSessionStartV3.Terminal("unsupported", "No subtitles", false))))
+        assertFalse(native.isNonfatalFailure(ApiResult.Success(VideoSessionStartV3.ServerUpgradeRequired)))
     }
 
     @Test

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplanTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileRecoveryReplanTest.kt
@@ -1,11 +1,53 @@
 package org.siloserver.silo.android.ui.screens.player
 
+import org.siloserver.silo.common.player.VideoSessionStartV3
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.model.playback.ClientCodecCapabilities
+import org.siloserver.silo.model.playback.ClientPlaybackContext
+import org.siloserver.silo.model.playback.PlayMethod
+import org.siloserver.silo.model.playback.PlaybackDelivery
+import org.siloserver.silo.model.playback.PlaybackPlanV3
+import org.siloserver.silo.model.playback.PlaybackSessionResponse
+import org.siloserver.silo.model.playback.PlaybackStreamProtocol
+import org.siloserver.silo.model.playback.PlaybackStreamV3
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MobileRecoveryReplanTest {
+    @Test
+    fun subtitleFallbackErrorsPreserveVideoButOtherRecoveryErrorsRemainFatal() {
+        val native = MobileRecoveryReplan("subtitle_embedded_failed", "Retrying", 4)
+        val transport = MobileRecoveryReplan("transport_stall", "Retrying")
+        val failures: List<ApiResult<VideoSessionStartV3>> = listOf(
+            ApiResult.Error(code = 503, error = "unavailable", message = "Unavailable"),
+            ApiResult.NetworkError(IllegalStateException("Offline")),
+            ApiResult.Success(VideoSessionStartV3.Terminal("unsupported", "No subtitles", false)),
+            ApiResult.Success(VideoSessionStartV3.ServerUpgradeRequired),
+        )
+        failures.forEach { failure ->
+            assertTrue(native.isNonfatalFailure(failure), "$failure")
+            assertFalse(transport.isNonfatalFailure(failure), "$failure")
+        }
+    }
+
+    @Test
+    fun successfulSubtitleFallbackStillReachesSessionAdoption() {
+        val ready = VideoSessionStartV3.Ready(
+            session = PlaybackSessionResponse("s2", 1, mediaFileId = 42, playMethod = PlayMethod.DIRECT, streamUrl = "/stream/s2"),
+            plan = PlaybackPlanV3(
+                planId = "p2", planAttemptKey = "key", delivery = PlaybackDelivery.ORIGINAL_HTTP,
+                stream = PlaybackStreamV3("/stream/s2", PlaybackStreamProtocol.HTTP_PROGRESSIVE),
+                decisionReason = "sidecar",
+            ),
+            playbackAttemptId = "attempt", planAttemptId = "plan-attempt", planAttemptKey = "key",
+            capabilities = ClientCodecCapabilities(),
+            clientPlaybackContext = ClientPlaybackContext(formFactor = "phone", appVersion = "test"),
+        )
+        assertFalse(MobileRecoveryReplan("subtitle_embedded_failed", "Retrying", 4).isNonfatalFailure(ApiResult.Success(ready)))
+    }
+
     @Test
     fun nativeFailureQueuesTheUncommittedTrackInsteadOfReusingTheCurrentSelection() {
         val failure = MobileRecoveryReplan("subtitle_embedded_failed", "Retrying", 4)

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
@@ -1450,12 +1450,46 @@ class MobileSubtitleTransactionAdapterTest {
         assertEquals(listOf(downloaded), harness.persistence.persisted.map { it.identity })
     }
 
+    @Test
+    fun `native decision commits exact identity and requests sidecar recovery on mount timeout`() = runTest {
+        val failures = mutableListOf<Int>()
+        val harness = harness(backgroundScope, onEmbeddedFailure = failures::add)
+        val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+        harness.adapter.select(sidecar(4))
+        runCurrent()
+        harness.port.completeStage(candidate("native", 4, hasSidecar = false, selectedSubtitleIdentity = native))
+        runCurrent()
+        assertEquals(native, harness.adapter.snapshot.localMountIdentity)
+        assertTrue(harness.persistence.persisted.isEmpty())
+        advanceTimeBy(5_000)
+        runCurrent()
+        assertEquals(listOf(4), failures)
+        assertNull(harness.adapter.snapshot.localMountIdentity)
+        assertTrue(harness.persistence.persisted.isEmpty())
+    }
+
+    @Test
+    fun `native decision only persists after exact mounted selection succeeds`() = runTest {
+        val harness = harness(backgroundScope)
+        val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+        harness.adapter.select(sidecar(4))
+        runCurrent()
+        harness.port.completeStage(candidate("native", 4, hasSidecar = false, selectedSubtitleIdentity = native))
+        runCurrent()
+        assertTrue(harness.persistence.persisted.isEmpty())
+        harness.adapter.reportMountedSelection(native, selected = true, snapshotKey = "native19", settled = true)
+        runCurrent()
+        assertEquals(native, harness.adapter.snapshot.committedIdentity)
+        assertEquals(listOf(native), harness.persistence.persisted.map { it.identity })
+    }
+
     private fun harness(
         scope: CoroutineScope,
         sessionId: String? = "s1",
         tracks: List<PlayerSubtitleInfo> = emptyList(),
         adoption: AdoptionControl = AdoptionControl(),
         durablePersistenceScope: CoroutineScope = scope,
+        onEmbeddedFailure: (Int) -> Unit = {},
     ): Harness {
         val port = FakeStagedPort()
         val persistence = RecordingPersistence()
@@ -1465,6 +1499,7 @@ class MobileSubtitleTransactionAdapterTest {
             stagedPort = port,
             persistencePort = persistence,
             durablePersistenceScope = durablePersistenceScope,
+            onEmbeddedSubtitleFailure = onEmbeddedFailure,
             onCommittedPlayback = { adoptionRequest ->
                 adoption.started += 1
                 adoption.requestedSourcePositions += adoptionRequest.requestedSourcePositionSeconds

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
@@ -1465,6 +1465,45 @@ class MobileSubtitleTransactionAdapterTest {
         runCurrent()
         assertEquals(listOf(4), failures)
         assertNull(harness.adapter.snapshot.localMountIdentity)
+        assertEquals(SubtitleIdentity.Off, harness.adapter.snapshot.committedIdentity)
+        assertTrue(harness.persistence.persisted.isEmpty())
+    }
+
+    @Test
+    fun `failed native restore clears its selected identity without changing playback preferences`() = runTest {
+        val failures = mutableListOf<Int>()
+        val harness = harness(backgroundScope, onEmbeddedFailure = failures::add)
+        val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+        harness.adapter.resetContent(context(), committedIdentity = native)
+        val prior = harness.adapter.snapshot.transition.committed
+        harness.adapter.restoreCommittedLocalMount()
+
+        repeat(2) {
+            harness.adapter.reportMountedSelection(native, selected = false, snapshotKey = "missing-native", settled = true)
+        }
+        runCurrent()
+
+        assertEquals(listOf(4), failures)
+        assertEquals(prior.copy(identity = SubtitleIdentity.Off), harness.adapter.snapshot.transition.committed)
+        assertNull(harness.adapter.snapshot.localMountIdentity)
+        assertFalse(harness.adapter.hasActiveTransaction)
+        assertTrue(harness.persistence.persisted.isEmpty())
+        assertTrue(harness.committedPlaybacks.isEmpty())
+    }
+
+    @Test
+    fun `failed pending native selection retains the prior committed subtitle`() = runTest {
+        val failures = mutableListOf<Int>()
+        val harness = harness(backgroundScope, onEmbeddedFailure = failures::add)
+        val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+        val prior = harness.adapter.snapshot.transition.committed
+        harness.adapter.select(native)
+        advanceTimeBy(5_000)
+        runCurrent()
+
+        assertEquals(listOf(4), failures)
+        assertEquals(prior, harness.adapter.snapshot.transition.committed)
+        assertNull(harness.adapter.snapshot.localMountIdentity)
         assertTrue(harness.persistence.persisted.isEmpty())
     }
 

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/MobileSubtitleTransactionAdapterTest.kt
@@ -1508,6 +1508,31 @@ class MobileSubtitleTransactionAdapterTest {
     }
 
     @Test
+    fun `replacement native mount ignores predecessor evidence and waits for selected publication`() = runTest {
+        val harness = harness(backgroundScope)
+        val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+        harness.adapter.resetContent(context(), committedIdentity = native)
+        harness.adapter.restoreCommittedLocalMount()
+        val replacement = MobileSubtitleMount(2, 0)
+        fun report(applied: MobileSubtitleMount?, awaiting: Long?, loading: Boolean, selected: Boolean, settled: Boolean) {
+            if (isCurrentMobileSubtitleMount(applied, replacement, awaiting, loading)) {
+                harness.adapter.reportMountedSelection(native, selected, "exact-native-19", settled)
+            }
+        }
+
+        report(MobileSubtitleMount(1, 0), 2, false, true, true)
+        report(MobileSubtitleMount(1, 0), null, false, true, true)
+        report(replacement, 2, false, true, true)
+        report(replacement, null, true, true, true)
+        assertEquals(native, harness.adapter.snapshot.localMountIdentity)
+        repeat(2) { report(replacement, null, false, false, false) }
+        assertEquals(native, harness.adapter.snapshot.localMountIdentity, "Accepted commands are not selected-track evidence")
+        report(replacement, null, false, true, true)
+        assertNull(harness.adapter.snapshot.localMountIdentity)
+        assertEquals(native, harness.adapter.snapshot.committedIdentity)
+    }
+
+    @Test
     fun `native decision only persists after exact mounted selection succeeds`() = runTest {
         val harness = harness(backgroundScope)
         val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModelLoadOwnershipIntegrationTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/player/PlayerViewModelLoadOwnershipIntegrationTest.kt
@@ -146,6 +146,46 @@ class PlayerViewModelLoadOwnershipIntegrationTest {
     }
 
     @Test
+    fun recreatedScreenObservesAppliedSubtitleMountWithoutRemountingRetainedPlayback() = runTest(dispatcher) {
+        val starter = DeferredNonCooperativeStarter()
+        val fixture = playerViewModel(starter, backgroundScope)
+        val store = ViewModelStore().also { it.put("player", fixture.viewModel) }
+        try {
+            val viewModel = fixture.viewModel
+            viewModel.loadContent(contentId = "movie", preferredFileId = 1)
+            starter.awaitRequestCount(1)
+            starter.complete(0, ready(starter.request(0), "session"))
+            viewModel.awaitState { it.sessionId == "session" && !it.isLoading }
+            val state = viewModel.uiState.value
+            val mount = MobileSubtitleMount(state.mediaMountGeneration, state.subtitleRefreshNonce)
+            viewModel.onSubtitleMediaMountApplied(mount)
+            viewModel.onMediaMountApplied(mount.generation)
+            assertTrue(viewModel.isCurrentSubtitleMount(mount))
+
+            // A replacement composition subscribes after the original collector is gone.
+            val reattachedMount = viewModel.mountedSubtitleMount.first()
+            assertEquals(mount, reattachedMount)
+            assertFalse(viewModel.shouldApplyMediaMount(mount.generation))
+            assertTrue(viewModel.isCurrentSubtitleMount(reattachedMount))
+
+            viewModel.onSubtitleMediaMountChanging()
+            assertNull(viewModel.mountedSubtitleMount.first())
+            assertFalse(viewModel.isCurrentSubtitleMount(reattachedMount))
+            viewModel.onSubtitleMediaMountApplied(mount)
+            assertTrue(viewModel.isCurrentSubtitleMount(viewModel.mountedSubtitleMount.first()))
+
+            viewModel.loadContent(contentId = "next", preferredFileId = 2)
+            assertNull(viewModel.mountedSubtitleMount.value)
+            assertFalse(viewModel.isCurrentSubtitleMount(mount))
+            starter.awaitRequestCount(2)
+            starter.complete(1, ready(starter.request(1), "next-session"))
+            viewModel.awaitState { it.sessionId == "next-session" && !it.isLoading }
+        } finally {
+            store.clear()
+        }
+    }
+
+    @Test
     fun differentContentLoadsCompletingOutOfOrderKeepNewestAndStopStaleReady() =
         runTest(dispatcher) {
             val starter = DeferredNonCooperativeStarter()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerScreen.kt
@@ -1842,6 +1842,7 @@ fun TvPlayerScreen(
     LaunchedEffect(videoBackend) {
         val backend = videoBackend ?: return@LaunchedEffect
         viewModel.subtitleMountRequests.collect { request ->
+            if (!viewModel.canApplySubtitleMount(request)) return@collect
             if (request.trackIndex == -1) {
                 if (backend.selectSubtitle(null)) {
                     viewModel.onSubtitleSelectionApplied(request)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -1126,6 +1126,7 @@ class TvPlayerViewModel(
         )
     private var subtitleMountGeneration = 0L
     private var lastAdapterMountIdentity: SubtitleIdentity? = null
+    private var lastAdapterMountGeneration: Long? = null
 
     /**
      * Authority for the NEXT mount the adapter arms, consumed by the snapshot
@@ -1188,6 +1189,7 @@ class TvPlayerViewModel(
             val localMountIdentity = snapshot.localMountIdentity
             if (localMountIdentity != null && localMountIdentity != lastAdapterMountIdentity) {
                 subtitleMountGeneration += 1
+                lastAdapterMountGeneration = subtitleMountGeneration
                 subtitleRemountReselection.arm(
                     identity = localMountIdentity,
                     generation = subtitleMountGeneration,
@@ -1202,6 +1204,12 @@ class TvPlayerViewModel(
                     .takeIf(List<PlayerTrackEntry>::isNotEmpty)
                     ?.let(::resolveSubtitleRemountReselection)
             } else if (localMountIdentity == null) {
+                lastAdapterMountGeneration?.let { generation ->
+                    if (subtitleRemountReselection.cancelOwned(generation)) {
+                        subtitleSnapshotSettlement.reset()
+                    }
+                }
+                lastAdapterMountGeneration = null
                 lastAdapterMountIdentity = null
             }
             if (autoSubtitleSelectionInFlight &&

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -1245,16 +1245,20 @@ class TvPlayerViewModel(
         onCommittedPlayback = ::adoptSubtitlePlayback,
         onCommittedPlaybackConfirmed = ::confirmSubtitlePlaybackPublication,
         onCommittedPlaybackRollback = ::rollbackSubtitlePlaybackPublication,
+        onEmbeddedSubtitleFailure = { serverIndex ->
+            startProtocolV3Replan(
+                classification = "subtitle_embedded_failed",
+                notice = "Embedded subtitles couldn't load. Retrying with a sidecar.",
+                state = _uiState.value,
+                subtitleTrackIndexOverride = serverIndex,
+            )
+        },
         onCommittedPlaybackFailure = { message ->
             _uiState.update { it.copy(error = message) }
         },
         hasMountableTracks = { _uiState.value.subtitleTracks.isNotEmpty() },
         isLocallyMountable = { identity ->
-            // Row-aware on purpose: a v3 inventory row describing a track muxed
-            // into a direct-play stream is still typed `delivery = sidecar`, so
-            // asking the identity resolver alone answered "not mounted" for the
-            // track Media3 already had, and every app-derived pick of it took
-            // the staged-replan path (see tvResolveMountedSubtitleTrack).
+            // Server-native and sidecar decisions require exact mounted IDs.
             val state = _uiState.value
             tvResolveMountedSubtitleTrack(
                 identity = identity,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -1776,6 +1776,10 @@ class TvPlayerViewModel(
      */
     fun onTransportMountApplied(nonce: Long) {
         if (transportMountGate.applied(nonce)) {
+            // A matching mount has replaced the item. Discard its predecessor's
+            // groups; only the new item's onTracksChanged can resolve subtitles.
+            _uiState.update { it.copy(subtitleTracks = emptyList()) }
+            subtitleSnapshotSettlement.reset()
             // The mounted item was replaced. Facts from the previous
             // transport's window must not be mapped through the new plan's
             // timeline offset — that can overstate the new extent and turn a
@@ -4377,15 +4381,16 @@ class TvPlayerViewModel(
         }
     }
 
+    internal fun canApplySubtitleMount(request: TvSubtitleMountRequest): Boolean =
+        !transportMountGate.suppressPositionReports &&
+            subtitleRemountReselection.ownsResolved(request.owner.generation)
+
     internal fun onSubtitleSelectionApplied(request: TvSubtitleMountRequest) {
-        val owner = request.owner
-        subtitleRemountReselection.acknowledgeResolved(owner.generation)
-        subtitleTransactions.reportMountedSelection(
-            identity = owner.identity,
-            selected = true,
-            snapshotKey = "tv-mounted:${owner.generation}:${request.trackIndex}",
-            settled = true,
-        )
+        if (!subtitleRemountReselection.ownsResolved(request.owner.generation)) return
+        // MediaController accepted the override, but its player may not have
+        // selected that group yet. A synchronous callback may already have
+        // published it; otherwise onTracksChanged will confirm it later.
+        resolveSubtitleRemountReselection(_uiState.value.subtitleTracks)
     }
 
     /**
@@ -4450,7 +4455,7 @@ class TvPlayerViewModel(
 
     internal fun onSubtitleSelectionFailed(request: TvSubtitleMountRequest) {
         val owner = request.owner
-        subtitleRemountReselection.acknowledgeResolved(owner.generation)
+        if (!subtitleRemountReselection.acknowledgeResolved(owner.generation)) return
         Log.w(
             TV_SUBTITLE_LOG_TAG,
             "Subtitle mount rejected by the player: track=${request.trackIndex} " +
@@ -4485,10 +4490,17 @@ class TvPlayerViewModel(
                 subtitleRows = _uiState.value.subtitleUrls,
                 snapshotKey = snapshotKey,
                 settled = subtitleSnapshotSettlement.observe(subtitle),
+                transportMounted = !transportMountGate.suppressPositionReports,
             )
         ) {
             is TvSubtitleRemountEvent.Select -> _subtitleMountRequests.tryEmit(
                 TvSubtitleMountRequest(owner = event.owner, trackIndex = event.trackIndex),
+            )
+            is TvSubtitleRemountEvent.Confirmed -> subtitleTransactions.reportMountedSelection(
+                identity = event.owner.identity,
+                selected = true,
+                snapshotKey = snapshotKey ?: "tv-subtitles-off:${event.owner.generation}",
+                settled = true,
             )
             is TvSubtitleRemountEvent.Failed -> subtitleTransactions.reportMountedSelection(
                 identity = event.owner.identity,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerViewModel.kt
@@ -180,7 +180,7 @@ internal fun authoritativePlaybackQualityOptions(
 ): List<VideoQualityOption> = available.map { quality ->
     VideoQualityOption(
         id = quality.label,
-        label = quality.label,
+        label = quality.displayName?.takeIf { it.isNotBlank() } ?: quality.label,
         isSelected = quality.label == selectedLabel,
         resolution = quality.height.takeIf { it > 0 }?.let { "${it}p" },
     )
@@ -2398,8 +2398,11 @@ class TvPlayerViewModel(
         if (recoveryJob?.isActive == true) {
             // Never silently drop a user selection: queue it (newest wins) and
             // re-drive it when the in-flight recovery completes. Failure-driven
-            // replans stay dropped — onPlayerError re-raises those.
-            if (classification in PlaybackSessionManager.USER_INVALIDATION_CLASSIFICATIONS) {
+            // replans stay dropped — onPlayerError re-raises those. Embedded
+            // mount failures have no player-error retry, so retain those too.
+            if (classification in PlaybackSessionManager.USER_INVALIDATION_CLASSIFICATIONS ||
+                classification == "subtitle_embedded_failed"
+            ) {
                 queuedRecoveryReplan = QueuedRecoveryReplan(
                     classification = classification,
                     notice = notice,
@@ -2596,6 +2599,10 @@ class TvPlayerViewModel(
                         )
                     }
                     is VideoSessionStartV3.Terminal -> {
+                        if (classification == "subtitle_embedded_failed") {
+                            onReplanRequestFailed(classification, notice, decision.message)
+                            return@launch
+                        }
                         val failedSessionId = state.sessionId ?: return@launch
                         val terminalMessage = serverTerminalUserMessage(decision.message)
                         cancelPendingCatalogSubtitle()
@@ -2627,6 +2634,10 @@ class TvPlayerViewModel(
                     }
                     VideoSessionStartV3.ServerUpgradeRequired -> {
                         cancelPendingCatalogSubtitle()
+                        if (classification == "subtitle_embedded_failed") {
+                            onReplanRequestFailed(classification, notice, "Server upgrade required")
+                            return@launch
+                        }
                         _uiState.update {
                             it.copy(
                                 error = "This Silo server must be updated to support playback recovery.",
@@ -2675,7 +2686,9 @@ class TvPlayerViewModel(
      * tear playback down with a fatal error banner.
      */
     private fun onReplanRequestFailed(classification: String, notice: String, detail: String?) {
-        if (classification in PlaybackSessionManager.USER_INVALIDATION_CLASSIFICATIONS) {
+        if (classification in PlaybackSessionManager.USER_INVALIDATION_CLASSIFICATIONS ||
+            classification == "subtitle_embedded_failed"
+        ) {
             Log.w(TAG, "Invalidation replan failed ($classification): $detail")
             _uiState.update { it.copy(isLoading = false, isBuffering = false) }
         } else {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleIdentity.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleIdentity.kt
@@ -29,25 +29,9 @@ internal fun tvMountedSubtitleIdentity(
         ?: tvSubtitleIdentity(track)
 
 /**
- * Resolves a typed identity onto the Media3 text track that ALREADY carries it,
- * or null when the player exposes no such track.
- *
- * [resolveMountedSubtitle] on its own is not enough for a SERVER-ROW identity.
- * Protocol v3 types every non-burn-in inventory row `delivery = sidecar`,
- * including a row that merely DESCRIBES a track muxed into a direct-play
- * stream — so an embedded PGS track plainly mounted by Media3 maps to
- * [SubtitleIdentity.ServerSidecar], and a sidecar identity is matched by its
- * authored `silo-subtitle:N` id alone, which a muxed track can never carry.
- * The answer came back "not mounted" for the very track on screen, and the
- * selection was routed to a server replan that re-extracted the same subtitle
- * as a sidecar: new session, media-item swap, rebuffer, restore seek.
- *
- * The inventory row is the missing evidence: matching through it is the same
- * mapping [tvMountedSubtitleIdentity] used to mint the identity in the first
- * place, so the two directions can no longer disagree. Only an identity that is
- * exactly some row's identity gets that fallback, and the row match still has
- * to find a mounted track — a catalog-only row, a sidecar the player has not
- * loaded and a burn-in row all still answer null and go on replanning.
+ * Server-native decisions resolve by their exact container track ID; sidecars
+ * resolve by their authored artifact ID. Only local/catalog rows without a v3
+ * delivery can use the metadata fallback below.
  */
 internal fun tvResolveMountedSubtitleTrack(
     identity: SubtitleIdentity,
@@ -56,6 +40,7 @@ internal fun tvResolveMountedSubtitleTrack(
 ): MountedSubtitleTrack? {
     resolveMountedSubtitle(identity = identity, tracks = mounted)?.let { return it.track }
     val row = identity.tvInventoryRow(subtitleRows) ?: return null
+    if (row.serverDelivery != null) return null
     return resolveMountedSubtitle(subtitle = row, tracks = mounted)?.track
 }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleRemountReselection.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleRemountReselection.kt
@@ -84,6 +84,8 @@ internal sealed interface TvSubtitleRemountEvent {
         val trackIndex: Int,
     ) : TvSubtitleRemountEvent
 
+    data class Confirmed(override val owner: TvSubtitleRemountOwner) : TvSubtitleRemountEvent
+
     data class Failed(
         override val owner: TvSubtitleRemountOwner,
         val reason: TvSubtitleRemountFailure,
@@ -105,7 +107,8 @@ internal class SubtitleRemountReselection(
      * survive until the mount is acknowledged, so a resolved owner keeps
      * defending its claim.
      *
-     * Released by [acknowledgeResolved] on mount success/failure, and by
+     * Released by a selected snapshot on success, [acknowledgeResolved] on
+     * failure, and by
      * [releaseResolved] when the acknowledgement can no longer arrive (backend
      * swap, mount deadline) — without which a dropped acknowledgement would
      * wedge subtitle mounting for the rest of the session.
@@ -113,7 +116,7 @@ internal class SubtitleRemountReselection(
     private var resolvedOwner: TvSubtitleRemountOwner? = null
 
     val hasPendingOwner: Boolean
-        get() = pendingOwner != null
+        get() = pendingOwner != null || resolvedOwner != null
 
     fun requiresRemount(identity: SubtitleIdentity): Boolean = when (identity) {
         SubtitleIdentity.Off,
@@ -129,9 +132,14 @@ internal class SubtitleRemountReselection(
     val pendingPriority: TvSubtitleMountPriority?
         get() = pendingOwner?.priority ?: resolvedOwner?.priority
 
-    /** Clears the resolved claim once its mount has been acknowledged. */
-    fun acknowledgeResolved(generation: Long) {
-        if (resolvedOwner?.generation == generation) resolvedOwner = null
+    fun ownsResolved(generation: Long): Boolean =
+        pendingOwner == null && resolvedOwner?.generation == generation
+
+    /** Clears the resolved claim once its mount has failed or been cancelled. */
+    fun acknowledgeResolved(generation: Long): Boolean {
+        if (!ownsResolved(generation)) return false
+        resolvedOwner = null
+        return true
     }
 
     /**
@@ -167,6 +175,7 @@ internal class SubtitleRemountReselection(
             return
         }
         SubDiag.log("REMOUNT arm $identity gen=$generation prio=$priority")
+        resolvedOwner = null
         pendingOwner = if (requiresRemount(identity)) {
             TvSubtitleRemountOwner(identity, generation, priority)
         } else {
@@ -187,9 +196,19 @@ internal class SubtitleRemountReselection(
         subtitleRows: List<PlayerSubtitleInfo> = emptyList(),
         snapshotKey: String?,
         settled: Boolean,
+        transportMounted: Boolean = true,
     ): TvSubtitleRemountEvent? {
-        val owner = pendingOwner ?: return null
+        // The old MediaItem can already contain this exact native track. Its
+        // group cannot satisfy a replacement item's selection.
+        if (!transportMounted) return null
+        val awaitingConfirmation = pendingOwner == null
+        val owner = pendingOwner ?: resolvedOwner ?: return null
         if (owner.identity == SubtitleIdentity.Off) {
+            if (awaitingConfirmation) {
+                if (subtitleTracks.any { it.isSelected }) return null
+                resolvedOwner = null
+                return TvSubtitleRemountEvent.Confirmed(owner)
+            }
             // Disabling the text renderer needs no track to exist, so this
             // deliberately resolves without inspecting the snapshot. A stale
             // Off owner reaching here at all is an OWNERSHIP failure, fixed by
@@ -229,10 +248,19 @@ internal class SubtitleRemountReselection(
         }
         SubDiag.log("REMOUNT consume id=${owner.identity} exact=$exactTrackId mounted=${mounted.map { it.trackId }} settled=$settled match=$matchIndex")
         if (matchIndex != null) {
+            if (awaitingConfirmation) {
+                if (subtitleTracks.none { it.index == matchIndex && it.isSelected }) return null
+                resolvedOwner = null
+                return TvSubtitleRemountEvent.Confirmed(owner)
+            }
             clear()
             resolvedOwner = owner
             return TvSubtitleRemountEvent.Select(owner, matchIndex)
         }
+
+        // Command acceptance is not evidence that Media3 selected the group.
+        // Keep ownership until a selected snapshot or the existing deadline.
+        if (awaitingConfirmation) return null
 
         val meaningfulKey = snapshotKey?.takeIf { subtitleTracks.isNotEmpty() }
         if (meaningfulKey != null) meaningfulSnapshotKeys += meaningfulKey

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleRemountReselection.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleRemountReselection.kt
@@ -154,6 +154,15 @@ internal class SubtitleRemountReselection(
         resolvedOwner = null
     }
 
+    /** Release an ended adapter mount without cancelling a newer transport mount. */
+    fun cancelOwned(generation: Long): Boolean {
+        val pending = pendingOwner?.generation == generation
+        val resolved = resolvedOwner?.generation == generation
+        if (pending) clear()
+        if (resolved) releaseResolved()
+        return pending || resolved
+    }
+
     fun arm(
         identity: SubtitleIdentity,
         generation: Long,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleRemountReselection.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleRemountReselection.kt
@@ -204,18 +204,14 @@ internal class SubtitleRemountReselection(
         val mounted = subtitleTracks.map(PlayerTrackEntry::toMountedTvSubtitleTrack)
         val exactTrackId = owner.identity.exactTvMountTrackId()
         val matchIndex = exactTrackId?.let { expected ->
-            // Every candidate here denotes the SAME authored artifact id, so
-            // multiple hits are the one sidecar merged more than once (Media3
-            // prefixes each with its MergingMediaSource child index, e.g.
-            // "1:silo-subtitle:3" and "2:silo-subtitle:3"). That is not the
-            // ambiguity this guard exists for — it cannot select the wrong
-            // language — so refusing on it left the mount unresolved until the
-            // deadline blew and the transaction rolled back to Off. Ambiguity
-            // between genuinely different tracks is still caught by the
-            // metadata path below and by hasAmbiguousTvLabel.
-            mounted.filter { trackIdDenotes(it.trackId, expected) }
-                .minByOrNull { it.index }
-                ?.index
+            // Authored sidecars may be merged more than once; choose the first
+            // copy. A native container identity must resolve to one track.
+            val matches = mounted.filter { trackIdDenotes(it.trackId, expected) }
+            if (owner.identity is SubtitleIdentity.Embedded && owner.identity.containerTrackId != null) {
+                matches.singleOrNull()?.index
+            } else {
+                matches.minByOrNull { it.index }?.index
+            }
         } ?: when {
             // An identity carrying a REAL Media3 id stays exact-only: falling
             // back to metadata could mount a different track that merely looks
@@ -267,7 +263,7 @@ internal class SubtitleRemountReselection(
 private fun SubtitleIdentity.exactTvMountTrackId(): String? = when (this) {
     is SubtitleIdentity.ServerSidecar -> subtitleArtifactTrackId(serverIndex)
     is SubtitleIdentity.Downloaded -> downloadedSubtitleArtifactTrackId(downloadId)
-    is SubtitleIdentity.Embedded -> media.trackId?.trim()?.takeIf(String::isNotEmpty)
+    is SubtitleIdentity.Embedded -> containerTrackId ?: media.trackId?.trim()?.takeIf(String::isNotEmpty)
     is SubtitleIdentity.LocalMedia3 -> media.trackId?.trim()?.takeIf(String::isNotEmpty)
     SubtitleIdentity.Off,
     is SubtitleIdentity.ServerBurnIn,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapter.kt
@@ -2148,10 +2148,28 @@ internal class TvSubtitleTransactionAdapter(
         val failedIdentity = (if (ownedSelection) pendingLocalSelection?.identity else pendingLocalRestore?.identity)
             as? SubtitleIdentity.Embedded
         if (failedIdentity?.containerTrackId != null) {
-            invalidateLocalMount()
-            failureMessage = "Embedded subtitles couldn't load. Retrying with a sidecar."
-            publish()
-            onEmbeddedSubtitleFailure(failedIdentity.serverIndex)
+            val selection = pendingLocalSelection.takeIf { ownedSelection }
+            if (selection?.committedPlayback != null) {
+                // Regular replans wait for publication settlement. Restore the
+                // healthy predecessor before starting the sidecar request.
+                val failedContentGeneration = contentGeneration
+                val failedIntentGeneration = subtitleIntentGeneration
+                val rollback = requestSupersessionSettlement(selection, restoreUi = true)
+                settlementScope.launch {
+                    if (rollback.await() && failedContentGeneration == contentGeneration &&
+                        failedIntentGeneration == subtitleIntentGeneration
+                    ) {
+                        failureMessage = "Embedded subtitles couldn't load. Retrying with a sidecar."
+                        publish()
+                        onEmbeddedSubtitleFailure(failedIdentity.serverIndex)
+                    }
+                }
+            } else {
+                invalidateLocalMount()
+                failureMessage = "Embedded subtitles couldn't load. Retrying with a sidecar."
+                publish()
+                onEmbeddedSubtitleFailure(failedIdentity.serverIndex)
+            }
             return
         }
         val selection = pendingLocalSelection

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapter.kt
@@ -2165,6 +2165,13 @@ internal class TvSubtitleTransactionAdapter(
                     }
                 }
             } else {
+                // A failed restore has no mounted subtitle to keep selected,
+                // even if its sidecar retry is rejected. Do not persist Off.
+                if (ownedRestore && transition.committed.identity == failedIdentity) {
+                    transition = transition.copy(
+                        committed = transition.committed.copy(identity = SubtitleIdentity.Off),
+                    )
+                }
                 invalidateLocalMount()
                 failureMessage = "Embedded subtitles couldn't load. Retrying with a sidecar."
                 publish()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapter.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapter.kt
@@ -267,6 +267,7 @@ internal class TvSubtitleTransactionAdapter(
         Boolean,
     ) -> Boolean = { _, _ -> true },
     private val onCommittedPlaybackFailure: suspend (String) -> Unit = {},
+    private val onEmbeddedSubtitleFailure: (Int) -> Unit = {},
     /**
      * Whether the player currently exposes any text track to mount against.
      * The mount deadline must not run while the answer is "none": a freshly
@@ -2144,6 +2145,15 @@ internal class TvSubtitleTransactionAdapter(
         val ownedSelection = pendingLocalSelection?.generation == generation
         val ownedRestore = pendingLocalRestore?.generation == generation
         if (!ownedSelection && !ownedRestore) return
+        val failedIdentity = (if (ownedSelection) pendingLocalSelection?.identity else pendingLocalRestore?.identity)
+            as? SubtitleIdentity.Embedded
+        if (failedIdentity?.containerTrackId != null) {
+            invalidateLocalMount()
+            failureMessage = "Embedded subtitles couldn't load. Retrying with a sidecar."
+            publish()
+            onEmbeddedSubtitleFailure(failedIdentity.serverIndex)
+            return
+        }
         val selection = pendingLocalSelection
         if (ownedSelection && selection?.committedPlayback != null) {
             requestCompensationSettlement(selection)
@@ -2490,6 +2500,10 @@ private fun TvStagedSubtitleCandidate.validationFailure(
             ?: return "The adapted candidate omitted its selected subtitle identity."
         return validationFailure(returnedIdentity)
     }
+    if (selectedSubtitleIdentity is SubtitleIdentity.Embedded &&
+        selectedSubtitleIdentity.containerTrackId != null &&
+        selectedSubtitleIndex == expectedSubtitleIndex && subtitleMode == PlaybackSubtitleModeV3.RENDER && !hasSidecar
+    ) return null
     return when (requested.identity) {
         is SubtitleIdentity.Embedded,
         is SubtitleIdentity.Downloaded,
@@ -2589,7 +2603,9 @@ private fun TvStagedSubtitleCandidate.validationFailure(
             "The candidate did not burn in the requested subtitle."
         else -> null
     }
-    is SubtitleIdentity.Embedded,
+    is SubtitleIdentity.Embedded -> if (identity.containerTrackId != null &&
+        selectedSubtitleIndex == identity.serverIndex && subtitleMode == PlaybackSubtitleModeV3.RENDER && !hasSidecar
+    ) null else "The candidate omitted the exact embedded subtitle."
     is SubtitleIdentity.Downloaded,
     is SubtitleIdentity.LocalMedia3,
     -> "A local subtitle identity unexpectedly reached staged validation."

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/SubtitleRemountReselectionTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/SubtitleRemountReselectionTest.kt
@@ -1,6 +1,8 @@
 package org.siloserver.silo.tv.ui.screens.player
 
 import org.siloserver.silo.common.player.subtitleArtifactTrackId
+import org.siloserver.silo.model.playback.PlayerSubtitleInfo
+import org.siloserver.silo.playback.playbackSubtitleIdentity
 import org.siloserver.silo.model.playback.SubtitleIdentity
 import org.siloserver.silo.model.playback.SubtitleMediaIdentity
 import java.io.File
@@ -12,6 +14,27 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SubtitleRemountReselectionTest {
+    @Test
+    fun `native inventory identity remounts only its unique container track`() {
+        val row = PlayerSubtitleInfo(
+            index = 0, language = "en", codec = "mov_text", label = "English",
+            source = "embedded", url = "/subtitles/0.vtt",
+            serverTrackId = "file:42:subtitle:0", serverDelivery = "sidecar",
+            nativeContainerTrackId = "19",
+        )
+        val identity = playbackSubtitleIdentity(row)
+        val intended = track(index = 3, trackId = "0:19", codec = "mov_text")
+        val sibling = track(index = 2, trackId = "0:23", codec = "mov_text")
+        fun consume(tracks: List<PlayerTrackEntry>): TvSubtitleRemountEvent? {
+            val latch = SubtitleRemountReselection()
+            latch.arm(identity, generation = 1)
+            return latch.consume(tracks, listOf(row), snapshotKey = "ready", settled = true)
+        }
+        assertEquals(3, assertIs<TvSubtitleRemountEvent.Select>(consume(listOf(sibling, intended))).trackIndex)
+        assertIs<TvSubtitleRemountEvent.Failed>(consume(listOf(sibling)))
+        assertIs<TvSubtitleRemountEvent.Failed>(consume(listOf(intended, intended.copy(index = 4))))
+    }
+
     @Test
     fun `ViewModel does not settle the first nonempty remount snapshot`() {
         val tracker = TvSubtitleSnapshotSettlementTracker()

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/SubtitleRemountReselectionTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/SubtitleRemountReselectionTest.kt
@@ -36,6 +36,74 @@ class SubtitleRemountReselectionTest {
     }
 
     @Test
+    fun `native selection waits for replacement media and an observed selected track`() {
+        val gate = TvTransportMountGate()
+        val latch = SubtitleRemountReselection()
+        val identity = SubtitleIdentity.Embedded(
+            serverIndex = 1, media = media(codec = "mov_text"), containerTrackId = "3",
+        )
+        val old = track(index = 0, trackId = "0:3", codec = "mov_text", selected = true)
+        fun consume(tracks: List<PlayerTrackEntry>) = latch.consume(
+            tracks, snapshotKey = tracks.toString(), settled = true,
+            transportMounted = !gate.suppressPositionReports,
+        )
+        gate.expect(2)
+        latch.arm(identity, generation = 2)
+        assertNull(consume(listOf(old)), "The old item already contains the native track")
+        assertFalse(gate.applied(1), "An older mount cannot open this boundary")
+        assertNull(consume(listOf(old)))
+        assertTrue(gate.applied(2))
+        assertNull(consume(emptyList()))
+        val replacement = old.copy(trackId = "3", isSelected = false)
+        val selection = assertIs<TvSubtitleRemountEvent.Select>(consume(listOf(replacement)))
+        assertEquals(0, selection.trackIndex)
+        assertTrue(latch.ownsResolved(selection.owner.generation))
+        assertNull(consume(listOf(replacement)), "An accepted override is not a selected track")
+        val confirmation = assertIs<TvSubtitleRemountEvent.Confirmed>(
+            consume(listOf(replacement.copy(isSelected = true))),
+        )
+        assertEquals(identity, confirmation.owner.identity)
+        assertFalse(latch.hasPendingOwner)
+        assertNull(consume(listOf(replacement.copy(isSelected = true))))
+    }
+
+    @Test
+    fun `replacement failure or burn-in cannot revive an older unconfirmed selection`() {
+        val oldTrack = track(0, "3", codec = "mov_text")
+        val oldIdentity = SubtitleIdentity.Embedded(1, media(codec = "mov_text"), "3")
+        for (replacement in listOf(SubtitleIdentity.ServerSidecar(9), SubtitleIdentity.ServerBurnIn(9))) {
+            val latch = SubtitleRemountReselection()
+            latch.arm(oldIdentity, generation = 1)
+            assertIs<TvSubtitleRemountEvent.Select>(
+                latch.consume(listOf(oldTrack), snapshotKey = "old", settled = true),
+            )
+            latch.arm(replacement, generation = 2)
+            assertFalse(latch.ownsResolved(1))
+            val result = latch.consume(listOf(oldTrack), snapshotKey = "missing", settled = true)
+            if (replacement is SubtitleIdentity.ServerSidecar) {
+                assertIs<TvSubtitleRemountEvent.Failed>(result)
+            } else {
+                assertNull(result)
+            }
+            assertNull(latch.consume(listOf(oldTrack.copy(isSelected = true)), snapshotKey = "late", settled = true))
+            assertFalse(latch.hasPendingOwner)
+        }
+    }
+
+    @Test
+    fun `Off waits until the mounted snapshot has no selected text`() {
+        val latch = SubtitleRemountReselection()
+        latch.arm(SubtitleIdentity.Off, generation = 3)
+        val selected = listOf(track(0, "3", selected = true))
+        assertIs<TvSubtitleRemountEvent.Select>(latch.consume(selected, snapshotKey = "old", settled = true))
+        assertNull(latch.consume(selected, snapshotKey = "old", settled = true))
+        assertIs<TvSubtitleRemountEvent.Confirmed>(
+            latch.consume(selected.map { it.copy(isSelected = false) }, snapshotKey = "off", settled = true),
+        )
+        assertFalse(latch.hasPendingOwner)
+    }
+
+    @Test
     fun `ViewModel does not settle the first nonempty remount snapshot`() {
         val tracker = TvSubtitleSnapshotSettlementTracker()
         val first = listOf(track(index = 1, trackId = "silo-subtitle:4"))
@@ -395,6 +463,9 @@ class SubtitleRemountReselectionTest {
 
         assertEquals(-1, event.trackIndex)
         assertEquals(5, event.owner.generation)
+        assertIs<TvSubtitleRemountEvent.Confirmed>(
+            latch.consume(emptyList(), snapshotKey = null, settled = false),
+        )
         assertNull(latch.consume(emptyList(), snapshotKey = null, settled = false))
     }
 

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/SubtitleRemountReselectionTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/SubtitleRemountReselectionTest.kt
@@ -15,6 +15,43 @@ import kotlin.test.assertTrue
 
 class SubtitleRemountReselectionTest {
     @Test
+    fun `ended adapter mount releases unconfirmed selection for automatic restore`() {
+        val latch = SubtitleRemountReselection()
+        val identity = SubtitleIdentity.ServerSidecar(4)
+        val mounted = listOf(track(0, subtitleArtifactTrackId(4)))
+        latch.arm(identity, generation = 1)
+        assertIs<TvSubtitleRemountEvent.Select>(latch.consume(mounted, snapshotKey = "ready", settled = true))
+        assertTrue(latch.hasPendingOwner)
+
+        assertTrue(latch.cancelOwned(1))
+        assertFalse(latch.hasPendingOwner)
+        assertFalse(latch.ownsResolved(1), "A queued command from the timed-out mount must be rejected")
+        latch.arm(identity, generation = 2, priority = TvSubtitleMountPriority.Auto)
+        val retry = assertIs<TvSubtitleRemountEvent.Select>(
+            latch.consume(mounted, snapshotKey = "retry", settled = true),
+        )
+        assertEquals(2, retry.owner.generation)
+    }
+
+    @Test
+    fun `ending an old adapter mount preserves a newer transport owner`() {
+        for (resolved in listOf(false, true)) {
+            val latch = SubtitleRemountReselection()
+            val identity = SubtitleIdentity.ServerSidecar(4)
+            val mounted = listOf(track(0, subtitleArtifactTrackId(4)))
+            latch.arm(identity, generation = 1)
+            latch.arm(identity, generation = 2)
+            if (resolved) {
+                assertIs<TvSubtitleRemountEvent.Select>(latch.consume(mounted, snapshotKey = "ready", settled = true))
+            }
+            assertFalse(latch.cancelOwned(1))
+            assertTrue(latch.hasPendingOwner)
+            assertTrue(latch.cancelOwned(2))
+            assertFalse(latch.hasPendingOwner)
+        }
+    }
+
+    @Test
     fun `native inventory identity remounts only its unique container track`() {
         val row = PlayerSubtitleInfo(
             index = 0, language = "en", codec = "mov_text", label = "English",

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackQualityOptionsTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlaybackQualityOptionsTest.kt
@@ -8,6 +8,20 @@ import kotlin.test.assertTrue
 
 class TvPlaybackQualityOptionsTest {
     @Test
+    fun displayNamesDoNotChangeSelectionIds() {
+        val options = authoritativePlaybackQualityOptions(
+            listOf(
+                PlaybackAvailableQualityV3("1080p-medium", displayName = "1080p Medium"),
+                PlaybackAvailableQualityV3("original", displayName = " "),
+            ),
+            selectedLabel = "1080p-medium",
+        )
+        assertEquals(listOf("1080p-medium", "original"), options.map { it.id })
+        assertEquals(listOf("1080p Medium", "original"), options.map { it.label })
+        assertTrue(options.first().isSelected)
+    }
+
+    @Test
     fun authoritativeMenuPreservesServerMembershipOrderAndLabels() {
         val options = authoritativePlaybackQualityOptions(
             available = listOf(

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerSubtitleIntegrationPolicyTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvPlayerSubtitleIntegrationPolicyTest.kt
@@ -434,35 +434,13 @@ class TvPlayerSubtitleIntegrationPolicyTest {
         )
     }
 
-    // ---- Already-mounted picks must never replan ---------------------------
-    //
-    // Regression: protocol v3 types EVERY non-burn-in inventory row
-    // `delivery = sidecar`, including the row that merely describes a track
-    // muxed into a direct-play stream. The launch auto-pick of an embedded PGS
-    // track therefore resolved to a ServerSidecar identity, which the mount
-    // resolver matches by its authored `silo-subtitle:N` id alone — so the
-    // adapter was told the track on screen was not mounted and staged a server
-    // replan for it: new session, media-item swap, seconds of rebuffering, and
-    // a duplicate of the same PGS track re-extracted as a sidecar.
-
     @Test
-    fun `a v3 row for a muxed track is a sidecar identity that still resolves in place`() {
+    fun `v3 sidecar rows do not infer native selection from matching metadata`() {
         val row = planEmbeddedPgsRow()
         val track = embeddedPgsTrack()
-
-        // The identity is genuinely ServerSidecar — this is the shape the HUD,
-        // persistence and the adapter all carry, and it is not being changed.
         val identity = assertIs<SubtitleIdentity.ServerSidecar>(tvSubtitleIdentity(row))
-        assertEquals(identity, tvMountedSubtitleIdentity(track, listOf(track), listOf(row)))
-
-        assertEquals(
-            track.index,
-            tvResolveMountedSubtitleTrack(
-                identity = identity,
-                subtitleRows = listOf(row),
-                mounted = listOf(track.toMountedTvSubtitleTrack()),
-            )?.index,
-        )
+        assertIs<SubtitleIdentity.LocalMedia3>(tvMountedSubtitleIdentity(track, listOf(track), listOf(row)))
+        assertEquals(null, tvResolveMountedSubtitleTrack(identity, listOf(row), listOf(track.toMountedTvSubtitleTrack())))
     }
 
     @Test
@@ -480,56 +458,22 @@ class TvPlayerSubtitleIntegrationPolicyTest {
     }
 
     @Test
-    fun `english always commits an already-mounted PGS track in place`() = runTest {
+    fun `server sidecar PGS choice negotiates despite a similar mounted track`() = runTest {
         val row = planEmbeddedPgsRow()
-        val track = embeddedPgsTrack()
-        val identity = tvSubtitleIdentity(row)
-        val harness = harness(backgroundScope, rows = listOf(row), mounted = listOf(track))
-
-        harness.adapter.selectAuto(identity)
+        val harness = harness(backgroundScope, rows = listOf(row), mounted = listOf(embeddedPgsTrack()))
+        harness.adapter.selectAuto(tvSubtitleIdentity(row))
         runCurrent()
+        assertEquals(listOf(row.index), harness.staged.map { it.subtitleTrackIndex })
+        assertEquals(null, harness.adapter.snapshot.localMountIdentity)
+    }
 
-        assertTrue(
-            harness.staged.isEmpty(),
-            "an already-mounted track must not ask the server to replan",
-        )
-        assertEquals(identity, harness.adapter.snapshot.localMountIdentity)
-
-        // The mount the adapter armed resolves onto the muxed ordinal…
-        val remount = SubtitleRemountReselection()
-        remount.arm(identity, generation = 1L)
-        val event = assertIs<TvSubtitleRemountEvent.Select>(
-            remount.consume(
-                subtitleTracks = listOf(track),
-                subtitleRows = listOf(row),
-                snapshotKey = "mounted",
-                settled = true,
-            ),
-        )
-        assertEquals(track.index, event.trackIndex)
-
-        // …and acknowledging it commits the identity the HUD ticks.
-        harness.adapter.reportMountedSelection(
-            identity = identity,
-            selected = true,
-            snapshotKey = "mounted",
-            settled = true,
-        )
-        runCurrent()
-
-        assertEquals(identity, harness.adapter.snapshot.committedIdentity)
-        assertTrue(harness.staged.isEmpty())
-        val presentation = buildTvSubtitleHudPresentation(
-            options = buildTvSubtitleHudOptions(
-                subtitleUrls = listOf(row),
-                subtitleTracks = listOf(track),
-            ),
-            committedIdentity = harness.adapter.snapshot.committedIdentity,
-            pendingIdentity = harness.adapter.snapshot.pendingIdentity,
-            hudOpen = true,
-            focusedStableId = null,
-        )
-        assertEquals(identity, presentation.rows.single { it.checked }.identity)
+    @Test
+    fun `native MP4 decision resolves exact container ID despite duplicate metadata`() {
+        val row = planEmbeddedPgsRow().copy(codec = "mov_text", nativeContainerTrackId = "19")
+        val track = embeddedPgsTrack().copy(trackId = "0:19")
+        val identity = assertIs<SubtitleIdentity.Embedded>(tvSubtitleIdentity(row))
+        assertEquals(track.index, tvResolveMountedSubtitleTrack(identity, listOf(row), listOf(track.toMountedTvSubtitleTrack()))?.index)
+        assertEquals(null, tvResolveMountedSubtitleTrack(identity, listOf(row), listOf(track.copy(trackId = "2").toMountedTvSubtitleTrack())))
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapterTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapterTest.kt
@@ -2200,12 +2200,46 @@ class TvSubtitleTransactionAdapterTest {
         assertEquals(listOf(sidecar(4)), harness.persistence.persisted.map { it.identity })
     }
 
+    @Test
+    fun `native decision commits exact identity and requests sidecar recovery on mount timeout`() = runTest {
+        val failures = mutableListOf<Int>()
+        val harness = harness(backgroundScope, onEmbeddedFailure = failures::add)
+        val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+        harness.adapter.select(sidecar(4))
+        runCurrent()
+        harness.port.completeStage(candidate("native", 4, hasSidecar = false, selectedSubtitleIdentity = native))
+        runCurrent()
+        assertEquals(native, harness.adapter.snapshot.localMountIdentity)
+        assertTrue(harness.persistence.persisted.isEmpty())
+        advanceTimeBy(5_000)
+        runCurrent()
+        assertEquals(listOf(4), failures)
+        assertNull(harness.adapter.snapshot.localMountIdentity)
+        assertTrue(harness.persistence.persisted.isEmpty())
+    }
+
+    @Test
+    fun `native decision only persists after exact mounted selection succeeds`() = runTest {
+        val harness = harness(backgroundScope)
+        val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+        harness.adapter.select(sidecar(4))
+        runCurrent()
+        harness.port.completeStage(candidate("native", 4, hasSidecar = false, selectedSubtitleIdentity = native))
+        runCurrent()
+        assertTrue(harness.persistence.persisted.isEmpty())
+        harness.adapter.reportMountedSelection(native, selected = true, snapshotKey = "native19", settled = true)
+        runCurrent()
+        assertEquals(native, harness.adapter.snapshot.committedIdentity)
+        assertEquals(listOf(native), harness.persistence.persisted.map { it.identity })
+    }
+
     private fun harness(
         scope: CoroutineScope,
         sessionId: String? = "s1",
         tracks: List<PlayerSubtitleInfo> = emptyList(),
         adoption: AdoptionControl = AdoptionControl(),
         durablePersistenceScope: CoroutineScope = scope,
+        onEmbeddedFailure: (Int) -> Unit = {},
         isLocallyMountable: (SubtitleIdentity) -> Boolean = { identity ->
             identity !is SubtitleIdentity.ServerSidecar
         },
@@ -2220,6 +2254,7 @@ class TvSubtitleTransactionAdapterTest {
             stagedPort = port,
             persistencePort = persistence,
             durablePersistenceScope = durablePersistenceScope,
+            onEmbeddedSubtitleFailure = onEmbeddedFailure,
             persistenceCoordinator = persistenceCoordinator,
             onCommittedPlayback = { adoptionRequest ->
                 adoption.started += 1

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapterTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapterTest.kt
@@ -2219,6 +2219,33 @@ class TvSubtitleTransactionAdapterTest {
     }
 
     @Test
+    fun `failed native restore clears only the unmounted committed subtitle`() = runTest {
+        for (timeout in listOf(false, true)) {
+            val failures = mutableListOf<Int>()
+            val harness = harness(backgroundScope, onEmbeddedFailure = failures::add)
+            val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+            harness.adapter.resetContent(context(), committedIdentity = native)
+            val prior = harness.adapter.snapshot.transition.committed
+            harness.adapter.restoreCommittedLocalMount()
+            if (timeout) {
+                advanceTimeBy(5_000)
+            } else {
+                repeat(2) {
+                    harness.adapter.reportMountedSelection(native, selected = false, snapshotKey = "missing-native", settled = true)
+                }
+            }
+            runCurrent()
+
+            assertEquals(listOf(4), failures)
+            assertEquals(prior.copy(identity = SubtitleIdentity.Off), harness.adapter.snapshot.transition.committed)
+            assertNull(harness.adapter.snapshot.localMountIdentity)
+            assertFalse(harness.adapter.hasActiveTransaction)
+            assertTrue(harness.persistence.persisted.isEmpty())
+            assertTrue(harness.committedPlaybacks.isEmpty())
+        }
+    }
+
+    @Test
     fun `native fallback waits for rollback before replanning the failed track`() = runTest {
         val failures = mutableListOf<Int>()
         val harness = harness(backgroundScope, onEmbeddedFailure = failures::add)

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapterTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/TvSubtitleTransactionAdapterTest.kt
@@ -2219,6 +2219,47 @@ class TvSubtitleTransactionAdapterTest {
     }
 
     @Test
+    fun `native fallback waits for rollback before replanning the failed track`() = runTest {
+        val failures = mutableListOf<Int>()
+        val harness = harness(backgroundScope, onEmbeddedFailure = failures::add)
+        harness.port.abandonGate = kotlinx.coroutines.CompletableDeferred()
+        val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+        harness.adapter.select(sidecar(4))
+        runCurrent()
+        harness.port.completeStage(candidate("native", 4, hasSidecar = false, selectedSubtitleIdentity = native, sessionId = "s2"))
+        runCurrent()
+        advanceTimeBy(5_000)
+        runCurrent()
+        assertTrue(failures.isEmpty())
+        assertTrue(harness.port.abandoned.isEmpty())
+        harness.port.abandonGate!!.complete(Unit)
+        runCurrent()
+        assertEquals(listOf("s2"), harness.port.abandoned)
+        assertEquals(listOf(4), failures)
+        assertEquals(sidecar(3), harness.adapter.snapshot.committedIdentity)
+        assertTrue(harness.persistence.persisted.isEmpty())
+    }
+
+    @Test
+    fun `content reset during native rollback does not retry the old track`() = runTest {
+        val failures = mutableListOf<Int>()
+        val harness = harness(backgroundScope, onEmbeddedFailure = failures::add)
+        harness.port.abandonGate = kotlinx.coroutines.CompletableDeferred()
+        val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
+        harness.adapter.select(sidecar(4))
+        runCurrent()
+        harness.port.completeStage(candidate("native", 4, hasSidecar = false, selectedSubtitleIdentity = native))
+        runCurrent()
+        advanceTimeBy(5_000)
+        runCurrent()
+        harness.adapter.resetContent(context(contentId = "next-content"), SubtitleIdentity.Off)
+        harness.port.abandonGate!!.complete(Unit)
+        runCurrent()
+        assertTrue(failures.isEmpty())
+        assertEquals(SubtitleIdentity.Off, harness.adapter.snapshot.committedIdentity)
+    }
+
+    @Test
     fun `native decision only persists after exact mounted selection succeeds`() = runTest {
         val harness = harness(backgroundScope)
         val native = SubtitleIdentity.Embedded(4, SubtitleMediaIdentity(language = "eng", codecFamily = "mov_text"), "19")
@@ -2533,7 +2574,10 @@ class TvSubtitleTransactionAdapterTest {
             }
         }
 
+        var abandonGate: kotlinx.coroutines.CompletableDeferred<Unit>? = null
+
         override suspend fun abandonCommitted(playback: TvSubtitleCommittedPlayback) {
+            abandonGate?.await()
             abandoned += playback.sessionId
         }
 

--- a/docs/playback/README.md
+++ b/docs/playback/README.md
@@ -62,3 +62,25 @@ feature token has the same name.
 - **Device outcomes** remain unproven until tested on the named device, display,
   HDMI/eARC chain, and AVR. A decoded frame alone does not prove correct HDR or
   passthrough output.
+
+## Native embedded subtitles
+
+Android advertises `embedded_subtitles_v1` only when the original-HTTP delivery
+includes a `native_embedded` capability. The first supported pair is MP4 with
+`mov_text`, using `container_track_id`. Media3 1.11.0 sets a timed-text format's
+ID from the MP4 `tkhd` track ID; FFmpeg stream indexes are not Media3 track IDs.
+See the pinned [Media3 MP4 parser](https://github.com/androidx/media/blob/1.11.0/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java).
+
+A plan's `subtitle.embedded` selects the exact container track. Inventory URLs
+remain fallback descriptions and are not mounted alongside that selection.
+Phone and TV commit the preference only after the native track is mounted.
+Missing, ambiguous, or unsupported identities produce `subtitle_embedded_failed`
+and let the server replan with its sidecar path. Matroska and tracks without a
+probed container ID keep using sidecars; metadata similarity is not exact
+identity evidence.
+
+Sidecar cues use absolute source timestamps. Android subtracts the plan's
+`timeline_offset_seconds` once, alongside the user's subtitle delay. Embedded
+cues already follow the extractor timeline and receive only the user delay.
+
+Cast uses the default receiver, which renders VTT in the transport clock. At a nonzero video timeline offset, the VTT URL adds `timestamp_offset=-timeline_offset_seconds`, preserving the file/provider identity and stream authorization query parameters. The server shifts the canonical source-time cues for that response; native Android renderers continue applying their local subtitle offset.

--- a/shared/src/androidUnitTest/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3ConformanceTest.kt
+++ b/shared/src/androidUnitTest/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3ConformanceTest.kt
@@ -78,6 +78,7 @@ private data class SourceDescriptorFixtureV3(
     @SerialName("hdr10_plus") val hdr10Plus: Boolean = false,
     @SerialName("dolby_vision_profile") val dolbyVisionProfile: Int = 0,
     @SerialName("dv_bl_compat_id") val dolbyVisionBaseLayerCompatibilityId: Int = 0,
+    @SerialName("dv_base_layer_proven") val dolbyVisionBaseLayerProven: Boolean = false,
     @SerialName("dv_enhancement_layer") val dolbyVisionEnhancementLayer: String,
     @SerialName("audio_codec") val audioCodec: String? = null,
     @SerialName("audio_channels") val audioChannels: Int = 0,
@@ -372,14 +373,6 @@ class PlaybackProtocolV3ConformanceTest {
      */
     @Test
     fun contextNamesTheBuildAndChannelBehindTheAppVersion() {
-        listOf("start_request.json", "replan_request.json").forEach { name ->
-            val context = SiloJson.parseToJsonElement(fixture(name))
-                .jsonObject["client_playback_context"]!!.jsonObject
-
-            assertEquals("5", context["app_build"]?.jsonPrimitive?.content, "$name: app_build")
-            assertEquals("production", context["app_channel"]?.jsonPrimitive?.content, "$name: app_channel")
-        }
-
         val encoded = json.encodeToJsonElement(
             ClientPlaybackContext.serializer(),
             ClientPlaybackContext(
@@ -548,8 +541,8 @@ class PlaybackProtocolV3ConformanceTest {
         val matrix = json.decodeFromString(ConformanceMatrixFixtureV3.serializer(), raw)
 
         assertEquals(1, matrix.schemaVersion)
-        assertEquals(17, matrix.plannerScenarios.size)
-        assertEquals(9, matrix.replanScenarios.size)
+        assertEquals(21, matrix.plannerScenarios.size)
+        assertEquals(10, matrix.replanScenarios.size)
         assertEquals(8, matrix.protocolScenarios.size)
         assertClientReadsEveryFieldExcept(
             raw,

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackModels.kt
@@ -70,6 +70,8 @@ data class PlayerSubtitleInfo(
     @SerialName("server_track_id") val serverTrackId: String? = null,
     /** Protocol-v3 representation: `sidecar` or `burn_in_only`. */
     @SerialName("server_delivery") val serverDelivery: String? = null,
+    /** Exact original-container track ID selected by a v3 embedded decision. */
+    @SerialName("native_container_track_id") val nativeContainerTrackId: String? = null,
 )
 
 /**
@@ -449,7 +451,17 @@ data class DeliveryCapability(
 )
 
 @Serializable
+data class NativeEmbeddedSubtitleCapability(
+    val container: String,
+    val codecs: List<String>,
+    @SerialName("track_identity") val trackIdentity: String,
+    @SerialName("ass_styling") val assStyling: Boolean = false,
+    @SerialName("font_attachments") val fontAttachments: Boolean = false,
+)
+
+@Serializable
 data class DeliverySubtitleCapabilities(
+    @SerialName("native_embedded") val nativeEmbedded: List<NativeEmbeddedSubtitleCapability> = emptyList(),
     @SerialName("embedded_text") val embeddedText: Boolean = true,
     @SerialName("sidecar_text") val sidecarText: Boolean = true,
     @SerialName("ass_styling") val assStyling: Boolean = false,

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/PlaybackProtocolV3.kt
@@ -20,6 +20,7 @@ const val CLIENT_VIDEO_TRANSFORMATIONS_FEATURE = "client_video_transformations_v
 const val DEVICE_QUIRKS_V3_FEATURE = "device_quirks_v1"
 const val SEEK_REANCHOR_V3_FEATURE = "seek_reanchor_v1"
 const val DIRECT_STREAM_RESUME_V1_FEATURE = "direct_stream_resume_v1"
+const val EMBEDDED_SUBTITLES_V1_FEATURE = "embedded_subtitles_v1"
 const val NATIVE_HLS_PLAYBACK_V1_FEATURE = "native_hls_playback_v1"
 
 /**
@@ -108,6 +109,9 @@ val PLAYBACK_START_CLIENT_FEATURES_V3 = listOf(
  */
 fun playbackClientFeaturesV3(context: ClientPlaybackContext): List<String> = buildList {
     addAll(PLAYBACK_START_CLIENT_FEATURES_V3)
+    if (!context.deliveries[DELIVERY_CLASS_ORIGINAL_HTTP]?.subtitles?.nativeEmbedded.isNullOrEmpty()) {
+        add(EMBEDDED_SUBTITLES_V1_FEATURE)
+    }
     if (!context.output.audioPassthrough?.entries.isNullOrEmpty()) {
         add(LAYOUT_AWARE_PASSTHROUGH_FEATURE)
     }
@@ -234,6 +238,7 @@ data class PlaybackAvailableQualityV3(
     val height: Int = 0,
     @SerialName("bitrate_kbps") val bitrateKbps: Int = 0,
     @SerialName("preserves_source") val preservesSource: Boolean = false,
+    @SerialName("display_name") val displayName: String? = null,
 )
 
 /**
@@ -333,10 +338,17 @@ data class PlaybackSubtitleArtifactV3(
 )
 
 @Serializable
+data class PlaybackEmbeddedSubtitleV3(
+    @SerialName("stream_index") val streamIndex: Int,
+    @SerialName("container_track_id") val containerTrackId: String? = null,
+)
+
+@Serializable
 data class PlaybackSubtitleDecisionV3(
     val mode: PlaybackSubtitleModeV3 = PlaybackSubtitleModeV3.OFF,
     @SerialName("track_id") val trackId: String? = null,
     val artifact: PlaybackSubtitleArtifactV3? = null,
+    val embedded: PlaybackEmbeddedSubtitleV3? = null,
     /**
      * The complete, gap-free combined-ordinal subtitle list for the effective
      * source. Authoritative: select a track by echoing an entry's
@@ -543,6 +555,16 @@ fun PlaybackDecisionResponseV3.validateForMedia3(): PlaybackV3Validation {
             plan,
             resolvedSessionId,
         )
+    }
+    plan.subtitle.embedded?.let { native ->
+        val nativeId = native.containerTrackId?.toLongOrNull()
+        if (plan.delivery != PlaybackDelivery.ORIGINAL_HTTP || plan.subtitle.mode != PlaybackSubtitleModeV3.RENDER ||
+            plan.subtitle.artifact != null || native.streamIndex < 0 ||
+            nativeId == null || nativeId !in 1..Int.MAX_VALUE.toLong() || native.containerTrackId != nativeId.toString() ||
+            selectedSubtitle?.source != "embedded" || selectedSubtitle.codec != "mov_text" ||
+            plan.source.container?.lowercase() !in setOf("mp4", "mov", "m4v") ||
+            plan.subtitle.trackId != plan.selectedTracks.subtitle?.id
+        ) return PlaybackV3Validation.ReplanRequired("subtitle_embedded_failed", plan, resolvedSessionId)
     }
     if (plan.stream.url.isBlank()) {
         return PlaybackV3Validation.Terminal("invalid_playback_plan", "The server returned an empty stream URL.", false)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/SubtitleTransition.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/playback/SubtitleTransition.kt
@@ -16,6 +16,8 @@ sealed interface SubtitleIdentity {
     data class Embedded(
         val serverIndex: Int,
         val media: SubtitleMediaIdentity,
+        /** Exact server-probed container identity; never permit metadata fallback. */
+        val containerTrackId: String? = null,
     ) : SubtitleIdentity
 
     data class Downloaded(

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/playback/PlaybackSubtitleIdentity.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/playback/PlaybackSubtitleIdentity.kt
@@ -36,6 +36,9 @@ fun playbackSubtitleIdentity(subtitle: PlayerSubtitleInfo): SubtitleIdentity {
         ).takeIf { it },
     )
 
+    subtitle.nativeContainerTrackId?.let {
+        return SubtitleIdentity.Embedded(subtitle.index, media, containerTrackId = it)
+    }
     when (subtitle.serverDelivery) {
         SUBTITLE_DELIVERY_BURN_IN_ONLY ->
             return SubtitleIdentity.ServerBurnIn(subtitle.index, media)

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/model/playback/NativeEmbeddedSubtitleProtocolTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/model/playback/NativeEmbeddedSubtitleProtocolTest.kt
@@ -1,0 +1,49 @@
+package org.siloserver.silo.model.playback
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import org.siloserver.silo.network.SiloJson
+import kotlin.test.*
+
+class NativeEmbeddedSubtitleProtocolTest {
+    private val track = PlaybackSubtitleInventoryItemV3("file:42:subtitle:0", 0, "embedded", codec = "mov_text", delivery = "sidecar", url = "/subtitle.vtt")
+    private val plan = PlaybackPlanV3(
+        planId = "native", planAttemptKey = "v3:native", sessionId = "session",
+        delivery = PlaybackDelivery.ORIGINAL_HTTP,
+        source = PlaybackSourceDescriptorV3(container = "mp4"),
+        stream = PlaybackStreamV3(url = "/stream/session", protocol = PlaybackStreamProtocol.HTTP_PROGRESSIVE, container = "mp4"),
+        selectedTracks = SelectedPlaybackTracksV3(subtitle = PlaybackTrackIdentityV3(track.trackId, 0)),
+        subtitle = PlaybackSubtitleDecisionV3(mode = PlaybackSubtitleModeV3.RENDER, trackId = track.trackId,
+            embedded = PlaybackEmbeddedSubtitleV3(2, "19"), inventory = listOf(track)),
+        decisionReason = "native",
+    )
+    private fun validate(candidate: PlaybackPlanV3) = PlaybackDecisionResponseV3(
+        protocolVersion = PLAYBACK_PROTOCOL_V3,
+        serverFeatures = listOf(PLAYBACK_PLAN_V3_FEATURE, NEUTRAL_PLAYBACK_V3_CONTRACT_FEATURE, EMBEDDED_SUBTITLES_V1_FEATURE),
+        outcome = PlaybackDecisionOutcome.PLAYABLE, playbackPlan = candidate,
+    ).validateForMedia3()
+
+    @Test fun originalMp4TimedTextIsPlayableAndRoundTripsIdentity() {
+        assertIs<PlaybackV3Validation.Playable>(validate(plan))
+        val decoded = SiloJson.decodeFromString<PlaybackPlanV3>(SiloJson.encodeToString(plan))
+        assertEquals(PlaybackEmbeddedSubtitleV3(2, "19"), decoded.subtitle.embedded)
+        assertNull(decoded.subtitle.artifact)
+    }
+
+    @Test fun missingInvalidOrUnsupportedNativeIdentityRequestsSidecarRecovery() {
+        listOf(null, "", "0", "-1", "019", "0x13", "2147483648").forEach { id ->
+            val result = validate(plan.copy(subtitle = plan.subtitle.copy(embedded = PlaybackEmbeddedSubtitleV3(2, id))))
+            assertEquals("subtitle_embedded_failed", assertIs<PlaybackV3Validation.ReplanRequired>(result).reason)
+        }
+        assertIs<PlaybackV3Validation.ReplanRequired>(validate(plan.copy(delivery = PlaybackDelivery.SERVER_REMUX_HLS)))
+        assertIs<PlaybackV3Validation.ReplanRequired>(validate(plan.copy(source = PlaybackSourceDescriptorV3(container = "mkv"))))
+    }
+
+    @Test fun nativeCapabilitiesHaveExactWireNames() {
+        val capability = DeliverySubtitleCapabilities(nativeEmbedded = listOf(NativeEmbeddedSubtitleCapability("mp4", listOf("mov_text"), "container_track_id")))
+        val json = SiloJson.encodeToString(capability)
+        assertTrue(json.contains("native_embedded"))
+        assertTrue(json.contains("track_identity"))
+        assertEquals(capability, SiloJson.decodeFromString<DeliverySubtitleCapabilities>(json))
+    }
+}

--- a/shared/src/commonTest/resources/playback/v3/SOURCE
+++ b/shared/src/commonTest/resources/playback/v3/SOURCE
@@ -1,6 +1,6 @@
 repository=https://github.com/Silo-Server/silo-server
 path=internal/playback/testdata/protocol_v3
-commit=2f9df5327f2728a266ad826ded36dac7d030d62b
+commit=5afc5bdd616e4f9c304889c8cadc4c6d31fbc7b7
 protocol_version=3
 
 Byte-identical copies of the server's golden playback-v3 wire fixtures; do not

--- a/shared/src/commonTest/resources/playback/v3/SOURCE
+++ b/shared/src/commonTest/resources/playback/v3/SOURCE
@@ -1,6 +1,6 @@
 repository=https://github.com/Silo-Server/silo-server
 path=internal/playback/testdata/protocol_v3
-commit=79e3e761ad391b1aa9f2c280eeceeb23df9d3c81
+commit=2f9df5327f2728a266ad826ded36dac7d030d62b
 protocol_version=3
 
 Byte-identical copies of the server's golden playback-v3 wire fixtures; do not

--- a/shared/src/commonTest/resources/playback/v3/attempt_keys.json
+++ b/shared/src/commonTest/resources/playback/v3/attempt_keys.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "hls_burn_in_sorted_transformations_and_pcm_mutations",
-    "server_plan_attempt_key": "v3:a90828494166fe72",
-    "replan_echo": "v3:a90828494166fe72",
+    "server_plan_attempt_key": "v3:a1531ef7c1bd7f75",
+    "replan_echo": "v3:a1531ef7c1bd7f75",
     "attempted_plan_keys": [
-      "v3:a90828494166fe72"
+      "v3:a1531ef7c1bd7f75"
     ],
     "expected_server_action": "reject_already_attempted_plan"
   },

--- a/shared/src/commonTest/resources/playback/v3/capability_response.json
+++ b/shared/src/commonTest/resources/playback/v3/capability_response.json
@@ -6,11 +6,18 @@
   "features": [
     "playback_plan_v3",
     "neutral_playback_v3_contract_v1",
+    "embedded_subtitles_v1",
     "layout_aware_passthrough",
     "playback_route_diagnostics",
     "device_quirks_v1",
     "seek_reanchor_v1",
+    "output_change_v1",
+    "output_display_evidence_v1",
     "direct_stream_resume_v1",
+    "header_authenticated_media_v1",
+    "authorized_media_origins_v1",
+    "software_video_decode_v1",
+    "plan_invalidated_v1",
     "plan_source_duration_v1"
   ],
   "deliveries": [
@@ -23,9 +30,18 @@
     {
       "name": "audio_to_aac",
       "executor": "server",
-      "recipe_version": "1",
+      "recipe_version": "4",
       "validated_claims": [
         "audio_decode"
+      ]
+    },
+    {
+      "name": "hdr_to_sdr_tonemap",
+      "executor": "server",
+      "recipe_version": "1",
+      "validated_claims": [
+        "hdr_metadata_removed",
+        "sdr_bt709_output"
       ]
     },
     {

--- a/shared/src/commonTest/resources/playback/v3/conformance_matrix.json
+++ b/shared/src/commonTest/resources/playback/v3/conformance_matrix.json
@@ -1978,7 +1978,7 @@
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
         "progress_persistence": "client",
-        "audio_track_id": "file:42:audio:0",
+        "audio_track_id": "file:77:audio:0",
         "audio_track_index": 0,
         "metered": false,
         "client_capabilities": {

--- a/shared/src/commonTest/resources/playback/v3/conformance_matrix.json
+++ b/shared/src/commonTest/resources/playback/v3/conformance_matrix.json
@@ -175,8 +175,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_original",
-        "plan_id": "plan:7b3b4cdf37a1a1084395bc810c9ac179",
-        "plan_attempt_key": "v3:5f2c9f8566a979cc",
+        "plan_id": "plan:176744988a004fd5f2230c221961c41a",
+        "plan_attempt_key": "v3:d1ecc0d9511b83b8",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -218,7 +218,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "4",
             "validated_claims": [
               "audio_decode"
             ]
@@ -232,13 +232,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -459,13 +489,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -667,16 +727,261 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "h264_constrained_baseline_direct",
+      "category": "profile_compatibility",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-h264-constrained-baseline",
+        "quality_preference": "auto",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "progress_persistence": "client",
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "baseline"
+              ],
+              "levels": [
+                52
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "h264",
+        "video_profile": "constrained baseline",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:ea7ae9cecded71f3a86ec20a152c8778",
+        "plan_attempt_key": "v3:706f66227a5cae0b",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
           }
         ]
       }
@@ -875,13 +1180,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -1086,13 +1421,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -1298,13 +1663,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -1467,8 +1862,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_fixed_rung",
-        "plan_id": "plan:36db80a93b9d295f44c2c3be6a7cb0ce",
-        "plan_attempt_key": "v3:aad5ccea009fea2a",
+        "plan_id": "plan:f12311eb7ac696c8bbeeab6c135b4225",
+        "plan_attempt_key": "v3:315d40199ceb0333",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -1510,7 +1905,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "4",
             "validated_claims": [
               "audio_decode"
             ]
@@ -1524,13 +1919,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -1947,6 +2372,556 @@
         "claims": {
           "video": {
             "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "hdr10_to_sdr_tone_map",
+      "category": "hdr_dv_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-hdr10-tone-map",
+        "quality_preference": "1080p",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "progress_persistence": "client",
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "hdr10",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_transcode_hls",
+        "decision_reason": "quality_fixed_rung",
+        "plan_id": "plan:1aae8ad82720984fbc14c38de3a5485b",
+        "plan_attempt_key": "v3:78825f13a334a7ed",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "server_audio_adaptation"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "transformations": [
+          {
+            "name": "video_to_h264",
+            "executor": "server",
+            "recipe_version": "2",
+            "validated_claims": [
+              "h264_decode"
+            ]
+          },
+          {
+            "name": "audio_to_aac",
+            "executor": "server",
+            "recipe_version": "4",
+            "validated_claims": [
+              "audio_decode"
+            ]
+          },
+          {
+            "name": "hdr_to_sdr_tonemap",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "hdr_metadata_removed",
+              "sdr_bt709_output"
+            ]
+          }
+        ],
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          },
+          {
+            "label": "2160p-high",
+            "display_name": "4K High",
+            "height": 2160,
+            "bitrate_kbps": 40000,
+            "preserves_source": false
+          },
+          {
+            "label": "2160p-medium",
+            "display_name": "4K Medium",
+            "height": 2160,
+            "bitrate_kbps": 20000,
+            "preserves_source": false
+          },
+          {
+            "label": "2160p-low",
+            "display_name": "4K Low",
+            "height": 2160,
+            "bitrate_kbps": 10000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-high",
+            "display_name": "1080p High",
+            "height": 1080,
+            "bitrate_kbps": 10000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "display_name": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "client_managed_hdr_selected_audio",
+      "category": "hdr_dv_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-client-managed-original",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "progress_persistence": "client",
+        "audio_track_id": "file:42:audio:1",
+        "audio_track_index": 1,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "2160p",
+          "hdr": false,
+          "hdr_details": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision_profiles": []
+          },
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                153
+              ],
+              "bit_depths": [
+                10
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 80000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "hdr_details": {
+              "hdr10": false,
+              "hdr10_plus": false,
+              "hlg": false,
+              "dolby_vision_profiles": []
+            },
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "hdr_details": {
+                "hdr10": false,
+                "hdr10_plus": false,
+                "hlg": false,
+                "dolby_vision_profiles": []
+              },
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [
+                "client_managed_dynamic_range_v1",
+                "client_selected_audio_track_v1"
+              ],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "hdr10",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "client_managed_dynamic_range",
+        "plan_id": "plan:880cfe7954be7aff16c5d89d2b2a09bd",
+        "plan_attempt_key": "v3:b020c19644d2bb36",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:1",
+            "index": 1
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
             "hdr10_plus": false,
             "hlg": false,
             "dolby_vision": false
@@ -2451,6 +3426,322 @@
       }
     },
     {
+      "name": "dolby_vision_7_id6_to_sdr_tone_map",
+      "category": "hdr_dv_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-dv7-id6-tone-map",
+        "quality_preference": "1080p",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "progress_persistence": "client",
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "dolby_vision",
+        "hdr10_plus": false,
+        "dolby_vision_profile": 7,
+        "dv_bl_compat_id": 6,
+        "dv_base_layer_proven": true,
+        "dv_enhancement_layer": "unknown",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_transcode_hls",
+        "decision_reason": "quality_fixed_rung",
+        "plan_id": "plan:e302dcdd4f94f3c3027c7603de66c0a5",
+        "plan_attempt_key": "v3:b1ff9bc2e47e341e",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "server_audio_adaptation"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "transformations": [
+          {
+            "name": "video_to_h264",
+            "executor": "server",
+            "recipe_version": "2",
+            "validated_claims": [
+              "h264_decode"
+            ]
+          },
+          {
+            "name": "audio_to_aac",
+            "executor": "server",
+            "recipe_version": "4",
+            "validated_claims": [
+              "audio_decode"
+            ]
+          },
+          {
+            "name": "hdr_to_sdr_tonemap",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "hdr_metadata_removed",
+              "sdr_bt709_output"
+            ]
+          }
+        ],
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          },
+          {
+            "label": "2160p-high",
+            "display_name": "4K High",
+            "height": 2160,
+            "bitrate_kbps": 40000,
+            "preserves_source": false
+          },
+          {
+            "label": "2160p-medium",
+            "display_name": "4K Medium",
+            "height": 2160,
+            "bitrate_kbps": 20000,
+            "preserves_source": false
+          },
+          {
+            "label": "2160p-low",
+            "display_name": "4K Low",
+            "height": 2160,
+            "bitrate_kbps": 10000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-high",
+            "display_name": "1080p High",
+            "height": 1080,
+            "bitrate_kbps": 10000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "display_name": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
       "name": "truehd_audio_conversion",
       "category": "audio_matrix",
       "request": {
@@ -2637,8 +3928,8 @@
         "outcome": "playable",
         "delivery": "server_remux_progressive",
         "decision_reason": "audio_adaptation",
-        "plan_id": "plan:cccf704a0487d09d54a95b51d095c474",
-        "plan_attempt_key": "v3:8a79df3157b88939",
+        "plan_id": "plan:4f78d95e9fdd6e085ec79506894da894",
+        "plan_attempt_key": "v3:4979cff59d1f3068",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -2672,7 +3963,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "4",
             "validated_claims": [
               "audio_decode"
             ]
@@ -3282,7 +4573,7 @@
               "audio_passthrough_codecs": [],
               "subtitles": {
                 "embedded_text": true,
-                "sidecar_text": false,
+                "sidecar_text": true,
                 "ass_styling": true,
                 "embedded_bitmap": false,
                 "sidecar_bitmap": false,
@@ -3310,7 +4601,7 @@
               "audio_passthrough_codecs": [],
               "subtitles": {
                 "embedded_text": true,
-                "sidecar_text": false,
+                "sidecar_text": true,
                 "ass_styling": true,
                 "embedded_bitmap": false,
                 "sidecar_bitmap": false,
@@ -3337,7 +4628,7 @@
               "audio_passthrough_codecs": [],
               "subtitles": {
                 "embedded_text": true,
-                "sidecar_text": false,
+                "sidecar_text": true,
                 "ass_styling": true,
                 "embedded_bitmap": false,
                 "sidecar_bitmap": false,
@@ -3611,8 +4902,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "subtitle_burn_in_required",
-        "plan_id": "plan:67e9593ed921a129645e41427a081943",
-        "plan_attempt_key": "v3:4d2de636abf938b1",
+        "plan_id": "plan:c42d17216c7049e49c5453bc2f21cfe5",
+        "plan_attempt_key": "v3:7ec0846b12cc97a6",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -3673,7 +4964,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "4",
             "validated_claims": [
               "audio_decode"
             ]
@@ -3687,13 +4978,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -3895,13 +5216,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -4145,6 +5496,124 @@
       "expected": {
         "http_status": 200,
         "selected_quality": "720p"
+      }
+    },
+    {
+      "name": "output_change",
+      "category": "output_change_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "output_change",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-output-change-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "auto",
+        "position_seconds": 42.5,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "http_status": 200,
+        "preserve_unmodified_tracks": true
       }
     },
     {
@@ -5284,11 +6753,18 @@
           "server_features": [
             "playback_plan_v3",
             "neutral_playback_v3_contract_v1",
+            "embedded_subtitles_v1",
             "layout_aware_passthrough",
             "playback_route_diagnostics",
             "device_quirks_v1",
             "seek_reanchor_v1",
+            "output_change_v1",
+            "output_display_evidence_v1",
             "direct_stream_resume_v1",
+            "header_authenticated_media_v1",
+            "authorized_media_origins_v1",
+            "software_video_decode_v1",
+            "plan_invalidated_v1",
             "plan_source_duration_v1"
           ],
           "outcome": "adaptation_unavailable",

--- a/shared/src/commonTest/resources/playback/v3/decision_response.json
+++ b/shared/src/commonTest/resources/playback/v3/decision_response.json
@@ -3,11 +3,18 @@
   "server_features": [
     "playback_plan_v3",
     "neutral_playback_v3_contract_v1",
+    "embedded_subtitles_v1",
     "layout_aware_passthrough",
     "playback_route_diagnostics",
     "device_quirks_v1",
     "seek_reanchor_v1",
+    "output_change_v1",
+    "output_display_evidence_v1",
     "direct_stream_resume_v1",
+    "header_authenticated_media_v1",
+    "authorized_media_origins_v1",
+    "software_video_decode_v1",
+    "plan_invalidated_v1",
     "plan_source_duration_v1"
   ],
   "outcome": "playable",
@@ -85,7 +92,7 @@
           "default": false,
           "hearing_impaired": false,
           "delivery": "sidecar",
-          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/0.vtt?file_id=42"
+          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/0.vtt?file_id=42\u0026external_subtitle_key=f903db1c5624c46c4a2c20f2fd8cd247fc0d46e6471c91d4ddb651ae4e039448"
         },
         {
           "track_id": "file:42:subtitle:1",
@@ -98,8 +105,8 @@
           "default": false,
           "hearing_impaired": false,
           "delivery": "sidecar",
-          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1.ass?file_id=42",
-          "font_bundle_url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42"
+          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1.ass?file_id=42\u0026embedded_stream_index=0",
+          "font_bundle_url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42\u0026embedded_stream_index=0"
         },
         {
           "track_id": "file:42:subtitle:2",
@@ -112,7 +119,7 @@
           "default": false,
           "hearing_impaired": false,
           "delivery": "sidecar",
-          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/2.sup?file_id=42"
+          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/2.sup?file_id=42\u0026embedded_stream_index=1"
         },
         {
           "track_id": "file:42:subtitle:3",

--- a/shared/src/commonTest/resources/playback/v3/replan_request.json
+++ b/shared/src/commonTest/resources/playback/v3/replan_request.json
@@ -68,8 +68,6 @@
     "protocol_version": 3,
     "form_factor": "tv",
     "app_version": "3.0-test",
-    "app_build": "5",
-    "app_channel": "production",
     "device": {
       "platform": "android",
       "os_version": "15",

--- a/shared/src/commonTest/resources/playback/v3/start_request.json
+++ b/shared/src/commonTest/resources/playback/v3/start_request.json
@@ -54,8 +54,6 @@
     "protocol_version": 3,
     "form_factor": "tv",
     "app_version": "3.0-test",
-    "app_build": "5",
-    "app_channel": "production",
     "device": {
       "platform": "android",
       "os_version": "15",

--- a/shared/src/commonTest/resources/playback/v3/subtitle_inventory.json
+++ b/shared/src/commonTest/resources/playback/v3/subtitle_inventory.json
@@ -70,7 +70,7 @@
       "default": false,
       "hearing_impaired": false,
       "delivery": "sidecar",
-      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/0.vtt?file_id=42"
+      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/0.vtt?file_id=42\u0026external_subtitle_key=f903db1c5624c46c4a2c20f2fd8cd247fc0d46e6471c91d4ddb651ae4e039448"
     },
     {
       "track_id": "file:42:subtitle:1",
@@ -83,8 +83,8 @@
       "default": false,
       "hearing_impaired": false,
       "delivery": "sidecar",
-      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1.ass?file_id=42",
-      "font_bundle_url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42"
+      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1.ass?file_id=42\u0026embedded_stream_index=0",
+      "font_bundle_url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42\u0026embedded_stream_index=0"
     },
     {
       "track_id": "file:42:subtitle:2",
@@ -97,7 +97,7 @@
       "default": false,
       "hearing_impaired": false,
       "delivery": "sidecar",
-      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/2.sup?file_id=42"
+      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/2.sup?file_id=42\u0026embedded_stream_index=1"
     },
     {
       "track_id": "file:42:subtitle:3",


### PR DESCRIPTION
## Problem

Related issue: #292

Phone and TV could infer an embedded subtitle from matching metadata even when the server had selected a sidecar. Duplicate same-language tracks can make that inference select the wrong track. Cast subtitle cues also need to follow the transport clock after playback resumes at a nonzero source offset. On TV, switching from an external sidecar to native MP4 subtitles could commit the old MediaItem’s track override before replacing that item, leaving the menu selected while playback had no subtitle selected.

## Approach

Negotiate `embedded_subtitles_v1` for original HTTP MP4 `mov_text` playback and carry the server-probed container track ID through the subtitle decision, session projection, and Media3 mount. Select only that exact ID, without a language or stream-index fallback. Phone and TV persist the preference after mount confirmation and request `subtitle_embedded_failed` recovery if the native track cannot mount. Explicit sidecars remain sidecars. Failed native TV mounts settle their deferred publication before sidecar recovery; callbacks recheck content and intent generations after rollback. 

Phone and TV queue native failures during an active recovery, retaining the explicit subtitle index. A failed native restore immediately clears the unmounted committed subtitle identity to Off on both phone and TV without persisting a new preference. Recovery retains the requested native index, while audio, quality, and the healthy playback session stay intact. For subtitle-only recovery, the manager rejects terminal, incompatible, and unexecutable candidates using staged cleanup: only the rejected candidate is stopped, and the healthy active session remains available for playback and another retry. Successful candidates still commit normally. Phone treats only API/network error results as nonfatal, so an actual terminal or upgrade success can never be mistaken for a retained session. 

TV remounts match the probed container ID and require a unique native track, with regression coverage for missing and ambiguous identities. TV quality labels use the server display name while retaining the wire identifier for selection. TV subtitle mounts now wait for the current replacement item and discard the predecessor’s cached track groups. Transactions commit after Media3 reports the exact track selected; an accepted command alone cannot confirm a mount. 

Phone confirmations carry the applied transport generation and subtitle-refresh nonce, and are rejected during a pending mount or fresh load. Both the track callback and composition path inspect the exact selected track; accepted-but-unselected commands remain provisional until selected evidence or the mount deadline. The applied token belongs to the retained ViewModel, so recreating the screen can resume observing the existing mount without reloading playback. A fresh load or MediaItem replacement clears that evidence before callbacks can act. Superseded queued commands and old unconfirmed owners cannot revive an earlier selection. When an adapter mount ends or times out, TV releases only that generation’s pending/unconfirmed owner; a newer transport owner remains intact and automatic restore is no longer blocked by an abandoned selection.

For Cast, append `timestamp_offset=-timeline_offset_seconds` to the VTT URL while preserving file/provider identity and authorization parameters. Authentication is inserted before URL fragments in both Cast signing paths. Native Android renderers retain their existing local timing adjustment.

Depends on Silo-Server/silo-server#938 for the native decision and timestamp-offset response contract. Vendored protocol fixtures are byte-identical to server commit `5afc5bdd616e4f9c304889c8cadc4c6d31fbc7b7`. Apple coordination: Silo-Server/silo-apple#252 (issue Silo-Server/silo-apple#152).

## Validation

Validated commit `401274aa6179f301cba0366e7b416c64d45428da`:

```sh
./scripts/test-check-build-supply-chain.sh
./scripts/check-build-supply-chain.sh
./gradlew testDebugUnitTest \
  :android-shared:lintDebug :androidApp:lintDebug :androidTvApp:lintDebug \
  :androidApp:lintVitalRelease :androidTvApp:lintVitalRelease \
  :androidApp:assembleDebug :androidTvApp:assembleDebug \
  --continue --max-workers=2 -Dorg.gradle.jvmargs=-Xmx6g
```

Supply-chain checks and the complete Gradle gate passed. Reports contain 4,272 tests with zero failures, errors, or skips: shared 1,100; android-shared 1,450; phone 616; TV 1,104; libass bridge 2. Unchanged modules reused successful Gradle results. Debug lint, release vital lint, and both debug APK builds passed. Existing lint baselines were not changed. `git diff --check` passed. An earlier full run hit an unrelated `ServerSetupPersistenceTest` Main-dispatcher setup race; the exact gate passed on one unchanged rerun. The final lifecycle-fix gate passed separately.

A physical Google TV reproduced the external-to-native switch failure before the fix. On the rebuilt APK, two repeated external-to-native switches selected the exact native MP4 track after the replacement item published its tracks, and only then committed the transaction. Native-to-Off and Off-to-external transitions passed. Native seeks to 620 and 630 seconds resumed advancing playback, with a visible native cue after the latter seek. An external-sidecar seek to 670 seconds resumed playback with a visible cue. No player error was reported during this focused matrix. That TV matrix tested commit `7c3710e2c605a53923c728763d000a3838f79de0`; the subsequent phone/TV restoration, manager rejection cleanup, TV timeout-owner, and phone mount-confirmation/lifecycle fixes were covered by automated regression tests and both-platform build gates. The tested 32-bit APK SHA256 is `0b8310220a748793c139ba31174ba8d701759a3805f854a797e95be3ed93e4cb`.

Regression coverage includes failed native restoration through both mount timeout and stable missing-track evidence, retention of the prior committed choice when a pending selection fails, rejected native recovery preserving the active session and allowing a later successful retry, generation-scoped timeout cleanup that preserves newer transport owners, retained-ViewModel reattachment and new-load invalidation, phone predecessor/refresh/load evidence rejection and actual exact-track selection, replacement-item selection, stale mount acknowledgements, observed selection versus command acceptance, Off confirmation, superseded owners followed by a missing track or burn-in decision, rollback ordering, explicit-index recovery, stale-content suppression, phone recovery queues, and Cast authentication fragments.

Earlier native Media3 harness testing on an API 34 ARM64 emulator selected one exact MP4 container track among two same-language tracks and observed only its expected cue. Physical Cast timing was not tested. Screenshots were waived by the requester.

## Risks

Native embedded support is limited to MP4 `mov_text` tracks with a valid probed container ID. Unsupported containers, codecs, and identities retain the sidecar route. Deploy the server dependency before relying on Cast timestamp shifting. Installed-phone playback and physical Cast timing remain untested here. The physical TV matrix did not include forced failure injection, HDR/bitmap formats, or a full-movie soak.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop; Codex CLI 0.153.3 for the final read-only review
- Tool(s): Codex tools, GitHub CLI (`gh`), Gradle, Android emulator/ADB
- Model(s): `gpt-6-astra`
- Involvement: AI-assisted
- Adversarial review: Independent correctness review and fresh read-only `@ponytail-review` CLI reviews covered the subtitle protocol, native identity, transaction recovery, Cast timing, and remount lifecycle. A review finding about superseded unconfirmed owners was fixed and regression-tested before publication. Separate fresh ponytail reviews completed before commit and push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native embedded MP4 subtitle support on Android and Android TV.
  * Embedded subtitles now use exact container-track identity for reliable selection.
  * Added playback negotiation for embedded subtitle capabilities and metadata.
  * Cast subtitle timing remains aligned after seeking or resuming.

* **Bug Fixes**
  * Failed embedded subtitle mounts automatically retry with sidecar subtitles when available.
  * Improved protection against incorrect subtitle selection.
  * Preserved subtitle URL authentication and fragments during Cast playback.

* **Documentation**
  * Added guidance for embedded subtitles, sidecars, and timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



