### PR TITLE
feat(apiv2): add the v2 contract harness, probe, and pilot operations [api-v2 phase 3]

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingAuthPort.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingAuthPort.kt
@@ -68,8 +68,8 @@ class RegistryPairingAuthPort(
                     serverRegistry.switchTo(previousServerId)
                     tokenManager.switchActiveServer(previousServerId)
                     // Restoring is a server switch too; re-establish its contract
-                    // verdict like every other switch path.
-                    authRepository?.refreshServerContract()
+                    // verdict like every other switch path, under the same bound.
+                    authRepository?.refreshServerContractBounded()
                 } else if (previousServerId == null) {
                     serverRegistry.remove(serverId)
                 }
@@ -81,7 +81,14 @@ class RegistryPairingAuthPort(
             // stale UPDATE_REQUIRED from an older build) and gated startup
             // consumers act on it. The probe never throws on a failed
             // request, so this cannot roll back a committed session.
-            authRepository?.refreshServerContract()
+            //
+            // Bounded: the companion waits only ~30 s for ServerResult while
+            // an unanswered request would sit on the client's ~60 s socket
+            // timeout, so an unbounded probe here made the phone report
+            // failure after the credentials were already committed. A
+            // timeout leaves the verdict UNKNOWN, which passes the gate and
+            // gets re-probed on the next switch or launch.
+            authRepository?.refreshServerContractBounded()
         }
     }
 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingAuthPort.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingAuthPort.kt
@@ -46,7 +46,7 @@ class RegistryPairingAuthPort(
         accessToken: String,
         refreshToken: String,
         expiresIn: Long,
-    ) = withContext(NonCancellable) {
+    ): Unit = withContext(NonCancellable) {
         commitMutex.withLock {
             if (cleartextOriginConsent?.requiresApproval(serverUrl) == true) {
                 throw CleartextOriginNotApprovedException(serverUrl)
@@ -75,6 +75,13 @@ class RegistryPairingAuthPort(
                 }
                 throw error
             }
+            // Pairing is a server switch too: the newly paired server is now
+            // active, so establish its v2 contract verdict before the port
+            // reports SignedIn — otherwise the entry keeps UNKNOWN (or a
+            // stale UPDATE_REQUIRED from an older build) and gated startup
+            // consumers act on it. The probe never throws on a failed
+            // request, so this cannot roll back a committed session.
+            authRepository?.refreshServerContract()
         }
     }
 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingAuthPort.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingAuthPort.kt
@@ -68,8 +68,9 @@ class RegistryPairingAuthPort(
                     serverRegistry.switchTo(previousServerId)
                     tokenManager.switchActiveServer(previousServerId)
                     // Restoring is a server switch too; re-establish its contract
-                    // verdict like every other switch path, under the same bound.
-                    authRepository?.refreshServerContractBounded()
+                    // verdict like every other switch path, under the same bound
+                    // and with the same background replacement on no verdict.
+                    authRepository?.refreshServerContractWithFallback(previousServerId)
                 } else if (previousServerId == null) {
                     serverRegistry.remove(serverId)
                 }
@@ -85,10 +86,12 @@ class RegistryPairingAuthPort(
             // Bounded: the companion waits only ~30 s for ServerResult while
             // an unanswered request would sit on the client's ~60 s socket
             // timeout, so an unbounded probe here made the phone report
-            // failure after the credentials were already committed. A
-            // timeout leaves the verdict UNKNOWN, which passes the gate and
-            // gets re-probed on the next switch or launch.
-            authRepository?.refreshServerContractBounded()
+            // failure after the credentials were already committed. No
+            // verdict within the bound (timeout or failure) leaves the stored
+            // state alone — which passes the gate for UNKNOWN but not for a
+            // stale UPDATE_REQUIRED — so, like switchToServer, a replacement
+            // probe is handed to the repository's background scope.
+            authRepository?.refreshServerContractWithFallback(serverId)
         }
     }
 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingAuthPort.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/pairing/PairingAuthPort.kt
@@ -9,6 +9,7 @@ import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.CleartextOriginConsent
 import org.siloserver.silo.network.CleartextOriginNotApprovedException
 import org.siloserver.silo.network.requiresApproval
+import org.siloserver.silo.repository.AuthRepository
 
 /**
  * Narrow commit seam for the pairing receiver after a candidate server approves device
@@ -35,6 +36,7 @@ class RegistryPairingAuthPort(
     private val tokenManager: TokenManager,
     private val serverRegistry: ServerRegistry,
     private val cleartextOriginConsent: CleartextOriginConsent? = null,
+    private val authRepository: AuthRepository? = null,
 ) : PairingAuthPort {
     private val commitMutex = Mutex()
 
@@ -65,6 +67,9 @@ class RegistryPairingAuthPort(
                 if (previousServerId != null && serverRegistry.activeServerId.value != previousServerId) {
                     serverRegistry.switchTo(previousServerId)
                     tokenManager.switchActiveServer(previousServerId)
+                    // Restoring is a server switch too; re-establish its contract
+                    // verdict like every other switch path.
+                    authRepository?.refreshServerContract()
                 } else if (previousServerId == null) {
                     serverRegistry.remove(serverId)
                 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
@@ -2,6 +2,16 @@ package org.siloserver.silo.common.pairing
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import org.siloserver.silo.model.server.ServerContract
+import org.siloserver.silo.network.api.AuthApi
+import org.siloserver.silo.network.apiv2.ApiV2Probe
+import org.siloserver.silo.repository.AuthRepository
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runCurrent
@@ -238,6 +248,89 @@ class RegistryPairingAuthPortTest {
         assertEquals("old-refresh", failingTokens.getRefreshToken())
         assertEquals("old-profile", failingTokens.getProfileId())
         assertFalse(prefs.contains(AndroidServerRegistry.serverScopedKey(newId, "access_token")))
+    }
+
+    @Test
+    fun rollbackToPreviousServerReprobesItsContractExactlyOnce() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("pairing-rollback-reprobe", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+        val transitions = DefaultIdentityTransitionBarrier()
+        val registry = AndroidServerRegistry(prefs, transitions)
+        val oldId = registry.addOrUpdate("https://old.example")
+        registry.switchTo(oldId)
+        // The commit hook runs after the registry has already switched to the
+        // new server, so failing it exercises the restore-and-reprobe branch.
+        val tokens = EncryptedTokenManagerImpl(
+            prefs,
+            registry,
+            transitions,
+            afterAccountSessionCommit = { error("injected post-commit failure") },
+        )
+        tokens.saveTokens("old-access", "old-refresh", 3600)
+        var probes = 0
+        val client = HttpClient(
+            MockEngine { request ->
+                check(request.url.encodedPath == ApiV2Probe.PATH) { "unexpected request ${request.url}" }
+                probes += 1
+                respond("not found", HttpStatusCode.NotFound, headersOf(HttpHeaders.ContentType, "text/plain"))
+            },
+        )
+        val authRepository = AuthRepository(
+            authApi = AuthApi(client),
+            tokenManager = tokens,
+            serverRegistry = registry,
+            apiV2Probe = ApiV2Probe(client),
+        )
+
+        assertFailsWith<IllegalStateException> {
+            RegistryPairingAuthPort(tokens, registry, authRepository = authRepository).persistApprovedSession(
+                serverUrl = "https://new.example",
+                serverName = null,
+                accessToken = "new-access",
+                refreshToken = "new-refresh",
+                expiresIn = 7200,
+            )
+        }
+
+        assertEquals(oldId, registry.activeServerId.value)
+        assertEquals(oldId, tokens.getCurrentServerId())
+        assertEquals("old-access", tokens.getAccessToken())
+        assertEquals(1, probes)
+        assertEquals(ServerContract.UPDATE_REQUIRED, registry.entries.value.first { it.id == oldId }.contract)
+    }
+
+    @Test
+    fun rollbackToPreviousServerWithoutAuthRepositorySkipsTheProbe() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("pairing-rollback-no-repository", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+        val transitions = DefaultIdentityTransitionBarrier()
+        val registry = AndroidServerRegistry(prefs, transitions)
+        val oldId = registry.addOrUpdate("https://old.example")
+        registry.switchTo(oldId)
+        val tokens = EncryptedTokenManagerImpl(
+            prefs,
+            registry,
+            transitions,
+            afterAccountSessionCommit = { error("injected post-commit failure") },
+        )
+        tokens.saveTokens("old-access", "old-refresh", 3600)
+
+        assertFailsWith<IllegalStateException> {
+            RegistryPairingAuthPort(tokens, registry).persistApprovedSession(
+                serverUrl = "https://new.example",
+                serverName = null,
+                accessToken = "new-access",
+                refreshToken = "new-refresh",
+                expiresIn = 7200,
+            )
+        }
+
+        assertEquals(oldId, registry.activeServerId.value)
+        assertEquals(oldId, tokens.getCurrentServerId())
+        assertEquals("old-access", tokens.getAccessToken())
+        assertEquals(ServerContract.UNKNOWN, registry.entries.value.first { it.id == oldId }.contract)
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
@@ -13,10 +13,13 @@ import org.siloserver.silo.network.api.AuthApi
 import org.siloserver.silo.network.apiv2.ApiV2Probe
 import org.siloserver.silo.repository.AuthRepository
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
@@ -409,6 +412,63 @@ class RegistryPairingAuthPortTest {
         assertEquals("new-access", tokens.getAccessToken())
         // The stalled probe recorded nothing: no verdict, which the gate passes.
         assertEquals(ServerContract.UNKNOWN, registry.entries.value.first { it.id == newId }.contract)
+    }
+
+    @Test
+    fun stalledProbeOnSuccessfulPairingIsReplacedInTheBackground() = runTest {
+        // Re-pairing a server that carries a stale UPDATE_REQUIRED from an
+        // older build: the bounded probe stalls, SignedIn is still reported
+        // within the bound, and a replacement probe on the repository's
+        // background scope corrects the verdict once the server answers —
+        // the same fallback switchToServer has.
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("pairing-stalled-probe-fallback", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+        val transitions = DefaultIdentityTransitionBarrier()
+        val registry = AndroidServerRegistry(prefs, transitions)
+        val staleId = registry.addOrUpdate("https://new.example")
+        registry.setContract(staleId, ServerContract.UPDATE_REQUIRED)
+        val tokens = EncryptedTokenManagerImpl(prefs, registry, transitions)
+        val answerGate = CompletableDeferred<Unit>()
+        val client = HttpClient(
+            MockEngine { request ->
+                check(request.url.encodedPath == ApiV2Probe.PATH) { "unexpected request ${request.url}" }
+                answerGate.await()
+                respond(
+                    """{"server_version":"1.0.0","api_major":2,"contract_digest":"d","links":{"openapi":"/api/v2/openapi.json","capabilities":"/api/v2/capabilities"}}""",
+                    HttpStatusCode.OK,
+                    headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val authRepository = AuthRepository(
+            authApi = AuthApi(client),
+            tokenManager = tokens,
+            serverRegistry = registry,
+            apiV2Probe = ApiV2Probe(client),
+            backgroundScope = background,
+        )
+
+        val startedAt = testScheduler.currentTime
+        RegistryPairingAuthPort(tokens, registry, authRepository = authRepository).persistApprovedSession(
+            serverUrl = "https://new.example",
+            serverName = null,
+            accessToken = "new-access",
+            refreshToken = "new-refresh",
+            expiresIn = 7200,
+        )
+        val elapsed = testScheduler.currentTime - startedAt
+
+        assertTrue(elapsed <= 3_000L, "persistApprovedSession took ${elapsed}ms of virtual time")
+        assertEquals(staleId, registry.activeServerId.value)
+        assertEquals("new-access", tokens.getAccessToken())
+        // Bound elapsed: the stale verdict is untouched so far.
+        assertEquals(ServerContract.UPDATE_REQUIRED, registry.entries.value.first { it.id == staleId }.contract)
+
+        answerGate.complete(Unit)
+        background.coroutineContext.job.children.forEach { it.join() }
+        assertEquals(ServerContract.V2, registry.entries.value.first { it.id == staleId }.contract)
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
@@ -273,7 +273,7 @@ class RegistryPairingAuthPortTest {
             MockEngine { request ->
                 check(request.url.encodedPath == ApiV2Probe.PATH) { "unexpected request ${request.url}" }
                 probes += 1
-                respond("not found", HttpStatusCode.NotFound, headersOf(HttpHeaders.ContentType, "text/plain"))
+                respond("404 page not found\n", HttpStatusCode.NotFound, headersOf(HttpHeaders.ContentType, "text/plain"))
             },
         )
         val authRepository = AuthRepository(
@@ -316,7 +316,7 @@ class RegistryPairingAuthPortTest {
             MockEngine { request ->
                 check(request.url.encodedPath == ApiV2Probe.PATH) { "unexpected request ${request.url}" }
                 probes += 1
-                respond("not found", HttpStatusCode.NotFound, headersOf(HttpHeaders.ContentType, "text/plain"))
+                respond("404 page not found\n", HttpStatusCode.NotFound, headersOf(HttpHeaders.ContentType, "text/plain"))
             },
         )
         val authRepository = AuthRepository(

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
@@ -13,7 +13,10 @@ import org.siloserver.silo.network.api.AuthApi
 import org.siloserver.silo.network.apiv2.ApiV2Probe
 import org.siloserver.silo.repository.AuthRepository
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
@@ -283,14 +286,18 @@ class RegistryPairingAuthPortTest {
             apiV2Probe = ApiV2Probe(client),
         )
 
+        // Real clock: the probe is bounded, and under the test scheduler the
+        // virtual-time bound would fire before the engine thread answers.
         assertFailsWith<IllegalStateException> {
-            RegistryPairingAuthPort(tokens, registry, authRepository = authRepository).persistApprovedSession(
-                serverUrl = "https://new.example",
-                serverName = null,
-                accessToken = "new-access",
-                refreshToken = "new-refresh",
-                expiresIn = 7200,
-            )
+            withContext(Dispatchers.Default) {
+                RegistryPairingAuthPort(tokens, registry, authRepository = authRepository).persistApprovedSession(
+                    serverUrl = "https://new.example",
+                    serverName = null,
+                    accessToken = "new-access",
+                    refreshToken = "new-refresh",
+                    expiresIn = 7200,
+                )
+            }
         }
 
         assertEquals(oldId, registry.activeServerId.value)
@@ -326,13 +333,17 @@ class RegistryPairingAuthPortTest {
             apiV2Probe = ApiV2Probe(client),
         )
 
-        RegistryPairingAuthPort(tokens, registry, authRepository = authRepository).persistApprovedSession(
-            serverUrl = "https://new.example",
-            serverName = null,
-            accessToken = "new-access",
-            refreshToken = "new-refresh",
-            expiresIn = 7200,
-        )
+        // Real clock: the probe is bounded, and under the test scheduler the
+        // virtual-time bound would fire before the engine thread answers.
+        withContext(Dispatchers.Default) {
+            RegistryPairingAuthPort(tokens, registry, authRepository = authRepository).persistApprovedSession(
+                serverUrl = "https://new.example",
+                serverName = null,
+                accessToken = "new-access",
+                refreshToken = "new-refresh",
+                expiresIn = 7200,
+            )
+        }
 
         val newId = registry.entries.value.first { it.url == "https://new.example" }.id
         assertEquals(newId, registry.activeServerId.value)
@@ -342,6 +353,62 @@ class RegistryPairingAuthPortTest {
         assertEquals(1, probes)
         assertEquals(ServerContract.UPDATE_REQUIRED, registry.entries.value.first { it.id == newId }.contract)
         assertEquals(ServerContract.UNKNOWN, registry.entries.value.first { it.id == oldId }.contract)
+    }
+
+    /**
+     * The companion waits ~30 s for ServerResult while an unanswered probe
+     * would sit on the client's ~60 s socket timeout. The success-path probe
+     * must therefore be bounded so the port reports SignedIn on time even
+     * when /api/v2/system/info stalls; the verdict stays UNKNOWN (passes the
+     * gate) and is re-probed on the next switch or launch.
+     *
+     * Runs on runTest's virtual clock: the never-answering engine leaves the
+     * test scheduler idle, so it skips straight to the 3 s bound instead of
+     * really waiting.
+     */
+    @Test
+    fun successfulPairingReportsSignedInWhenTheProbeNeverAnswers() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("pairing-stalled-probe", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+        val transitions = DefaultIdentityTransitionBarrier()
+        val registry = AndroidServerRegistry(prefs, transitions)
+        val tokens = EncryptedTokenManagerImpl(prefs, registry, transitions)
+        // Whether the engine thread even reaches this handler before the
+        // virtual clock jumps to the bound is a race, so the test asserts on
+        // the outcome (bounded return, intact session, no verdict), not on a
+        // request count.
+        val client = HttpClient(
+            MockEngine { request ->
+                check(request.url.encodedPath == ApiV2Probe.PATH) { "unexpected request ${request.url}" }
+                awaitCancellation()
+            },
+        )
+        val authRepository = AuthRepository(
+            authApi = AuthApi(client),
+            tokenManager = tokens,
+            serverRegistry = registry,
+            apiV2Probe = ApiV2Probe(client),
+        )
+
+        val startedAt = testScheduler.currentTime
+        RegistryPairingAuthPort(tokens, registry, authRepository = authRepository).persistApprovedSession(
+            serverUrl = "https://new.example",
+            serverName = null,
+            accessToken = "new-access",
+            refreshToken = "new-refresh",
+            expiresIn = 7200,
+        )
+        val elapsed = testScheduler.currentTime - startedAt
+
+        // The commit completed inside the probe bound, well under the
+        // companion's 30 s ServerResult wait, with the session intact.
+        assertTrue(elapsed <= 3_000L, "persistApprovedSession took ${elapsed}ms of virtual time")
+        val newId = registry.entries.value.first { it.url == "https://new.example" }.id
+        assertEquals(newId, registry.activeServerId.value)
+        assertEquals("new-access", tokens.getAccessToken())
+        // The stalled probe recorded nothing: no verdict, which the gate passes.
+        assertEquals(ServerContract.UNKNOWN, registry.entries.value.first { it.id == newId }.contract)
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/pairing/RegistryPairingAuthPortTest.kt
@@ -301,6 +301,50 @@ class RegistryPairingAuthPortTest {
     }
 
     @Test
+    fun successfulPairingProbesTheNewServerExactlyOnce() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("pairing-success-probe", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+        val transitions = DefaultIdentityTransitionBarrier()
+        val registry = AndroidServerRegistry(prefs, transitions)
+        val oldId = registry.addOrUpdate("https://old.example")
+        registry.switchTo(oldId)
+        val tokens = EncryptedTokenManagerImpl(prefs, registry, transitions)
+        tokens.saveTokens("old-access", "old-refresh", 3600)
+        var probes = 0
+        val client = HttpClient(
+            MockEngine { request ->
+                check(request.url.encodedPath == ApiV2Probe.PATH) { "unexpected request ${request.url}" }
+                probes += 1
+                respond("not found", HttpStatusCode.NotFound, headersOf(HttpHeaders.ContentType, "text/plain"))
+            },
+        )
+        val authRepository = AuthRepository(
+            authApi = AuthApi(client),
+            tokenManager = tokens,
+            serverRegistry = registry,
+            apiV2Probe = ApiV2Probe(client),
+        )
+
+        RegistryPairingAuthPort(tokens, registry, authRepository = authRepository).persistApprovedSession(
+            serverUrl = "https://new.example",
+            serverName = null,
+            accessToken = "new-access",
+            refreshToken = "new-refresh",
+            expiresIn = 7200,
+        )
+
+        val newId = registry.entries.value.first { it.url == "https://new.example" }.id
+        assertEquals(newId, registry.activeServerId.value)
+        assertEquals("new-access", tokens.getAccessToken())
+        // Exactly one probe, and its verdict lands on the newly paired
+        // server's entry — not the old one's.
+        assertEquals(1, probes)
+        assertEquals(ServerContract.UPDATE_REQUIRED, registry.entries.value.first { it.id == newId }.contract)
+        assertEquals(ServerContract.UNKNOWN, registry.entries.value.first { it.id == oldId }.contract)
+    }
+
+    @Test
     fun rollbackToPreviousServerWithoutAuthRepositorySkipsTheProbe() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val prefs = context.getSharedPreferences("pairing-rollback-no-repository", Context.MODE_PRIVATE)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MainActivity.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MainActivity.kt
@@ -439,8 +439,16 @@ class MainActivity : ComponentActivity() {
 
         // Restored servers were probed by whichever build saved them (or never,
         // before the v2 pilot); re-establish the contract verdict once per launch.
+        // A stored UPDATE_REQUIRED may be stale (server upgraded since), and
+        // gated startup consumers would act on it, so that case waits
+        // (bounded) for the probe before routing; UNKNOWN and V2 pass the
+        // gate and refresh in the background.
+        val authRepository = get<AuthRepository>(AuthRepository::class.java)
+        val knownContract = kotlinx.coroutines.withContext(Dispatchers.IO) {
+            authRepository.awaitContractRefreshIfUpdateRequired()
+        }
         lifecycleScope.launch(Dispatchers.IO) {
-            get<AuthRepository>(AuthRepository::class.java).refreshActiveServerName()
+            authRepository.refreshActiveServerName(knownContract = knownContract)
         }
 
         val cleartextConsent = get<org.siloserver.silo.network.CleartextOriginConsent>(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MainActivity.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MainActivity.kt
@@ -439,13 +439,15 @@ class MainActivity : ComponentActivity() {
 
         // Restored servers were probed by whichever build saved them (or never,
         // before the v2 pilot); re-establish the contract verdict once per launch.
-        // A stored UPDATE_REQUIRED may be stale (server upgraded since), and
-        // gated startup consumers would act on it, so that case waits
-        // (bounded) for the probe before routing; UNKNOWN and V2 pass the
-        // gate and refresh in the background.
+        // A stored UPDATE_REQUIRED may be stale (server upgraded since), and a
+        // stored UNKNOWN (first launch after upgrading the app) passes the gate,
+        // so authenticated startup consumers would race the probe and could
+        // receive raw v2 404s from a v1-only server. Both wait (bounded) for
+        // the probe before routing; only a settled V2 skips the wait. A null
+        // result (V2, timeout, or failure) makes the name refresh re-probe.
         val authRepository = get<AuthRepository>(AuthRepository::class.java)
         val knownContract = kotlinx.coroutines.withContext(Dispatchers.IO) {
-            authRepository.awaitContractRefreshIfUpdateRequired()
+            authRepository.awaitContractRefreshIfUnsettled()
         }
         lifecycleScope.launch(Dispatchers.IO) {
             authRepository.refreshActiveServerName(knownContract = knownContract)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MainActivity.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/MainActivity.kt
@@ -437,6 +437,12 @@ class MainActivity : ComponentActivity() {
         val activeEntry = registry.activeEntry.value
             ?: return Route.ServerSetup.route
 
+        // Restored servers were probed by whichever build saved them (or never,
+        // before the v2 pilot); re-establish the contract verdict once per launch.
+        lifecycleScope.launch(Dispatchers.IO) {
+            get<AuthRepository>(AuthRepository::class.java).refreshActiveServerName()
+        }
+
         val cleartextConsent = get<org.siloserver.silo.network.CleartextOriginConsent>(
             org.siloserver.silo.network.CleartextOriginConsent::class.java,
         )

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -451,7 +451,7 @@ val androidModule = module {
     viewModel { ProfileSelectionViewModel(get(), get()) }
     viewModel { CreateProfileViewModel(get()) }
     viewModel { EditProfileViewModel(get()) }
-    viewModel { ServerListViewModel(get(), get()) }
+    viewModel { ServerListViewModel(get(), get(), get()) }
     viewModel { params ->
         val args = params.get<Pair<String?, String?>>()
         DevicePairingViewModel(

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/navigation/AppNavigation.kt
@@ -142,6 +142,7 @@ fun AppNavigation(
 ) {
     val tokenManager: TokenManager = koinInject()
     val serverRegistry: org.siloserver.silo.network.ServerRegistry = koinInject()
+    val authRepository: org.siloserver.silo.repository.AuthRepository = koinInject()
     val overlayPrefsStore: OverlayPrefsStore = koinInject()
     val cardPresentationStore: CardPresentationStore = koinInject()
     val siloCastController: SiloCastController = koinInject()
@@ -488,7 +489,7 @@ fun AppNavigation(
                         serverName = resolved.entry.displayName,
                         onSwitch = {
                             pairingScope.launch {
-                                serverRegistry.switchTo(resolved.entry.id)
+                                authRepository.switchToServer(resolved.entry.id)
                                 // Re-queue ONLY if the target server will send
                                 // the user through auth: that flow ends at
                                 // profile selection, whose popUpTo(0) wipes this

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/ServerSetupViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/ServerSetupViewModel.kt
@@ -11,7 +11,7 @@ import org.siloserver.silo.network.apiv2.ApiV2ProbeResult
 import org.siloserver.silo.network.AndroidServerRegistry
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.AuthRepository
-import org.siloserver.silo.repository.toServerContract
+import org.siloserver.silo.repository.CONTRACT_PROVEN_BY_V2_RESPONSE
 import java.net.URI
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -128,7 +128,11 @@ class ServerSetupViewModel(
                     }
                     return@launch
                 }
-                val contract = probe?.toServerContract()
+                // Anything else the probe said (V2, a transient failure, or a
+                // timeout) is superseded by the v2 setup call succeeding below,
+                // which is proof of v2 on its own; a Failure must not be handed
+                // on as UNKNOWN, or a stale UPDATE_REQUIRED would survive.
+                val contract = CONTRACT_PROVEN_BY_V2_RESPONSE
                 when (val setupResult = getSetupStatus(candidate)) {
                     is ApiResult.Success -> {
                         if (setupResult.data.needsSetup) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/ServerSetupViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/auth/ServerSetupViewModel.kt
@@ -6,9 +6,12 @@ import org.siloserver.silo.common.network.CleartextConsentStore
 import org.siloserver.silo.common.network.cleartextOrigin
 import org.siloserver.silo.model.auth.SetupStatusResponse
 import org.siloserver.silo.model.auth.SignupStatusResponse
+import org.siloserver.silo.model.server.ServerContract
+import org.siloserver.silo.network.apiv2.ApiV2ProbeResult
 import org.siloserver.silo.network.AndroidServerRegistry
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.AuthRepository
+import org.siloserver.silo.repository.toServerContract
 import java.net.URI
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -56,6 +59,10 @@ class ServerSetupViewModel(
     },
     private val getSignupStatus: suspend (String) -> ApiResult<SignupStatusResponse> = {
         authRepository.getSignupStatus(it)
+    },
+    /** v2 contract probe for a candidate; null when no probe is wired in. */
+    private val probeContract: suspend (String) -> ApiV2ProbeResult? = {
+        authRepository.probeServerContract(it)
     },
     private val candidateUrls: (ServerSetupUiState) -> List<String> = {
         buildServerSetupCandidateUrls(it.serverUrl, it.selectedScheme, it.port)
@@ -112,10 +119,20 @@ class ServerSetupViewModel(
 
             var lastError: String? = null
             for (candidate in candidates) {
+                // One contract probe per established connection: a v1-only
+                // server is reported as update-server, never retried on v1.
+                val probe = probeContract(candidate)
+                if (probe is ApiV2ProbeResult.UpdateServer) {
+                    _uiState.update {
+                        it.copy(isLoading = false, error = ServerContract.UPDATE_REQUIRED_MESSAGE)
+                    }
+                    return@launch
+                }
+                val contract = probe?.toServerContract()
                 when (val setupResult = getSetupStatus(candidate)) {
                     is ApiResult.Success -> {
                         if (setupResult.data.needsSetup) {
-                            handleSuccessfulConnection(candidate, ServerSetupDestination.Setup)
+                            handleSuccessfulConnection(candidate, ServerSetupDestination.Setup, contract)
                             return@launch
                         }
                     }
@@ -139,6 +156,7 @@ class ServerSetupViewModel(
                 handleSuccessfulConnection(
                     candidate,
                     ServerSetupDestination.Login(signupEnabled = signupEnabled),
+                    contract,
                 )
                 return@launch
             }
@@ -163,7 +181,7 @@ class ServerSetupViewModel(
             cleartextConsentStore.approve(pending.origin)
             if (pendingCleartextConnection !== pending) return@launch
             pendingCleartextConnection = null
-            persistAndNavigate(pending.serverUrl, pending.destination)
+            persistAndNavigate(pending.serverUrl, pending.destination, pending.contract)
         }
     }
 
@@ -182,6 +200,7 @@ class ServerSetupViewModel(
     private suspend fun handleSuccessfulConnection(
         serverUrl: String,
         destination: ServerSetupDestination,
+        contract: ServerContract?,
     ) {
         if (serverUrl.startsWith("http://", ignoreCase = true)) {
             val origin = cleartextOrigin(serverUrl)
@@ -197,13 +216,14 @@ class ServerSetupViewModel(
                 return
             }
             if (cleartextConsentStore.isApproved(origin)) {
-                persistAndNavigate(serverUrl, destination)
+                persistAndNavigate(serverUrl, destination, contract)
                 return
             }
             pendingCleartextConnection = PendingCleartextConnection(
                 serverUrl = serverUrl,
                 origin = origin,
                 destination = destination,
+                contract = contract,
             )
             _uiState.update {
                 it.copy(
@@ -214,14 +234,15 @@ class ServerSetupViewModel(
             }
             return
         }
-        persistAndNavigate(serverUrl, destination)
+        persistAndNavigate(serverUrl, destination, contract)
     }
 
     private suspend fun persistAndNavigate(
         serverUrl: String,
         destination: ServerSetupDestination,
+        contract: ServerContract?,
     ) {
-        authRepository.setServerUrl(serverUrl)
+        authRepository.setServerUrl(serverUrl, contract)
         _uiState.update {
             it.copy(
                 isLoading = false,
@@ -236,6 +257,7 @@ private data class PendingCleartextConnection(
     val serverUrl: String,
     val origin: String,
     val destination: ServerSetupDestination,
+    val contract: ServerContract?,
 )
 
 /**

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.model.profile.Profile
 import org.siloserver.silo.model.profile.authorizedProfileToken
+import org.siloserver.silo.model.server.ServerContract
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.AuthScopeSnapshot
 import org.siloserver.silo.repository.AuthRepository
@@ -50,6 +51,27 @@ class ProfileSelectionViewModel(
 
     init {
         loadProfiles()
+        reloadWhenUpdateRequiredLifts()
+    }
+
+    /**
+     * The admin lookup in [loadProfiles] is a gated v2 call. On launch the
+     * stored verdict can be a stale UPDATE_REQUIRED (server upgraded since),
+     * which the gate rejects without a request; once the launch probe
+     * records V2 the grid must be reloaded so the manage affordances match
+     * the real answer.
+     */
+    private fun reloadWhenUpdateRequiredLifts() {
+        val contracts = authRepository?.activeServerContractFlow ?: return
+        viewModelScope.launch {
+            var previous: ServerContract? = null
+            contracts.collect { contract ->
+                if (previous == ServerContract.UPDATE_REQUIRED && contract == ServerContract.V2) {
+                    loadProfiles()
+                }
+                previous = contract
+            }
+        }
     }
 
     /**

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/servers/ServerListViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/servers/ServerListViewModel.kt
@@ -103,7 +103,17 @@ class ServerListViewModel(
 
     fun onRemove(serverId: String) {
         viewModelScope.launch {
+            val wasActive = serverRegistry.activeServerId.value == serverId
             serverRegistry.remove(serverId)
+
+            // Removing the ACTIVE server promotes the next-MRU entry inside
+            // the registry, which never probes: without this the promoted
+            // server keeps whatever contract verdict an older build stored
+            // (or UNKNOWN). Re-establish its identity and verdict like every
+            // other switch path.
+            if (wasActive && serverRegistry.activeServerId.value != null) {
+                authRepository.refreshActiveServerName()
+            }
         }
     }
 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/servers/ServerListViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/servers/ServerListViewModel.kt
@@ -109,10 +109,15 @@ class ServerListViewModel(
             // Removing the ACTIVE server promotes the next-MRU entry inside
             // the registry, which never probes: without this the promoted
             // server keeps whatever contract verdict an older build stored
-            // (or UNKNOWN). Re-establish its identity and verdict like every
-            // other switch path.
-            if (wasActive && serverRegistry.activeServerId.value != null) {
-                authRepository.refreshActiveServerName()
+            // (or UNKNOWN). Route it through the same durable switch path as
+            // every other promotion: the registry already points at it, so
+            // switchToServer is idempotent there, and its bounded probe hands
+            // a replacement to the repository's process-lifetime background
+            // scope — popping this screen cancels viewModelScope, which must
+            // not strand the promoted server on a stale verdict.
+            val promotedId = serverRegistry.activeServerId.value
+            if (wasActive && promotedId != null) {
+                authRepository.switchToServer(promotedId)
             }
         }
     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/servers/ServerListViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/servers/ServerListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.model.server.ServerEntry
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.repository.AuthRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,6 +38,7 @@ data class ServerListUiState(
 class ServerListViewModel(
     private val serverRegistry: ServerRegistry,
     private val tokenManager: TokenManager,
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ServerListUiState())
@@ -66,11 +68,9 @@ class ServerListViewModel(
         }
         _uiState.update { it.copy(pendingSwitchToId = serverId) }
         viewModelScope.launch {
-            serverRegistry.switchTo(serverId)
-            // Force the token manager to flush its cache and reload from the
-            // new server's slot before the navigator advances. Without this,
-            // the destination screen could read stale tokens for one frame.
-            tokenManager.switchActiveServer(serverId)
+            // Switch the registry + token scope (so the destination screen never
+            // reads stale tokens) and probe the target server.s contract.
+            authRepository.switchToServer(serverId)
 
             // Route to the deepest screen the new server's stored credentials
             // can populate. Mirrors MainActivity.resolveStartDestination so a

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/auth/ServerSetupPersistenceTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/auth/ServerSetupPersistenceTest.kt
@@ -9,7 +9,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -18,14 +21,18 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
+import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.SiloAuthPlugin
 import org.siloserver.silo.network.SiloJson
 import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.api.AuthApi
+import org.siloserver.silo.network.apiv2.ApiV2ProbeResult
 import org.siloserver.silo.common.network.CleartextConsentStore
 import org.siloserver.silo.model.auth.SetupStatusResponse
 import org.siloserver.silo.model.auth.SignupStatusResponse
+import org.siloserver.silo.model.server.ServerContract
+import org.siloserver.silo.model.server.ServerEntry
 import org.siloserver.silo.repository.AuthRepository
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -195,6 +202,39 @@ class ServerSetupPersistenceTest {
         assertEquals("Could not safely identify this HTTP server.", viewModel.uiState.value.error)
     }
 
+    @Test
+    fun failedProbeWithSuccessfulSetupRecordsV2OverAStaleVerdict() = runTest(dispatcher) {
+        // The candidate probe fails transiently (or times out) but the v2
+        // setup call succeeds: that answer is proof of v2, so the registry
+        // entry's stale UPDATE_REQUIRED must be replaced with V2 rather than
+        // left alone behind a non-null UNKNOWN.
+        val tokenManager = RecordingTokenManager()
+        val registry = StaleContractRegistry("https://secure.silo", ServerContract.UPDATE_REQUIRED)
+        val viewModel = ServerSetupViewModel(
+            authRepository = AuthRepository(
+                authApi = AuthApi(
+                    HttpClient(MockEngine { throw IOException("Unexpected network request") }) {
+                        install(ContentNegotiation) { json(SiloJson) }
+                        install(SiloAuthPlugin) { this.tokenManager = tokenManager }
+                    },
+                ),
+                tokenManager = tokenManager,
+                serverRegistry = registry,
+            ),
+            cleartextConsentStore = FakeCleartextConsentStore(),
+            getSetupStatus = { ApiResult.Success(SetupStatusResponse(needsSetup = false)) },
+            getSignupStatus = { ApiResult.Success(SignupStatusResponse(enabled = true)) },
+            probeContract = { ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.TIMEOUT) },
+        )
+
+        viewModel.onServerUrlChanged("https://secure.silo")
+        viewModel.onConnectClick()
+        awaitSettled(viewModel)
+
+        assertEquals(listOf("https://secure.silo"), registry.switchedTo)
+        assertEquals(ServerContract.V2, registry.activeEntry.value?.contract)
+    }
+
     private fun viewModelFor(
         tokenManager: RecordingTokenManager,
         approvals: FakeCleartextConsentStore = FakeCleartextConsentStore(),
@@ -256,6 +296,32 @@ private class RecordingTokenManager(
     override suspend fun getCurrentServerId(): String? = null
     override suspend fun switchActiveServer(serverId: String?) = Unit
     override suspend fun signOutCurrentServer() = Unit
+}
+
+/** One saved server, [url], whose stored contract starts at [initial]; records switches and contract writes. */
+private class StaleContractRegistry(url: String, initial: ServerContract) : ServerRegistry {
+    private val entry = MutableStateFlow(ServerEntry(id = "a", url = url, contract = initial))
+    val switchedTo = mutableListOf<String>()
+    override val entries: StateFlow<List<ServerEntry>> = MutableStateFlow(listOf(entry.value))
+    override val activeServerId = MutableStateFlow<String?>(null)
+    override val activeEntry: StateFlow<ServerEntry?> = entry
+    override suspend fun addOrUpdate(url: String, fetchedName: String?): String {
+        check(url == entry.value.url) { "unexpected server $url" }
+        return entry.value.id
+    }
+    override suspend fun rename(serverId: String, userOverrideName: String?) = Unit
+    override suspend fun setFetchedName(serverId: String, fetchedName: String?) = Unit
+    override suspend fun setProfileId(serverId: String, profileId: String?) = Unit
+    override suspend fun setContract(serverId: String, contract: ServerContract) {
+        entry.update { it.copy(contract = contract) }
+    }
+    override suspend fun remove(serverId: String) = Unit
+    override suspend fun signOut(serverId: String) = Unit
+    override suspend fun switchTo(serverId: String) {
+        switchedTo += entry.value.url
+        activeServerId.value = serverId
+    }
+    override suspend fun touchActive() = Unit
 }
 
 private open class FakeCleartextConsentStore : CleartextConsentStore {

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModelContractTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModelContractTest.kt
@@ -10,6 +10,7 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -21,6 +22,8 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.siloserver.silo.model.server.ServerContract
 import org.siloserver.silo.model.server.ServerEntry
 import org.siloserver.silo.network.ServerRegistry
@@ -54,10 +57,13 @@ class ProfileSelectionViewModelContractTest {
     @Test
     fun v2VerdictArrivingAfterUpdateRequiredRetriggersTheGatedLoad() = runTest(dispatcher) {
         val registry = MutableContractRegistry(ServerContract.UPDATE_REQUIRED)
-        val recorded = mutableListOf<String>()
+        // The mock engine answers on its own thread, outside the test
+        // scheduler, so each request is awaited rather than assumed to have
+        // landed by the time an assertion runs.
+        val requests = Channel<String>(Channel.UNLIMITED)
         val client = HttpClient(
             MockEngine { request ->
-                recorded += request.url.encodedPath
+                requests.trySend(request.url.encodedPath)
                 when (request.url.encodedPath) {
                     "/api/v1/profiles" -> respond(
                         """{"profiles":[]}""",
@@ -83,8 +89,9 @@ class ProfileSelectionViewModelContractTest {
         ProfileSelectionViewModel(profileRepository, authRepository)
         runCurrent()
 
-        // First load: the gate rejects the v2 call, so only the v1 list ran.
-        assertEquals(listOf("/api/v1/profiles"), recorded)
+        // First load: the gate rejects the v2 call without a request, so the
+        // first thing to reach the network is the v1 list.
+        assertEquals("/api/v1/profiles", requests.awaitNext())
 
         registry.setContract("a", ServerContract.V2)
         // The collector's resumption is queued on the unconfined event loop
@@ -92,11 +99,14 @@ class ProfileSelectionViewModelContractTest {
         advanceUntilIdle()
 
         // The contract change re-ran the load, and this time the gate let
-        // the v2 admin lookup through to the network. (The follow-up v1 list
-        // completes on the engine thread, outside the test scheduler, so it
-        // is deliberately not asserted here.)
-        assertEquals(1, recorded.count { it == "/api/v2/account/me" }, recorded.toString())
+        // the v2 admin lookup through to the network, followed by the list.
+        assertEquals("/api/v2/account/me", requests.awaitNext())
+        assertEquals("/api/v1/profiles", requests.awaitNext())
     }
+
+    /** Real-clock wait: under the test scheduler a virtual-time timeout would fire at once. */
+    private suspend fun Channel<String>.awaitNext(): String =
+        withContext(Dispatchers.Default) { withTimeout(5_000) { receive() } }
 }
 
 private class MutableContractRegistry(initial: ServerContract) : ServerRegistry {

--- a/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModelContractTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/org/siloserver/silo/android/ui/screens/profiles/ProfileSelectionViewModelContractTest.kt
@@ -1,0 +1,136 @@
+package org.siloserver.silo.android.ui.screens.profiles
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.siloserver.silo.model.server.ServerContract
+import org.siloserver.silo.model.server.ServerEntry
+import org.siloserver.silo.network.ServerRegistry
+import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.api.AuthApi
+import org.siloserver.silo.network.api.ProfileApi
+import org.siloserver.silo.network.apiv2.ApiV2Gate
+import org.siloserver.silo.repository.AuthRepository
+import org.siloserver.silo.repository.ProfileRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The admin lookup behind the profile grid is a gated v2 call. A stale
+ * UPDATE_REQUIRED verdict at launch blocks it without a request; when the
+ * launch probe then records V2, the view model must re-run the load.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileSelectionViewModelContractTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @AfterTest
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun v2VerdictArrivingAfterUpdateRequiredRetriggersTheGatedLoad() = runTest(dispatcher) {
+        val registry = MutableContractRegistry(ServerContract.UPDATE_REQUIRED)
+        val recorded = mutableListOf<String>()
+        val client = HttpClient(
+            MockEngine { request ->
+                recorded += request.url.encodedPath
+                when (request.url.encodedPath) {
+                    "/api/v1/profiles" -> respond(
+                        """{"profiles":[]}""",
+                        HttpStatusCode.OK,
+                        headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                    else -> respond(
+                        """{"type":"about:blank","title":"nope","status":500,"detail":"x","instance":"urn:x"}""",
+                        HttpStatusCode.InternalServerError,
+                        headersOf(HttpHeaders.ContentType, "application/problem+json"),
+                    )
+                }
+            },
+        ) { install(ContentNegotiation) { json(SiloJson) } }
+        val tokens = StubTokenManager()
+        val authRepository = AuthRepository(
+            authApi = AuthApi(client, ApiV2Gate(registry)),
+            tokenManager = tokens,
+            serverRegistry = registry,
+        )
+        val profileRepository = ProfileRepository(ProfileApi(client), tokens, registry)
+
+        ProfileSelectionViewModel(profileRepository, authRepository)
+        runCurrent()
+
+        // First load: the gate rejects the v2 call, so only the v1 list ran.
+        assertEquals(listOf("/api/v1/profiles"), recorded)
+
+        registry.setContract("a", ServerContract.V2)
+        // The collector's resumption is queued on the unconfined event loop
+        // rather than run inline; pump it (and the reload it launches).
+        advanceUntilIdle()
+
+        // The contract change re-ran the load, and this time the gate let
+        // the v2 admin lookup through to the network. (The follow-up v1 list
+        // completes on the engine thread, outside the test scheduler, so it
+        // is deliberately not asserted here.)
+        assertEquals(1, recorded.count { it == "/api/v2/account/me" }, recorded.toString())
+    }
+}
+
+private class MutableContractRegistry(initial: ServerContract) : ServerRegistry {
+    private val entry = MutableStateFlow(ServerEntry(id = "a", url = "https://a.example", contract = initial))
+    override val entries: StateFlow<List<ServerEntry>> = MutableStateFlow(listOf(entry.value))
+    override val activeServerId: StateFlow<String?> = MutableStateFlow("a")
+    override val activeEntry: StateFlow<ServerEntry?> = entry
+    override suspend fun addOrUpdate(url: String, fetchedName: String?): String = "a"
+    override suspend fun rename(serverId: String, userOverrideName: String?) = Unit
+    override suspend fun setFetchedName(serverId: String, fetchedName: String?) = Unit
+    override suspend fun setProfileId(serverId: String, profileId: String?) = Unit
+    override suspend fun setContract(serverId: String, contract: ServerContract) {
+        entry.update { it.copy(contract = contract) }
+    }
+    override suspend fun remove(serverId: String) = Unit
+    override suspend fun signOut(serverId: String) = Unit
+    override suspend fun switchTo(serverId: String) = Unit
+    override suspend fun touchActive() = Unit
+}
+
+private class StubTokenManager : TokenManager {
+    override suspend fun getAccessToken(): String? = "access"
+    override suspend fun getRefreshToken(): String? = null
+    override suspend fun saveTokens(accessToken: String, refreshToken: String, expiresIn: Long) = Unit
+    override suspend fun clearTokens() = Unit
+    override suspend fun invalidateSession() = Unit
+    override suspend fun getProfileId(): String? = null
+    override suspend fun setProfileId(profileId: String?) = Unit
+    override suspend fun getProfileToken(): String? = null
+    override suspend fun setProfileToken(token: String?) = Unit
+    override suspend fun getServerUrl(): String = "https://a.example"
+    override suspend fun setServerUrl(url: String) = Unit
+    override suspend fun getCurrentServerId(): String? = "a"
+    override suspend fun switchActiveServer(serverId: String?) = Unit
+    override suspend fun signOutCurrentServer() = Unit
+    override val sessionExpired: SharedFlow<Unit> = MutableSharedFlow()
+}

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/MainTvActivity.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/MainTvActivity.kt
@@ -305,8 +305,16 @@ class MainTvActivity : ComponentActivity() {
 
         // Restored servers were probed by whichever build saved them (or never,
         // before the v2 pilot); re-establish the contract verdict once per launch.
+        // A stored UPDATE_REQUIRED may be stale (server upgraded since), and
+        // gated startup consumers would act on it, so that case waits
+        // (bounded) for the probe before routing; UNKNOWN and V2 pass the
+        // gate and refresh in the background.
+        val authRepository = get<AuthRepository>(AuthRepository::class.java)
+        val knownContract = kotlinx.coroutines.withContext(Dispatchers.IO) {
+            authRepository.awaitContractRefreshIfUpdateRequired()
+        }
         lifecycleScope.launch(Dispatchers.IO) {
-            get<AuthRepository>(AuthRepository::class.java).refreshActiveServerName()
+            authRepository.refreshActiveServerName(knownContract = knownContract)
         }
 
         val cleartextConsent = get<org.siloserver.silo.network.CleartextOriginConsent>(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/MainTvActivity.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/MainTvActivity.kt
@@ -303,6 +303,12 @@ class MainTvActivity : ComponentActivity() {
         val activeEntry = registry.activeEntry.value
             ?: return TvRoute.ServerSetup.route
 
+        // Restored servers were probed by whichever build saved them (or never,
+        // before the v2 pilot); re-establish the contract verdict once per launch.
+        lifecycleScope.launch(Dispatchers.IO) {
+            get<AuthRepository>(AuthRepository::class.java).refreshActiveServerName()
+        }
+
         val cleartextConsent = get<org.siloserver.silo.network.CleartextOriginConsent>(
             org.siloserver.silo.network.CleartextOriginConsent::class.java,
         )

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/MainTvActivity.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/MainTvActivity.kt
@@ -305,13 +305,15 @@ class MainTvActivity : ComponentActivity() {
 
         // Restored servers were probed by whichever build saved them (or never,
         // before the v2 pilot); re-establish the contract verdict once per launch.
-        // A stored UPDATE_REQUIRED may be stale (server upgraded since), and
-        // gated startup consumers would act on it, so that case waits
-        // (bounded) for the probe before routing; UNKNOWN and V2 pass the
-        // gate and refresh in the background.
+        // A stored UPDATE_REQUIRED may be stale (server upgraded since), and a
+        // stored UNKNOWN (first launch after upgrading the app) passes the gate,
+        // so authenticated startup consumers would race the probe and could
+        // receive raw v2 404s from a v1-only server. Both wait (bounded) for
+        // the probe before routing; only a settled V2 skips the wait. A null
+        // result (V2, timeout, or failure) makes the name refresh re-probe.
         val authRepository = get<AuthRepository>(AuthRepository::class.java)
         val knownContract = kotlinx.coroutines.withContext(Dispatchers.IO) {
-            authRepository.awaitContractRefreshIfUpdateRequired()
+            authRepository.awaitContractRefreshIfUnsettled()
         }
         lifecycleScope.launch(Dispatchers.IO) {
             authRepository.refreshActiveServerName(knownContract = knownContract)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -312,7 +312,7 @@ val androidTvModule = module {
     // machine. A later step wires the UI to PairingReceiver.status.
     single {
         org.siloserver.silo.common.pairing.PairingReceiver(
-            authPort = org.siloserver.silo.common.pairing.RegistryPairingAuthPort(get(), get(), get()),
+            authPort = org.siloserver.silo.common.pairing.RegistryPairingAuthPort(get(), get(), get(), get()),
             deviceLogin = org.siloserver.silo.common.pairing.DeviceLoginRepositoryPort(get()),
             identityProvider = {
                 org.siloserver.silo.common.pairing.PairingDeviceIdentity(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvLoginViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvLoginViewModel.kt
@@ -106,6 +106,9 @@ class TvLoginViewModel(
                         )
                         return@launch
                     }
+                    // Tokens are committed outside persistSession here, so refresh the
+                    // server's v2 contract verdict the same way every other sign-in does.
+                    authRepository.onSessionCommitted()
                     _uiState.update { it.copy(isLoading = false, loginSuccess = true) }
                 }
                 is ApiResult.Error -> {
@@ -196,6 +199,9 @@ class TvLoginViewModel(
             handleSessionPersistenceFailure(accessToken, refreshToken)
             return
         }
+        // Tokens are committed outside persistSession here, so refresh the
+        // server's v2 contract verdict the same way every other sign-in does.
+        authRepository.onSessionCommitted()
         _uiState.update { it.copy(isLoading = false, loginSuccess = true) }
     }
 
@@ -207,6 +213,7 @@ class TvLoginViewModel(
             tokenManager.getAccessToken() == accessToken &&
                 tokenManager.getRefreshToken() == refreshToken
         }.getOrDefault(false)
+        if (committed) authRepository.onSessionCommitted()
         authCompleted = committed
         _uiState.update {
             it.copy(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupViewModel.kt
@@ -6,6 +6,9 @@ import org.siloserver.silo.common.network.CleartextConsentStore
 import org.siloserver.silo.common.network.cleartextOrigin
 import org.siloserver.silo.model.auth.SetupStatusResponse
 import org.siloserver.silo.model.auth.SignupStatusResponse
+import org.siloserver.silo.model.server.ServerContract
+import org.siloserver.silo.network.apiv2.ApiV2ProbeResult
+import org.siloserver.silo.repository.toServerContract
 import org.siloserver.silo.network.AndroidServerRegistry
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.AuthRepository
@@ -45,6 +48,8 @@ internal sealed class TvServerSetupProbeResult {
     data class Success(
         val serverUrl: String,
         val destination: TvServerSetupDestination,
+        /** Verdict of the v2 contract probe, or null when no probe ran / it failed without a verdict. */
+        val contract: ServerContract? = null,
     ) : TvServerSetupProbeResult()
 
     data class Failure(
@@ -73,6 +78,10 @@ class TvServerSetupViewModel(
     },
     private val getSignupStatus: suspend (String) -> ApiResult<SignupStatusResponse> = {
         authRepository.getSignupStatus(it)
+    },
+    /** v2 contract probe for a candidate; null when no probe is wired in. */
+    private val probeContract: suspend (String) -> ApiV2ProbeResult? = {
+        authRepository.probeServerContract(it)
     },
 ) : ViewModel() {
 
@@ -120,9 +129,10 @@ class TvServerSetupViewModel(
                 candidates = candidates,
                 getSetupStatus = getSetupStatus,
                 getSignupStatus = getSignupStatus,
+                probeContract = probeContract,
             )) {
                 is TvServerSetupProbeResult.Success -> {
-                    handleSuccessfulConnection(result.serverUrl, result.destination)
+                    handleSuccessfulConnection(result.serverUrl, result.destination, result.contract)
                 }
                 is TvServerSetupProbeResult.Failure -> {
                     _uiState.update {
@@ -145,7 +155,7 @@ class TvServerSetupViewModel(
             cleartextConsentStore.approve(pending.origin)
             if (pendingCleartextConnection !== pending) return@launch
             pendingCleartextConnection = null
-            persistAndNavigate(pending.serverUrl, pending.destination)
+            persistAndNavigate(pending.serverUrl, pending.destination, pending.contract)
         }
     }
 
@@ -163,6 +173,7 @@ class TvServerSetupViewModel(
     private suspend fun handleSuccessfulConnection(
         serverUrl: String,
         destination: TvServerSetupDestination,
+        contract: ServerContract?,
     ) {
         if (serverUrl.startsWith("http://", ignoreCase = true)) {
             val origin = cleartextOrigin(serverUrl)
@@ -178,13 +189,14 @@ class TvServerSetupViewModel(
                 return
             }
             if (cleartextConsentStore.isApproved(origin)) {
-                persistAndNavigate(serverUrl, destination)
+                persistAndNavigate(serverUrl, destination, contract)
                 return
             }
             pendingCleartextConnection = PendingTvCleartextConnection(
                 serverUrl = serverUrl,
                 origin = origin,
                 destination = destination,
+                contract = contract,
             )
             _uiState.update {
                 it.copy(
@@ -195,14 +207,15 @@ class TvServerSetupViewModel(
             }
             return
         }
-        persistAndNavigate(serverUrl, destination)
+        persistAndNavigate(serverUrl, destination, contract)
     }
 
     private suspend fun persistAndNavigate(
         serverUrl: String,
         destination: TvServerSetupDestination,
+        contract: ServerContract?,
     ) {
-        authRepository.setServerUrl(serverUrl)
+        authRepository.setServerUrl(serverUrl, contract)
         _uiState.update {
             it.copy(
                 serverUrl = serverUrl,
@@ -218,15 +231,28 @@ private data class PendingTvCleartextConnection(
     val serverUrl: String,
     val origin: String,
     val destination: TvServerSetupDestination,
+    val contract: ServerContract?,
 )
 
 internal suspend fun probeTvServerSetupCandidates(
     candidates: List<String>,
     getSetupStatus: suspend (String) -> ApiResult<SetupStatusResponse>,
     getSignupStatus: suspend (String) -> ApiResult<SignupStatusResponse>,
+    probeContract: suspend (String) -> ApiV2ProbeResult? = { null },
 ): TvServerSetupProbeResult {
     for ((index, candidate) in candidates.withIndex()) {
         val isLastCandidate = index == candidates.lastIndex
+
+        // One contract probe per established connection: a v1-only server is
+        // the explicit update-server state, never a v1 retry.
+        val probe = probeContract(candidate)
+        if (probe is ApiV2ProbeResult.UpdateServer) {
+            return TvServerSetupProbeResult.Failure(
+                serverUrl = candidate,
+                message = ServerContract.UPDATE_REQUIRED_MESSAGE,
+            )
+        }
+        val contract = probe?.toServerContract()
 
         when (val result = getSetupStatus(candidate)) {
             is ApiResult.Success -> {
@@ -234,6 +260,7 @@ internal suspend fun probeTvServerSetupCandidates(
                     return TvServerSetupProbeResult.Success(
                         serverUrl = candidate,
                         destination = TvServerSetupDestination.Setup,
+                        contract = contract,
                     )
                 }
             }
@@ -259,6 +286,7 @@ internal suspend fun probeTvServerSetupCandidates(
         return TvServerSetupProbeResult.Success(
             serverUrl = candidate,
             destination = TvServerSetupDestination.Login(signupEnabled = signupEnabled),
+            contract = contract,
         )
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupViewModel.kt
@@ -8,7 +8,7 @@ import org.siloserver.silo.model.auth.SetupStatusResponse
 import org.siloserver.silo.model.auth.SignupStatusResponse
 import org.siloserver.silo.model.server.ServerContract
 import org.siloserver.silo.network.apiv2.ApiV2ProbeResult
-import org.siloserver.silo.repository.toServerContract
+import org.siloserver.silo.repository.CONTRACT_PROVEN_BY_V2_RESPONSE
 import org.siloserver.silo.network.AndroidServerRegistry
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.repository.AuthRepository
@@ -252,7 +252,11 @@ internal suspend fun probeTvServerSetupCandidates(
                 message = ServerContract.UPDATE_REQUIRED_MESSAGE,
             )
         }
-        val contract = probe?.toServerContract()
+        // Anything else the probe said (V2, a transient failure, or a timeout)
+        // is superseded by the v2 setup call succeeding below, which is proof
+        // of v2 on its own; a Failure must not be handed on as UNKNOWN, or a
+        // stale UPDATE_REQUIRED would survive.
+        val contract = CONTRACT_PROVEN_BY_V2_RESPONSE
 
         when (val result = getSetupStatus(candidate)) {
             is ApiResult.Success -> {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.siloserver.silo.model.profile.Profile
 import org.siloserver.silo.model.profile.authorizedProfileToken
+import org.siloserver.silo.model.server.ServerContract
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.AuthScopeSnapshot
 import org.siloserver.silo.repository.AuthRepository
@@ -53,6 +54,29 @@ class TvProfileSelectionViewModel(
 
     init {
         loadProfiles()
+        reloadWhenUpdateRequiredLifts()
+    }
+
+    /**
+     * The admin lookup in [loadProfiles] is a gated v2 call. On launch the
+     * stored verdict can be a stale UPDATE_REQUIRED (server upgraded since),
+     * which the gate rejects without a request; when the launch probe outlasts
+     * its bound, routing proceeds on the stale verdict and the background
+     * refresh records V2 later. The grid must then be reloaded so the manage
+     * affordances match the real answer instead of staying hidden for the
+     * ViewModel's lifetime.
+     */
+    private fun reloadWhenUpdateRequiredLifts() {
+        val contracts = authRepository?.activeServerContractFlow ?: return
+        viewModelScope.launch {
+            var previous: ServerContract? = null
+            contracts.collect { contract ->
+                if (previous == ServerContract.UPDATE_REQUIRED && contract == ServerContract.V2) {
+                    loadProfiles()
+                }
+                previous = contract
+            }
+        }
     }
 
     /**

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/servers/TvServerListViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/servers/TvServerListViewModel.kt
@@ -64,8 +64,8 @@ class TvServerListViewModel(
         if (_uiState.value.activeId == serverId) return
         _uiState.update { it.copy(pendingSwitchToId = serverId) }
         viewModelScope.launch {
-            serverRegistry.switchTo(serverId)
-            tokenManager.switchActiveServer(serverId)
+            // Switch the registry + token scope and probe the target server.s contract.
+            authRepository.switchToServer(serverId)
 
             // Land on the deepest screen the new server's stored credentials
             // can reach — preserves the signed-in user when tokens are present.

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/servers/TvServerListViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/servers/TvServerListViewModel.kt
@@ -114,7 +114,11 @@ class TvServerListViewModel(
                 return@launch
             }
 
-            tokenManager.switchActiveServer(promotedId)
+            // The registry already points at the promoted server, but only the
+            // full switch path also moves the token scope and probes the
+            // promoted server's identity and v2 contract verdict (it is
+            // idempotent when the registry is already there).
+            authRepository.switchToServer(promotedId)
 
             // Land on the deepest screen the promoted server's stored
             // credentials can reach — preserves that server's session if tokens

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupUrlProbeTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/auth/TvServerSetupUrlProbeTest.kt
@@ -3,7 +3,9 @@ package org.siloserver.silo.tv.ui.screens.auth
 import kotlinx.coroutines.test.runTest
 import org.siloserver.silo.model.auth.SetupStatusResponse
 import org.siloserver.silo.model.auth.SignupStatusResponse
+import org.siloserver.silo.model.server.ServerContract
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.apiv2.ApiV2ProbeResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -55,5 +57,36 @@ class TvServerSetupUrlProbeTest {
         assertEquals(TvServerSetupDestination.Login(signupEnabled = true), success.destination)
         assertEquals(listOf("https://media.local", "http://media.local"), setupRequests)
         assertEquals(listOf("http://media.local"), signupRequests)
+    }
+
+    @Test
+    fun failedProbeWithSuccessfulSetupYieldsV2NotUnknown() = runTest {
+        // A transient probe failure (or timeout) is no verdict; the v2 setup
+        // call succeeding is proof of v2, so the connect result carries V2
+        // for setServerUrl to record over any stale UPDATE_REQUIRED.
+        val result = probeTvServerSetupCandidates(
+            candidates = listOf("https://media.local"),
+            getSetupStatus = { ApiResult.Success(SetupStatusResponse(needsSetup = false)) },
+            getSignupStatus = { ApiResult.Success(SignupStatusResponse(enabled = false)) },
+            probeContract = { ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.TIMEOUT) },
+        )
+
+        val success = assertIs<TvServerSetupProbeResult.Success>(result)
+        assertEquals(ServerContract.V2, success.contract)
+    }
+
+    @Test
+    fun updateServerProbeStillShortCircuitsBeforeSetup() = runTest {
+        var setupCalls = 0
+        val result = probeTvServerSetupCandidates(
+            candidates = listOf("https://media.local"),
+            getSetupStatus = { setupCalls += 1; ApiResult.Success(SetupStatusResponse(needsSetup = false)) },
+            getSignupStatus = { ApiResult.Success(SignupStatusResponse(enabled = false)) },
+            probeContract = { ApiV2ProbeResult.UpdateServer },
+        )
+
+        val failure = assertIs<TvServerSetupProbeResult.Failure>(result)
+        assertEquals(ServerContract.UPDATE_REQUIRED_MESSAGE, failure.message)
+        assertEquals(0, setupCalls)
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionViewModelContractTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/profiles/TvProfileSelectionViewModelContractTest.kt
@@ -1,0 +1,148 @@
+package org.siloserver.silo.tv.ui.screens.profiles
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.siloserver.silo.model.server.ServerContract
+import org.siloserver.silo.model.server.ServerEntry
+import org.siloserver.silo.network.ServerRegistry
+import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.api.AuthApi
+import org.siloserver.silo.network.api.ProfileApi
+import org.siloserver.silo.network.apiv2.ApiV2Gate
+import org.siloserver.silo.repository.AuthRepository
+import org.siloserver.silo.repository.ProfileRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The admin lookup behind the TV profile grid is a gated v2 call. When the
+ * launch probe outlasts its bound, routing proceeds on a stale
+ * UPDATE_REQUIRED verdict that blocks the lookup without a request; when the
+ * background refresh then records V2, the view model must re-run the load
+ * rather than leave the admin without manage controls for its lifetime.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvProfileSelectionViewModelContractTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @AfterTest
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun v2VerdictArrivingAfterUpdateRequiredRetriggersTheGatedLoad() = runTest(dispatcher) {
+        val registry = MutableContractRegistry(ServerContract.UPDATE_REQUIRED)
+        // The mock engine answers on its own thread, outside the test
+        // scheduler, so each request is awaited rather than assumed to have
+        // landed by the time an assertion runs.
+        val requests = Channel<String>(Channel.UNLIMITED)
+        val client = HttpClient(
+            MockEngine { request ->
+                requests.trySend(request.url.encodedPath)
+                when (request.url.encodedPath) {
+                    "/api/v1/profiles" -> respond(
+                        """{"profiles":[]}""",
+                        HttpStatusCode.OK,
+                        headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                    else -> respond(
+                        """{"type":"about:blank","title":"nope","status":500,"detail":"x","instance":"urn:x"}""",
+                        HttpStatusCode.InternalServerError,
+                        headersOf(HttpHeaders.ContentType, "application/problem+json"),
+                    )
+                }
+            },
+        ) { install(ContentNegotiation) { json(SiloJson) } }
+        val tokens = StubTokenManager()
+        val authRepository = AuthRepository(
+            authApi = AuthApi(client, ApiV2Gate(registry)),
+            tokenManager = tokens,
+            serverRegistry = registry,
+        )
+        val profileRepository = ProfileRepository(ProfileApi(client), tokens, registry)
+
+        TvProfileSelectionViewModel(profileRepository, authRepository)
+        runCurrent()
+
+        // First load: the gate rejects the v2 call without a request, so the
+        // first thing to reach the network is the v1 list.
+        assertEquals("/api/v1/profiles", requests.awaitNext())
+
+        registry.setContract("a", ServerContract.V2)
+        // The collector's resumption is queued on the unconfined event loop
+        // rather than run inline; pump it (and the reload it launches).
+        advanceUntilIdle()
+
+        // The contract change re-ran the load, and this time the gate let
+        // the v2 admin lookup through to the network, followed by the list.
+        assertEquals("/api/v2/account/me", requests.awaitNext())
+        assertEquals("/api/v1/profiles", requests.awaitNext())
+    }
+
+    /** Real-clock wait: under the test scheduler a virtual-time timeout would fire at once. */
+    private suspend fun Channel<String>.awaitNext(): String =
+        withContext(Dispatchers.Default) { withTimeout(5_000) { receive() } }
+}
+
+private class MutableContractRegistry(initial: ServerContract) : ServerRegistry {
+    private val entry = MutableStateFlow(ServerEntry(id = "a", url = "https://a.example", contract = initial))
+    override val entries: StateFlow<List<ServerEntry>> = MutableStateFlow(listOf(entry.value))
+    override val activeServerId: StateFlow<String?> = MutableStateFlow("a")
+    override val activeEntry: StateFlow<ServerEntry?> = entry
+    override suspend fun addOrUpdate(url: String, fetchedName: String?): String = "a"
+    override suspend fun rename(serverId: String, userOverrideName: String?) = Unit
+    override suspend fun setFetchedName(serverId: String, fetchedName: String?) = Unit
+    override suspend fun setProfileId(serverId: String, profileId: String?) = Unit
+    override suspend fun setContract(serverId: String, contract: ServerContract) {
+        entry.update { it.copy(contract = contract) }
+    }
+    override suspend fun remove(serverId: String) = Unit
+    override suspend fun signOut(serverId: String) = Unit
+    override suspend fun switchTo(serverId: String) = Unit
+    override suspend fun touchActive() = Unit
+}
+
+private class StubTokenManager : TokenManager {
+    override suspend fun getAccessToken(): String? = "access"
+    override suspend fun getRefreshToken(): String? = null
+    override suspend fun saveTokens(accessToken: String, refreshToken: String, expiresIn: Long) = Unit
+    override suspend fun clearTokens() = Unit
+    override suspend fun invalidateSession() = Unit
+    override suspend fun getProfileId(): String? = null
+    override suspend fun setProfileId(profileId: String?) = Unit
+    override suspend fun getProfileToken(): String? = null
+    override suspend fun setProfileToken(token: String?) = Unit
+    override suspend fun getServerUrl(): String = "https://a.example"
+    override suspend fun setServerUrl(url: String) = Unit
+    override suspend fun getCurrentServerId(): String? = "a"
+    override suspend fun switchActiveServer(serverId: String?) = Unit
+    override suspend fun signOutCurrentServer() = Unit
+    override val sessionExpired: SharedFlow<Unit> = MutableSharedFlow()
+}

--- a/scripts/sync-apiv2-fixtures.sh
+++ b/scripts/sync-apiv2-fixtures.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Vendors the selected native API v2 contract fixtures from a silo-server
+# checkout into shared/src/commonTest/resources/api/v2/fixtures.
+#
+# Usage: scripts/sync-apiv2-fixtures.sh /path/to/silo-server
+#
+# Only the fixtures the Android client consumes are copied (the four pilot
+# operations, the probe's system-info body, and the generic problem bodies)
+# plus fixtures.schema.json and an index.json filtered to the vendored
+# entries. The full OpenAPI document is never vendored. SOURCE records the
+# exact server commit in the repository's key=value convention.
+set -euo pipefail
+
+SERVER_DIR="${1:?usage: $0 /path/to/silo-server}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$REPO_ROOT/shared/src/commonTest/resources/api/v2/fixtures"
+SRC="$SERVER_DIR/contracts/api/v2/fixtures"
+SCHEMA="$SERVER_DIR/contracts/api/v2/fixtures.schema.json"
+
+SELECTED=(
+  get_system_info_ok
+  get_setup_status_ok
+  get_current_user_ok
+  list_progress_ok
+  list_progress_profile_header_required
+  list_progress_offset_rejected
+  update_profile_ok
+  update_profile_null_not_clearable
+  authentication_required
+  validation_failed_body
+  not_found
+  rate_limited
+  profile_verification_required
+  not_acceptable
+)
+
+[ -d "$SRC" ] || { echo "no fixtures at $SRC" >&2; exit 1; }
+[ -f "$SCHEMA" ] || { echo "no schema at $SCHEMA" >&2; exit 1; }
+
+mkdir -p "$DEST"
+find "$DEST" -maxdepth 1 -name '*.json' -delete
+for name in "${SELECTED[@]}"; do
+  cp "$SRC/$name.json" "$DEST/$name.json"
+done
+cp "$SCHEMA" "$DEST/fixtures.schema.json"
+
+# index.json keeps the server's entry objects byte-for-byte but only for the
+# vendored bodies, so a test can iterate it and expect every body_file to exist.
+SELECTED_CSV="$(IFS=,; echo "${SELECTED[*]}")" python3 - "$SRC/index.json" "$DEST/index.json" <<'PY'
+import json, os, sys
+selected = set(os.environ["SELECTED_CSV"].split(","))
+with open(sys.argv[1]) as f:
+    index = json.load(f)
+index["fixtures"] = [e for e in index["fixtures"] if e["name"] in selected]
+missing = selected - {e["name"] for e in index["fixtures"]}
+if missing:
+    sys.exit("fixtures missing from server index: %s" % ", ".join(sorted(missing)))
+with open(sys.argv[2], "w") as f:
+    json.dump(index, f, indent=2)
+    f.write("\n")
+PY
+
+COMMIT="$(git -C "$SERVER_DIR" rev-parse HEAD)"
+REF="$(git -C "$SERVER_DIR" rev-parse --abbrev-ref HEAD)"
+cat > "$DEST/SOURCE" <<EOS
+repository=https://github.com/Silo-Server/silo-server
+path=contracts/api/v2/fixtures
+commit=$COMMIT
+ref=$REF
+api_major=2
+
+Byte-identical copies of a subset of the server's native API v2 contract
+fixtures; do not hand-edit any of them. The server generates them through its
+real v2 router (make apiv2-fixtures) and validates the bodies against the
+committed OpenAPI artifact. Only the fixtures the Android pilot consumes are
+vendored here, and index.json is filtered to those entries; the OpenAPI
+document itself is never vendored. Re-vendor with
+scripts/sync-apiv2-fixtures.sh <server checkout> and run :shared:testDebugUnitTest.
+
+ApiV2ContractTest decodes every body here with the production SiloJson.
+EOS
+echo "wrote ${#SELECTED[@]} fixtures to $DEST (server commit $COMMIT)"

--- a/shared/src/androidMain/kotlin/org/siloserver/silo/network/AndroidServerRegistry.kt
+++ b/shared/src/androidMain/kotlin/org/siloserver/silo/network/AndroidServerRegistry.kt
@@ -3,6 +3,7 @@ package org.siloserver.silo.network
 import android.content.SharedPreferences
 import android.util.Base64
 import java.net.URI
+import org.siloserver.silo.model.server.ServerContract
 import org.siloserver.silo.model.server.ServerEntry
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -97,6 +98,15 @@ class AndroidServerRegistry(
                 if (entry.id == serverId) {
                     entry.copy(userOverrideName = userOverrideName?.trim()?.takeIf { it.isNotBlank() })
                 } else entry
+            }
+            persistAndApplyLocked(updated, _activeServerId.value)
+        }
+    }
+
+    override suspend fun setContract(serverId: String, contract: ServerContract) {
+        mutex.withLock {
+            val updated = _entries.value.map { entry ->
+                if (entry.id == serverId) entry.copy(contract = contract) else entry
             }
             persistAndApplyLocked(updated, _activeServerId.value)
         }

--- a/shared/src/androidUnitTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2FixtureSupport.android.kt
+++ b/shared/src/androidUnitTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2FixtureSupport.android.kt
@@ -1,0 +1,6 @@
+package org.siloserver.silo.network.apiv2
+
+actual fun readApiV2FixtureResource(name: String): String =
+    checkNotNull(ApiV2Fixtures::class.java.classLoader?.getResource("api/v2/fixtures/$name")) {
+        "Missing vendored fixture api/v2/fixtures/$name; run scripts/sync-apiv2-fixtures.sh"
+    }.readText()

--- a/shared/src/androidUnitTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2NoV1TransportSourceTest.kt
+++ b/shared/src/androidUnitTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2NoV1TransportSourceTest.kt
@@ -1,0 +1,21 @@
+package org.siloserver.silo.network.apiv2
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/** The v2 package must not know a v1 path: no `/api/v1` literal anywhere under network/apiv2/. */
+class ApiV2NoV1TransportSourceTest {
+    @Test
+    fun noV1PathLiteralUnderApiV2Package() {
+        val dir = generateSequence(File("").absoluteFile) { it.parentFile }
+            .map { File(it, "shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2") }
+            .firstOrNull { it.isDirectory }
+            ?: File("src/commonMain/kotlin/org/siloserver/silo/network/apiv2")
+        assertTrue(dir.isDirectory, "missing ${dir.absolutePath}")
+        val sources = dir.walkTopDown().filter { it.extension == "kt" }.toList()
+        assertTrue(sources.isNotEmpty(), "no Kotlin sources under $dir")
+        val offenders = sources.filter { "/api/v1" in it.readText() }.map { it.name }
+        assertTrue(offenders.isEmpty(), "v1 path literal in v2 package: $offenders")
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/NetworkModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/NetworkModule.kt
@@ -21,7 +21,7 @@ val networkModule = module {
     single<DeviceLoginApi> { DefaultDeviceLoginApi(get()) }
     single { CatalogApi(get()) }
     single { PlaybackApi(get()) }
-    single { PersonalDataApi(get(), get()) }
+    single { PersonalDataApi(get(), get(), get()) }
     single { CollectionApi(get()) }
     single { ProfileApi(get(), get()) }
     single { SectionApi(get()) }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/NetworkModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/NetworkModule.kt
@@ -6,20 +6,24 @@ import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
 import org.siloserver.silo.network.IdentityTransitionBarrier
 import org.siloserver.silo.network.createSiloClient
 import org.siloserver.silo.network.api.*
+import org.siloserver.silo.network.apiv2.ApiV2Gate
+import org.siloserver.silo.network.apiv2.ApiV2Probe
 import org.koin.dsl.module
 
 val networkModule = module {
     single<IdentityTransitionBarrier> { DefaultIdentityTransitionBarrier() }
     single<TokenManager> { TokenManagerImpl(get()) }
     single { createSiloClient(get(), getOrNull(), getOrNull(), getOrNull()) }
-    single { AuthApi(get()) }
+    single { ApiV2Gate(getOrNull()) }
+    single { ApiV2Probe(get()) }
+    single { AuthApi(get(), get()) }
     single { OnboardingApi(get()) }
     single<DeviceLoginApi> { DefaultDeviceLoginApi(get()) }
     single { CatalogApi(get()) }
     single { PlaybackApi(get()) }
-    single { PersonalDataApi(get()) }
+    single { PersonalDataApi(get(), get()) }
     single { CollectionApi(get()) }
-    single { ProfileApi(get()) }
+    single { ProfileApi(get(), get()) }
     single { SectionApi(get()) }
     single { RecommendationApi(get()) }
     single<RequestsApi> { DefaultRequestsApi(get()) }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
@@ -54,6 +54,7 @@ val repositoryModule = module {
             serverRegistry = getOrNull(),
             healthApi = getOrNull(),
             brandingApi = getOrNull(),
+            apiV2Probe = getOrNull(),
         )
     }
     single { OnboardingRepository(get()) }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/di/RepositoryModule.kt
@@ -55,6 +55,9 @@ val repositoryModule = module {
             healthApi = getOrNull(),
             brandingApi = getOrNull(),
             apiV2Probe = getOrNull(),
+            // Owns the post-switch display-name refresh so a server-list
+            // spinner never waits on branding/health.
+            backgroundScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
         )
     }
     single { OnboardingRepository(get()) }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/auth/AuthModels.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/auth/AuthModels.kt
@@ -32,7 +32,8 @@ data class RefreshResponse(
 
 @Serializable
 data class User(
-    val id: Int,
+    /** Opaque account id. v2 emits a string; v1 login bodies still carry a number, which lenient decoding accepts. */
+    val id: String,
     val username: String,
     val email: String,
     val role: String,
@@ -43,7 +44,7 @@ data class User(
 @Serializable
 data class ImpersonationInfo(
     val active: Boolean,
-    @SerialName("impersonator_user_id") val impersonatorUserId: Int,
+    @SerialName("impersonator_user_id") val impersonatorUserId: String,
     @SerialName("impersonator_username") val impersonatorUsername: String
 )
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/server/ServerContract.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/server/ServerContract.kt
@@ -1,0 +1,31 @@
+package org.siloserver.silo.model.server
+
+import kotlinx.serialization.Serializable
+
+/**
+ * What the app has learned about a saved server's native API contract.
+ *
+ * Set from [org.siloserver.silo.network.apiv2.ApiV2Probe] when a connection is
+ * established or the server identity is refreshed — never per request.
+ * [UPDATE_REQUIRED] is the explicit update-server state for a v1-only alpha
+ * server; it blocks the pilot's v2 operations (see
+ * [org.siloserver.silo.network.apiv2.ApiV2Gate]). Transport, TLS, auth, rate
+ * limit, and server errors leave the previous value in place.
+ */
+@Serializable
+enum class ServerContract {
+    /** Not probed yet, or the last probe failed for a reason unrelated to the contract. */
+    UNKNOWN,
+
+    /** The server answered GET /api/v2/system/info with a valid v2 info body. */
+    V2,
+
+    /** The server has no /api/v2 listener: it predates the v2 contract and must be updated. */
+    UPDATE_REQUIRED;
+
+    companion object {
+        /** The one user-facing message for [UPDATE_REQUIRED]. */
+        const val UPDATE_REQUIRED_MESSAGE: String =
+            "This server runs an older Silo release that this app no longer supports. Update the server, then try again."
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/model/server/ServerEntry.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/model/server/ServerEntry.kt
@@ -23,6 +23,8 @@ data class ServerEntry(
     val userOverrideName: String? = null,
     val profileId: String? = null,
     val lastUsedAtEpochMs: Long = 0L,
+    /** Native API contract learned on connect; see [ServerContract]. */
+    val contract: ServerContract = ServerContract.UNKNOWN,
 ) {
     val displayName: String
         get() = userOverrideName?.takeIf { it.isNotBlank() }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthScopeSnapshot.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/AuthScopeSnapshot.kt
@@ -53,6 +53,17 @@ data class AuthScopeSnapshot(
      */
     val credentialEpoch: Long = 0L,
 ) {
+    /**
+     * Whether [current] is still the identity this snapshot was captured from:
+     * same server, identity generation, and persistent-credential epoch. A
+     * null [current] means the identity is gone, so it never matches.
+     */
+    fun isSameIdentityAs(current: AuthScopeSnapshot?): Boolean =
+        current != null &&
+            current.serverId == serverId &&
+            current.identityGeneration == identityGeneration &&
+            current.credentialEpoch == credentialEpoch
+
     override fun toString(): String =
         "AuthScopeSnapshot(" +
             "serverId=<redacted>, profileId=<redacted>, serverUrl=<redacted>, " +

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/ServerRegistry.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/ServerRegistry.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.network
 
+import org.siloserver.silo.model.server.ServerContract
 import org.siloserver.silo.model.server.ServerEntry
 import kotlinx.coroutines.flow.StateFlow
 
@@ -48,6 +49,12 @@ interface ServerRegistry {
 
     /** Persist the per-server selected profile so a future switch restores it. */
     suspend fun setProfileId(serverId: String, profileId: String?)
+
+    /**
+     * Records what the v2 contract probe learned about [serverId]. Default is a
+     * no-op so single-purpose fakes need not track it.
+     */
+    suspend fun setContract(serverId: String, contract: ServerContract) {}
 
     /** Remove an entry entirely. If it was active, fall back to the next-MRU server. */
     suspend fun remove(serverId: String)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/AuthApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/AuthApi.kt
@@ -61,8 +61,15 @@ class AuthApi(
             client.get("/api/v2/system/setup") { skipSiloAuth() }
         }.map { status -> SetupStatusResponse(needsSetup = status.needsSetup) }
 
+    /**
+     * Explicit-server form: probes a candidate the app is not connected to
+     * yet, so the ACTIVE entry's verdict must not gate it — otherwise an
+     * UPDATE_REQUIRED active server would block adding (or reconnecting to)
+     * a supported one. The candidate's own gate is the contract probe the
+     * add-server flow runs before switching.
+     */
     suspend fun getSetupStatus(serverUrl: String): ApiResult<SetupStatusResponse> =
-        safeApiV2Call<SetupStatus>(apiV2Gate) {
+        safeApiV2Call<SetupStatus>(ApiV2Gate.Unrestricted) {
             client.get("${serverUrl.trimEnd('/')}/api/v2/system/setup") {
                 skipSiloAuth()
             }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/AuthApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/AuthApi.kt
@@ -8,9 +8,17 @@ import io.ktor.http.*
 import org.siloserver.silo.model.auth.*
 import org.siloserver.silo.network.ApiErrorBody
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.map
 import org.siloserver.silo.network.skipSiloAuth
+import org.siloserver.silo.network.apiv2.Account
+import org.siloserver.silo.network.apiv2.ApiV2Gate
+import org.siloserver.silo.network.apiv2.SetupStatus
+import org.siloserver.silo.network.apiv2.safeApiV2Call
 
-class AuthApi(private val client: HttpClient) {
+class AuthApi(
+    private val client: HttpClient,
+    private val apiV2Gate: ApiV2Gate = ApiV2Gate.Unrestricted,
+) {
 
     suspend fun login(request: LoginRequest): ApiResult<LoginResponse> = safeApiCall {
         client.post("/api/v1/auth/login") {
@@ -44,18 +52,21 @@ class AuthApi(private val client: HttpClient) {
         }
     }
 
-    suspend fun getSetupStatus(): ApiResult<SetupStatusResponse> = safeApiCall {
-        // Public, exactly like the explicit-server variant below — which
-        // already opted out. Without this the relative form carries a bearer
-        // it never needed, and a dead session would fail it.
-        client.get("/api/v1/auth/setup") { skipSiloAuth() }
-    }
+    // Pilot v2 operation (getSetupStatus): v2 only, no v1 fallback.
+    suspend fun getSetupStatus(): ApiResult<SetupStatusResponse> =
+        safeApiV2Call<SetupStatus>(apiV2Gate) {
+            // Public, exactly like the explicit-server variant below — which
+            // already opted out. Without this the relative form carries a bearer
+            // it never needed, and a dead session would fail it.
+            client.get("/api/v2/system/setup") { skipSiloAuth() }
+        }.map { status -> SetupStatusResponse(needsSetup = status.needsSetup) }
 
-    suspend fun getSetupStatus(serverUrl: String): ApiResult<SetupStatusResponse> = safeApiCall {
-        client.get("${serverUrl.trimEnd('/')}/api/v1/auth/setup") {
-            skipSiloAuth()
-        }
-    }
+    suspend fun getSetupStatus(serverUrl: String): ApiResult<SetupStatusResponse> =
+        safeApiV2Call<SetupStatus>(apiV2Gate) {
+            client.get("${serverUrl.trimEnd('/')}/api/v2/system/setup") {
+                skipSiloAuth()
+            }
+        }.map { status -> SetupStatusResponse(needsSetup = status.needsSetup) }
 
     suspend fun getSignupStatus(): ApiResult<SignupStatusResponse> = safeApiCall {
         client.get("/api/v1/auth/signup") { skipSiloAuth() }
@@ -98,9 +109,9 @@ class AuthApi(private val client: HttpClient) {
         }
     }
 
-    suspend fun getMe(): ApiResult<User> = safeApiCall {
-        client.get("/api/v1/auth/me")
-    }
+    // Pilot v2 operation (getCurrentUser): v2 only, no v1 fallback.
+    suspend fun getMe(): ApiResult<User> =
+        safeApiV2Call<Account>(apiV2Gate) { client.get("/api/v2/account/me") }.map { account -> account.toUser() }
 
     suspend fun logout(): ApiResult<Unit> = safeApiCall {
         client.post("/api/v1/auth/logout")
@@ -170,3 +181,19 @@ internal suspend inline fun <reified T> safeApiCall(
         ApiResult.NetworkError(e)
     }
 }
+
+/** Adapts the v2 account to the v1-shaped [User] the repositories and screens consume. */
+internal fun Account.toUser(): User = User(
+    id = id,
+    username = username,
+    email = email,
+    role = role.wire,
+    downloadAllowed = downloadAllowed,
+    impersonation = impersonation?.let {
+        ImpersonationInfo(
+            active = it.active,
+            impersonatorUserId = it.impersonatorUserId,
+            impersonatorUsername = it.impersonatorUsername,
+        )
+    },
+)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/PersonalDataApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/PersonalDataApi.kt
@@ -8,6 +8,7 @@ import org.siloserver.silo.model.catalog.CatalogResponse
 import org.siloserver.silo.model.personal.*
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.network.authScope
 import org.siloserver.silo.network.apiv2.ApiV2Gate
 import org.siloserver.silo.network.apiv2.ProgressCollection
@@ -26,9 +27,17 @@ private const val PROGRESS_MAX_PAGES = 100
 /** [ApiResult.Error.error] when the progress walk stopped before the last page. */
 const val PROGRESS_INCOMPLETE_ERROR = "progress_incomplete"
 
+/** [ApiResult.Error.error] when the active identity moved while the progress walk was in flight. */
+const val PROGRESS_IDENTITY_CHANGED_ERROR = "identity_changed"
+
 class PersonalDataApi(
     private val client: HttpClient,
     private val apiV2Gate: ApiV2Gate = ApiV2Gate.Unrestricted,
+    /**
+     * Source of the identity a multi-request operation is pinned to. Null
+     * (single-scope tests) leaves each request on the globally-active scope.
+     */
+    private val tokenManager: TokenManager? = null,
 ) {
 
     // --- User Libraries ---
@@ -103,19 +112,44 @@ class PersonalDataApi(
      * Pilot v2 operation (listProgress): v2 only, no v1 fallback. v1 returned
      * the whole list; v2 pages by opaque cursor, so every page is walked here.
      *
+     * The whole walk runs under ONE identity. [scope] pins it explicitly;
+     * otherwise the active scope is captured once up front and applied to
+     * every page, so a server or profile switch mid-walk cannot send a later
+     * page under a different identity than the entries already collected.
+     * When the scope was captured here and the active identity moves between
+     * pages, the walk aborts with [PROGRESS_IDENTITY_CHANGED_ERROR] instead of
+     * relying on the server to reject the cursor.
+     *
      * The result is either the complete list or an error — never a silent
      * prefix. A page failure returns that page's error; exceeding
      * [PROGRESS_MAX_PAGES] with more pages left returns an
      * [ApiResult.Error] whose `error` is [PROGRESS_INCOMPLETE_ERROR], so
      * continue-watching consumers never treat older entries as absent.
      */
-    suspend fun listProgress(): ApiResult<ProgressListResponse> {
+    suspend fun listProgress(scope: AuthScopeSnapshot? = null): ApiResult<ProgressListResponse> {
+        val pinned = scope ?: tokenManager?.snapshotCurrentScope()
+        // Only a scope captured here is checked against the live identity; an
+        // explicitly pinned scope is the caller's to send whatever is active.
+        val liveIdentityGuard = if (scope == null) pinned else null
         val entries = mutableListOf<ProgressEntry>()
         var cursor: String? = null
         var pages = 0
         while (true) {
+            if (
+                pages > 0 &&
+                liveIdentityGuard != null &&
+                !liveIdentityGuard.isSameIdentityAs(tokenManager?.snapshotCurrentScope())
+            ) {
+                return ApiResult.Error(
+                    code = 0,
+                    error = PROGRESS_IDENTITY_CHANGED_ERROR,
+                    message = "Active identity changed after $pages progress page(s); " +
+                        "refusing to continue the walk under a different identity.",
+                )
+            }
             val page = safeApiV2Call<ProgressCollection>(apiV2Gate) {
                 client.get("/api/v2/progress") {
+                    pinned?.let { authScope(it) }
                     parameter("limit", PROGRESS_PAGE_SIZE)
                     cursor?.let { parameter("cursor", it) }
                 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/PersonalDataApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/PersonalDataApi.kt
@@ -9,8 +9,17 @@ import org.siloserver.silo.model.personal.*
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.AuthScopeSnapshot
 import org.siloserver.silo.network.authScope
+import org.siloserver.silo.network.apiv2.ApiV2Gate
+import org.siloserver.silo.network.apiv2.ProgressCollection
+import org.siloserver.silo.network.apiv2.safeApiV2Call
 
-class PersonalDataApi(private val client: HttpClient) {
+private const val PROGRESS_PAGE_SIZE = 200
+private const val PROGRESS_MAX_PAGES = 50
+
+class PersonalDataApi(
+    private val client: HttpClient,
+    private val apiV2Gate: ApiV2Gate = ApiV2Gate.Unrestricted,
+) {
 
     // --- User Libraries ---
 
@@ -80,8 +89,39 @@ class PersonalDataApi(private val client: HttpClient) {
 
     // --- Progress ---
 
-    suspend fun listProgress(): ApiResult<ProgressListResponse> = safeApiCall {
-        client.get("/api/v1/progress")
+    // Pilot v2 operation (listProgress): v2 only, no v1 fallback. v1 returned
+    // the whole list; v2 pages by opaque cursor, so walk every page here.
+    suspend fun listProgress(): ApiResult<ProgressListResponse> {
+        val entries = mutableListOf<ProgressEntry>()
+        var cursor: String? = null
+        var pages = 0
+        while (true) {
+            val page = safeApiV2Call<ProgressCollection>(apiV2Gate) {
+                client.get("/api/v2/progress") {
+                    parameter("limit", PROGRESS_PAGE_SIZE)
+                    cursor?.let { parameter("cursor", it) }
+                }
+            }
+            val collection = when (page) {
+                is ApiResult.Success -> page.data
+                is ApiResult.Error -> return page
+                is ApiResult.NetworkError -> return page
+            }
+            collection.items.mapTo(entries) {
+                ProgressEntry(
+                    mediaItemId = it.mediaItemId,
+                    positionSeconds = it.positionSeconds,
+                    durationSeconds = it.durationSeconds,
+                    completed = it.completed,
+                    updatedAt = it.updatedAt,
+                )
+            }
+            val next = collection.page.nextCursor
+            pages++
+            if (!collection.page.hasMore || next == null || pages >= PROGRESS_MAX_PAGES) break
+            cursor = next
+        }
+        return ApiResult.Success(ProgressListResponse(progress = entries))
     }
 
     suspend fun syncProgress(

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/PersonalDataApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/PersonalDataApi.kt
@@ -13,8 +13,18 @@ import org.siloserver.silo.network.apiv2.ApiV2Gate
 import org.siloserver.silo.network.apiv2.ProgressCollection
 import org.siloserver.silo.network.apiv2.safeApiV2Call
 
+/** The v2 contract caps `limit` at 200; ask for the maximum so the walk is as short as possible. */
 private const val PROGRESS_PAGE_SIZE = 200
-private const val PROGRESS_MAX_PAGES = 50
+
+/**
+ * Runaway guard only (100 pages × 200 = 20,000 entries). Hitting it with
+ * `has_more` still true is reported as [PROGRESS_INCOMPLETE_ERROR], never
+ * as a silent prefix.
+ */
+private const val PROGRESS_MAX_PAGES = 100
+
+/** [ApiResult.Error.error] when the progress walk stopped before the last page. */
+const val PROGRESS_INCOMPLETE_ERROR = "progress_incomplete"
 
 class PersonalDataApi(
     private val client: HttpClient,
@@ -89,8 +99,16 @@ class PersonalDataApi(
 
     // --- Progress ---
 
-    // Pilot v2 operation (listProgress): v2 only, no v1 fallback. v1 returned
-    // the whole list; v2 pages by opaque cursor, so walk every page here.
+    /**
+     * Pilot v2 operation (listProgress): v2 only, no v1 fallback. v1 returned
+     * the whole list; v2 pages by opaque cursor, so every page is walked here.
+     *
+     * The result is either the complete list or an error — never a silent
+     * prefix. A page failure returns that page's error; exceeding
+     * [PROGRESS_MAX_PAGES] with more pages left returns an
+     * [ApiResult.Error] whose `error` is [PROGRESS_INCOMPLETE_ERROR], so
+     * continue-watching consumers never treat older entries as absent.
+     */
     suspend fun listProgress(): ApiResult<ProgressListResponse> {
         val entries = mutableListOf<ProgressEntry>()
         var cursor: String? = null
@@ -118,7 +136,15 @@ class PersonalDataApi(
             }
             val next = collection.page.nextCursor
             pages++
-            if (!collection.page.hasMore || next == null || pages >= PROGRESS_MAX_PAGES) break
+            if (!collection.page.hasMore || next == null) break
+            if (pages >= PROGRESS_MAX_PAGES) {
+                return ApiResult.Error(
+                    code = 0,
+                    error = PROGRESS_INCOMPLETE_ERROR,
+                    message = "Progress list still has more pages after $PROGRESS_MAX_PAGES pages of " +
+                        "$PROGRESS_PAGE_SIZE; refusing to return a partial list.",
+                )
+            }
             cursor = next
         }
         return ApiResult.Success(ProgressListResponse(progress = entries))

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/ProfileApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/ProfileApi.kt
@@ -5,8 +5,20 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import org.siloserver.silo.model.profile.*
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.map
+import org.siloserver.silo.network.apiv2.ApiV2Gate
+import org.siloserver.silo.network.apiv2.MaxPlaybackQuality
+import org.siloserver.silo.network.apiv2.Patch
+import org.siloserver.silo.network.apiv2.ProfileUpdate
+import org.siloserver.silo.network.apiv2.ProfileV2
+import org.siloserver.silo.network.apiv2.QualityPreference
+import org.siloserver.silo.network.apiv2.SubtitleMode
+import org.siloserver.silo.network.apiv2.safeApiV2Call
 
-class ProfileApi(private val client: HttpClient) {
+class ProfileApi(
+    private val client: HttpClient,
+    private val apiV2Gate: ApiV2Gate = ApiV2Gate.Unrestricted,
+) {
 
     suspend fun listProfiles(): ApiResult<ProfilesResponse> = safeApiCall {
         client.get("/api/v1/profiles")
@@ -19,15 +31,22 @@ class ProfileApi(private val client: HttpClient) {
         }
     }
 
+    // Pilot v2 operation (updateProfile): PATCH v2 only, no v1 fallback and
+    // no replay of a failed mutation against another API major.
     suspend fun updateProfile(
         id: String,
         request: UpdateProfileRequest
-    ): ApiResult<Profile> = safeApiCall {
-        client.put("/api/v1/profiles/$id") {
+    ): ApiResult<Profile> = updateProfile(id, request.toProfileUpdate())
+
+    suspend fun updateProfile(
+        id: String,
+        update: ProfileUpdate,
+    ): ApiResult<Profile> = safeApiV2Call<ProfileV2>(apiV2Gate) {
+        client.patch("/api/v2/profiles/$id") {
             contentType(ContentType.Application.Json)
-            setBody(request)
+            setBody(update.toJsonObject())
         }
-    }
+    }.map { profile -> profile.toProfile() }
 
     suspend fun deleteProfile(id: String): ApiResult<Unit> = safeApiCall {
         client.delete("/api/v1/profiles/$id")
@@ -43,3 +62,63 @@ class ProfileApi(private val client: HttpClient) {
         }
     }
 }
+
+/**
+ * v1 request semantics on the v2 PATCH: a null member is omitted (unchanged);
+ * an empty string on a clearable member is the v1 clearing form and becomes a
+ * literal `null`; everything else is sent as-is.
+ */
+internal fun UpdateProfileRequest.toProfileUpdate(): ProfileUpdate = ProfileUpdate(
+    name = Patch.ofOptional(name),
+    avatar = clearable(avatar),
+    pin = clearable(pin),
+    isChild = Patch.ofOptional(isChild),
+    maxContentRating = clearable(maxContentRating),
+    qualityPreference = Patch.ofOptional(qualityPreference?.let(::QualityPreference)),
+    language = clearable(language),
+    subtitleLanguage = clearable(subtitleLanguage),
+    preferredMetadataLanguage = clearable(preferredMetadataLanguage),
+    subtitleMode = Patch.ofOptional(subtitleMode?.let(::SubtitleMode)),
+    showForcedSubtitles = Patch.ofOptional(showForcedSubtitles),
+    autoSkipIntro = Patch.ofOptional(autoSkipIntro),
+    autoSkipCredits = Patch.ofOptional(autoSkipCredits),
+    libraryRestrictionsEnabled = Patch.ofOptional(libraryRestrictionsEnabled),
+    allowedLibraryIds = Patch.ofOptional(allowedLibraryIds?.map { it.toString() }),
+    maxPlaybackQuality = when (maxPlaybackQuality) {
+        null -> Patch.Omit
+        "" -> Patch.Clear
+        else -> Patch.Set(MaxPlaybackQuality(maxPlaybackQuality))
+    },
+)
+
+private fun clearable(value: String?): Patch<String> = when (value) {
+    null -> Patch.Omit
+    "" -> Patch.Clear
+    else -> Patch.Set(value)
+}
+
+/** Adapts the v2 profile to the v1-shaped [Profile] the repositories and screens consume. */
+internal fun ProfileV2.toProfile(): Profile = Profile(
+    id = id,
+    name = name,
+    avatar = avatar.ifEmpty { null },
+    avatarUrl = avatarUrl,
+    avatarSource = avatarSource.wire,
+    isPrimary = isPrimary,
+    hasPin = hasPin,
+    isChild = isChild,
+    maxContentRating = maxContentRating.ifEmpty { null },
+    qualityPreference = qualityPreference.wire,
+    language = language.ifEmpty { null },
+    subtitleLanguage = subtitleLanguage.ifEmpty { null },
+    preferredMetadataLanguage = preferredMetadataLanguage.ifEmpty { null },
+    subtitleMode = subtitleMode.wire,
+    showForcedSubtitles = showForcedSubtitles,
+    autoSkipIntro = autoSkipIntro,
+    autoSkipCredits = autoSkipCredits,
+    libraryRestrictionsEnabled = libraryRestrictionsEnabled,
+    allowedLibraryIds = allowedLibraryIds.mapNotNull { it.toIntOrNull() },
+    maxPlaybackQuality = maxPlaybackQuality.wire,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Call.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Call.kt
@@ -1,0 +1,46 @@
+package org.siloserver.silo.network.apiv2
+
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.SiloJson
+
+/**
+ * Wraps one v2 exchange: a 2xx body decodes to [T] with the production
+ * [SiloJson]; a non-2xx body is read as a [Problem] and surfaced as
+ * [ApiResult.Error] (`error` = the problem code, `message` = its detail).
+ * Nothing here retries, and nothing here knows a v1 path.
+ */
+internal suspend inline fun <reified T> safeApiV2Call(
+    gate: ApiV2Gate,
+    block: () -> HttpResponse,
+): ApiResult<T> {
+    gate.blocked()?.let { return it }
+    return try {
+        val response = block()
+        if (response.status.isSuccess()) {
+            ApiResult.Success(SiloJson.decodeFromString(response.bodyAsText()))
+        } else {
+            response.toApiV2Error()
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        ApiResult.NetworkError(e)
+    }
+}
+
+internal suspend fun HttpResponse.toApiV2Error(): ApiResult.Error {
+    val problem = try {
+        SiloJson.decodeFromString(Problem.serializer(), bodyAsText())
+    } catch (_: Exception) {
+        null
+    }
+    return ApiResult.Error(
+        code = status.value,
+        error = problem?.code ?: "",
+        message = problem?.detail ?: "",
+    )
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Enums.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Enums.kt
@@ -1,0 +1,72 @@
+package org.siloserver.silo.network.apiv2
+
+import kotlin.jvm.JvmInline
+import kotlinx.serialization.Serializable
+
+/**
+ * String-backed enums for the native API v2 pilot.
+ *
+ * Each wire enum is an inline value class over the raw string with a typed
+ * [Known] accessor. A value the app does not know decodes successfully and is
+ * observable as `known == null` with the raw wire value intact — unlike a
+ * Kotlin `enum class`, where `coerceInputValues` would silently substitute the
+ * property default and the app could never tell the difference.
+ */
+@Serializable
+@JvmInline
+value class AccountRole(val wire: String) {
+    enum class Known(val wire: String) { ADMIN("admin"), USER("user") }
+
+    val known: Known? get() = Known.entries.firstOrNull { it.wire == wire }
+    val isAdmin: Boolean get() = known == Known.ADMIN
+
+    companion object {
+        val ADMIN = AccountRole(Known.ADMIN.wire)
+        val USER = AccountRole(Known.USER.wire)
+    }
+}
+
+@Serializable
+@JvmInline
+value class AvatarSource(val wire: String) {
+    enum class Known(val wire: String) { NONE("none"), PRESET("preset"), UPLOAD("upload") }
+
+    val known: Known? get() = Known.entries.firstOrNull { it.wire == wire }
+}
+
+@Serializable
+@JvmInline
+value class QualityPreference(val wire: String) {
+    enum class Known(val wire: String) { AUTO("auto"), ORIGINAL("original") }
+
+    val known: Known? get() = Known.entries.firstOrNull { it.wire == wire }
+}
+
+@Serializable
+@JvmInline
+value class SubtitleMode(val wire: String) {
+    enum class Known(val wire: String) { AUTO("auto"), ALWAYS("always"), OFF("off") }
+
+    val known: Known? get() = Known.entries.firstOrNull { it.wire == wire }
+}
+
+@Serializable
+@JvmInline
+value class MaxPlaybackQuality(val wire: String) {
+    enum class Known(val wire: String) { P1080("1080p"), P2160("2160p") }
+
+    val known: Known? get() = Known.entries.firstOrNull { it.wire == wire }
+}
+
+@Serializable
+@JvmInline
+value class ProgressStatus(val wire: String) {
+    enum class Known(val wire: String) { IN_PROGRESS("in_progress"), COMPLETED("completed") }
+
+    val known: Known? get() = Known.entries.firstOrNull { it.wire == wire }
+
+    companion object {
+        val IN_PROGRESS = ProgressStatus(Known.IN_PROGRESS.wire)
+        val COMPLETED = ProgressStatus(Known.COMPLETED.wire)
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Gate.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Gate.kt
@@ -1,0 +1,38 @@
+package org.siloserver.silo.network.apiv2
+
+import org.siloserver.silo.model.server.ServerContract
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.ServerRegistry
+
+/**
+ * Blocks the pilot's v2 operations while the active server is in the
+ * [ServerContract.UPDATE_REQUIRED] state. The state comes from the registry
+ * entry (set by [ApiV2Probe] on connect); nothing here ever performs a
+ * request, and a blocked call is never redirected to a v1 path.
+ */
+class ApiV2Gate(private val registry: ServerRegistry? = null) {
+
+    val contract: ServerContract
+        get() = registry?.activeEntry?.value?.contract ?: ServerContract.UNKNOWN
+
+    /** The error to return instead of calling the server, or null when the call may proceed. */
+    fun blocked(): ApiResult.Error? =
+        if (contract == ServerContract.UPDATE_REQUIRED) {
+            ApiResult.Error(
+                code = UPDATE_REQUIRED_CODE,
+                error = UPDATE_REQUIRED_ERROR,
+                message = ServerContract.UPDATE_REQUIRED_MESSAGE,
+            )
+        } else {
+            null
+        }
+
+    companion object {
+        /** No HTTP exchange happened; distinguishes the gate from any server status. */
+        const val UPDATE_REQUIRED_CODE = 0
+        const val UPDATE_REQUIRED_ERROR = "update_server"
+
+        /** For construction sites without a registry (commonMain tests, single-server hosts). */
+        val Unrestricted = ApiV2Gate(null)
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Instant.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Instant.kt
@@ -1,0 +1,74 @@
+package org.siloserver.silo.network.apiv2
+
+/**
+ * Parses an RFC 3339 / ISO 8601 instant as emitted by API v2 (`date-time`
+ * members such as `updated_at`) into epoch milliseconds, or null when the
+ * text is not a well-formed instant. Fractional seconds beyond milliseconds
+ * are truncated. The shared module does not depend on kotlinx-datetime, so
+ * this is the one parser v2 models share.
+ */
+fun parseApiV2Instant(text: String): Long? {
+    // YYYY-MM-DDTHH:MM:SS[.fff...](Z|±HH:MM)
+    if (text.length < 20) return null
+    fun digits(from: Int, to: Int): Int? {
+        if (to > text.length) return null
+        var value = 0
+        for (i in from until to) {
+            val c = text[i]
+            if (c !in '0'..'9') return null
+            value = value * 10 + (c - '0')
+        }
+        return value
+    }
+    val year = digits(0, 4) ?: return null
+    if (text[4] != '-') return null
+    val month = digits(5, 7) ?: return null
+    if (text[7] != '-') return null
+    val day = digits(8, 10) ?: return null
+    if (text[10] != 'T' && text[10] != 't') return null
+    val hour = digits(11, 13) ?: return null
+    if (text[13] != ':') return null
+    val minute = digits(14, 16) ?: return null
+    if (text[16] != ':') return null
+    val second = digits(17, 19) ?: return null
+    var index = 19
+    var millis = 0
+    if (index < text.length && text[index] == '.') {
+        index++
+        val start = index
+        while (index < text.length && text[index] in '0'..'9') index++
+        if (index == start) return null
+        val fraction = text.substring(start, index).take(3).padEnd(3, '0')
+        millis = fraction.toInt()
+    }
+    if (index >= text.length) return null
+    val offsetMinutes: Int = when (text[index]) {
+        'Z', 'z' -> {
+            if (index + 1 != text.length) return null
+            0
+        }
+        '+', '-' -> {
+            val sign = if (text[index] == '+') 1 else -1
+            if (index + 6 != text.length || text[index + 3] != ':') return null
+            val oh = digits(index + 1, index + 3) ?: return null
+            val om = digits(index + 4, index + 6) ?: return null
+            sign * (oh * 60 + om)
+        }
+        else -> return null
+    }
+    if (month !in 1..12 || day !in 1..31 || hour > 23 || minute > 59 || second > 60) return null
+    val days = daysFromCivil(year, month, day)
+    val seconds = days * 86_400L + hour * 3_600L + minute * 60L + second - offsetMinutes * 60L
+    return seconds * 1_000L + millis
+}
+
+/** Days since 1970-01-01 for a proleptic Gregorian date (Howard Hinnant's algorithm). */
+private fun daysFromCivil(year: Int, month: Int, day: Int): Long {
+    val y = if (month <= 2) year - 1 else year
+    val era = (if (y >= 0) y else y - 399) / 400
+    val yoe = y - era * 400
+    val mp = (month + 9) % 12
+    val doy = (153 * mp + 2) / 5 + day - 1
+    val doe = yoe * 365 + yoe / 4 - yoe / 100 + doy
+    return era * 146_097L + doe - 719_468L
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Models.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Models.kt
@@ -1,0 +1,208 @@
+package org.siloserver.silo.network.apiv2
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/*
+ * Handwritten lenient models for the native API v2 pilot. They are decoded
+ * with the production [org.siloserver.silo.network.SiloJson] instance and are
+ * deliberately separate from the v1 data classes: v2 ids are opaque strings,
+ * instants are RFC 3339 text (see [parseApiV2Instant]), and enums are
+ * string-backed value classes with an observable unknown case.
+ */
+
+/** GET /api/v2/system/info — the contract probe body. */
+@Serializable
+data class SystemInfo(
+    @SerialName("server_version") val serverVersion: String,
+    @SerialName("api_major") val apiMajor: Int,
+    @SerialName("contract_digest") val contractDigest: String,
+    val links: SystemInfoLinks,
+)
+
+@Serializable
+data class SystemInfoLinks(
+    val openapi: String,
+    val capabilities: String,
+)
+
+/** RFC 9457 problem details; every v2 error body. */
+@Serializable
+data class Problem(
+    val type: String,
+    val title: String,
+    val status: Int,
+    val detail: String = "",
+    val instance: String? = null,
+    val errors: List<ProblemError> = emptyList(),
+) {
+    /** The stable code: the last path segment of [type], e.g. `validation_failed`. */
+    val code: String get() = type.trimEnd('/').substringAfterLast('/')
+}
+
+@Serializable
+data class ProblemError(
+    val location: String,
+    val code: String,
+    val detail: String = "",
+)
+
+/** GET /api/v2/system/setup */
+@Serializable
+data class SetupStatus(
+    @SerialName("needs_setup") val needsSetup: Boolean,
+)
+
+/** GET /api/v2/account/me */
+@Serializable
+data class Account(
+    val id: String,
+    val username: String,
+    val email: String,
+    val role: AccountRole,
+    val permissions: List<String> = emptyList(),
+    @SerialName("download_allowed") val downloadAllowed: Boolean = false,
+    /** Present only inside an admin impersonation session. */
+    val impersonation: Impersonation? = null,
+)
+
+@Serializable
+data class Impersonation(
+    val active: Boolean,
+    @SerialName("impersonator_user_id") val impersonatorUserId: String,
+    @SerialName("impersonator_username") val impersonatorUsername: String,
+)
+
+/** GET /api/v2/progress */
+@Serializable
+data class ProgressCollection(
+    val items: List<ProgressEntryV2> = emptyList(),
+    val page: PageInfo = PageInfo(hasMore = false),
+)
+
+@Serializable
+data class ProgressEntryV2(
+    @SerialName("media_item_id") val mediaItemId: String,
+    @SerialName("position_seconds") val positionSeconds: Double,
+    @SerialName("duration_seconds") val durationSeconds: Double,
+    val completed: Boolean = false,
+    @SerialName("updated_at") val updatedAt: String,
+) {
+    val updatedAtEpochMillis: Long? get() = parseApiV2Instant(updatedAt)
+}
+
+@Serializable
+data class PageInfo(
+    @SerialName("has_more") val hasMore: Boolean,
+    /** Absent (null) exactly when [hasMore] is false. */
+    @SerialName("next_cursor") val nextCursor: String? = null,
+)
+
+/** PATCH /api/v2/profiles/{id} response; every string member is always emitted. */
+@Serializable
+data class ProfileV2(
+    val id: String,
+    val name: String,
+    val avatar: String = "",
+    @SerialName("avatar_url") val avatarUrl: String? = null,
+    @SerialName("avatar_source") val avatarSource: AvatarSource = AvatarSource("none"),
+    @SerialName("has_pin") val hasPin: Boolean = false,
+    @SerialName("is_child") val isChild: Boolean = false,
+    @SerialName("is_primary") val isPrimary: Boolean = false,
+    @SerialName("max_content_rating") val maxContentRating: String = "",
+    @SerialName("quality_preference") val qualityPreference: QualityPreference = QualityPreference("auto"),
+    val language: String = "",
+    @SerialName("preferred_metadata_language") val preferredMetadataLanguage: String = "",
+    @SerialName("subtitle_language") val subtitleLanguage: String = "",
+    @SerialName("subtitle_mode") val subtitleMode: SubtitleMode = SubtitleMode("auto"),
+    @SerialName("auto_skip_intro") val autoSkipIntro: Boolean = false,
+    @SerialName("auto_skip_credits") val autoSkipCredits: Boolean = false,
+    @SerialName("auto_skip_recap") val autoSkipRecap: Boolean = false,
+    @SerialName("auto_play_next_preview") val autoPlayNextPreview: Boolean = false,
+    @SerialName("show_forced_subtitles") val showForcedSubtitles: Boolean = false,
+    @SerialName("library_restrictions_enabled") val libraryRestrictionsEnabled: Boolean = false,
+    @SerialName("allowed_library_ids") val allowedLibraryIds: List<String> = emptyList(),
+    @SerialName("max_playback_quality") val maxPlaybackQuality: MaxPlaybackQuality = MaxPlaybackQuality("1080p"),
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String,
+)
+
+/**
+ * One member of a PATCH body. [Omit] leaves the member unchanged on the
+ * server (absent from the JSON), [Clear] sends a literal `null` (only valid
+ * for the clearable members), [Set] sends the value.
+ *
+ * `SiloJson` has `explicitNulls = false`, so a nullable property can never
+ * distinguish omitted from cleared; the PATCH body is therefore built as a
+ * [JsonObject] by [ProfileUpdate.toJsonObject] rather than serialized from a
+ * class.
+ */
+sealed class Patch<out T> {
+    data object Omit : Patch<Nothing>()
+    data object Clear : Patch<Nothing>()
+    data class Set<T>(val value: T) : Patch<T>()
+
+    companion object {
+        /** v1-style convenience: null means "leave unchanged", never "clear". */
+        fun <T : Any> ofOptional(value: T?): Patch<T> = if (value == null) Omit else Set(value)
+    }
+}
+
+/** PATCH /api/v2/profiles/{id} request. Nullable-on-PATCH members accept [Patch.Clear]. */
+data class ProfileUpdate(
+    val name: Patch<String> = Patch.Omit,
+    val avatar: Patch<String> = Patch.Omit,
+    val pin: Patch<String> = Patch.Omit,
+    val isChild: Patch<Boolean> = Patch.Omit,
+    val maxContentRating: Patch<String> = Patch.Omit,
+    val qualityPreference: Patch<QualityPreference> = Patch.Omit,
+    val language: Patch<String> = Patch.Omit,
+    val preferredMetadataLanguage: Patch<String> = Patch.Omit,
+    val subtitleLanguage: Patch<String> = Patch.Omit,
+    val subtitleMode: Patch<SubtitleMode> = Patch.Omit,
+    val showForcedSubtitles: Patch<Boolean> = Patch.Omit,
+    val autoSkipIntro: Patch<Boolean> = Patch.Omit,
+    val autoSkipCredits: Patch<Boolean> = Patch.Omit,
+    val autoSkipRecap: Patch<Boolean> = Patch.Omit,
+    val autoPlayNextPreview: Patch<Boolean> = Patch.Omit,
+    val libraryRestrictionsEnabled: Patch<Boolean> = Patch.Omit,
+    val allowedLibraryIds: Patch<List<String>> = Patch.Omit,
+    val maxPlaybackQuality: Patch<MaxPlaybackQuality> = Patch.Omit,
+) {
+    fun toJsonObject(): JsonObject {
+        val members = LinkedHashMap<String, JsonElement>()
+        fun <T> put(key: String, patch: Patch<T>, encode: (T) -> JsonElement) {
+            when (patch) {
+                Patch.Omit -> Unit
+                Patch.Clear -> members[key] = JsonNull
+                is Patch.Set -> members[key] = encode(patch.value)
+            }
+        }
+        val str = { s: String -> JsonPrimitive(s) }
+        val bool = { b: Boolean -> JsonPrimitive(b) }
+        put("name", name, str)
+        put("avatar", avatar, str)
+        put("pin", pin, str)
+        put("is_child", isChild, bool)
+        put("max_content_rating", maxContentRating, str)
+        put("quality_preference", qualityPreference) { JsonPrimitive(it.wire) }
+        put("language", language, str)
+        put("preferred_metadata_language", preferredMetadataLanguage, str)
+        put("subtitle_language", subtitleLanguage, str)
+        put("subtitle_mode", subtitleMode) { JsonPrimitive(it.wire) }
+        put("show_forced_subtitles", showForcedSubtitles, bool)
+        put("auto_skip_intro", autoSkipIntro, bool)
+        put("auto_skip_credits", autoSkipCredits, bool)
+        put("auto_skip_recap", autoSkipRecap, bool)
+        put("auto_play_next_preview", autoPlayNextPreview, bool)
+        put("library_restrictions_enabled", libraryRestrictionsEnabled, bool)
+        put("allowed_library_ids", allowedLibraryIds) { ids -> JsonArray(ids.map(::JsonPrimitive)) }
+        put("max_playback_quality", maxPlaybackQuality) { JsonPrimitive(it.wire) }
+        return JsonObject(members)
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Probe.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Probe.kt
@@ -6,9 +6,7 @@ import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
-import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
 import kotlinx.coroutines.CancellationException
 import org.siloserver.silo.network.SiloJson
 import org.siloserver.silo.network.skipSiloAuth
@@ -36,7 +34,7 @@ sealed class ApiV2ProbeResult {
         SERVER_ERROR,
         /** A 200 that is not a syntactically valid v2 info body (HTML from a proxy, malformed JSON, api_major != 2). */
         MALFORMED_RESPONSE,
-        /** Any other status, including a 404 that is not the legacy listener's plain-text 404. */
+        /** Any other status, including a 404 whose body is not the legacy listener's exact `404 page not found`. */
         UNEXPECTED_STATUS,
     }
 }
@@ -47,14 +45,17 @@ sealed class ApiV2ProbeResult {
  *
  * Compatibility rule:
  * - A syntactically valid info body with `api_major == 2` is [ApiV2ProbeResult.V2].
- * - A 404 whose Content-Type is `text/plain` is [ApiV2ProbeResult.UpdateServer]:
- *   that is exactly what Go's `http.NotFound` on the legacy v1 listener emits
- *   (`404 page not found`). It is the only input that produces the
- *   update-server state.
- * - A 404 with any other media type (an HTML page from a proxy, a v2
- *   `application/problem+json` body) is [ApiV2ProbeResult.Failure] with
- *   [ApiV2ProbeResult.Kind.UNEXPECTED_STATUS]: it does not prove the server is
- *   a v1-only Silo, so it is a reachability problem, not a contract verdict.
+ * - A 404 whose body is exactly what Go's `http.NotFound` on the legacy v1
+ *   listener writes — [LEGACY_NOT_FOUND_BODY], tolerating only the single
+ *   trailing newline the helper appends — is [ApiV2ProbeResult.UpdateServer].
+ *   It is the only input that produces the update-server state. The body
+ *   decides; the Content-Type is not consulted.
+ * - A 404 with any other body (an HTML page from a proxy, a v2
+ *   `application/problem+json` body, a proxy's own plain-text `Not Found`,
+ *   leading whitespace or extra newlines around the Go text) is
+ *   [ApiV2ProbeResult.Failure] with [ApiV2ProbeResult.Kind.UNEXPECTED_STATUS]:
+ *   it does not prove the server is a v1-only Silo, so it is a reachability
+ *   problem, not a contract verdict.
  * - Timeouts, TLS/connect failures, 401/403, 429, 5xx, and unparseable 200
  *   bodies are each their own [ApiV2ProbeResult.Failure] kind.
  *
@@ -82,10 +83,9 @@ class ApiV2Probe(private val client: HttpClient) {
             return ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.CONNECTION, cause = e)
         }
         val status = response.status.value
-        val contentType = response.contentType()
         return when {
             response.status == HttpStatusCode.NotFound -> {
-                if (contentType?.withoutParameters() == ContentType.Text.Plain) {
+                if (isLegacyNotFound(response.bodyAsText())) {
                     ApiV2ProbeResult.UpdateServer
                 } else {
                     ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.UNEXPECTED_STATUS, status)
@@ -113,5 +113,16 @@ class ApiV2Probe(private val client: HttpClient) {
 
     companion object {
         const val PATH = "/api/v2/system/info"
+
+        /** What Go's `http.NotFound` writes, before its trailing newline. */
+        const val LEGACY_NOT_FOUND_BODY = "404 page not found"
+
+        /**
+         * Exact match, tolerating only the single trailing newline the Go helper
+         * writes. Leading whitespace or any other decoration is some other
+         * service's 404, not the legacy listener's.
+         */
+        fun isLegacyNotFound(body: String): Boolean =
+            body == LEGACY_NOT_FOUND_BODY || body == LEGACY_NOT_FOUND_BODY + "\n"
     }
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Probe.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/apiv2/ApiV2Probe.kt
@@ -1,0 +1,117 @@
+package org.siloserver.silo.network.apiv2
+
+import io.ktor.client.HttpClient
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.CancellationException
+import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.skipSiloAuth
+
+/** Outcome of one [ApiV2Probe] call. */
+sealed class ApiV2ProbeResult {
+    /** The server speaks API v2. */
+    data class V2(val info: SystemInfo) : ApiV2ProbeResult()
+
+    /** A v1-only alpha server: the v2 prefix fell through to the legacy listener's plain 404. */
+    data object UpdateServer : ApiV2ProbeResult()
+
+    /** Anything else; never treated as a contract verdict. */
+    data class Failure(val kind: Kind, val status: Int? = null, val cause: Throwable? = null) : ApiV2ProbeResult()
+
+    enum class Kind {
+        /** DNS, connect, TLS, or a closed socket. */
+        CONNECTION,
+        TIMEOUT,
+        /** 401 or 403. */
+        AUTHENTICATION,
+        /** 429. */
+        RATE_LIMITED,
+        /** 5xx. */
+        SERVER_ERROR,
+        /** A 200 that is not a syntactically valid v2 info body (HTML from a proxy, malformed JSON, api_major != 2). */
+        MALFORMED_RESPONSE,
+        /** Any other status, including a 404 that is not the legacy listener's plain-text 404. */
+        UNEXPECTED_STATUS,
+    }
+}
+
+/**
+ * The v2 contract probe: `GET /api/v2/system/info`, once per established
+ * connection (or identity refresh), never per request.
+ *
+ * Compatibility rule:
+ * - A syntactically valid info body with `api_major == 2` is [ApiV2ProbeResult.V2].
+ * - A 404 whose Content-Type is `text/plain` is [ApiV2ProbeResult.UpdateServer]:
+ *   that is exactly what Go's `http.NotFound` on the legacy v1 listener emits
+ *   (`404 page not found`). It is the only input that produces the
+ *   update-server state.
+ * - A 404 with any other media type (an HTML page from a proxy, a v2
+ *   `application/problem+json` body) is [ApiV2ProbeResult.Failure] with
+ *   [ApiV2ProbeResult.Kind.UNEXPECTED_STATUS]: it does not prove the server is
+ *   a v1-only Silo, so it is a reachability problem, not a contract verdict.
+ * - Timeouts, TLS/connect failures, 401/403, 429, 5xx, and unparseable 200
+ *   bodies are each their own [ApiV2ProbeResult.Failure] kind.
+ *
+ * No result enables a v1 transport for a pilot operation.
+ */
+class ApiV2Probe(private val client: HttpClient) {
+
+    /**
+     * Probes [serverUrl] (or the active server when null, resolved by the auth
+     * plugin exactly like every other relative call).
+     */
+    suspend fun probe(serverUrl: String? = null): ApiV2ProbeResult {
+        val url = if (serverUrl == null) PATH else "${serverUrl.trimEnd('/')}$PATH"
+        val response = try {
+            client.get(url) { skipSiloAuth() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpRequestTimeoutException) {
+            return ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.TIMEOUT, cause = e)
+        } catch (e: ConnectTimeoutException) {
+            return ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.TIMEOUT, cause = e)
+        } catch (e: SocketTimeoutException) {
+            return ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.TIMEOUT, cause = e)
+        } catch (e: Throwable) {
+            return ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.CONNECTION, cause = e)
+        }
+        val status = response.status.value
+        val contentType = response.contentType()
+        return when {
+            response.status == HttpStatusCode.NotFound -> {
+                if (contentType?.withoutParameters() == ContentType.Text.Plain) {
+                    ApiV2ProbeResult.UpdateServer
+                } else {
+                    ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.UNEXPECTED_STATUS, status)
+                }
+            }
+            status == 401 || status == 403 -> ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.AUTHENTICATION, status)
+            status == 429 -> ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.RATE_LIMITED, status)
+            status >= 500 -> ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.SERVER_ERROR, status)
+            status != 200 -> ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.UNEXPECTED_STATUS, status)
+            else -> decodeInfo(response.bodyAsText(), status)
+        }
+    }
+
+    private fun decodeInfo(body: String, status: Int): ApiV2ProbeResult {
+        val info = try {
+            SiloJson.decodeFromString(SystemInfo.serializer(), body)
+        } catch (e: Throwable) {
+            return ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.MALFORMED_RESPONSE, status, e)
+        }
+        if (info.apiMajor != 2) {
+            return ApiV2ProbeResult.Failure(ApiV2ProbeResult.Kind.MALFORMED_RESPONSE, status)
+        }
+        return ApiV2ProbeResult.V2(info)
+    }
+
+    companion object {
+        const val PATH = "/api/v2/system/info"
+    }
+}

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -50,7 +50,9 @@ class AuthRepository(
     /**
      * Persists a successful auth response's tokens into the active server's
      * scope and unwraps the [User] — the shared tail of every path that ends
-     * a signed-out state (login, signup, setup, invitation claim).
+     * a signed-out state (login, signup, setup, invitation claim). Once the
+     * tokens are stored, [onSessionCommitted] refreshes the server's v2
+     * contract verdict.
      */
     private suspend fun persistSession(
         result: ApiResult<LoginResponse>,
@@ -60,18 +62,53 @@ class AuthRepository(
         when (result) {
             is ApiResult.Success -> {
                 val data = result.data
+                val serverId = targetServerId ?: tokenManager.getCurrentServerId()
                 tokenManager.replaceAccountSession(
-                    serverId = targetServerId ?: tokenManager.getCurrentServerId(),
+                    serverId = serverId,
                     serverUrl = targetServerUrl,
                     accessToken = data.accessToken,
                     refreshToken = data.refreshToken,
                     expiresIn = data.expiresIn,
                 )
+                onSessionCommitted(serverId)
                 ApiResult.Success(data.user)
             }
             is ApiResult.Error -> result
             is ApiResult.NetworkError -> result
         }
+
+    /**
+     * Re-establishes the v2 contract verdict of [serverId] (the active server
+     * when null) after a session was committed on it. A v1 login proves
+     * nothing about v2, but the stored verdict can be stale — the server may
+     * have been upgraded while the sign-in screen stayed open — and without
+     * a fresh probe an old UPDATE_REQUIRED would keep the gate rejecting
+     * every pilot v2 call for the whole session.
+     *
+     * Launched on [backgroundScope] so sign-in never waits on the probe: the
+     * gate already passes UNKNOWN and V2, and a stale UPDATE_REQUIRED clears
+     * as soon as the probe answers. Without a scope the same sequence runs
+     * inline in the caller. No-op without a registry or probe (single-server
+     * hosts, tests). Every path that commits tokens outside
+     * [persistSession] (the TV credential and QR sign-ins) must call this
+     * after its commit.
+     */
+    suspend fun onSessionCommitted(serverId: String? = null) {
+        val registry = serverRegistry ?: return
+        if (apiV2Probe == null) return
+        val committedId = serverId ?: registry.activeServerId.value ?: return
+        val scope = backgroundScope
+        if (scope == null) {
+            if (registry.activeServerId.value != committedId) return
+            probeContractWithFallback(committedId) {}
+            return
+        }
+        scope.launch {
+            if (registry.activeServerId.value == committedId) {
+                probeContractWithFallback(committedId) {}
+            }
+        }
+    }
 
     /**
      * Logs in with username and password.
@@ -160,7 +197,10 @@ class AuthRepository(
             targetServerId = targetServerId,
             targetServerUrl = serverUrl.takeIf { serverRegistry == null },
         )
-        if (persisted is ApiResult.Success) refreshActiveServerName()
+        // persistSession already refreshed the contract; only the name is left.
+        if (persisted is ApiResult.Success) {
+            serverRegistry?.activeServerId?.value?.let { refreshActiveServerDisplayName(it) }
+        }
         return persisted
     }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -227,11 +227,13 @@ class AuthRepository(
      * Callers await this behind a spinner, so only the probe is awaited and
      * only for [SWITCH_PROBE_TIMEOUT_MS]: a server that accepts the socket
      * but never answers leaves the stored verdict alone (the gate still
-     * passes UNKNOWN and V2). When the bound cancels the probe and a
+     * passes UNKNOWN and V2). When the bounded probe yields no verdict —
+     * the bound cancelled it or it failed (connection error, 5xx) — and a
      * [backgroundScope] is wired in, a replacement unbounded probe (the
      * client's own timeouts still apply) is launched there for [serverId],
-     * so a stale UPDATE_REQUIRED on a since-upgraded server is corrected
-     * once it answers instead of gating v2 calls until the next launch; the
+     * so a stale UPDATE_REQUIRED on a since-upgraded or briefly unreachable
+     * server is corrected once it answers instead of gating v2 calls until
+     * the next launch; the
      * active-id guard in [recordServerContract] drops the result if the user
      * switched again meanwhile. Without a scope the verdict stays as stored
      * until the next switch or launch re-probes. The display-name refresh
@@ -331,9 +333,10 @@ class AuthRepository(
      * have been upgraded since), probe now and wait at most [timeoutMs] so
      * gated startup consumers see the refreshed verdict instead of the
      * stale one. Returns the recorded verdict, or null when nothing was
-     * awaited (not UPDATE_REQUIRED, no probe wired in, or timed out) — pass
-     * it to [refreshActiveServerName] as `knownContract` to avoid a second
-     * probe.
+     * recorded (not UPDATE_REQUIRED, no probe wired in, timed out, or the
+     * probe failed) — pass it to [refreshActiveServerName] as
+     * `knownContract`: a verdict avoids a second probe, while null makes
+     * that call probe again so a briefly unreachable server is retried.
      */
     suspend fun awaitContractRefreshIfUpdateRequired(timeoutMs: Long = SWITCH_PROBE_TIMEOUT_MS): ServerContract? {
         if (activeServerContract() != ServerContract.UPDATE_REQUIRED) return null
@@ -343,13 +346,19 @@ class AuthRepository(
     /**
      * [refreshServerContract] with a wall-clock bound. Every path that awaits
      * the probe before letting the user (or a peer, in pairing) proceed goes
-     * through here so the bound lives in one place. Null when nothing was
-     * recorded: no probe wired in, or the server accepted the socket but did
-     * not answer within [timeoutMs] — the stored verdict is left alone, which
-     * the gate treats as passable, and the next switch or launch re-probes.
+     * through here so the bound lives in one place. Returns a real verdict
+     * ([ServerContract.V2] or [ServerContract.UPDATE_REQUIRED]) only; null
+     * means nothing was recorded — no probe wired in, the server did not
+     * answer within [timeoutMs], or the probe failed (connection error, 5xx)
+     * — and the stored verdict is left alone. "No verdict" is uniform so
+     * callers re-probe on null instead of treating a transient failure as
+     * settled, which would otherwise leave a stale UPDATE_REQUIRED gating the
+     * whole session.
      */
     suspend fun refreshServerContractBounded(timeoutMs: Long = SWITCH_PROBE_TIMEOUT_MS): ServerContract? =
-        withTimeoutOrNull(timeoutMs) { refreshServerContract() }?.toServerContract()
+        withTimeoutOrNull(timeoutMs) { refreshServerContract() }
+            ?.toServerContract()
+            ?.takeUnless { it == ServerContract.UNKNOWN }
 
     /**
      * Runs the v2 contract probe against [serverUrl] (a candidate the app is

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -227,23 +227,42 @@ class AuthRepository(
      * Callers await this behind a spinner, so only the probe is awaited and
      * only for [SWITCH_PROBE_TIMEOUT_MS]: a server that accepts the socket
      * but never answers leaves the stored verdict alone (the gate still
-     * passes UNKNOWN and V2, and a stale UPDATE_REQUIRED gets the launch-path
-     * refresh). The display-name refresh (branding, then health) is launched
-     * on [backgroundScope] without being awaited; without a scope it runs
-     * inline after the probe.
+     * passes UNKNOWN and V2). When the bound cancels the probe and a
+     * [backgroundScope] is wired in, a replacement unbounded probe (the
+     * client's own timeouts still apply) is launched there for [serverId],
+     * so a stale UPDATE_REQUIRED on a since-upgraded server is corrected
+     * once it answers instead of gating v2 calls until the next launch; the
+     * active-id guard in [recordServerContract] drops the result if the user
+     * switched again meanwhile. Without a scope the verdict stays as stored
+     * until the next switch or launch re-probes. The display-name refresh
+     * (branding, then health) is likewise launched on [backgroundScope]
+     * without being awaited; without a scope it runs inline after the probe.
      */
     suspend fun switchToServer(serverId: String) {
         val registry = serverRegistry ?: return
         registry.switchTo(serverId)
         tokenManager.switchActiveServer(serverId)
-        refreshServerContractBounded()
+        val bounded = refreshServerContractBounded()
         if (registry.activeServerId.value != serverId) return
         val scope = backgroundScope
         if (scope == null) {
             refreshActiveServerDisplayName(serverId)
         } else {
+            if (bounded == null && apiV2Probe != null) scope.launch { refreshServerContractFor(serverId) }
             scope.launch { refreshActiveServerDisplayName(serverId) }
         }
+    }
+
+    /**
+     * Unbounded contract probe pinned to [serverId]: skipped if it is no
+     * longer active by the time this runs, and its verdict is dropped by
+     * [recordServerContract] if the active server changed while in flight.
+     */
+    private suspend fun refreshServerContractFor(serverId: String) {
+        val probe = apiV2Probe ?: return
+        val registry = serverRegistry ?: return
+        if (registry.activeServerId.value != serverId) return
+        recordServerContract(serverId, probe.probe().toServerContract())
     }
 
     /**

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -17,6 +17,11 @@ import org.siloserver.silo.network.api.AuthApi
 import org.siloserver.silo.network.api.BrandingApi
 import org.siloserver.silo.network.api.HealthApi
 import org.siloserver.silo.network.map
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withTimeoutOrNull
 
 class AuthRepository(
     private val authApi: AuthApi,
@@ -247,6 +252,35 @@ class AuthRepository(
     /** The active server's learned [ServerContract]; [ServerContract.UNKNOWN] without a registry. */
     fun activeServerContract(): ServerContract =
         serverRegistry?.activeEntry?.value?.contract ?: ServerContract.UNKNOWN
+
+    /**
+     * [activeServerContract] as a stream, so a consumer whose gated v2 call
+     * failed on a stale [ServerContract.UPDATE_REQUIRED] can re-run it once
+     * the launch probe records the real verdict. Emits the current value
+     * first; a single [ServerContract.UNKNOWN] without a registry.
+     */
+    val activeServerContractFlow: Flow<ServerContract> =
+        serverRegistry?.activeEntry
+            ?.map { it?.contract ?: ServerContract.UNKNOWN }
+            ?.distinctUntilChanged()
+            ?: flowOf(ServerContract.UNKNOWN)
+
+    /**
+     * Launch-time guard for the stored verdict. Only a stale
+     * [ServerContract.UPDATE_REQUIRED] is harmful: UNKNOWN and V2 both pass
+     * [org.siloserver.silo.network.apiv2.ApiV2Gate], so those refresh in the
+     * background. When the stored state is UPDATE_REQUIRED (the server may
+     * have been upgraded since), probe now and wait at most [timeoutMs] so
+     * gated startup consumers see the refreshed verdict instead of the
+     * stale one. Returns the recorded verdict, or null when nothing was
+     * awaited (not UPDATE_REQUIRED, no probe wired in, or timed out) — pass
+     * it to [refreshActiveServerName] as `knownContract` to avoid a second
+     * probe.
+     */
+    suspend fun awaitContractRefreshIfUpdateRequired(timeoutMs: Long = 3_000L): ServerContract? {
+        if (activeServerContract() != ServerContract.UPDATE_REQUIRED) return null
+        return withTimeoutOrNull(timeoutMs) { refreshServerContract() }?.toServerContract()
+    }
 
     /**
      * Runs the v2 contract probe against [serverUrl] (a candidate the app is

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -17,6 +17,7 @@ import org.siloserver.silo.network.api.AuthApi
 import org.siloserver.silo.network.api.BrandingApi
 import org.siloserver.silo.network.api.HealthApi
 import org.siloserver.silo.network.map
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -256,22 +257,37 @@ class AuthRepository(
 
     /**
      * The contract half of every "this server just became active" path
-     * ([switchToServer], pairing): awaits [refreshServerContractBounded] and,
-     * when that yields no verdict (bound elapsed, or the probe failed), hands
-     * the retry to a replacement unbounded probe pinned to [serverId] on
-     * [backgroundScope] so a stale UPDATE_REQUIRED stops gating the session
-     * once the server answers. Returns the bounded result; null means the
-     * stored verdict was left alone (and, with a scope and a probe wired in,
-     * that a replacement is now in flight). Skips the replacement when
-     * [serverId] is no longer active by the time the bound returns.
+     * ([switchToServer], pairing): runs [refreshServerContractBounded] and,
+     * when that yields no verdict (bound elapsed, or the probe failed), a
+     * replacement unbounded probe pinned to [serverId], so a stale
+     * UPDATE_REQUIRED stops gating the session once the server answers.
+     * Returns the bounded result; null means the stored verdict was left
+     * alone (and, with a scope and a probe wired in, that a replacement is
+     * now in flight). The replacement is skipped when [serverId] is no longer
+     * active by the time the bound returns.
+     *
+     * With [backgroundScope] wired in, the whole sequence is launched there
+     * before the caller starts waiting, and the caller only awaits the bounded
+     * verdict for at most [SWITCH_PROBE_TIMEOUT_MS]. Callers usually run in a
+     * UI scope (a server-list `viewModelScope`) that dies when the user
+     * presses Back during the bound; that cancels only this call's wait, not
+     * the probe, so the switched-to server does not stay UNKNOWN or stale
+     * UPDATE_REQUIRED for the session. Without a scope everything runs inline
+     * in the caller and is cancelled with it.
      */
     suspend fun refreshServerContractWithFallback(serverId: String): ServerContract? {
-        val bounded = refreshServerContractBounded()
-        if (bounded != null) return bounded
-        val scope = backgroundScope ?: return null
-        if (apiV2Probe == null || serverRegistry?.activeServerId?.value != serverId) return null
-        scope.launch { refreshServerContractFor(serverId) }
-        return null
+        val scope = backgroundScope
+        if (scope == null || apiV2Probe == null) return refreshServerContractBounded()
+        val bounded = CompletableDeferred<ServerContract?>()
+        val job = scope.launch {
+            val verdict = refreshServerContractBounded()
+            bounded.complete(verdict)
+            if (verdict == null) refreshServerContractFor(serverId)
+        }
+        // A scope torn down mid-probe must not leave the caller waiting out
+        // the bound on its own; completing after a verdict is a no-op.
+        job.invokeOnCompletion { bounded.complete(null) }
+        return withTimeoutOrNull(SWITCH_PROBE_TIMEOUT_MS) { bounded.await() }
     }
 
     /**

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -17,11 +17,20 @@ import org.siloserver.silo.network.api.AuthApi
 import org.siloserver.silo.network.api.BrandingApi
 import org.siloserver.silo.network.api.HealthApi
 import org.siloserver.silo.network.map
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * How long [AuthRepository.switchToServer] waits for the contract probe before
+ * returning with the stored verdict untouched. Matches the launch-path bound
+ * in [AuthRepository.awaitContractRefreshIfUpdateRequired].
+ */
+private const val SWITCH_PROBE_TIMEOUT_MS = 3_000L
 
 class AuthRepository(
     private val authApi: AuthApi,
@@ -30,6 +39,12 @@ class AuthRepository(
     private val healthApi: HealthApi? = null,
     private val brandingApi: BrandingApi? = null,
     private val apiV2Probe: ApiV2Probe? = null,
+    /**
+     * Process-lifetime scope for fire-and-forget work the caller must not wait
+     * on (the display-name refresh after a server switch). When null that
+     * work runs inline instead — single-server hosts and tests.
+     */
+    private val backgroundScope: CoroutineScope? = null,
 ) {
     /**
      * Persists a successful auth response's tokens into the active server's
@@ -204,16 +219,31 @@ class AuthRepository(
 
     /**
      * The single entry point for activating an already-registered server:
-     * switches the registry and the token scope, then refreshes the server's
-     * identity and v2 contract verdict. Every "switch to server" UI path must
-     * go through here so a server saved by an older build gets probed. No-op
+     * switches the registry and the token scope, then re-establishes the
+     * server's v2 contract verdict. Every "switch to server" UI path must go
+     * through here so a server saved by an older build gets probed. No-op
      * without a registry.
+     *
+     * Callers await this behind a spinner, so only the probe is awaited and
+     * only for [SWITCH_PROBE_TIMEOUT_MS]: a server that accepts the socket
+     * but never answers leaves the stored verdict alone (the gate still
+     * passes UNKNOWN and V2, and a stale UPDATE_REQUIRED gets the launch-path
+     * refresh). The display-name refresh (branding, then health) is launched
+     * on [backgroundScope] without being awaited; without a scope it runs
+     * inline after the probe.
      */
     suspend fun switchToServer(serverId: String) {
         val registry = serverRegistry ?: return
         registry.switchTo(serverId)
         tokenManager.switchActiveServer(serverId)
-        refreshActiveServerName()
+        withTimeoutOrNull(SWITCH_PROBE_TIMEOUT_MS) { refreshServerContract() }
+        if (registry.activeServerId.value != serverId) return
+        val scope = backgroundScope
+        if (scope == null) {
+            refreshActiveServerDisplayName(serverId)
+        } else {
+            scope.launch { refreshActiveServerDisplayName(serverId) }
+        }
     }
 
     /**
@@ -233,6 +263,15 @@ class AuthRepository(
         val registry = serverRegistry ?: return
         val activeId = registry.activeServerId.value ?: return
         if (knownContract != null) recordServerContract(activeId, knownContract) else refreshServerContract()
+        refreshActiveServerDisplayName(activeId)
+    }
+
+    /**
+     * The name half of [refreshActiveServerName]: branding, then health as a
+     * fallback, recorded only while [activeId] is still the active server.
+     */
+    private suspend fun refreshActiveServerDisplayName(activeId: String) {
+        val registry = serverRegistry ?: return
         if (registry.activeServerId.value != activeId) return
         val brandingName = (brandingApi?.getBranding() as? ApiResult.Success)
             ?.data

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -244,15 +244,34 @@ class AuthRepository(
         val registry = serverRegistry ?: return
         registry.switchTo(serverId)
         tokenManager.switchActiveServer(serverId)
-        val bounded = refreshServerContractBounded()
+        refreshServerContractWithFallback(serverId)
         if (registry.activeServerId.value != serverId) return
         val scope = backgroundScope
         if (scope == null) {
             refreshActiveServerDisplayName(serverId)
         } else {
-            if (bounded == null && apiV2Probe != null) scope.launch { refreshServerContractFor(serverId) }
             scope.launch { refreshActiveServerDisplayName(serverId) }
         }
+    }
+
+    /**
+     * The contract half of every "this server just became active" path
+     * ([switchToServer], pairing): awaits [refreshServerContractBounded] and,
+     * when that yields no verdict (bound elapsed, or the probe failed), hands
+     * the retry to a replacement unbounded probe pinned to [serverId] on
+     * [backgroundScope] so a stale UPDATE_REQUIRED stops gating the session
+     * once the server answers. Returns the bounded result; null means the
+     * stored verdict was left alone (and, with a scope and a probe wired in,
+     * that a replacement is now in flight). Skips the replacement when
+     * [serverId] is no longer active by the time the bound returns.
+     */
+    suspend fun refreshServerContractWithFallback(serverId: String): ServerContract? {
+        val bounded = refreshServerContractBounded()
+        if (bounded != null) return bounded
+        val scope = backgroundScope ?: return null
+        if (apiV2Probe == null || serverRegistry?.activeServerId?.value != serverId) return null
+        scope.launch { refreshServerContractFor(serverId) }
+        return null
     }
 
     /**

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -236,7 +236,7 @@ class AuthRepository(
         val registry = serverRegistry ?: return
         registry.switchTo(serverId)
         tokenManager.switchActiveServer(serverId)
-        withTimeoutOrNull(SWITCH_PROBE_TIMEOUT_MS) { refreshServerContract() }
+        refreshServerContractBounded()
         if (registry.activeServerId.value != serverId) return
         val scope = backgroundScope
         if (scope == null) {
@@ -316,10 +316,21 @@ class AuthRepository(
      * it to [refreshActiveServerName] as `knownContract` to avoid a second
      * probe.
      */
-    suspend fun awaitContractRefreshIfUpdateRequired(timeoutMs: Long = 3_000L): ServerContract? {
+    suspend fun awaitContractRefreshIfUpdateRequired(timeoutMs: Long = SWITCH_PROBE_TIMEOUT_MS): ServerContract? {
         if (activeServerContract() != ServerContract.UPDATE_REQUIRED) return null
-        return withTimeoutOrNull(timeoutMs) { refreshServerContract() }?.toServerContract()
+        return refreshServerContractBounded(timeoutMs)
     }
+
+    /**
+     * [refreshServerContract] with a wall-clock bound. Every path that awaits
+     * the probe before letting the user (or a peer, in pairing) proceed goes
+     * through here so the bound lives in one place. Null when nothing was
+     * recorded: no probe wired in, or the server accepted the socket but did
+     * not answer within [timeoutMs] — the stored verdict is left alone, which
+     * the gate treats as passable, and the next switch or launch re-probes.
+     */
+    suspend fun refreshServerContractBounded(timeoutMs: Long = SWITCH_PROBE_TIMEOUT_MS): ServerContract? =
+        withTimeoutOrNull(timeoutMs) { refreshServerContract() }?.toServerContract()
 
     /**
      * Runs the v2 contract probe against [serverUrl] (a candidate the app is

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -7,6 +7,9 @@ import org.siloserver.silo.model.auth.SetupStatusResponse
 import org.siloserver.silo.model.auth.SignupRequest
 import org.siloserver.silo.model.auth.SignupStatusResponse
 import org.siloserver.silo.model.auth.User
+import org.siloserver.silo.model.server.ServerContract
+import org.siloserver.silo.network.apiv2.ApiV2Probe
+import org.siloserver.silo.network.apiv2.ApiV2ProbeResult
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.TokenManager
@@ -21,6 +24,7 @@ class AuthRepository(
     private val serverRegistry: ServerRegistry? = null,
     private val healthApi: HealthApi? = null,
     private val brandingApi: BrandingApi? = null,
+    private val apiV2Probe: ApiV2Probe? = null,
 ) {
     /**
      * Persists a successful auth response's tokens into the active server's
@@ -180,12 +184,15 @@ class AuthRepository(
      * reactivating an existing one). The auth/profile/token state for that
      * server (if any) is restored automatically.
      */
-    suspend fun setServerUrl(url: String) {
+    suspend fun setServerUrl(url: String, contract: ServerContract? = null) {
         if (serverRegistry != null) {
             val id = serverRegistry.addOrUpdate(url)
             serverRegistry.switchTo(id)
             tokenManager.switchActiveServer(id)
             refreshActiveServerName()
+            // The connect path already probed the candidate; record that
+            // verdict instead of probing twice. Other callers probe now.
+            if (contract != null) recordServerContract(contract) else refreshServerContract()
         } else {
             tokenManager.setServerUrl(url)
         }
@@ -214,4 +221,48 @@ class AuthRepository(
     }
 
     private fun String?.usableServerName(): String? = this?.trim()?.takeIf { it.isNotBlank() }
+
+    /** The active server's learned [ServerContract]; [ServerContract.UNKNOWN] without a registry. */
+    fun activeServerContract(): ServerContract =
+        serverRegistry?.activeEntry?.value?.contract ?: ServerContract.UNKNOWN
+
+    /**
+     * Runs the v2 contract probe against [serverUrl] (a candidate the app is
+     * not connected to yet) without recording anything. Null when no probe is
+     * wired in (single-server hosts, tests).
+     */
+    suspend fun probeServerContract(serverUrl: String): ApiV2ProbeResult? =
+        apiV2Probe?.probe(serverUrl)
+
+    /**
+     * Records [contract] on the active registry entry when it is a verdict
+     * ([ServerContract.V2] or [ServerContract.UPDATE_REQUIRED]); an
+     * [ServerContract.UNKNOWN] result leaves the stored state alone, because a
+     * transport, TLS, auth, rate-limit, or server error says nothing about
+     * the contract.
+     */
+    suspend fun recordServerContract(contract: ServerContract) {
+        if (contract == ServerContract.UNKNOWN) return
+        val registry = serverRegistry ?: return
+        val activeId = registry.activeServerId.value ?: return
+        registry.setContract(activeId, contract)
+    }
+
+    /**
+     * Runs the v2 contract probe once against the active server and records
+     * the verdict. Called when a connection is established or its identity is
+     * refreshed, never per request.
+     */
+    suspend fun refreshServerContract(): ApiV2ProbeResult? {
+        val result = apiV2Probe?.probe() ?: return null
+        recordServerContract(result.toServerContract())
+        return result
+    }
+}
+
+/** Maps a probe outcome to the stored state; failures are [ServerContract.UNKNOWN] (no verdict). */
+fun ApiV2ProbeResult.toServerContract(): ServerContract = when (this) {
+    is ApiV2ProbeResult.V2 -> ServerContract.V2
+    ApiV2ProbeResult.UpdateServer -> ServerContract.UPDATE_REQUIRED
+    is ApiV2ProbeResult.Failure -> ServerContract.UNKNOWN
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 /**
  * How long [AuthRepository.switchToServer] waits for the contract probe before
  * returning with the stored verdict untouched. Matches the launch-path bound
- * in [AuthRepository.awaitContractRefreshIfUpdateRequired].
+ * in [AuthRepository.awaitContractRefreshIfUnsettled].
  */
 private const val SWITCH_PROBE_TIMEOUT_MS = 3_000L
 
@@ -345,20 +345,24 @@ class AuthRepository(
             ?: flowOf(ServerContract.UNKNOWN)
 
     /**
-     * Launch-time guard for the stored verdict. Only a stale
-     * [ServerContract.UPDATE_REQUIRED] is harmful: UNKNOWN and V2 both pass
-     * [org.siloserver.silo.network.apiv2.ApiV2Gate], so those refresh in the
-     * background. When the stored state is UPDATE_REQUIRED (the server may
-     * have been upgraded since), probe now and wait at most [timeoutMs] so
-     * gated startup consumers see the refreshed verdict instead of the
-     * stale one. Returns the recorded verdict, or null when nothing was
-     * recorded (not UPDATE_REQUIRED, no probe wired in, timed out, or the
-     * probe failed) — pass it to [refreshActiveServerName] as
-     * `knownContract`: a verdict avoids a second probe, while null makes
-     * that call probe again so a briefly unreachable server is retried.
+     * Launch-time guard for the stored verdict. Only a settled
+     * [ServerContract.V2] is safe to route on immediately. A stored
+     * [ServerContract.UPDATE_REQUIRED] may be stale (server upgraded since)
+     * and would gate the whole session; a stored [ServerContract.UNKNOWN]
+     * (every entry saved by a build before the v2 pilot) passes
+     * [org.siloserver.silo.network.apiv2.ApiV2Gate], so authenticated startup
+     * consumers would race the background probe and could receive raw v2
+     * 404s from a v1-only server before UPDATE_REQUIRED is recorded — and
+     * those one-shot loads do not retry. Both unsettled states probe now and
+     * wait at most [timeoutMs] so startup consumers see a real verdict.
+     * Returns the recorded verdict, or null when nothing was recorded
+     * (stored V2, no probe wired in, timed out, or the probe failed) — pass
+     * it to [refreshActiveServerName] as `knownContract`: a verdict avoids a
+     * second probe, while null makes that call probe again so a briefly
+     * unreachable server is retried.
      */
-    suspend fun awaitContractRefreshIfUpdateRequired(timeoutMs: Long = SWITCH_PROBE_TIMEOUT_MS): ServerContract? {
-        if (activeServerContract() != ServerContract.UPDATE_REQUIRED) return null
+    suspend fun awaitContractRefreshIfUnsettled(timeoutMs: Long = SWITCH_PROBE_TIMEOUT_MS): ServerContract? {
+        if (activeServerContract() == ServerContract.V2) return null
         return refreshServerContractBounded(timeoutMs)
     }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -427,6 +427,19 @@ class AuthRepository(
     }
 }
 
+/**
+ * The verdict to record once a v2 operation (the connect path's
+ * `/api/v2/system/setup` call) has succeeded against a candidate: that answer
+ * is itself proof of v2, whatever the earlier bounded candidate probe said. A
+ * probe [ApiV2ProbeResult.Failure] or timeout is no verdict and must not be
+ * mapped through [toServerContract] into a non-null [ServerContract.UNKNOWN]
+ * here — [AuthRepository.refreshActiveServerName] neither records UNKNOWN
+ * nor re-probes when handed a known contract, so a stale UPDATE_REQUIRED
+ * would survive a successful v2 connection. Only the probe's
+ * [ApiV2ProbeResult.UpdateServer] is acted on, before the setup call.
+ */
+val CONTRACT_PROVEN_BY_V2_RESPONSE: ServerContract = ServerContract.V2
+
 /** Maps a probe outcome to the stored state; failures are [ServerContract.UNKNOWN] (no verdict). */
 fun ApiV2ProbeResult.toServerContract(): ServerContract = when (this) {
     is ApiV2ProbeResult.V2 -> ServerContract.V2

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -189,24 +189,46 @@ class AuthRepository(
             val id = serverRegistry.addOrUpdate(url)
             serverRegistry.switchTo(id)
             tokenManager.switchActiveServer(id)
-            refreshActiveServerName()
             // The connect path already probed the candidate; record that
             // verdict instead of probing twice. Other callers probe now.
-            if (contract != null) recordServerContract(contract) else refreshServerContract()
+            refreshActiveServerName(knownContract = contract)
         } else {
             tokenManager.setServerUrl(url)
         }
     }
 
     /**
-     * Best-effort: read the native branding identity and update the active
-     * registry entry's fetched name. Health is a fallback for older servers
-     * without the branding endpoint. Quietly no-ops if no usable name can be
-     * resolved — this is purely for nicer UX in the server list.
+     * The single entry point for activating an already-registered server:
+     * switches the registry and the token scope, then refreshes the server's
+     * identity and v2 contract verdict. Every "switch to server" UI path must
+     * go through here so a server saved by an older build gets probed. No-op
+     * without a registry.
      */
-    suspend fun refreshActiveServerName() {
+    suspend fun switchToServer(serverId: String) {
+        val registry = serverRegistry ?: return
+        registry.switchTo(serverId)
+        tokenManager.switchActiveServer(serverId)
+        refreshActiveServerName()
+    }
+
+    /**
+     * Best-effort: (re)establish the active server's v2 contract verdict, then
+     * read the native branding identity and update the active registry
+     * entry's fetched name. Health is a fallback for older servers without the
+     * branding endpoint. Quietly no-ops if no usable name can be resolved —
+     * this is purely for nicer UX in the server list.
+     *
+     * [knownContract] lets the connect path pass the verdict it already has
+     * instead of probing twice; every other caller probes now. Both the
+     * contract and the name are dropped if the active server changed while
+     * the request was in flight, so a slow answer from one server never
+     * relabels another.
+     */
+    suspend fun refreshActiveServerName(knownContract: ServerContract? = null) {
         val registry = serverRegistry ?: return
         val activeId = registry.activeServerId.value ?: return
+        if (knownContract != null) recordServerContract(activeId, knownContract) else refreshServerContract()
+        if (registry.activeServerId.value != activeId) return
         val brandingName = (brandingApi?.getBranding() as? ApiResult.Success)
             ?.data
             ?.serverName
@@ -242,20 +264,34 @@ class AuthRepository(
      * the contract.
      */
     suspend fun recordServerContract(contract: ServerContract) {
+        val activeId = serverRegistry?.activeServerId?.value ?: return
+        recordServerContract(activeId, contract)
+    }
+
+    /**
+     * Records [contract] for [serverId] only while it is still the active
+     * server, so a probe answer that arrives after a switch cannot overwrite
+     * the newer server's state.
+     */
+    private suspend fun recordServerContract(serverId: String, contract: ServerContract) {
         if (contract == ServerContract.UNKNOWN) return
         val registry = serverRegistry ?: return
-        val activeId = registry.activeServerId.value ?: return
-        registry.setContract(activeId, contract)
+        if (registry.activeServerId.value != serverId) return
+        registry.setContract(serverId, contract)
     }
 
     /**
      * Runs the v2 contract probe once against the active server and records
-     * the verdict. Called when a connection is established or its identity is
-     * refreshed, never per request.
+     * the verdict. Called when a connection is established, restored on
+     * launch, switched to, or its identity is refreshed — never per request.
+     * A failure records nothing (the stored state stays as it was), and a
+     * result for a server that is no longer active is dropped.
      */
     suspend fun refreshServerContract(): ApiV2ProbeResult? {
-        val result = apiV2Probe?.probe() ?: return null
-        recordServerContract(result.toServerContract())
+        val probe = apiV2Probe ?: return null
+        val activeId = serverRegistry?.activeServerId?.value
+        val result = probe.probe()
+        if (activeId != null) recordServerContract(activeId, result.toServerContract())
         return result
     }
 }

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -381,11 +381,22 @@ class AuthRepository(
 
     /**
      * Runs the v2 contract probe against [serverUrl] (a candidate the app is
-     * not connected to yet) without recording anything. Null when no probe is
-     * wired in (single-server hosts, tests).
+     * not connected to yet) without recording anything, bounded to
+     * [timeoutMs]. Null when no probe is wired in (single-server hosts,
+     * tests) or the candidate accepted the socket but did not answer within
+     * the bound — "no verdict", which the connect path treats the same as a
+     * [ApiV2ProbeResult.Failure]: it moves on to the setup call, whose own
+     * client timeout decides reachability. Unbounded, a stalled candidate
+     * held the setup spinner for the client's ~60 s timeout per candidate
+     * (HTTPS then HTTP for a bare host) before the setup call waited again.
      */
-    suspend fun probeServerContract(serverUrl: String): ApiV2ProbeResult? =
-        apiV2Probe?.probe(serverUrl)
+    suspend fun probeServerContract(
+        serverUrl: String,
+        timeoutMs: Long = SWITCH_PROBE_TIMEOUT_MS,
+    ): ApiV2ProbeResult? {
+        val probe = apiV2Probe ?: return null
+        return withTimeoutOrNull(timeoutMs) { probe.probe(serverUrl) }
+    }
 
     /**
      * Records [contract] on the active registry entry when it is a verdict

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/AuthRepository.kt
@@ -225,34 +225,61 @@ class AuthRepository(
      * through here so a server saved by an older build gets probed. No-op
      * without a registry.
      *
-     * Callers await this behind a spinner, so only the probe is awaited and
-     * only for [SWITCH_PROBE_TIMEOUT_MS]: a server that accepts the socket
-     * but never answers leaves the stored verdict alone (the gate still
-     * passes UNKNOWN and V2). When the bounded probe yields no verdict —
-     * the bound cancelled it or it failed (connection error, 5xx) — and a
-     * [backgroundScope] is wired in, a replacement unbounded probe (the
-     * client's own timeouts still apply) is launched there for [serverId],
-     * so a stale UPDATE_REQUIRED on a since-upgraded or briefly unreachable
-     * server is corrected once it answers instead of gating v2 calls until
-     * the next launch; the
-     * active-id guard in [recordServerContract] drops the result if the user
-     * switched again meanwhile. Without a scope the verdict stays as stored
-     * until the next switch or launch re-probes. The display-name refresh
-     * (branding, then health) is likewise launched on [backgroundScope]
-     * without being awaited; without a scope it runs inline after the probe.
+     * Callers await this behind a spinner, so they are released once the
+     * registry and token scope have switched and the probe has its bounded
+     * verdict: the probe waits at most [SWITCH_PROBE_TIMEOUT_MS], so a server
+     * that accepts the socket but never answers leaves the stored verdict
+     * alone (the gate still passes UNKNOWN and V2). When the bounded probe
+     * yields no verdict — the bound cancelled it or it failed (connection
+     * error, 5xx) — and a [backgroundScope] is wired in, a replacement
+     * unbounded probe (the client's own timeouts still apply) follows for
+     * [serverId], so a stale UPDATE_REQUIRED on a since-upgraded or briefly
+     * unreachable server is corrected once it answers instead of gating v2
+     * calls until the next launch; the active-id guard in
+     * [recordServerContract] drops the result if the user switched again
+     * meanwhile. Without a scope the verdict stays as stored until the next
+     * switch or launch re-probes. The display-name refresh (branding, then
+     * health) is never awaited.
+     *
+     * With [backgroundScope] wired in, the whole activation — registry
+     * switch, token switch, bounded probe, replacement probe, display-name
+     * refresh — runs as one job there, started before the caller begins
+     * waiting. Callers usually run in a UI scope (a server-list
+     * `viewModelScope`) that dies when the user presses Back; that cancels
+     * only this call's wait, never the activation, so the registry and token
+     * scope cannot land on the new server without its probe handoff. A
+     * background scope torn down mid-activation releases the caller too.
+     * Without a scope everything runs inline in the caller and is cancelled
+     * with it.
      */
     suspend fun switchToServer(serverId: String) {
         val registry = serverRegistry ?: return
-        registry.switchTo(serverId)
-        tokenManager.switchActiveServer(serverId)
-        refreshServerContractWithFallback(serverId)
-        if (registry.activeServerId.value != serverId) return
         val scope = backgroundScope
         if (scope == null) {
+            registry.switchTo(serverId)
+            tokenManager.switchActiveServer(serverId)
+            refreshServerContractWithFallback(serverId)
+            if (registry.activeServerId.value != serverId) return
             refreshActiveServerDisplayName(serverId)
-        } else {
-            scope.launch { refreshActiveServerDisplayName(serverId) }
+            return
         }
+        val ready = CompletableDeferred<Unit>()
+        val job = scope.launch {
+            registry.switchTo(serverId)
+            tokenManager.switchActiveServer(serverId)
+            probeContractWithFallback(serverId) {
+                // Launch before releasing the caller so a test joining the
+                // scope's children after the switch returns sees this job.
+                if (registry.activeServerId.value == serverId) {
+                    scope.launch { refreshActiveServerDisplayName(serverId) }
+                }
+                ready.complete(Unit)
+            }
+        }
+        // A scope torn down mid-activation must not leave the caller waiting;
+        // completing after the verdict is a no-op.
+        job.invokeOnCompletion { ready.complete(Unit) }
+        ready.await()
     }
 
     /**
@@ -279,15 +306,27 @@ class AuthRepository(
         val scope = backgroundScope
         if (scope == null || apiV2Probe == null) return refreshServerContractBounded()
         val bounded = CompletableDeferred<ServerContract?>()
-        val job = scope.launch {
-            val verdict = refreshServerContractBounded()
-            bounded.complete(verdict)
-            if (verdict == null) refreshServerContractFor(serverId)
-        }
+        val job = scope.launch { probeContractWithFallback(serverId) { bounded.complete(it) } }
         // A scope torn down mid-probe must not leave the caller waiting out
         // the bound on its own; completing after a verdict is a no-op.
         job.invokeOnCompletion { bounded.complete(null) }
         return withTimeoutOrNull(SWITCH_PROBE_TIMEOUT_MS) { bounded.await() }
+    }
+
+    /**
+     * The probe sequence shared by [switchToServer] and
+     * [refreshServerContractWithFallback], run in the calling coroutine:
+     * the bounded probe, then [onBoundedVerdict] with its result (null when
+     * the stored verdict was left alone), then — only for null — the
+     * replacement unbounded probe pinned to [serverId].
+     */
+    private suspend fun probeContractWithFallback(
+        serverId: String,
+        onBoundedVerdict: (ServerContract?) -> Unit,
+    ) {
+        val verdict = refreshServerContractBounded()
+        onBoundedVerdict(verdict)
+        if (verdict == null) refreshServerContractFor(serverId)
     }
 
     /**

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/ProfileRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/ProfileRepository.kt
@@ -168,10 +168,7 @@ open class ProfileRepository(
      */
     suspend fun identityScopeUnchanged(expected: AuthScopeSnapshot?): Boolean {
         if (expected == null) return true
-        val current = tokenManager.snapshotCurrentScope() ?: return false
-        return current.serverId == expected.serverId &&
-            current.identityGeneration == expected.identityGeneration &&
-            current.credentialEpoch == expected.credentialEpoch
+        return expected.isSameIdentityAs(tokenManager.snapshotCurrentScope())
     }
 
     /**

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/AuthApiUnauthenticatedProbeTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/AuthApiUnauthenticatedProbeTest.kt
@@ -37,7 +37,7 @@ class AuthApiUnauthenticatedProbeTest {
 
         assertEquals(
             listOf(
-                "https://candidate.example/api/v1/auth/setup",
+                "https://candidate.example/api/v2/system/setup",
                 "https://candidate.example/api/v1/auth/signup",
             ),
             captured.map { it.url },
@@ -64,7 +64,7 @@ class AuthApiUnauthenticatedProbeTest {
         assertIs<ApiResult.Error>(api.getSetupStatus("https://candidate.example"))
 
         assertEquals(
-            listOf("https://candidate.example/api/v1/auth/setup"),
+            listOf("https://candidate.example/api/v2/system/setup"),
             captured.map { it.url },
         )
         assertEquals("ACTIVE", tokenManager.getAccessToken())

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/PersonalDataApiTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/PersonalDataApiTest.kt
@@ -2,10 +2,15 @@ package org.siloserver.silo.network.api
 
 import org.siloserver.silo.model.personal.ProgressListResponse
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.SiloAuthPlugin
 import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.TokenManagerImpl
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -90,6 +95,101 @@ class PersonalDataApiTest {
         assertIs<ApiResult.Error>(result)
         assertEquals(PROGRESS_INCOMPLETE_ERROR, result.error)
         assertEquals(100, requests)
+    }
+
+    @Test
+    fun `listProgress sends every page under the identity pinned at the start of the walk`() = runTest {
+        val tokenManager = PinnedIdentityTokenManager()
+        val profileHeaders = mutableListOf<String?>()
+        val api = pinnedProgressApi(tokenManager) { request, cursor ->
+            profileHeaders += request.headers["X-Profile-Id"]
+            when (cursor) {
+                null -> progressPage(listOf("a"), nextCursor = "c1")
+                "c1" -> progressPage(listOf("b"), nextCursor = "c2")
+                "c2" -> progressPage(listOf("c"), nextCursor = null)
+                else -> error("unexpected cursor $cursor")
+            }
+        }
+        val result = api.listProgress()
+        assertIs<ApiResult.Success<ProgressListResponse>>(result)
+        assertEquals(listOf("a", "b", "c"), result.data.progress.map { it.mediaItemId })
+        assertEquals(3, profileHeaders.size)
+        // The snapshot, not the live profile read, decides the header on every page.
+        assertEquals(PinnedIdentityTokenManager.PINNED_PROFILE, profileHeaders.first())
+        profileHeaders.forEach { assertEquals(profileHeaders.first(), it) }
+    }
+
+    @Test
+    fun `listProgress aborts with identity_changed when the identity moves between pages`() = runTest {
+        val tokenManager = PinnedIdentityTokenManager()
+        var requests = 0
+        val api = pinnedProgressApi(tokenManager) { _, _ ->
+            requests += 1
+            tokenManager.switchIdentity()
+            progressPage(listOf("item-$requests"), nextCursor = "c$requests")
+        }
+        val result = api.listProgress()
+        assertIs<ApiResult.Error>(result)
+        assertEquals(PROGRESS_IDENTITY_CHANGED_ERROR, result.error)
+        assertEquals(1, requests)
+    }
+
+    private fun pinnedProgressApi(
+        tokenManager: TokenManager,
+        handler: (request: HttpRequestData, cursor: String?) -> String,
+    ): PersonalDataApi {
+        val client = HttpClient(
+            MockEngine { request ->
+                respond(
+                    content = handler(request, request.url.parameters["cursor"]),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        ) {
+            install(ContentNegotiation) { json(SiloJson) }
+            install(SiloAuthPlugin) { this.tokenManager = tokenManager }
+        }
+        return PersonalDataApi(client, tokenManager = tokenManager)
+    }
+
+    /**
+     * Snapshots report [PINNED_PROFILE]; the live profile read reports a
+     * different id so a page resolved against the active scope is visible.
+     * [switchIdentity] bumps the identity generation like a profile switch.
+     */
+    private class PinnedIdentityTokenManager(
+        private val delegate: TokenManager = TokenManagerImpl(),
+    ) : TokenManager by delegate {
+        private var generation = 0L
+
+        fun switchIdentity() {
+            generation += 1
+        }
+
+        override suspend fun getServerUrl(): String = "https://server-a.example"
+
+        override suspend fun getCurrentServerId(): String = "server-a"
+
+        override suspend fun getAccessToken(): String = "access-token"
+
+        override suspend fun getProfileId(): String = "live-profile"
+
+        override suspend fun getProfileToken(): String = "live-profile-token"
+
+        override suspend fun snapshotCurrentScope(): AuthScopeSnapshot =
+            AuthScopeSnapshot(
+                serverId = "server-a",
+                profileId = PINNED_PROFILE,
+                serverUrl = "https://server-a.example",
+                profileToken = "pinned-profile-token",
+                identityGeneration = generation,
+                isIdentityGenerationStamped = true,
+            )
+
+        companion object {
+            const val PINNED_PROFILE = "pinned-profile"
+        }
     }
 
     // --- checkFavorite ---

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/PersonalDataApiTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/api/PersonalDataApiTest.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.network.api
 
+import org.siloserver.silo.model.personal.ProgressListResponse
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.SiloJson
 import io.ktor.client.HttpClient
@@ -33,6 +34,62 @@ class PersonalDataApiTest {
             install(ContentNegotiation) { json(SiloJson) }
         }
         return PersonalDataApi(client)
+    }
+
+    private fun progressPage(ids: List<String>, nextCursor: String?): String {
+        val items = ids.joinToString(",") {
+            """{"media_item_id":"$it","position_seconds":1.0,"duration_seconds":10.0,"updated_at":"2026-01-01T00:00:00Z"}"""
+        }
+        val page = if (nextCursor == null) """{"has_more":false}""" else """{"has_more":true,"next_cursor":"$nextCursor"}"""
+        return """{"items":[$items],"page":$page}"""
+    }
+
+    private fun progressApi(handler: (cursor: String?, limit: String?) -> String): PersonalDataApi {
+        val client = HttpClient(
+            MockEngine { request ->
+                respond(
+                    content = handler(request.url.parameters["cursor"], request.url.parameters["limit"]),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        ) {
+            install(ContentNegotiation) { json(SiloJson) }
+        }
+        return PersonalDataApi(client)
+    }
+
+    // --- listProgress ---
+
+    @Test
+    fun `listProgress walks every page in order at the server maximum page size`() = runTest {
+        val limits = mutableListOf<String?>()
+        val api = progressApi { cursor, limit ->
+            limits += limit
+            when (cursor) {
+                null -> progressPage(listOf("a", "b"), nextCursor = "c1")
+                "c1" -> progressPage(listOf("c"), nextCursor = "c2")
+                "c2" -> progressPage(listOf("d"), nextCursor = null)
+                else -> error("unexpected cursor $cursor")
+            }
+        }
+        val result = api.listProgress()
+        assertIs<ApiResult.Success<ProgressListResponse>>(result)
+        assertEquals(listOf("a", "b", "c", "d"), result.data.progress.map { it.mediaItemId })
+        assertEquals(listOf<String?>("200", "200", "200"), limits)
+    }
+
+    @Test
+    fun `listProgress reports an error instead of a prefix when the page cap is reached`() = runTest {
+        var requests = 0
+        val api = progressApi { _, _ ->
+            requests += 1
+            progressPage(listOf("item-$requests"), nextCursor = "c$requests")
+        }
+        val result = api.listProgress()
+        assertIs<ApiResult.Error>(result)
+        assertEquals(PROGRESS_INCOMPLETE_ERROR, result.error)
+        assertEquals(100, requests)
     }
 
     // --- checkFavorite ---

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2ContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2ContractTest.kt
@@ -1,0 +1,323 @@
+package org.siloserver.silo.network.apiv2
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import org.siloserver.silo.network.apiv2.ApiV2Fixtures.plusUnknown
+import org.siloserver.silo.network.apiv2.ApiV2Fixtures.with
+
+/**
+ * Decodes every vendored API v2 fixture with the production `SiloJson` and
+ * pins the null/absence semantics each UI flow relies on. Fixture bodies are
+ * byte-identical copies of the server's generated contract fixtures (see
+ * `shared/src/commonTest/resources/api/v2/fixtures/SOURCE`).
+ */
+class ApiV2ContractTest {
+
+    @Test
+    fun sourceRecordsTheServerCommit() {
+        val commit = ApiV2Fixtures.source["commit"]
+        assertNotNull(commit)
+        assertTrue(Regex("^[0-9a-f]{40}$").matches(commit), "commit=$commit is not a full SHA")
+        assertEquals("contracts/api/v2/fixtures", ApiV2Fixtures.source["path"])
+    }
+
+    @Test
+    fun everyIndexedFixtureDecodesToItsModel() {
+        val index = ApiV2Fixtures.index.fixtures
+        assertTrue(index.size >= 14, "expected the vendored subset, got ${index.size}")
+        index.forEach { entry ->
+            val body = ApiV2Fixtures.bodyObject(entry.name)
+            if (entry.responseMediaType == "application/problem+json") {
+                val problem = ApiV2Fixtures.decode<Problem>(body)
+                assertEquals(entry.expectedStatus, problem.status, entry.name)
+                assertTrue(problem.code.isNotBlank(), entry.name)
+            } else {
+                assertEquals(200, entry.expectedStatus, entry.name)
+                when (entry.operationId) {
+                    "getSetupStatus" -> ApiV2Fixtures.decode<SetupStatus>(body)
+                    "getCurrentUser" -> ApiV2Fixtures.decode<Account>(body)
+                    "listProgress" -> ApiV2Fixtures.decode<ProgressCollection>(body)
+                    "updateProfile" -> ApiV2Fixtures.decode<ProfileV2>(body)
+                    "getSystemInfo" -> ApiV2Fixtures.decode<SystemInfo>(body)
+                    else -> error("unhandled success fixture ${entry.name} (${entry.operationId})")
+                }
+            }
+        }
+    }
+
+    // --- getSetupStatus ---
+
+    @Test
+    fun setupStatusFixture() {
+        val status = ApiV2Fixtures.decode<SetupStatus>(ApiV2Fixtures.bodyObject("get_setup_status_ok").plusUnknown())
+        assertFalse(status.needsSetup)
+    }
+
+    // --- getCurrentUser ---
+
+    @Test
+    fun accountFixtureConsumedFields() {
+        val account = ApiV2Fixtures.decode<Account>(ApiV2Fixtures.bodyObject("get_current_user_ok"))
+        assertEquals("1", account.id)
+        assertEquals("laura", account.username)
+        assertEquals("laura@example.test", account.email)
+        assertEquals(AccountRole.Known.USER, account.role.known)
+        assertFalse(account.role.isAdmin)
+        assertEquals(listOf("marker_edit"), account.permissions)
+        assertTrue(account.downloadAllowed)
+        assertNull(account.impersonation, "impersonation is absent outside an impersonation session")
+    }
+
+    @Test
+    fun accountImpersonationExplicitNullAndPresent() {
+        val base = ApiV2Fixtures.bodyObject("get_current_user_ok")
+        assertNull(ApiV2Fixtures.decode<Account>(with(base, "impersonation" to JsonNull)).impersonation)
+        val active = ApiV2Fixtures.json.parseToJsonElement(
+            """{"active":true,"impersonator_user_id":"42","impersonator_username":"root"}""",
+        )
+        val account = ApiV2Fixtures.decode<Account>(with(base, "impersonation" to active))
+        assertEquals("42", account.impersonation?.impersonatorUserId)
+        assertEquals("root", account.impersonation?.impersonatorUsername)
+        assertTrue(account.impersonation?.active == true)
+    }
+
+    @Test
+    fun accountUnknownFieldAndUnknownRoleAreObservable() {
+        val body = with(ApiV2Fixtures.bodyObject("get_current_user_ok"), "role" to JsonPrimitive("auditor")).plusUnknown()
+        val account = ApiV2Fixtures.decode<Account>(body)
+        assertEquals("auditor", account.role.wire)
+        assertNull(account.role.known, "an unknown role must not collapse to a known default")
+        assertFalse(account.role.isAdmin)
+    }
+
+    @Test
+    fun accountDefaults() {
+        val account = ApiV2Fixtures.json.decodeFromString(
+            Account.serializer(),
+            """{"id":"7","username":"u","email":"e","role":"admin"}""",
+        )
+        assertEquals(emptyList(), account.permissions)
+        assertFalse(account.downloadAllowed)
+        assertNull(account.impersonation)
+        assertTrue(account.role.isAdmin)
+    }
+
+    // --- listProgress ---
+
+    @Test
+    fun progressFixtureConsumedFields() {
+        val page = ApiV2Fixtures.decode<ProgressCollection>(ApiV2Fixtures.bodyObject("list_progress_ok").plusUnknown())
+        val entry = page.items.single()
+        assertEquals("movie-8f2c1a", entry.mediaItemId)
+        assertEquals(1325.5, entry.positionSeconds)
+        assertEquals(5400.0, entry.durationSeconds)
+        assertFalse(entry.completed)
+        assertEquals("2026-01-02T03:04:05.000Z", entry.updatedAt)
+        assertEquals(1767323045000L, entry.updatedAtEpochMillis)
+        assertTrue(page.page.hasMore)
+        assertNotNull(page.page.nextCursor)
+    }
+
+    @Test
+    fun progressPageNextCursorNullWhenNoMore() {
+        val last = ApiV2Fixtures.json.decodeFromString(
+            ProgressCollection.serializer(),
+            """{"items":[],"page":{"has_more":false}}""",
+        )
+        assertFalse(last.page.hasMore)
+        assertNull(last.page.nextCursor)
+        val explicit = ApiV2Fixtures.json.decodeFromString(
+            ProgressCollection.serializer(),
+            """{"items":[],"page":{"has_more":false,"next_cursor":null}}""",
+        )
+        assertNull(explicit.page.nextCursor)
+    }
+
+    @Test
+    fun progressDefaults() {
+        val empty = ApiV2Fixtures.json.decodeFromString(ProgressCollection.serializer(), "{}")
+        assertEquals(emptyList(), empty.items)
+        assertFalse(empty.page.hasMore)
+        assertNull(empty.page.nextCursor)
+        val entry = ApiV2Fixtures.json.decodeFromString(
+            ProgressEntryV2.serializer(),
+            """{"media_item_id":"m","position_seconds":1,"duration_seconds":2,"updated_at":"nonsense"}""",
+        )
+        assertFalse(entry.completed)
+        assertNull(entry.updatedAtEpochMillis, "an unparseable instant is observable as null, not a crash")
+    }
+
+    // --- updateProfile ---
+
+    @Test
+    fun profileFixtureConsumedFields() {
+        val profile = ApiV2Fixtures.decode<ProfileV2>(ApiV2Fixtures.bodyObject("update_profile_ok"))
+        assertEquals("p-owner", profile.id)
+        assertEquals("Laura", profile.name)
+        assertEquals("preset:fox", profile.avatar)
+        assertEquals("/avatars/presets/fox.png", profile.avatarUrl)
+        assertEquals(AvatarSource.Known.PRESET, profile.avatarSource.known)
+        assertFalse(profile.hasPin)
+        assertTrue(profile.isPrimary)
+        assertEquals("", profile.maxContentRating, "cleared string members are emitted as empty, never absent")
+        assertEquals(QualityPreference.Known.AUTO, profile.qualityPreference.known)
+        assertEquals("en", profile.language)
+        assertEquals(SubtitleMode.Known.AUTO, profile.subtitleMode.known)
+        assertTrue(profile.autoSkipIntro)
+        assertEquals(listOf("3"), profile.allowedLibraryIds)
+        assertEquals(MaxPlaybackQuality.Known.P1080, profile.maxPlaybackQuality.known)
+        assertEquals(1767323045000L, parseApiV2Instant(profile.createdAt))
+    }
+
+    @Test
+    fun profileUnknownEnumsAreObservable() {
+        val body = with(
+            ApiV2Fixtures.bodyObject("update_profile_ok"),
+            "avatar_source" to JsonPrimitive("hologram"),
+            "quality_preference" to JsonPrimitive("balanced"),
+            "subtitle_mode" to JsonPrimitive("forced_only"),
+            "max_playback_quality" to JsonPrimitive("4320p"),
+        ).plusUnknown()
+        val profile = ApiV2Fixtures.decode<ProfileV2>(body)
+        assertEquals("hologram", profile.avatarSource.wire)
+        assertNull(profile.avatarSource.known)
+        assertEquals("balanced", profile.qualityPreference.wire)
+        assertNull(profile.qualityPreference.known)
+        assertEquals("forced_only", profile.subtitleMode.wire)
+        assertNull(profile.subtitleMode.known)
+        assertEquals("4320p", profile.maxPlaybackQuality.wire)
+        assertNull(profile.maxPlaybackQuality.known)
+    }
+
+    @Test
+    fun profileDefaultsAndExplicitNulls() {
+        val minimal = ApiV2Fixtures.json.decodeFromString(
+            ProfileV2.serializer(),
+            """{"id":"p","name":"n","created_at":"2026-01-02T03:04:05Z","updated_at":"2026-01-02T03:04:05Z"}""",
+        )
+        assertEquals("", minimal.avatar)
+        assertNull(minimal.avatarUrl)
+        assertEquals(AvatarSource.Known.NONE, minimal.avatarSource.known)
+        assertFalse(minimal.hasPin)
+        assertFalse(minimal.isChild)
+        assertFalse(minimal.isPrimary)
+        assertEquals("", minimal.maxContentRating)
+        assertEquals(QualityPreference.Known.AUTO, minimal.qualityPreference.known)
+        assertEquals("", minimal.language)
+        assertEquals("", minimal.preferredMetadataLanguage)
+        assertEquals("", minimal.subtitleLanguage)
+        assertEquals(SubtitleMode.Known.AUTO, minimal.subtitleMode.known)
+        assertFalse(minimal.autoSkipIntro)
+        assertFalse(minimal.autoSkipCredits)
+        assertFalse(minimal.autoSkipRecap)
+        assertFalse(minimal.autoPlayNextPreview)
+        assertFalse(minimal.showForcedSubtitles)
+        assertFalse(minimal.libraryRestrictionsEnabled)
+        assertEquals(emptyList(), minimal.allowedLibraryIds)
+        assertEquals(MaxPlaybackQuality.Known.P1080, minimal.maxPlaybackQuality.known)
+
+        // Explicit null: nullable member → null; non-nullable member with a
+        // default → coerced to the default (coerceInputValues), documented here
+        // so a contract change to nullable strings is caught.
+        val nulled = ApiV2Fixtures.decode<ProfileV2>(
+            with(ApiV2Fixtures.bodyObject("update_profile_ok"), "avatar_url" to JsonNull, "language" to JsonNull),
+        )
+        assertNull(nulled.avatarUrl)
+        assertEquals("", nulled.language)
+    }
+
+    @Test
+    fun profileUpdateEncodesOmittedAbsentAndClearedAsNull() {
+        val update = ProfileUpdate(
+            name = Patch.Set("Laura"),
+            subtitleMode = Patch.Set(SubtitleMode("always")),
+            maxContentRating = Patch.Clear,
+            allowedLibraryIds = Patch.Set(listOf("3")),
+        )
+        val encoded = ApiV2Fixtures.json.encodeToString(kotlinx.serialization.json.JsonObject.serializer(), update.toJsonObject())
+        // Matches the vendored update_profile_ok request body member for member.
+        val expected = ApiV2Fixtures.index.fixtures.single { it.name == "update_profile_ok" }.request.body
+        assertEquals(ApiV2Fixtures.json.parseToJsonElement(checkNotNull(expected)), ApiV2Fixtures.json.parseToJsonElement(encoded))
+        assertTrue("\"max_content_rating\":null" in encoded, encoded)
+        assertFalse("\"avatar\"" in encoded, "omitted member must be absent: $encoded")
+        assertFalse("\"pin\"" in encoded, encoded)
+        assertEquals("{}", ApiV2Fixtures.json.encodeToString(kotlinx.serialization.json.JsonObject.serializer(), ProfileUpdate().toJsonObject()))
+    }
+
+    @Test
+    fun profileUpdateNullNotClearableProblem() {
+        val problem = ApiV2Fixtures.decode<Problem>(ApiV2Fixtures.bodyObject("update_profile_null_not_clearable"))
+        assertEquals(422, problem.status)
+        assertEquals("validation_failed", problem.code)
+        val error = problem.errors.single()
+        assertEquals("body.is_child", error.location)
+        assertEquals("invalid_type", error.code)
+    }
+
+    // --- getSystemInfo ---
+
+    @Test
+    fun systemInfoFixture() {
+        val info = ApiV2Fixtures.decode<SystemInfo>(ApiV2Fixtures.bodyObject("get_system_info_ok").plusUnknown())
+        assertEquals(2, info.apiMajor)
+        assertTrue(info.contractDigest.isNotBlank())
+        assertEquals("/api/v2/openapi.json", info.links.openapi)
+        assertEquals("/api/v2/capabilities", info.links.capabilities)
+    }
+
+    // --- Problems ---
+
+    @Test
+    fun problemFixturesDecodeToTheirType() {
+        val expected = mapOf(
+            "authentication_required" to (401 to "authentication_required"),
+            "validation_failed_body" to (422 to "validation_failed"),
+            "not_found" to (404 to "not_found"),
+            "rate_limited" to (429 to "rate_limited"),
+            "profile_verification_required" to (403 to "profile_verification_required"),
+            "not_acceptable" to (406 to "not_acceptable"),
+            "list_progress_profile_header_required" to (422 to "validation_failed"),
+            "list_progress_offset_rejected" to (422 to "validation_failed"),
+        )
+        expected.forEach { (name, statusAndCode) ->
+            val problem = ApiV2Fixtures.decode<Problem>(ApiV2Fixtures.bodyObject(name).plusUnknown())
+            assertEquals(statusAndCode.first, problem.status, name)
+            assertEquals(statusAndCode.second, problem.code, name)
+            assertTrue(problem.title.isNotBlank(), name)
+            assertTrue(ApiV2Fixtures.bodyObject(name)["type"]!!.jsonPrimitive.content.startsWith("https://"), name)
+        }
+        assertEquals(2, ApiV2Fixtures.decode<Problem>(ApiV2Fixtures.bodyObject("validation_failed_body")).errors.size)
+    }
+
+    @Test
+    fun problemDefaults() {
+        val problem = ApiV2Fixtures.json.decodeFromString(
+            Problem.serializer(),
+            """{"type":"https://siloserver.org/docs/api/v2/problems/x","title":"X","status":500}""",
+        )
+        assertEquals("", problem.detail)
+        assertNull(problem.instance)
+        assertEquals(emptyList(), problem.errors)
+        assertEquals("x", problem.code)
+    }
+
+    // --- Instants ---
+
+    @Test
+    fun instantParsing() {
+        assertEquals(1767323045000L, parseApiV2Instant("2026-01-02T03:04:05Z"))
+        assertEquals(1767323045123L, parseApiV2Instant("2026-01-02T03:04:05.123456Z"))
+        assertEquals(1767323045000L - 3_600_000L, parseApiV2Instant("2026-01-02T03:04:05+01:00"))
+        assertEquals(0L, parseApiV2Instant("1970-01-01T00:00:00Z"))
+        assertNull(parseApiV2Instant("2026-01-02"))
+        assertNull(parseApiV2Instant("2026-01-02T03:04:05"))
+        assertNull(parseApiV2Instant(""))
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2FixtureSupport.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2FixtureSupport.kt
@@ -1,0 +1,69 @@
+package org.siloserver.silo.network.apiv2
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import org.siloserver.silo.network.SiloJson
+
+/** Reads one vendored file under `api/v2/fixtures/` from the test resources. */
+expect fun readApiV2FixtureResource(name: String): String
+
+/** One entry of the vendored `index.json` (the members these tests consume). */
+@Serializable
+data class ApiV2FixtureEntry(
+    val name: String,
+    @SerialName("operation_id") val operationId: String? = null,
+    @SerialName("expected_status") val expectedStatus: Int,
+    @SerialName("response_media_type") val responseMediaType: String,
+    @SerialName("body_file") val bodyFile: String,
+    val request: ApiV2FixtureRequest,
+)
+
+@Serializable
+data class ApiV2FixtureRequest(
+    val method: String,
+    val path: String,
+    val body: String? = null,
+)
+
+@Serializable
+data class ApiV2FixtureIndex(val fixtures: List<ApiV2FixtureEntry>)
+
+object ApiV2Fixtures {
+    /** The production decoder; every assertion in these tests runs through it. */
+    val json = SiloJson
+
+    val index: ApiV2FixtureIndex by lazy {
+        json.decodeFromString(ApiV2FixtureIndex.serializer(), readApiV2FixtureResource("index.json"))
+    }
+
+    fun body(name: String): String = readApiV2FixtureResource("$name.json")
+
+    fun bodyObject(name: String): JsonObject = json.parseToJsonElement(body(name)).jsonObject
+
+    /** The vendored SOURCE file's `key=value` header lines. */
+    val source: Map<String, String> by lazy {
+        readApiV2FixtureResource("SOURCE").lineSequence()
+            .takeWhile { it.isNotBlank() }
+            .mapNotNull { line -> line.split('=', limit = 2).takeIf { it.size == 2 }?.let { it[0] to it[1] } }
+            .toMap()
+    }
+
+    /** Copies [base] with [overrides] applied (a null value removes the member). */
+    fun with(base: JsonObject, vararg overrides: Pair<String, JsonElement?>): JsonObject {
+        val members = LinkedHashMap<String, JsonElement>(base)
+        overrides.forEach { (key, value) -> if (value == null) members.remove(key) else members[key] = value }
+        return JsonObject(members)
+    }
+
+    fun JsonObject.plusUnknown(): JsonObject = with(
+        this,
+        "zz_unknown_member" to JsonObject(mapOf("nested" to JsonPrimitive(true))),
+        "zz_unknown_scalar" to JsonPrimitive("later-contract"),
+    )
+
+    inline fun <reified T> decode(element: JsonObject): T = json.decodeFromJsonElement(kotlinx.serialization.serializer<T>(), element)
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2NoFallbackTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2NoFallbackTest.kt
@@ -15,12 +15,14 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
+import org.siloserver.silo.model.auth.SetupStatusResponse
 import org.siloserver.silo.model.profile.UpdateProfileRequest
 import org.siloserver.silo.model.server.ServerContract
 import org.siloserver.silo.model.server.ServerEntry
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.ServerRegistry
 import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.api.AuthApi
 import org.siloserver.silo.network.api.ProfileApi
 
 /** A failed v2 mutation is never replayed against another API major, and the update-server state blocks it outright. */
@@ -71,6 +73,23 @@ class ApiV2NoFallbackTest {
         assertEquals(ApiV2Gate.UPDATE_REQUIRED_ERROR, error.error)
         assertEquals(ServerContract.UPDATE_REQUIRED_MESSAGE, error.message)
         assertEquals(emptyList(), recorded)
+    }
+
+    @Test
+    fun explicitServerSetupStatusBypassesTheActiveServersUpdateRequiredVerdict() = runTest {
+        val recorded = mutableListOf<String>()
+        val gate = ApiV2Gate(ContractRegistry(ServerContract.UPDATE_REQUIRED))
+        val api = AuthApi(client(recorded, HttpStatusCode.OK, """{"needs_setup":false}"""), gate)
+
+        // Candidate (absolute URL): the active entry's verdict says nothing about it.
+        val candidate = assertIs<ApiResult.Success<SetupStatusResponse>>(api.getSetupStatus("https://other.example/"))
+        assertEquals(false, candidate.data.needsSetup)
+        assertEquals(listOf("GET /api/v2/system/setup"), recorded)
+
+        // Relative form targets the active server and stays blocked.
+        val error = assertIs<ApiResult.Error>(api.getSetupStatus())
+        assertEquals(ApiV2Gate.UPDATE_REQUIRED_ERROR, error.error)
+        assertEquals(1, recorded.size)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2NoFallbackTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2NoFallbackTest.kt
@@ -1,0 +1,97 @@
+package org.siloserver.silo.network.apiv2
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import org.siloserver.silo.model.profile.UpdateProfileRequest
+import org.siloserver.silo.model.server.ServerContract
+import org.siloserver.silo.model.server.ServerEntry
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.ServerRegistry
+import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.api.ProfileApi
+
+/** A failed v2 mutation is never replayed against another API major, and the update-server state blocks it outright. */
+class ApiV2NoFallbackTest {
+
+    private fun client(recorded: MutableList<String>, status: HttpStatusCode, body: String) =
+        HttpClient(
+            MockEngine { request ->
+                recorded += "${request.method.value} ${request.url.encodedPath}"
+                respond(body, status, headersOf(HttpHeaders.ContentType, "application/problem+json"))
+            },
+        ) { install(ContentNegotiation) { json(SiloJson) } }
+
+    @Test
+    fun failedUpdateProfileIsNotRetriedOnV1() = runTest {
+        val recorded = mutableListOf<String>()
+        val api = ProfileApi(client(recorded, HttpStatusCode.InternalServerError, """{"type":"https://siloserver.org/docs/api/v2/problems/internal","title":"Internal","status":500,"detail":"boom","instance":"urn:x"}"""))
+
+        val result = api.updateProfile("p-owner", UpdateProfileRequest(name = "Laura"))
+
+        val error = assertIs<ApiResult.Error>(result)
+        assertEquals(500, error.code)
+        assertEquals("internal", error.error)
+        assertEquals(listOf("PATCH /api/v2/profiles/p-owner"), recorded)
+        assertTrue(recorded.none { "/api/v1" in it }, recorded.toString())
+    }
+
+    @Test
+    fun validationProblemSurfacesCodeAndDetailWithoutRetry() = runTest {
+        val recorded = mutableListOf<String>()
+        val api = ProfileApi(client(recorded, HttpStatusCode.UnprocessableEntity, ApiV2Fixtures.body("update_profile_null_not_clearable")))
+
+        val error = assertIs<ApiResult.Error>(api.updateProfile("p-owner", UpdateProfileRequest(name = "Laura")))
+
+        assertEquals(422, error.code)
+        assertEquals("validation_failed", error.error)
+        assertEquals(1, recorded.size)
+    }
+
+    @Test
+    fun updateRequiredStateBlocksTheCallBeforeAnyRequest() = runTest {
+        val recorded = mutableListOf<String>()
+        val registry = ContractRegistry(ServerContract.UPDATE_REQUIRED)
+        val api = ProfileApi(client(recorded, HttpStatusCode.OK, "{}"), ApiV2Gate(registry))
+
+        val error = assertIs<ApiResult.Error>(api.updateProfile("p-owner", UpdateProfileRequest(name = "Laura")))
+
+        assertEquals(ApiV2Gate.UPDATE_REQUIRED_ERROR, error.error)
+        assertEquals(ServerContract.UPDATE_REQUIRED_MESSAGE, error.message)
+        assertEquals(emptyList(), recorded)
+    }
+
+    @Test
+    fun unknownAndV2StatesDoNotBlock() {
+        assertEquals(null, ApiV2Gate(ContractRegistry(ServerContract.UNKNOWN)).blocked())
+        assertEquals(null, ApiV2Gate(ContractRegistry(ServerContract.V2)).blocked())
+        assertEquals(null, ApiV2Gate.Unrestricted.blocked())
+    }
+}
+
+private class ContractRegistry(contract: ServerContract) : ServerRegistry {
+    private val entry = ServerEntry(id = "active", url = "https://silo.example", contract = contract)
+    override val entries: StateFlow<List<ServerEntry>> = MutableStateFlow(listOf(entry))
+    override val activeServerId: StateFlow<String?> = MutableStateFlow("active")
+    override val activeEntry: StateFlow<ServerEntry?> = MutableStateFlow(entry)
+    override suspend fun addOrUpdate(url: String, fetchedName: String?): String = "active"
+    override suspend fun rename(serverId: String, userOverrideName: String?) = Unit
+    override suspend fun setFetchedName(serverId: String, fetchedName: String?) = Unit
+    override suspend fun setProfileId(serverId: String, profileId: String?) = Unit
+    override suspend fun remove(serverId: String) = Unit
+    override suspend fun signOut(serverId: String) = Unit
+    override suspend fun switchTo(serverId: String) = Unit
+    override suspend fun touchActive() = Unit
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2ProbeTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2ProbeTest.kt
@@ -17,9 +17,10 @@ import kotlinx.coroutines.test.runTest
 import org.siloserver.silo.network.SiloJson
 
 /**
- * The compatibility rule, case by case. Only a plain-text 404 — what the v1
- * alpha listener's `http.NotFound` emits for an unknown `/api/v2` path — is
- * the update-server state; everything else stays its own failure kind.
+ * The compatibility rule, case by case. Only a 404 whose body is exactly what
+ * the v1 alpha listener's `http.NotFound` emits for an unknown `/api/v2` path
+ * (`404 page not found`, at most one trailing newline) is the update-server
+ * state; everything else stays its own failure kind.
  */
 class ApiV2ProbeTest {
 
@@ -55,9 +56,39 @@ class ApiV2ProbeTest {
     }
 
     @Test
-    fun plainText404IsUpdateServer() = runTest {
+    fun legacyNotFoundBodyIsUpdateServer() = runTest {
+        val result = probe(HttpStatusCode.NotFound, "404 page not found", "text/plain; charset=utf-8")
+        assertEquals(ApiV2ProbeResult.UpdateServer, result)
+    }
+
+    @Test
+    fun legacyNotFoundBodyWithTrailingNewlineIsUpdateServer() = runTest {
         val result = probe(HttpStatusCode.NotFound, "404 page not found\n", "text/plain; charset=utf-8")
         assertEquals(ApiV2ProbeResult.UpdateServer, result)
+    }
+
+    @Test
+    fun legacyNotFoundBodyWithLeadingWhitespaceIsNotUpdateServer() = runTest {
+        val result = probe(HttpStatusCode.NotFound, " 404 page not found", "text/plain; charset=utf-8")
+        val failure = assertIs<ApiV2ProbeResult.Failure>(result)
+        assertEquals(ApiV2ProbeResult.Kind.UNEXPECTED_STATUS, failure.kind)
+        assertEquals(404, failure.status)
+    }
+
+    @Test
+    fun legacyNotFoundBodyWithTwoTrailingNewlinesIsNotUpdateServer() = runTest {
+        val result = probe(HttpStatusCode.NotFound, "404 page not found\n\n", "text/plain; charset=utf-8")
+        val failure = assertIs<ApiV2ProbeResult.Failure>(result)
+        assertEquals(ApiV2ProbeResult.Kind.UNEXPECTED_STATUS, failure.kind)
+        assertEquals(404, failure.status)
+    }
+
+    @Test
+    fun otherPlainText404IsNotUpdateServer() = runTest {
+        val result = probe(HttpStatusCode.NotFound, "Not Found", "text/plain; charset=utf-8")
+        val failure = assertIs<ApiV2ProbeResult.Failure>(result)
+        assertEquals(ApiV2ProbeResult.Kind.UNEXPECTED_STATUS, failure.kind)
+        assertEquals(404, failure.status)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2ProbeTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/network/apiv2/ApiV2ProbeTest.kt
@@ -1,0 +1,144 @@
+package org.siloserver.silo.network.apiv2
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.coroutines.test.runTest
+import org.siloserver.silo.network.SiloJson
+
+/**
+ * The compatibility rule, case by case. Only a plain-text 404 — what the v1
+ * alpha listener's `http.NotFound` emits for an unknown `/api/v2` path — is
+ * the update-server state; everything else stays its own failure kind.
+ */
+class ApiV2ProbeTest {
+
+    private val infoBody = ApiV2Fixtures.body("get_system_info_ok")
+
+    private fun client(
+        handler: suspend io.ktor.client.engine.mock.MockRequestHandleScope.(io.ktor.client.request.HttpRequestData) -> io.ktor.client.request.HttpResponseData,
+    ) = HttpClient(MockEngine { request -> handler(request) }) {
+        install(ContentNegotiation) { json(SiloJson) }
+    }
+
+    private suspend fun probe(
+        status: HttpStatusCode,
+        body: String,
+        contentType: String,
+    ): ApiV2ProbeResult {
+        val recorded = mutableListOf<String>()
+        val client = client { request ->
+            recorded += request.url.toString()
+            respond(body, status, headersOf(HttpHeaders.ContentType, contentType))
+        }
+        val result = ApiV2Probe(client).probe("https://silo.example/")
+        assertEquals(listOf("https://silo.example/api/v2/system/info"), recorded)
+        return result
+    }
+
+    @Test
+    fun validInfoIsV2() = runTest {
+        val result = probe(HttpStatusCode.OK, infoBody, "application/json")
+        val v2 = assertIs<ApiV2ProbeResult.V2>(result)
+        assertEquals(2, v2.info.apiMajor)
+        assertEquals("/api/v2/openapi.json", v2.info.links.openapi)
+    }
+
+    @Test
+    fun plainText404IsUpdateServer() = runTest {
+        val result = probe(HttpStatusCode.NotFound, "404 page not found\n", "text/plain; charset=utf-8")
+        assertEquals(ApiV2ProbeResult.UpdateServer, result)
+    }
+
+    @Test
+    fun html404IsNotUpdateServer() = runTest {
+        val result = probe(HttpStatusCode.NotFound, "<html><body>Not Found</body></html>", "text/html")
+        val failure = assertIs<ApiV2ProbeResult.Failure>(result)
+        assertEquals(ApiV2ProbeResult.Kind.UNEXPECTED_STATUS, failure.kind)
+        assertEquals(404, failure.status)
+    }
+
+    @Test
+    fun problemJson404IsNotUpdateServer() = runTest {
+        val result = probe(HttpStatusCode.NotFound, ApiV2Fixtures.body("not_found"), "application/problem+json")
+        val failure = assertIs<ApiV2ProbeResult.Failure>(result)
+        assertEquals(ApiV2ProbeResult.Kind.UNEXPECTED_STATUS, failure.kind)
+    }
+
+    @Test
+    fun html200IsMalformedNotUpdateServer() = runTest {
+        val result = probe(HttpStatusCode.OK, "<html><body>Login</body></html>", "text/html")
+        val failure = assertIs<ApiV2ProbeResult.Failure>(result)
+        assertEquals(ApiV2ProbeResult.Kind.MALFORMED_RESPONSE, failure.kind)
+    }
+
+    @Test
+    fun malformedJsonIsMalformed() = runTest {
+        val result = probe(HttpStatusCode.OK, """{"server_version": "1.0", "api_major": """, "application/json")
+        assertEquals(ApiV2ProbeResult.Kind.MALFORMED_RESPONSE, assertIs<ApiV2ProbeResult.Failure>(result).kind)
+    }
+
+    @Test
+    fun wrongApiMajorIsMalformed() = runTest {
+        val body = infoBody.replace("\"api_major\": 2", "\"api_major\": 3")
+        val result = probe(HttpStatusCode.OK, body, "application/json")
+        assertEquals(ApiV2ProbeResult.Kind.MALFORMED_RESPONSE, assertIs<ApiV2ProbeResult.Failure>(result).kind)
+    }
+
+    @Test
+    fun unauthorizedIsAuthentication() = runTest {
+        val result = probe(HttpStatusCode.Unauthorized, ApiV2Fixtures.body("authentication_required"), "application/problem+json")
+        val failure = assertIs<ApiV2ProbeResult.Failure>(result)
+        assertEquals(ApiV2ProbeResult.Kind.AUTHENTICATION, failure.kind)
+        assertEquals(401, failure.status)
+    }
+
+    @Test
+    fun rateLimitedIsRateLimited() = runTest {
+        val result = probe(HttpStatusCode.TooManyRequests, ApiV2Fixtures.body("rate_limited"), "application/problem+json")
+        assertEquals(ApiV2ProbeResult.Kind.RATE_LIMITED, assertIs<ApiV2ProbeResult.Failure>(result).kind)
+    }
+
+    @Test
+    fun serverErrorIsServerError() = runTest {
+        val result = probe(HttpStatusCode.InternalServerError, "boom", "text/plain")
+        val failure = assertIs<ApiV2ProbeResult.Failure>(result)
+        assertEquals(ApiV2ProbeResult.Kind.SERVER_ERROR, failure.kind)
+        assertEquals(500, failure.status)
+    }
+
+    @Test
+    fun badGatewayHtmlIsServerErrorNotUpdateServer() = runTest {
+        val result = probe(HttpStatusCode.BadGateway, "<html>502</html>", "text/html")
+        assertEquals(ApiV2ProbeResult.Kind.SERVER_ERROR, assertIs<ApiV2ProbeResult.Failure>(result).kind)
+    }
+
+    @Test
+    fun timeoutIsTimeout() = runTest {
+        val client = client { throw HttpRequestTimeoutException("https://silo.example/api/v2/system/info", 30_000L) }
+        val result = ApiV2Probe(client).probe("https://silo.example")
+        assertEquals(ApiV2ProbeResult.Kind.TIMEOUT, assertIs<ApiV2ProbeResult.Failure>(result).kind)
+
+        val connect = client { throw ConnectTimeoutException("connect timed out", null) }
+        assertEquals(ApiV2ProbeResult.Kind.TIMEOUT, assertIs<ApiV2ProbeResult.Failure>(ApiV2Probe(connect).probe("https://silo.example")).kind)
+    }
+
+    @Test
+    fun tlsOrConnectFailureIsConnection() = runTest {
+        val client = client { throw IllegalStateException("SSL handshake failed: certificate unknown") }
+        val result = ApiV2Probe(client).probe("https://silo.example")
+        val failure = assertIs<ApiV2ProbeResult.Failure>(result)
+        assertEquals(ApiV2ProbeResult.Kind.CONNECTION, failure.kind)
+        assertEquals("SSL handshake failed: certificate unknown", failure.cause?.message)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -8,6 +8,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -74,6 +76,33 @@ class AuthRepositoryContractTest {
     }
 
     @Test
+    fun `awaitContractRefreshIfUpdateRequired replaces a stale UPDATE_REQUIRED verdict`() = runTest {
+        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+        // Real clock: under the test scheduler the probe's suspension on the
+        // engine dispatcher lets virtual time skip straight past the timeout.
+        val verdict = withContext(Dispatchers.Default) {
+            repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"))
+                .awaitContractRefreshIfUpdateRequired()
+        }
+
+        assertEquals(ServerContract.V2, verdict)
+        assertEquals(mapOf("a" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `awaitContractRefreshIfUpdateRequired does not probe when the gate would pass`() = runTest {
+        var requests = 0
+        val client = client {
+            requests += 1
+            respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val verdict = repository(ContractRegistry(), client).awaitContractRefreshIfUpdateRequired()
+
+        assertEquals(null, verdict)
+        assertEquals(0, requests)
+    }
+
+    @Test
     fun `stale probe result for a previous server is dropped`() = runTest {
         val registry = ContractRegistry()
         val client = client {
@@ -108,12 +137,15 @@ class AuthRepositoryContractTest {
     )
 }
 
-private class ContractRegistry : ServerRegistry {
+private class ContractRegistry(initialContract: ServerContract = ServerContract.UNKNOWN) : ServerRegistry {
     private val activeId = MutableStateFlow<String?>("a")
     val contracts = mutableMapOf<String, ServerContract>()
 
     override val entries: StateFlow<List<ServerEntry>> = MutableStateFlow(
-        listOf(ServerEntry(id = "a", url = "https://a.example"), ServerEntry(id = "b", url = "https://b.example")),
+        listOf(
+            ServerEntry(id = "a", url = "https://a.example", contract = initialContract),
+            ServerEntry(id = "b", url = "https://b.example"),
+        ),
     )
     override val activeServerId: StateFlow<String?> = activeId
     override val activeEntry: StateFlow<ServerEntry?> = MutableStateFlow(entries.value.first())

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -181,6 +181,79 @@ class AuthRepositoryContractTest {
     }
 
     @Test
+    fun `refreshServerContractBounded returns null when the probe answers 503`() = runTest {
+        val registry = ContractRegistry()
+        registry.setContract("a", ServerContract.UPDATE_REQUIRED)
+        // Real clock: the probe answers, so virtual time must not skip the bound.
+        val verdict = withContext(Dispatchers.Default) {
+            repository(registry, respondWith(HttpStatusCode.ServiceUnavailable, "", "text/plain"))
+                .refreshServerContractBounded()
+        }
+
+        // A failure is "no verdict", not UNKNOWN: callers re-probe on null.
+        assertEquals(null, verdict)
+        assertEquals(mapOf("a" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+    }
+
+    @Test
+    fun `switchToServer re-probes in the background when the bounded probe fails`() = runTest {
+        // A stale UPDATE_REQUIRED on a server that is briefly unreachable at
+        // switch time must not gate pilot calls for the whole session: the
+        // failed bounded probe launches the same replacement as a timeout.
+        val registry = ContractRegistry()
+        registry.setContract("b", ServerContract.UPDATE_REQUIRED)
+        var requests = 0
+        val recovered = CompletableDeferred<Unit>()
+        val client = client {
+            requests++
+            if (requests == 1) {
+                respond("", HttpStatusCode.ServiceUnavailable, headersOf(HttpHeaders.ContentType, "text/plain"))
+            } else {
+                // The replacement probe holds until the server "recovers".
+                recovered.await()
+                respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+            }
+        }
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val repository = repository(registry, client, backgroundScope = background)
+
+        // Real clock: the bounded probe answers (with 503) inside the bound.
+        withContext(Dispatchers.Default) { repository.switchToServer("b") }
+
+        // Returned with the verdict untouched: 503 recorded nothing.
+        assertEquals("b", registry.activeServerId.value)
+        assertEquals(mapOf("b" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+
+        // The server recovers; only the background replacement can produce V2.
+        recovered.complete(Unit)
+        background.joinChildren()
+        assertEquals(2, requests)
+        assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `switchToServer does not re-probe when the bounded probe answered UPDATE_REQUIRED`() = runTest {
+        val registry = ContractRegistry()
+        var requests = 0
+        val client = client {
+            requests++
+            respond("404 page not found\n", HttpStatusCode.NotFound, headersOf(HttpHeaders.ContentType, "text/plain"))
+        }
+        val repository = repository(
+            registry,
+            client,
+            backgroundScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
+        )
+
+        withContext(Dispatchers.Default) { repository.switchToServer("b") }
+        advanceUntilIdle()
+
+        // A real verdict, even a negative one, is settled: no replacement probe.
+        assertEquals(mapOf("b" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+        assertEquals(1, requests)
+    }
+
+    @Test
     fun `switchToServer does not re-probe when the bounded probe answered`() = runTest {
         val registry = ContractRegistry()
         var requests = 0
@@ -232,6 +305,34 @@ class AuthRepositoryContractTest {
 
         assertEquals(ServerContract.V2, verdict)
         assertEquals(mapOf("a" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `awaitContractRefreshIfUpdateRequired returns null when the probe cannot connect`() = runTest {
+        // The launch path passes the result to refreshActiveServerName as
+        // knownContract; null makes that call probe again instead of
+        // treating the stale UPDATE_REQUIRED as confirmed for the session.
+        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+        // ApiV2Probe maps any thrown transport error to Failure(CONNECTION).
+        val client = client { throw RuntimeException("connection refused") }
+        val verdict = withContext(Dispatchers.Default) {
+            repository(registry, client).awaitContractRefreshIfUpdateRequired()
+        }
+
+        assertEquals(null, verdict)
+        assertEquals(emptyMap<String, ServerContract>(), registry.contracts)
+    }
+
+    @Test
+    fun `awaitContractRefreshIfUpdateRequired returns a confirmed UPDATE_REQUIRED verdict`() = runTest {
+        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+        val verdict = withContext(Dispatchers.Default) {
+            repository(registry, respondWith(HttpStatusCode.NotFound, "404 page not found\n", "text/plain"))
+                .awaitContractRefreshIfUpdateRequired()
+        }
+
+        assertEquals(ServerContract.UPDATE_REQUIRED, verdict)
+        assertEquals(mapOf("a" to ServerContract.UPDATE_REQUIRED), registry.contracts)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.api.BrandingApi
@@ -116,11 +115,14 @@ class AuthRepositoryContractTest {
                 return ApiResult.Success(BrandingStatus("Named"))
             }
         }
+        // Real clock on both sides: the probe now runs on the background
+        // scope, and virtual time would skip the bound while the engine answers.
+        val background = CoroutineScope(Dispatchers.Default)
         val repository = repository(
             registry,
             respondWith(HttpStatusCode.OK, infoBody, "application/json"),
             brandingApi = branding,
-            backgroundScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
+            backgroundScope = background,
         )
 
         withContext(Dispatchers.Default) { repository.switchToServer("b") }
@@ -130,7 +132,7 @@ class AuthRepositoryContractTest {
         assertEquals(emptyMap<String, String?>(), registry.fetchedNames)
 
         brandingGate.complete(Unit)
-        advanceUntilIdle()
+        background.joinChildren()
         assertEquals(mapOf<String, String?>("b" to "Named"), registry.fetchedNames)
     }
 
@@ -191,6 +193,71 @@ class AuthRepositoryContractTest {
         // The same-id switch still records the scope change; the Android
         // token manager itself short-circuits when the id is unchanged.
         assertEquals(listOf<String?>("b"), tokens.switchedTo)
+    }
+
+    @Test
+    fun `fallback probe survives the caller being cancelled during the bound`() = runTest {
+        // The user presses Back while the server list's viewModelScope is
+        // still inside the bounded wait. That must cancel only the wait: the
+        // probe already lives on the background scope and still records V2
+        // when the server answers late.
+        val registry = ContractRegistry()
+        registry.setContract("b", ServerContract.UPDATE_REQUIRED)
+        val answerGate = CompletableDeferred<Unit>()
+        val client = client {
+            answerGate.await()
+            respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val repository = repository(registry, client, backgroundScope = background)
+
+        val caller = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val call = caller.launch { repository.switchToServer("b") }
+        // Let the caller reach its wait, then kill it well inside the bound.
+        testScheduler.advanceTimeBy(1_000L)
+        testScheduler.runCurrent()
+        assertEquals(false, call.isCompleted)
+        caller.cancel()
+        call.join()
+        assertEquals("b", registry.activeServerId.value)
+        assertEquals(mapOf("b" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+
+        // The bound elapses in the background with the caller already gone;
+        // only then does the server answer, to the unbounded replacement.
+        testScheduler.advanceTimeBy(3_000L)
+        testScheduler.runCurrent()
+        answerGate.complete(Unit)
+        background.joinChildren()
+        assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `fallback probe records nothing when the caller is cancelled and the server switched`() = runTest {
+        val registry = ContractRegistry()
+        registry.setContract("b", ServerContract.UPDATE_REQUIRED)
+        val answerGate = CompletableDeferred<Unit>()
+        val client = client {
+            answerGate.await()
+            respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val repository = repository(registry, client, backgroundScope = background)
+
+        val caller = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val call = caller.launch { repository.switchToServer("b") }
+        testScheduler.advanceTimeBy(1_000L)
+        testScheduler.runCurrent()
+        caller.cancel()
+        call.join()
+        // The user moves on to another server before "b" ever answers.
+        registry.switchTo("a")
+        testScheduler.advanceTimeBy(3_000L)
+        testScheduler.runCurrent()
+
+        answerGate.complete(Unit)
+        background.joinChildren()
+        assertEquals("a", registry.activeServerId.value)
+        assertEquals(mapOf("b" to ServerContract.UPDATE_REQUIRED), registry.contracts)
     }
 
     @Test
@@ -275,14 +342,12 @@ class AuthRepositoryContractTest {
             requests++
             respond("404 page not found\n", HttpStatusCode.NotFound, headersOf(HttpHeaders.ContentType, "text/plain"))
         }
-        val repository = repository(
-            registry,
-            client,
-            backgroundScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
-        )
+        // Real clock on both sides: the probe runs on the background scope.
+        val background = CoroutineScope(Dispatchers.Default)
+        val repository = repository(registry, client, backgroundScope = background)
 
         withContext(Dispatchers.Default) { repository.switchToServer("b") }
-        advanceUntilIdle()
+        background.joinChildren()
 
         // A real verdict, even a negative one, is settled: no replacement probe.
         assertEquals(mapOf("b" to ServerContract.UPDATE_REQUIRED), registry.contracts)
@@ -297,16 +362,14 @@ class AuthRepositoryContractTest {
             requests++
             respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
         }
-        val repository = repository(
-            registry,
-            client,
-            backgroundScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
-        )
+        // Real clock on both sides: the probe runs on the background scope.
+        val background = CoroutineScope(Dispatchers.Default)
+        val repository = repository(registry, client, backgroundScope = background)
 
         // Real clock: the switch bounds the probe, and virtual time would
         // skip past that bound while the engine answers.
         withContext(Dispatchers.Default) { repository.switchToServer("b") }
-        advanceUntilIdle()
+        background.joinChildren()
 
         assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
         assertEquals(1, requests)

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -1,0 +1,155 @@
+package org.siloserver.silo.repository
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import org.siloserver.silo.model.server.ServerContract
+import org.siloserver.silo.model.server.ServerEntry
+import org.siloserver.silo.network.ServerRegistry
+import org.siloserver.silo.network.SiloJson
+import org.siloserver.silo.network.TokenManager
+import org.siloserver.silo.network.api.AuthApi
+import org.siloserver.silo.network.apiv2.ApiV2Fixtures
+import org.siloserver.silo.network.apiv2.ApiV2Probe
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The contract verdict is (re)established on every connect, launch restore,
+ * and server switch through [AuthRepository.refreshActiveServerName]; these
+ * tests pin the recording rules: verdicts stick, failures record nothing,
+ * and a result for a server that is no longer active is dropped.
+ */
+class AuthRepositoryContractTest {
+    private val infoBody = ApiV2Fixtures.body("get_system_info_ok")
+
+    @Test
+    fun `refreshActiveServerName records V2 from the probe`() = runTest {
+        val registry = ContractRegistry()
+        repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"))
+            .refreshActiveServerName()
+
+        assertEquals(mapOf("a" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `refreshActiveServerName records UPDATE_REQUIRED from a v1-only server`() = runTest {
+        val registry = ContractRegistry()
+        repository(registry, respondWith(HttpStatusCode.NotFound, "404 page not found\n", "text/plain"))
+            .refreshActiveServerName()
+
+        assertEquals(mapOf("a" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+    }
+
+    @Test
+    fun `probe failure leaves the stored contract unchanged`() = runTest {
+        val registry = ContractRegistry()
+        registry.setContract("a", ServerContract.V2)
+        repository(registry, respondWith(HttpStatusCode.ServiceUnavailable, "", "text/plain"))
+            .refreshActiveServerName()
+
+        assertEquals(mapOf("a" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `switchToServer probes the switched-to server`() = runTest {
+        val registry = ContractRegistry()
+        val tokens = SwitchRecordingTokenManager()
+        repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"), tokens)
+            .switchToServer("b")
+
+        assertEquals("b", registry.activeServerId.value)
+        assertEquals(listOf<String?>("b"), tokens.switchedTo)
+        assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `stale probe result for a previous server is dropped`() = runTest {
+        val registry = ContractRegistry()
+        val client = client {
+            // The user switches servers while the probe of "a" is in flight.
+            registry.switchTo("b")
+            respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        repository(registry, client).refreshActiveServerName()
+
+        assertEquals(emptyMap<String, ServerContract>(), registry.contracts)
+    }
+
+    private fun respondWith(status: HttpStatusCode, body: String, contentType: String) = client {
+        respond(body, status, headersOf(HttpHeaders.ContentType, contentType))
+    }
+
+    private fun client(
+        handler: suspend io.ktor.client.engine.mock.MockRequestHandleScope.(io.ktor.client.request.HttpRequestData) -> io.ktor.client.request.HttpResponseData,
+    ) = HttpClient(MockEngine { request -> handler(request) }) {
+        install(ContentNegotiation) { json(SiloJson) }
+    }
+
+    private fun repository(
+        registry: ContractRegistry,
+        client: HttpClient,
+        tokenManager: TokenManager = SwitchRecordingTokenManager(),
+    ) = AuthRepository(
+        authApi = AuthApi(client),
+        tokenManager = tokenManager,
+        serverRegistry = registry,
+        apiV2Probe = ApiV2Probe(client),
+    )
+}
+
+private class ContractRegistry : ServerRegistry {
+    private val activeId = MutableStateFlow<String?>("a")
+    val contracts = mutableMapOf<String, ServerContract>()
+
+    override val entries: StateFlow<List<ServerEntry>> = MutableStateFlow(
+        listOf(ServerEntry(id = "a", url = "https://a.example"), ServerEntry(id = "b", url = "https://b.example")),
+    )
+    override val activeServerId: StateFlow<String?> = activeId
+    override val activeEntry: StateFlow<ServerEntry?> = MutableStateFlow(entries.value.first())
+
+    override suspend fun addOrUpdate(url: String, fetchedName: String?): String = "a"
+    override suspend fun rename(serverId: String, userOverrideName: String?) = Unit
+    override suspend fun setFetchedName(serverId: String, fetchedName: String?) = Unit
+    override suspend fun setProfileId(serverId: String, profileId: String?) = Unit
+    override suspend fun setContract(serverId: String, contract: ServerContract) {
+        contracts[serverId] = contract
+    }
+    override suspend fun remove(serverId: String) = Unit
+    override suspend fun signOut(serverId: String) = Unit
+    override suspend fun switchTo(serverId: String) {
+        activeId.value = serverId
+    }
+    override suspend fun touchActive() = Unit
+}
+
+private class SwitchRecordingTokenManager : TokenManager {
+    val switchedTo = mutableListOf<String?>()
+    override suspend fun getAccessToken(): String? = null
+    override suspend fun getRefreshToken(): String? = null
+    override suspend fun saveTokens(accessToken: String, refreshToken: String, expiresIn: Long) = Unit
+    override suspend fun clearTokens() = Unit
+    override suspend fun invalidateSession() = Unit
+    override suspend fun getProfileId(): String? = null
+    override suspend fun setProfileId(profileId: String?) = Unit
+    override suspend fun getProfileToken(): String? = null
+    override suspend fun setProfileToken(token: String?) = Unit
+    override suspend fun getServerUrl(): String = "https://a.example"
+    override suspend fun setServerUrl(url: String) = Unit
+    override suspend fun getCurrentServerId(): String? = "a"
+    override suspend fun switchActiveServer(serverId: String?) {
+        switchedTo += serverId
+    }
+    override suspend fun signOutCurrentServer() = Unit
+    override val sessionExpired: SharedFlow<Unit> = MutableSharedFlow()
+}

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -295,13 +295,13 @@ class AuthRepositoryContractTest {
     }
 
     @Test
-    fun `awaitContractRefreshIfUpdateRequired replaces a stale UPDATE_REQUIRED verdict`() = runTest {
+    fun `awaitContractRefreshIfUnsettled replaces a stale UPDATE_REQUIRED verdict`() = runTest {
         val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
         // Real clock: under the test scheduler the probe's suspension on the
         // engine dispatcher lets virtual time skip straight past the timeout.
         val verdict = withContext(Dispatchers.Default) {
             repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"))
-                .awaitContractRefreshIfUpdateRequired()
+                .awaitContractRefreshIfUnsettled()
         }
 
         assertEquals(ServerContract.V2, verdict)
@@ -309,27 +309,14 @@ class AuthRepositoryContractTest {
     }
 
     @Test
-    fun `awaitContractRefreshIfUpdateRequired returns null when the probe cannot connect`() = runTest {
-        // The launch path passes the result to refreshActiveServerName as
-        // knownContract; null makes that call probe again instead of
-        // treating the stale UPDATE_REQUIRED as confirmed for the session.
-        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
-        // ApiV2Probe maps any thrown transport error to Failure(CONNECTION).
-        val client = client { throw RuntimeException("connection refused") }
-        val verdict = withContext(Dispatchers.Default) {
-            repository(registry, client).awaitContractRefreshIfUpdateRequired()
-        }
-
-        assertEquals(null, verdict)
-        assertEquals(emptyMap<String, ServerContract>(), registry.contracts)
-    }
-
-    @Test
-    fun `awaitContractRefreshIfUpdateRequired returns a confirmed UPDATE_REQUIRED verdict`() = runTest {
-        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+    fun `awaitContractRefreshIfUnsettled awaits UNKNOWN and records UPDATE_REQUIRED from a v1-only server`() = runTest {
+        // First launch after upgrading the app: the restored entry carries
+        // UNKNOWN, which passes the gate, so startup consumers must not be
+        // routed until the v1-only server's verdict is on record.
+        val registry = ContractRegistry(initialContract = ServerContract.UNKNOWN)
         val verdict = withContext(Dispatchers.Default) {
             repository(registry, respondWith(HttpStatusCode.NotFound, "404 page not found\n", "text/plain"))
-                .awaitContractRefreshIfUpdateRequired()
+                .awaitContractRefreshIfUnsettled()
         }
 
         assertEquals(ServerContract.UPDATE_REQUIRED, verdict)
@@ -337,13 +324,54 @@ class AuthRepositoryContractTest {
     }
 
     @Test
-    fun `awaitContractRefreshIfUpdateRequired does not probe when the gate would pass`() = runTest {
+    fun `awaitContractRefreshIfUnsettled awaits UNKNOWN and records V2`() = runTest {
+        val registry = ContractRegistry(initialContract = ServerContract.UNKNOWN)
+        val verdict = withContext(Dispatchers.Default) {
+            repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"))
+                .awaitContractRefreshIfUnsettled()
+        }
+
+        assertEquals(ServerContract.V2, verdict)
+        assertEquals(mapOf("a" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `awaitContractRefreshIfUnsettled returns null when the probe cannot connect`() = runTest {
+        // The launch path passes the result to refreshActiveServerName as
+        // knownContract; null makes that call probe again instead of
+        // treating the stale UPDATE_REQUIRED as confirmed for the session.
+        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+        // ApiV2Probe maps any thrown transport error to Failure(CONNECTION).
+        val client = client { throw RuntimeException("connection refused") }
+        val verdict = withContext(Dispatchers.Default) {
+            repository(registry, client).awaitContractRefreshIfUnsettled()
+        }
+
+        assertEquals(null, verdict)
+        assertEquals(emptyMap<String, ServerContract>(), registry.contracts)
+    }
+
+    @Test
+    fun `awaitContractRefreshIfUnsettled returns a confirmed UPDATE_REQUIRED verdict`() = runTest {
+        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+        val verdict = withContext(Dispatchers.Default) {
+            repository(registry, respondWith(HttpStatusCode.NotFound, "404 page not found\n", "text/plain"))
+                .awaitContractRefreshIfUnsettled()
+        }
+
+        assertEquals(ServerContract.UPDATE_REQUIRED, verdict)
+        assertEquals(mapOf("a" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+    }
+
+    @Test
+    fun `awaitContractRefreshIfUnsettled does not probe when the stored verdict is V2`() = runTest {
         var requests = 0
         val client = client {
             requests += 1
             respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
         }
-        val verdict = repository(ContractRegistry(), client).awaitContractRefreshIfUpdateRequired()
+        val verdict = repository(ContractRegistry(initialContract = ServerContract.V2), client)
+            .awaitContractRefreshIfUnsettled()
 
         assertEquals(null, verdict)
         assertEquals(0, requests)

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -232,6 +232,46 @@ class AuthRepositoryContractTest {
     }
 
     @Test
+    fun `activation survives the caller being cancelled during the registry switch`() = runTest {
+        // The user presses Back while the server list's viewModelScope is
+        // still inside the registry switch itself. The activation must not
+        // die with the caller: the token switch, the probe, and its V2
+        // record all still land, so the entry never stays UNKNOWN or stale
+        // UPDATE_REQUIRED with the server already persisted as active.
+        val registry = ContractRegistry()
+        registry.setContract("b", ServerContract.UPDATE_REQUIRED)
+        val switchGate = CompletableDeferred<Unit>()
+        registry.switchGate = switchGate
+        val tokens = SwitchRecordingTokenManager()
+        // Real clock on both sides: the activation runs on the background
+        // scope, and a virtual-clock background would let runTest skip the
+        // bound while the caller waits out the real one.
+        val background = CoroutineScope(Dispatchers.Default)
+        val repository = repository(
+            registry,
+            respondWith(HttpStatusCode.OK, infoBody, "application/json"),
+            tokenManager = tokens,
+            backgroundScope = background,
+        )
+
+        val caller = CoroutineScope(Dispatchers.Default)
+        val call = caller.launch { repository.switchToServer("b") }
+        registry.switchEntered.await()
+        caller.cancel()
+        call.join()
+        // Nothing has been activated yet; the switch is still gated.
+        assertEquals("a", registry.activeServerId.value)
+        assertEquals(emptyList<String?>(), tokens.switchedTo)
+        assertEquals(mapOf("b" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+
+        switchGate.complete(Unit)
+        background.joinChildren()
+        assertEquals("b", registry.activeServerId.value)
+        assertEquals(listOf<String?>("b"), tokens.switchedTo)
+        assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
     fun `fallback probe records nothing when the caller is cancelled and the server switched`() = runTest {
         val registry = ContractRegistry()
         registry.setContract("b", ServerContract.UPDATE_REQUIRED)
@@ -581,7 +621,15 @@ private class ContractRegistry(initialContract: ServerContract = ServerContract.
     }
     override suspend fun remove(serverId: String) = Unit
     override suspend fun signOut(serverId: String) = Unit
+    /** When set, [switchTo] signals [switchEntered] and suspends on this until released. */
+    var switchGate: CompletableDeferred<Unit>? = null
+    val switchEntered = CompletableDeferred<Unit>()
+
     override suspend fun switchTo(serverId: String) {
+        switchGate?.let {
+            switchEntered.complete(Unit)
+            it.await()
+        }
         activeId.value = serverId
     }
     override suspend fun touchActive() = Unit

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -12,7 +12,9 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -156,6 +158,39 @@ class AuthRepositoryContractTest {
         answerGate.complete(Unit)
         background.joinChildren()
         assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `promoted server re-probe survives cancellation of the calling scope`() = runTest {
+        // ServerListViewModel.onRemove: the registry has already promoted "b"
+        // (so the id is already active) and the call runs in viewModelScope,
+        // which dies when the server list is popped. The replacement probe
+        // must live on the repository's background scope, not the caller's.
+        val registry = ContractRegistry()
+        registry.setContract("b", ServerContract.UPDATE_REQUIRED)
+        registry.switchTo("b")
+        val answerGate = CompletableDeferred<Unit>()
+        val client = client {
+            answerGate.await()
+            respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val tokens = SwitchRecordingTokenManager()
+        val repository = repository(registry, client, tokenManager = tokens, backgroundScope = background)
+
+        val caller = CoroutineScope(StandardTestDispatcher(testScheduler))
+        // Virtual clock: the bound elapses without the engine answering.
+        caller.launch { repository.switchToServer("b") }.join()
+        assertEquals("b", registry.activeServerId.value)
+        assertEquals(mapOf("b" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+        caller.cancel()
+
+        answerGate.complete(Unit)
+        background.joinChildren()
+        assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+        // The same-id switch still records the scope change; the Android
+        // token manager itself short-circuits when the id is unchanged.
+        assertEquals(listOf<String?>("b"), tokens.switchedTo)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -131,6 +132,78 @@ class AuthRepositoryContractTest {
     }
 
     @Test
+    fun `switchToServer re-probes in the background when the bounded probe times out`() = runTest {
+        // A stale UPDATE_REQUIRED on a since-upgraded server that answers
+        // after the bound must still be corrected for this session.
+        val registry = ContractRegistry()
+        registry.setContract("b", ServerContract.UPDATE_REQUIRED)
+        val answerGate = CompletableDeferred<Unit>()
+        val client = client {
+            answerGate.await()
+            respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val repository = repository(registry, client, backgroundScope = background)
+
+        // Virtual clock: the bound elapses without the engine answering.
+        repository.switchToServer("b")
+
+        // Returned at the bound with the verdict untouched.
+        assertEquals("b", registry.activeServerId.value)
+        assertEquals(mapOf("b" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+
+        answerGate.complete(Unit)
+        background.joinChildren()
+        assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `background re-probe result is dropped when the active server changed meanwhile`() = runTest {
+        val registry = ContractRegistry()
+        registry.setContract("b", ServerContract.UPDATE_REQUIRED)
+        val answerGate = CompletableDeferred<Unit>()
+        val client = client {
+            answerGate.await()
+            // The user switches away while the replacement probe is in flight.
+            registry.switchTo("a")
+            respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val repository = repository(registry, client, backgroundScope = background)
+
+        repository.switchToServer("b")
+        assertEquals(mapOf("b" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+
+        answerGate.complete(Unit)
+        background.joinChildren()
+        assertEquals("a", registry.activeServerId.value)
+        assertEquals(mapOf("b" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+    }
+
+    @Test
+    fun `switchToServer does not re-probe when the bounded probe answered`() = runTest {
+        val registry = ContractRegistry()
+        var requests = 0
+        val client = client {
+            requests++
+            respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val repository = repository(
+            registry,
+            client,
+            backgroundScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
+        )
+
+        // Real clock: the switch bounds the probe, and virtual time would
+        // skip past that bound while the engine answers.
+        withContext(Dispatchers.Default) { repository.switchToServer("b") }
+        advanceUntilIdle()
+
+        assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+        assertEquals(1, requests)
+    }
+
+    @Test
     fun `switchToServer on the already-active id still probes`() = runTest {
         // Removing the active server promotes the next-MRU entry inside the
         // registry; the view model then switches to the id that is already
@@ -198,6 +271,13 @@ class AuthRepositoryContractTest {
     }
 
     private fun unusedClient() = HttpClient(MockEngine { error("Unexpected request") })
+
+    /**
+     * Waits for the fire-and-forget work launched on a background scope. The
+     * mock engine answers on its own thread, so `advanceUntilIdle` alone can
+     * return before the reply has been posted back to the test scheduler.
+     */
+    private suspend fun CoroutineScope.joinChildren() = coroutineContext.job.children.forEach { it.join() }
 
     private fun repository(
         registry: ContractRegistry,

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -317,10 +317,13 @@ class AuthRepositoryContractTest {
                 respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
             }
         }
-        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        // Real clock on both sides: the bounded probe now runs on the
+        // background scope, and a virtual-clock background would let runTest
+        // skip its bound while the caller waits out the real one.
+        val background = CoroutineScope(Dispatchers.Default)
         val repository = repository(registry, client, backgroundScope = background)
 
-        // Real clock: the bounded probe answers (with 503) inside the bound.
+        // The bounded probe answers (with 503) inside the bound.
         withContext(Dispatchers.Default) { repository.switchToServer("b") }
 
         // Returned with the verdict untouched: 503 recorded nothing.

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -32,6 +32,7 @@ import org.siloserver.silo.network.TokenManager
 import org.siloserver.silo.network.api.AuthApi
 import org.siloserver.silo.network.apiv2.ApiV2Fixtures
 import org.siloserver.silo.network.apiv2.ApiV2Probe
+import org.siloserver.silo.network.apiv2.ApiV2ProbeResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -346,6 +347,36 @@ class AuthRepositoryContractTest {
 
         assertEquals(null, verdict)
         assertEquals(0, requests)
+    }
+
+    @Test
+    fun `probeServerContract returns null when the candidate hangs past the bound`() = runTest {
+        // A candidate that accepts the socket but never answers must not
+        // hold the setup spinner for the client's full timeout; virtual
+        // time: the bound elapses without the engine answering.
+        val registry = ContractRegistry()
+        val startedAt = testScheduler.currentTime
+        val result = repository(registry, client { awaitCancellation() })
+            .probeServerContract("https://candidate.example")
+
+        assertEquals(null, result)
+        assertEquals(3_000L, testScheduler.currentTime - startedAt)
+        // Nothing recorded: the candidate is not the active server.
+        assertEquals(emptyMap<String, ServerContract>(), registry.contracts)
+    }
+
+    @Test
+    fun `probeServerContract returns the verdict when the candidate answers`() = runTest {
+        val registry = ContractRegistry()
+        val repository = repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"))
+        // Real clock: under the test scheduler the virtual-time bound would
+        // fire before the engine thread posts its answer back.
+        val result = withContext(Dispatchers.Default) {
+            repository.probeServerContract("https://candidate.example")
+        }
+
+        assertEquals(true, result is ApiV2ProbeResult.V2, "expected V2, got $result")
+        assertEquals(emptyMap<String, ServerContract>(), registry.contracts)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -76,6 +76,21 @@ class AuthRepositoryContractTest {
     }
 
     @Test
+    fun `switchToServer on the already-active id still probes`() = runTest {
+        // Removing the active server promotes the next-MRU entry inside the
+        // registry; the view model then switches to the id that is already
+        // active, which must still move the token scope and probe.
+        val registry = ContractRegistry()
+        val tokens = SwitchRecordingTokenManager()
+        repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"), tokens)
+            .switchToServer("a")
+
+        assertEquals("a", registry.activeServerId.value)
+        assertEquals(listOf<String?>("a"), tokens.switchedTo)
+        assertEquals(mapOf("a" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
     fun `awaitContractRefreshIfUpdateRequired replaces a stale UPDATE_REQUIRED verdict`() = runTest {
         val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
         // Real clock: under the test scheduler the probe's suspension on the

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -8,13 +8,21 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.api.BrandingApi
+import org.siloserver.silo.network.api.BrandingStatus
 import org.siloserver.silo.model.server.ServerContract
 import org.siloserver.silo.model.server.ServerEntry
 import org.siloserver.silo.network.ServerRegistry
@@ -67,12 +75,59 @@ class AuthRepositoryContractTest {
     fun `switchToServer probes the switched-to server`() = runTest {
         val registry = ContractRegistry()
         val tokens = SwitchRecordingTokenManager()
-        repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"), tokens)
-            .switchToServer("b")
+        // Real clock: the switch bounds the probe, and virtual time would
+        // skip past that bound while the engine answers.
+        withContext(Dispatchers.Default) {
+            repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"), tokens)
+                .switchToServer("b")
+        }
 
         assertEquals("b", registry.activeServerId.value)
         assertEquals(listOf<String?>("b"), tokens.switchedTo)
         assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `switchToServer returns with the verdict unchanged when the probe hangs past the bound`() = runTest {
+        // A saved server that accepts the connection but never answers must
+        // not hold the switch spinner for the full client timeouts.
+        val registry = ContractRegistry()
+        registry.setContract("b", ServerContract.V2)
+        val tokens = SwitchRecordingTokenManager()
+        val hanging = client { awaitCancellation() }
+        repository(registry, hanging, tokens).switchToServer("b")
+
+        assertEquals("b", registry.activeServerId.value)
+        assertEquals(listOf<String?>("b"), tokens.switchedTo)
+        assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `switchToServer does not await the display-name refresh`() = runTest {
+        val registry = ContractRegistry()
+        val brandingGate = CompletableDeferred<Unit>()
+        val branding = object : BrandingApi(unusedClient()) {
+            override suspend fun getBranding(): ApiResult<BrandingStatus> {
+                brandingGate.await()
+                return ApiResult.Success(BrandingStatus("Named"))
+            }
+        }
+        val repository = repository(
+            registry,
+            respondWith(HttpStatusCode.OK, infoBody, "application/json"),
+            brandingApi = branding,
+            backgroundScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
+        )
+
+        withContext(Dispatchers.Default) { repository.switchToServer("b") }
+
+        // Returned with the verdict recorded while branding is still pending.
+        assertEquals(mapOf("b" to ServerContract.V2), registry.contracts)
+        assertEquals(emptyMap<String, String?>(), registry.fetchedNames)
+
+        brandingGate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(mapOf<String, String?>("b" to "Named"), registry.fetchedNames)
     }
 
     @Test
@@ -82,8 +137,10 @@ class AuthRepositoryContractTest {
         // active, which must still move the token scope and probe.
         val registry = ContractRegistry()
         val tokens = SwitchRecordingTokenManager()
-        repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"), tokens)
-            .switchToServer("a")
+        withContext(Dispatchers.Default) {
+            repository(registry, respondWith(HttpStatusCode.OK, infoBody, "application/json"), tokens)
+                .switchToServer("a")
+        }
 
         assertEquals("a", registry.activeServerId.value)
         assertEquals(listOf<String?>("a"), tokens.switchedTo)
@@ -140,21 +197,28 @@ class AuthRepositoryContractTest {
         install(ContentNegotiation) { json(SiloJson) }
     }
 
+    private fun unusedClient() = HttpClient(MockEngine { error("Unexpected request") })
+
     private fun repository(
         registry: ContractRegistry,
         client: HttpClient,
         tokenManager: TokenManager = SwitchRecordingTokenManager(),
+        brandingApi: BrandingApi? = null,
+        backgroundScope: CoroutineScope? = null,
     ) = AuthRepository(
         authApi = AuthApi(client),
         tokenManager = tokenManager,
         serverRegistry = registry,
+        brandingApi = brandingApi,
         apiV2Probe = ApiV2Probe(client),
+        backgroundScope = backgroundScope,
     )
 }
 
 private class ContractRegistry(initialContract: ServerContract = ServerContract.UNKNOWN) : ServerRegistry {
     private val activeId = MutableStateFlow<String?>("a")
     val contracts = mutableMapOf<String, ServerContract>()
+    val fetchedNames = mutableMapOf<String, String?>()
 
     override val entries: StateFlow<List<ServerEntry>> = MutableStateFlow(
         listOf(
@@ -167,7 +231,9 @@ private class ContractRegistry(initialContract: ServerContract = ServerContract.
 
     override suspend fun addOrUpdate(url: String, fetchedName: String?): String = "a"
     override suspend fun rename(serverId: String, userOverrideName: String?) = Unit
-    override suspend fun setFetchedName(serverId: String, fetchedName: String?) = Unit
+    override suspend fun setFetchedName(serverId: String, fetchedName: String?) {
+        fetchedNames[serverId] = fetchedName
+    }
     override suspend fun setProfileId(serverId: String, profileId: String?) = Unit
     override suspend fun setContract(serverId: String, contract: ServerContract) {
         contracts[serverId] = contract

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/AuthRepositoryContractTest.kt
@@ -36,6 +36,8 @@ import org.siloserver.silo.network.apiv2.ApiV2Probe
 import org.siloserver.silo.network.apiv2.ApiV2ProbeResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 /**
  * The contract verdict is (re)established on every connect, launch restore,
@@ -559,6 +561,129 @@ class AuthRepositoryContractTest {
         repository(registry, client).refreshActiveServerName()
 
         assertEquals(emptyMap<String, ServerContract>(), registry.contracts)
+    }
+
+    private val loginBody =
+        """{"access_token":"at","refresh_token":"rt","expires_in":3600,"user":{"id":"1","username":"u","email":"u@example","role":"user"}}"""
+
+    @Test
+    fun `login re-probes a stale UPDATE_REQUIRED without waiting on the probe`() = runTest {
+        // The server was upgraded while the login screen stayed open: the v1
+        // login succeeds and the stored verdict must be corrected for this
+        // session, but sign-in must not wait on the probe.
+        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+        registry.setContract("a", ServerContract.UPDATE_REQUIRED)
+        val answerGate = CompletableDeferred<Unit>()
+        var probeRequests = 0
+        val client = client { request ->
+            if (request.url.encodedPath.endsWith("/auth/login")) {
+                respond(loginBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+            } else {
+                probeRequests++
+                answerGate.await()
+                respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+            }
+        }
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val repository = repository(registry, client, backgroundScope = background)
+
+        val result = repository.login("u", "p")
+
+        // Returned while the probe is still gated: the verdict is untouched.
+        assertIs<ApiResult.Success<*>>(result)
+        assertEquals(mapOf("a" to ServerContract.UPDATE_REQUIRED), registry.contracts)
+
+        answerGate.complete(Unit)
+        background.joinChildren()
+        // One request when the gated reply lands inside the bound, two when
+        // the virtual clock ran the bound out first and the pinned fallback
+        // re-probed; either way the stale verdict is corrected.
+        assertTrue(probeRequests in 1..2, "probe requests: $probeRequests")
+        assertEquals(mapOf("a" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `failed login launches no contract probe`() = runTest {
+        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+        var probeRequests = 0
+        val client = client { request ->
+            if (request.url.encodedPath.endsWith("/auth/login")) {
+                respond("""{"error":"invalid credentials"}""", HttpStatusCode.Unauthorized, headersOf(HttpHeaders.ContentType, "application/json"))
+            } else {
+                probeRequests++
+                respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+            }
+        }
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val repository = repository(registry, client, backgroundScope = background)
+
+        val result = repository.login("u", "wrong")
+
+        assertTrue(result is ApiResult.Error)
+        background.joinChildren()
+        assertEquals(0, probeRequests)
+        assertEquals(emptyMap(), registry.contracts)
+    }
+
+    @Test
+    fun `login re-probes inline when no background scope is wired in`() = runTest {
+        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+        registry.setContract("a", ServerContract.UPDATE_REQUIRED)
+        val client = client { request ->
+            if (request.url.encodedPath.endsWith("/auth/login")) {
+                respond(loginBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+            } else {
+                respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+            }
+        }
+        val repository = repository(registry, client)
+
+        val result = repository.login("u", "p")
+
+        assertIs<ApiResult.Success<*>>(result)
+        assertEquals(mapOf("a" to ServerContract.V2), registry.contracts)
+    }
+
+    @Test
+    fun `session refresh queued before a server switch does not probe the new server`() = runTest {
+        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val repository = repository(registry, unusedClient(), backgroundScope = background)
+
+        repository.onSessionCommitted("a")
+        registry.switchTo("b")
+        background.joinChildren()
+
+        assertEquals(emptyMap(), registry.contracts)
+    }
+
+    @Test
+    fun `committed session refresh survives cancellation of its caller`() = runTest {
+        val registry = ContractRegistry(initialContract = ServerContract.UPDATE_REQUIRED)
+        val background = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val answerGate = CompletableDeferred<Unit>()
+        val repository = repository(
+            registry,
+            client {
+                answerGate.await()
+                respond(infoBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+            },
+            backgroundScope = background,
+        )
+        val scheduled = CompletableDeferred<Unit>()
+        val caller = launch {
+            repository.onSessionCommitted("a")
+            scheduled.complete(Unit)
+            awaitCancellation()
+        }
+        scheduled.await()
+        caller.cancel()
+        caller.join()
+        assertEquals(emptyMap(), registry.contracts)
+        answerGate.complete(Unit)
+        background.joinChildren()
+
+        assertEquals(mapOf("a" to ServerContract.V2), registry.contracts)
     }
 
     private fun respondWith(status: HttpStatusCode, body: String, contentType: String) = client {

--- a/shared/src/commonTest/resources/api/v2/fixtures/SOURCE
+++ b/shared/src/commonTest/resources/api/v2/fixtures/SOURCE
@@ -1,0 +1,15 @@
+repository=https://github.com/Silo-Server/silo-server
+path=contracts/api/v2/fixtures
+commit=b9e8359b4724155cfc0fb1d70b7c825854e726fc
+ref=api-v2/phase-3-pilot
+api_major=2
+
+Byte-identical copies of a subset of the server's native API v2 contract
+fixtures; do not hand-edit any of them. The server generates them through its
+real v2 router (make apiv2-fixtures) and validates the bodies against the
+committed OpenAPI artifact. Only the fixtures the Android pilot consumes are
+vendored here, and index.json is filtered to those entries; the OpenAPI
+document itself is never vendored. Re-vendor with
+scripts/sync-apiv2-fixtures.sh <server checkout> and run :shared:testDebugUnitTest.
+
+ApiV2ContractTest decodes every body here with the production SiloJson.

--- a/shared/src/commonTest/resources/api/v2/fixtures/SOURCE
+++ b/shared/src/commonTest/resources/api/v2/fixtures/SOURCE
@@ -1,6 +1,6 @@
 repository=https://github.com/Silo-Server/silo-server
 path=contracts/api/v2/fixtures
-commit=17380cbca59dff44d8e1454fd07ece37efc26afe
+commit=74fe2b4ac97349167d1bb85892d7f0566bd43d49
 ref=api-v2/phase-3-pilot
 api_major=2
 

--- a/shared/src/commonTest/resources/api/v2/fixtures/SOURCE
+++ b/shared/src/commonTest/resources/api/v2/fixtures/SOURCE
@@ -1,6 +1,6 @@
 repository=https://github.com/Silo-Server/silo-server
 path=contracts/api/v2/fixtures
-commit=b9e8359b4724155cfc0fb1d70b7c825854e726fc
+commit=17380cbca59dff44d8e1454fd07ece37efc26afe
 ref=api-v2/phase-3-pilot
 api_major=2
 

--- a/shared/src/commonTest/resources/api/v2/fixtures/SOURCE
+++ b/shared/src/commonTest/resources/api/v2/fixtures/SOURCE
@@ -1,6 +1,6 @@
 repository=https://github.com/Silo-Server/silo-server
 path=contracts/api/v2/fixtures
-commit=c9e5a4e376f919a90e76aa8408892ba925d5661e
+commit=7bd3af1430962a8b6662510caffe49e2954c4055
 ref=api-v2/phase-3-pilot
 api_major=2
 

--- a/shared/src/commonTest/resources/api/v2/fixtures/SOURCE
+++ b/shared/src/commonTest/resources/api/v2/fixtures/SOURCE
@@ -1,6 +1,6 @@
 repository=https://github.com/Silo-Server/silo-server
 path=contracts/api/v2/fixtures
-commit=74fe2b4ac97349167d1bb85892d7f0566bd43d49
+commit=c9e5a4e376f919a90e76aa8408892ba925d5661e
 ref=api-v2/phase-3-pilot
 api_major=2
 

--- a/shared/src/commonTest/resources/api/v2/fixtures/authentication_required.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/authentication_required.json
@@ -1,0 +1,8 @@
+{
+  "type": "https://siloserver.org/docs/api/v2/problems/authentication_required",
+  "title": "Authentication required",
+  "status": 401,
+  "detail": "Authentication is required.",
+  "instance": "urn:silo:request:000000000000000000000008"
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/fixtures.schema.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/fixtures.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://siloserver.org/contracts/api/v2/fixtures.schema.json",
+  "title": "Native API v2 contract fixture index",
+  "description": "Index of the committed request/response fixtures under contracts/api/v2/fixtures. Every entry is generated through the real v2 router by TestContractFixtures in internal/apiv2 (make apiv2-fixtures); the bodies are validated against the committed OpenAPI artifact by internal/contractspec. Fixtures are public: synthetic identities and reserved origins only.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["fixtures"],
+  "properties": {
+    "fixtures": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/fixture" }
+    }
+  },
+  "$defs": {
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "operation_id", "scenario", "request", "expected_status", "response_headers", "response_media_type", "schema", "body_file"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Fixture name; body_file is <name>.json."
+        },
+        "operation_id": {
+          "type": ["string", "null"],
+          "pattern": "^[a-z][A-Za-z0-9]*$",
+          "description": "The contract operation the request targets, or null when the fixture shows an envelope produced without a contract operation: a router fallback, or a probe operation that exists only in the server's test build (request paths under /api/v2/probe/)."
+        },
+        "scenario": { "type": "string", "minLength": 1 },
+        "request": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["method", "path"],
+          "properties": {
+            "method": { "type": "string", "enum": ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"] },
+            "path": { "type": "string", "pattern": "^/api/v2/" },
+            "headers": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "body": { "type": "string" }
+          }
+        },
+        "expected_status": { "type": "integer", "minimum": 200, "maximum": 599 },
+        "response_headers": {
+          "type": "object",
+          "description": "The response headers a client should assert on. X-Request-ID is present on every v2 response and omitted here; its value is the fixture's synthetic request id, which also names the problem instance.",
+          "additionalProperties": { "type": "string" }
+        },
+        "response_media_type": { "type": "string", "enum": ["application/json", "application/problem+json"] },
+        "schema": {
+          "type": "string",
+          "pattern": "^#/components/schemas/[A-Z][A-Za-z0-9]*$",
+          "description": "JSON pointer into contracts/api/v2/openapi.json naming the schema the body satisfies."
+        },
+        "body_file": { "type": "string", "pattern": "^[a-z][a-z0-9_]*\\.json$" }
+      }
+    }
+  }
+}

--- a/shared/src/commonTest/resources/api/v2/fixtures/get_current_user_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/get_current_user_ok.json
@@ -1,0 +1,11 @@
+{
+  "id": "1",
+  "username": "laura",
+  "email": "laura@example.test",
+  "role": "user",
+  "permissions": [
+    "marker_edit"
+  ],
+  "download_allowed": true
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/get_setup_status_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/get_setup_status_ok.json
@@ -1,0 +1,4 @@
+{
+  "needs_setup": false
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/get_system_info_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/get_system_info_ok.json
@@ -1,7 +1,7 @@
 {
   "server_version": "unavailable",
   "api_major": 2,
-  "contract_digest": "78ce78223dad87ee02da7c875da0b55c8629fe61bed8cfc9298c2bdd6b849205",
+  "contract_digest": "3e6322e9ecf4fc629d28b806b1b07bc8a002a0386af38b8be25e601c5530d34e",
   "links": {
     "openapi": "/api/v2/openapi.json",
     "capabilities": "/api/v2/capabilities"

--- a/shared/src/commonTest/resources/api/v2/fixtures/get_system_info_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/get_system_info_ok.json
@@ -1,7 +1,7 @@
 {
   "server_version": "unavailable",
   "api_major": 2,
-  "contract_digest": "2fe19ec915f79a07a73e86d385ba16c54592cbf16bd0018a507ed21ecaeda772",
+  "contract_digest": "78ce78223dad87ee02da7c875da0b55c8629fe61bed8cfc9298c2bdd6b849205",
   "links": {
     "openapi": "/api/v2/openapi.json",
     "capabilities": "/api/v2/capabilities"

--- a/shared/src/commonTest/resources/api/v2/fixtures/get_system_info_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/get_system_info_ok.json
@@ -1,7 +1,7 @@
 {
   "server_version": "unavailable",
   "api_major": 2,
-  "contract_digest": "3e6322e9ecf4fc629d28b806b1b07bc8a002a0386af38b8be25e601c5530d34e",
+  "contract_digest": "ec898815f87e2576fd4c971f78a7a6c41a1a6e94dd43adc83b3332eb6e6c5c16",
   "links": {
     "openapi": "/api/v2/openapi.json",
     "capabilities": "/api/v2/capabilities"

--- a/shared/src/commonTest/resources/api/v2/fixtures/get_system_info_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/get_system_info_ok.json
@@ -1,7 +1,7 @@
 {
   "server_version": "unavailable",
   "api_major": 2,
-  "contract_digest": "daea4a66755581e49438decf1749300cfa0af1015272562bc5dc486277688e40",
+  "contract_digest": "2fe19ec915f79a07a73e86d385ba16c54592cbf16bd0018a507ed21ecaeda772",
   "links": {
     "openapi": "/api/v2/openapi.json",
     "capabilities": "/api/v2/capabilities"

--- a/shared/src/commonTest/resources/api/v2/fixtures/get_system_info_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/get_system_info_ok.json
@@ -1,0 +1,10 @@
+{
+  "server_version": "unavailable",
+  "api_major": 2,
+  "contract_digest": "daea4a66755581e49438decf1749300cfa0af1015272562bc5dc486277688e40",
+  "links": {
+    "openapi": "/api/v2/openapi.json",
+    "capabilities": "/api/v2/capabilities"
+  }
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/index.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/index.json
@@ -1,0 +1,285 @@
+{
+  "fixtures": [
+    {
+      "name": "authentication_required",
+      "operation_id": null,
+      "scenario": "An authenticated operation called without a credential.",
+      "request": {
+        "method": "POST",
+        "path": "/api/v2/probe/authenticated",
+        "body": "{\"name\":\"fixture\",\"cleared\":null}"
+      },
+      "expected_status": 401,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json"
+      },
+      "response_media_type": "application/problem+json",
+      "schema": "#/components/schemas/Problem",
+      "body_file": "authentication_required.json"
+    },
+    {
+      "name": "get_current_user_ok",
+      "operation_id": "getCurrentUser",
+      "scenario": "The signed-in account with no profile selected; impersonation is absent outside an admin impersonation session.",
+      "request": {
+        "method": "GET",
+        "path": "/api/v2/account/me",
+        "headers": {
+          "Authorization": "Bearer tok-member"
+        }
+      },
+      "expected_status": 200,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/json"
+      },
+      "response_media_type": "application/json",
+      "schema": "#/components/schemas/Account",
+      "body_file": "get_current_user_ok.json"
+    },
+    {
+      "name": "get_setup_status_ok",
+      "operation_id": "getSetupStatus",
+      "scenario": "First-run discovery before login: whether the server still needs its initial admin account.",
+      "request": {
+        "method": "GET",
+        "path": "/api/v2/system/setup"
+      },
+      "expected_status": 200,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/json"
+      },
+      "response_media_type": "application/json",
+      "schema": "#/components/schemas/SetupStatus",
+      "body_file": "get_setup_status_ok.json"
+    },
+    {
+      "name": "get_system_info_ok",
+      "operation_id": "getSystemInfo",
+      "scenario": "Discovery before login: a public operation answered with the contract identity.",
+      "request": {
+        "method": "GET",
+        "path": "/api/v2/system/info",
+        "headers": {
+          "X-Silo-Client": "Silo Fixture Client",
+          "X-Silo-Client-Version": "0.0.0"
+        }
+      },
+      "expected_status": 200,
+      "response_headers": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json"
+      },
+      "response_media_type": "application/json",
+      "schema": "#/components/schemas/SystemInfo",
+      "body_file": "get_system_info_ok.json"
+    },
+    {
+      "name": "list_progress_offset_rejected",
+      "operation_id": "listProgress",
+      "scenario": "The v1 offset parameter is not part of v2 pagination; cursor-paginated operations refuse it as unknown.",
+      "request": {
+        "method": "GET",
+        "path": "/api/v2/progress?offset=50",
+        "headers": {
+          "Authorization": "Bearer tok-member",
+          "X-Profile-Id": "p-owner"
+        }
+      },
+      "expected_status": 422,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json"
+      },
+      "response_media_type": "application/problem+json",
+      "schema": "#/components/schemas/Problem",
+      "body_file": "list_progress_offset_rejected.json"
+    },
+    {
+      "name": "list_progress_ok",
+      "operation_id": "listProgress",
+      "scenario": "The first page of a profile's watch progress, newest first, with an opaque cursor for the next page.",
+      "request": {
+        "method": "GET",
+        "path": "/api/v2/progress?limit=1",
+        "headers": {
+          "Authorization": "Bearer tok-member",
+          "X-Profile-Id": "p-owner"
+        }
+      },
+      "expected_status": 200,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/json"
+      },
+      "response_media_type": "application/json",
+      "schema": "#/components/schemas/ProgressCollection",
+      "body_file": "list_progress_ok.json"
+    },
+    {
+      "name": "list_progress_profile_header_required",
+      "operation_id": "listProgress",
+      "scenario": "A profile-scoped operation called without X-Profile-Id: a validation failure naming the header.",
+      "request": {
+        "method": "GET",
+        "path": "/api/v2/progress",
+        "headers": {
+          "Authorization": "Bearer tok-member"
+        }
+      },
+      "expected_status": 422,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json"
+      },
+      "response_media_type": "application/problem+json",
+      "schema": "#/components/schemas/Problem",
+      "body_file": "list_progress_profile_header_required.json"
+    },
+    {
+      "name": "not_acceptable",
+      "operation_id": "getSystemInfo",
+      "scenario": "An Accept header that admits no JSON representation.",
+      "request": {
+        "method": "GET",
+        "path": "/api/v2/system/info",
+        "headers": {
+          "Accept": "text/html"
+        }
+      },
+      "expected_status": 406,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json"
+      },
+      "response_media_type": "application/problem+json",
+      "schema": "#/components/schemas/Problem",
+      "body_file": "not_acceptable.json"
+    },
+    {
+      "name": "not_found",
+      "operation_id": null,
+      "scenario": "A path under /api/v2/ with no operation registered at it.",
+      "request": {
+        "method": "GET",
+        "path": "/api/v2/library/items/fixture-missing"
+      },
+      "expected_status": 404,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json"
+      },
+      "response_media_type": "application/problem+json",
+      "schema": "#/components/schemas/Problem",
+      "body_file": "not_found.json"
+    },
+    {
+      "name": "profile_verification_required",
+      "operation_id": null,
+      "scenario": "A profile-scoped operation called for a PIN-locked profile without X-Profile-Token; clients start PIN entry on this type.",
+      "request": {
+        "method": "POST",
+        "path": "/api/v2/probe/profile_scoped",
+        "headers": {
+          "Authorization": "Bearer tok-member",
+          "X-Profile-Id": "p-locked"
+        },
+        "body": "{\"name\":\"fixture\",\"cleared\":null}"
+      },
+      "expected_status": 403,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json"
+      },
+      "response_media_type": "application/problem+json",
+      "schema": "#/components/schemas/Problem",
+      "body_file": "profile_verification_required.json"
+    },
+    {
+      "name": "rate_limited",
+      "operation_id": null,
+      "scenario": "The authenticated-route limiter refused the request; Retry-After is the only rate-limit header on v2.",
+      "request": {
+        "method": "POST",
+        "path": "/api/v2/probe/authenticated",
+        "headers": {
+          "Authorization": "Bearer tok-member"
+        },
+        "body": "{\"name\":\"fixture\",\"cleared\":null}"
+      },
+      "expected_status": 429,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json",
+        "Retry-After": "30"
+      },
+      "response_media_type": "application/problem+json",
+      "schema": "#/components/schemas/Problem",
+      "body_file": "rate_limited.json"
+    },
+    {
+      "name": "update_profile_null_not_clearable",
+      "operation_id": "updateProfile",
+      "scenario": "Explicit null on a member that does not admit clearing is a validation failure; omit it to leave it unchanged.",
+      "request": {
+        "method": "PATCH",
+        "path": "/api/v2/profiles/p-owner",
+        "headers": {
+          "Authorization": "Bearer tok-member",
+          "X-Profile-Id": "p-owner"
+        },
+        "body": "{\"is_child\":null}"
+      },
+      "expected_status": 422,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json"
+      },
+      "response_media_type": "application/problem+json",
+      "schema": "#/components/schemas/Problem",
+      "body_file": "update_profile_null_not_clearable.json"
+    },
+    {
+      "name": "update_profile_ok",
+      "operation_id": "updateProfile",
+      "scenario": "A partial PATCH: omitted members stay unchanged, null clears a clearable member, the whole profile is returned.",
+      "request": {
+        "method": "PATCH",
+        "path": "/api/v2/profiles/p-owner",
+        "headers": {
+          "Authorization": "Bearer tok-member",
+          "X-Profile-Id": "p-owner"
+        },
+        "body": "{\"name\":\"Laura\",\"subtitle_mode\":\"always\",\"max_content_rating\":null,\"allowed_library_ids\":[\"3\"]}"
+      },
+      "expected_status": 200,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/json"
+      },
+      "response_media_type": "application/json",
+      "schema": "#/components/schemas/Profile",
+      "body_file": "update_profile_ok.json"
+    },
+    {
+      "name": "validation_failed_body",
+      "operation_id": null,
+      "scenario": "A JSON body with a missing required member and an out-of-range member: one errors[] entry per failure, the rejected values never echoed.",
+      "request": {
+        "method": "POST",
+        "path": "/api/v2/probe/public",
+        "body": "{\"count\":99,\"cleared\":null}"
+      },
+      "expected_status": 422,
+      "response_headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json"
+      },
+      "response_media_type": "application/problem+json",
+      "schema": "#/components/schemas/Problem",
+      "body_file": "validation_failed_body.json"
+    }
+  ]
+}

--- a/shared/src/commonTest/resources/api/v2/fixtures/list_progress_offset_rejected.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/list_progress_offset_rejected.json
@@ -1,0 +1,15 @@
+{
+  "type": "https://siloserver.org/docs/api/v2/problems/validation_failed",
+  "title": "Validation failed",
+  "status": 422,
+  "detail": "The request did not pass validation; see errors.",
+  "instance": "urn:silo:request:00000000000000000000000f",
+  "errors": [
+    {
+      "location": "query.offset",
+      "code": "unknown_parameter",
+      "detail": "unknown query parameter"
+    }
+  ]
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/list_progress_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/list_progress_ok.json
@@ -9,7 +9,7 @@
     }
   ],
   "page": {
-    "next_cursor": "eyJ2IjoxLCJwIjp7InUiOiIyMDI2LTAxLTAyVDAzOjA0OjA1WiIsIm0iOiJtb3ZpZS04ZjJjMWEifX0.sdxqzj8duUdylByCdeSMBtd5RPybx-ZRme9wwWxZzXM",
+    "next_cursor": "eyJ2IjoxLCJwIjp7InUiOiIyMDI2LTAxLTAyVDAzOjA0OjA1WiIsIm0iOiJtb3ZpZS04ZjJjMWEifX0.i9Iz-3URhvDchLeIECW5NkDYdAgcktS3Fyrj9sKPbE0",
     "has_more": true
   }
 }

--- a/shared/src/commonTest/resources/api/v2/fixtures/list_progress_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/list_progress_ok.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "media_item_id": "movie-8f2c1a",
+      "position_seconds": 1325.5,
+      "duration_seconds": 5400,
+      "completed": false,
+      "updated_at": "2026-01-02T03:04:05.000Z"
+    }
+  ],
+  "page": {
+    "next_cursor": "eyJ2IjoxLCJwIjp7Im8iOjF9fQ.6RrklufYca6vR_NlD0Wmye3hHSIxFk-hQbz1exv6I0I",
+    "has_more": true
+  }
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/list_progress_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/list_progress_ok.json
@@ -9,7 +9,7 @@
     }
   ],
   "page": {
-    "next_cursor": "eyJ2IjoxLCJwIjp7InUiOiIyMDI2LTAxLTAyVDAzOjA0OjA1WiIsIm0iOiJtb3ZpZS04ZjJjMWEifX0.i9Iz-3URhvDchLeIECW5NkDYdAgcktS3Fyrj9sKPbE0",
+    "next_cursor": "eyJ2IjoxLCJwIjp7InUiOiIyMDI2LTAxLTAyVDAzOjA0OjA1WiIsIm0iOiJtb3ZpZS04ZjJjMWEifX0.7fNOMpzpMssIVUy2sr5knHSZhSdx8HPH7x4WWFoLLDQ",
     "has_more": true
   }
 }

--- a/shared/src/commonTest/resources/api/v2/fixtures/list_progress_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/list_progress_ok.json
@@ -9,7 +9,7 @@
     }
   ],
   "page": {
-    "next_cursor": "eyJ2IjoxLCJwIjp7Im8iOjF9fQ.6RrklufYca6vR_NlD0Wmye3hHSIxFk-hQbz1exv6I0I",
+    "next_cursor": "eyJ2IjoxLCJwIjp7InUiOiIyMDI2LTAxLTAyVDAzOjA0OjA1WiIsIm0iOiJtb3ZpZS04ZjJjMWEifX0.sdxqzj8duUdylByCdeSMBtd5RPybx-ZRme9wwWxZzXM",
     "has_more": true
   }
 }

--- a/shared/src/commonTest/resources/api/v2/fixtures/list_progress_profile_header_required.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/list_progress_profile_header_required.json
@@ -1,0 +1,15 @@
+{
+  "type": "https://siloserver.org/docs/api/v2/problems/validation_failed",
+  "title": "Validation failed",
+  "status": 422,
+  "detail": "The request did not pass validation; see errors.",
+  "instance": "urn:silo:request:00000000000000000000000e",
+  "errors": [
+    {
+      "location": "header.x-profile-id",
+      "code": "required",
+      "detail": "The X-Profile-Id header is required."
+    }
+  ]
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/not_acceptable.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/not_acceptable.json
@@ -1,0 +1,8 @@
+{
+  "type": "https://siloserver.org/docs/api/v2/problems/not_acceptable",
+  "title": "Not acceptable",
+  "status": 406,
+  "detail": "No acceptable representation is available for this operation.",
+  "instance": "urn:silo:request:000000000000000000000004"
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/not_found.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/not_found.json
@@ -1,0 +1,8 @@
+{
+  "type": "https://siloserver.org/docs/api/v2/problems/not_found",
+  "title": "Not found",
+  "status": 404,
+  "detail": "No operation is registered at this path.",
+  "instance": "urn:silo:request:000000000000000000000007"
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/profile_verification_required.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/profile_verification_required.json
@@ -1,0 +1,8 @@
+{
+  "type": "https://siloserver.org/docs/api/v2/problems/profile_verification_required",
+  "title": "Profile verification required",
+  "status": 403,
+  "detail": "The declared profile is locked; verify it and retry with X-Profile-Token.",
+  "instance": "urn:silo:request:000000000000000000000009"
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/rate_limited.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/rate_limited.json
@@ -1,0 +1,8 @@
+{
+  "type": "https://siloserver.org/docs/api/v2/problems/rate_limited",
+  "title": "Rate limited",
+  "status": 429,
+  "detail": "Too many requests; retry after the Retry-After delay.",
+  "instance": "urn:silo:request:00000000000000000000000a"
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/update_profile_null_not_clearable.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/update_profile_null_not_clearable.json
@@ -1,0 +1,15 @@
+{
+  "type": "https://siloserver.org/docs/api/v2/problems/validation_failed",
+  "title": "Validation failed",
+  "status": 422,
+  "detail": "The request did not pass validation; see errors.",
+  "instance": "urn:silo:request:000000000000000000000011",
+  "errors": [
+    {
+      "location": "body.is_child",
+      "code": "invalid_type",
+      "detail": "null is not a value for this member; omit it to leave it unchanged"
+    }
+  ]
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/update_profile_ok.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/update_profile_ok.json
@@ -1,0 +1,29 @@
+{
+  "id": "p-owner",
+  "name": "Laura",
+  "avatar": "preset:fox",
+  "avatar_url": "/avatars/presets/fox.png",
+  "avatar_source": "preset",
+  "has_pin": false,
+  "is_child": false,
+  "is_primary": true,
+  "max_content_rating": "",
+  "quality_preference": "auto",
+  "language": "en",
+  "preferred_metadata_language": "",
+  "subtitle_language": "",
+  "subtitle_mode": "auto",
+  "auto_skip_intro": true,
+  "auto_skip_credits": false,
+  "auto_skip_recap": false,
+  "auto_play_next_preview": false,
+  "show_forced_subtitles": false,
+  "library_restrictions_enabled": false,
+  "allowed_library_ids": [
+    "3"
+  ],
+  "max_playback_quality": "1080p",
+  "created_at": "2026-01-02T03:04:05.000Z",
+  "updated_at": "2026-01-02T03:04:05.000Z"
+}
+

--- a/shared/src/commonTest/resources/api/v2/fixtures/validation_failed_body.json
+++ b/shared/src/commonTest/resources/api/v2/fixtures/validation_failed_body.json
@@ -1,0 +1,20 @@
+{
+  "type": "https://siloserver.org/docs/api/v2/problems/validation_failed",
+  "title": "Validation failed",
+  "status": 422,
+  "detail": "The request did not pass validation; see errors.",
+  "instance": "urn:silo:request:000000000000000000000003",
+  "errors": [
+    {
+      "location": "body.count",
+      "code": "out_of_range",
+      "detail": "expected number <= 10"
+    },
+    {
+      "location": "body.name",
+      "code": "required",
+      "detail": "expected required property name to be present"
+    }
+  ]
+}
+


### PR DESCRIPTION
## Problem

The server's API v2 pilot (silo-server `[api-v2 phase 3]`, branch `api-v2/phase-3-pilot`) publishes five operations with deterministic contract fixtures. The Android client had no offline proof that `SiloJson` and its handwritten models decode that contract, no v2 discovery probe, and no explicit state for a server that only speaks v1.

## Solution

- **Sync script** `scripts/sync-apiv2-fixtures.sh <server checkout>` vendors only the fixtures this client consumes (four pilot operations, the system-info probe body, the generic problem bodies; 14 files) plus `fixtures.schema.json` and a filtered `index.json` into `shared/src/commonTest/resources/api/v2/fixtures/`, and writes `SOURCE` in the existing key=value convention with `commit=17380cbca59dff44d8e1454fd07ece37efc26afe`. The OpenAPI document is never vendored.
- **Models** under `network/apiv2/` (new `@Serializable` types, never the v1 data classes) for `getSetupStatus`, `getCurrentUser`, `listProgress`, `updateProfile`, plus `Problem` and `SystemInfo`. Enums carry an explicit unknown fallback that is observable, not silently coerced to a default.
- **Conformance tests** (`ApiV2ContractTest`, `ApiV2ProbeTest`, `ApiV2NoFallbackTest`, `ApiV2NoV1TransportSourceTest`, `AuthRepositoryContractTest`): every vendored fixture decodes with the production `SiloJson`; the fields each UI flow consumes are asserted with explicit null/absence semantics; unknown fields and unknown enum values are injected; the PATCH encoder distinguishes omitted from literal `null` under `explicitNulls = false`; a source scan asserts no `/api/v1` literal under `network/apiv2/`; a failed v2 `updateProfile` is never retried against v1.
- **Probe and update-server state.** `ApiV2Probe` GETs `/api/v2/system/info` and maps only the legacy listener's plain 404 to `UpdateServer`; timeout, TLS failure, HTML with 200, malformed JSON, 401, 429, and 5xx each remain their own failure. `ServerContract.UPDATE_REQUIRED` is stored per registry entry and `ApiV2Gate` blocks the pilot v2 calls with one user-visible message. The probe runs on connect (`ServerSetupViewModel`), on launch restore (`MainActivity`, `MainTvActivity`), on every server switch through the new `AuthRepository.switchToServer`, on `refreshActiveServerName`, and after a pairing rollback restores the previous server. A stale verdict for a previous server id is dropped; failures never overwrite a stored state.
- **Migration.** `AuthApi` setup status and current user, `ProfileApi` profile update, and `PersonalDataApi` progress listing use v2. Non-pilot operations stay on v1 during the bridge, as the server contract specifies.

## Validation

On `97315e86`: `./scripts/test-check-build-supply-chain.sh`, `./scripts/check-build-supply-chain.sh`, `./gradlew testDebugUnitTest`, `./gradlew :android-shared:lintDebug :androidApp:lintDebug :androidTvApp:lintDebug :androidApp:lintVitalRelease :androidTvApp:lintVitalRelease` (no baseline regenerated), `./gradlew :androidApp:assembleDebug :androidTvApp:assembleDebug`, clean tree. All passed. Server side: `make verify-apiv2-fixtures-siblings` against this branch reports the vendored copies current.

## Review history

A 3-lens blind review found one Android major: the probe ran only inside `setServerUrl`, so servers saved before this build never reached the update-server state. Fixed by probing on launch, on every switch path, and on identity refresh; the re-verify lens then asked for coverage of the pairing rollback path, added in `RegistryPairingAuthPortTest` with a real `AuthRepository` over Ktor `MockEngine`.

## Risks and follow-up

- Whether the update-server state should block the whole session UI is out of the pilot; the state exists, is tested, and gates the pilot v2 calls.
- `ServerListViewModel` now takes an `AuthRepository`; Koin wiring updated in `AndroidModule` and `AndroidTvModule`.

Companion PRs: https://github.com/Silo-Server/silo-server/pull/941 (fixtures source), https://github.com/Silo-Server/silo-apple/pull/253.

Related issue: Silo-Server/silo-server#135

## Recovery validation

Commit `c2ec861e` refreshes the server contract after shared and TV sign-in commits a session. Queued refreshes check the active server, and the refresh survives cancellation of the sign-in caller once scheduled.

Focused validation: 31 shared contract tests and the TV sign-in race test passed; TV production and test sources compiled. The strengthened cancellation regression passed on a subsequent shared-suite run. Independent review of this fix found no additional actionable defects. No live-device validation or full-suite rerun was performed for this follow-up.

## AI Disclosure

- Recovery tooling: Codex with `gpt-6-astra` at low effort for implementation and medium effort for independent orchestration/review; earlier Claude contributions remain described below.
- Harness: Claude Code
- Tool(s): Claude Code (orchestrator session driving implementation and review subagents through the Workflow tool and the Agent tool)
- Model(s): claude-fable-5-1 (`claude-fable-5-1[1m]`) for orchestration, all implementers, and all review agents
- Involvement: Fully AI-generated; maintainer review pending (opened by the orchestrating agent under the maintainer's program instruction)
- Adversarial review: see "Review history" above; the finding was arbitrated by the orchestrator against the plan's compatibility rule before the fix was briefed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)