### PR TITLE
feat(tv): refine detail layout and continuous episode browsing

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt
@@ -183,6 +183,7 @@ private fun describeColorRange(format: Format): String? = when (format.colorInfo
     else -> null
 }
 
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 private fun describeHdrMode(format: Format, decoderMimeType: String?): String? {
     if (decoderMimeType == null) return null
     if (decoderMimeType.equals(MimeTypes.VIDEO_DOLBY_VISION, ignoreCase = true)) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvAnchoredSelectorMenu.kt
@@ -233,6 +233,7 @@ internal fun TvAnchoredSelectorMenu(
                 },
                 onClick = { if (interactive) expansionRequested = true },
                 focusRequester = triggerFr,
+                titleOnFocus = label,
             )
             TvSelectorTriggerStyle.ConnectedSegment -> ConnectedSelectorTrigger(
                 icon = icon,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSquaredButtons.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSquaredButtons.kt
@@ -403,15 +403,16 @@ fun TvSquareToggleButton(
         val textWidth = textMeasurer.measure(titleOnFocus.orEmpty(), titleStyle).size.width
         with(density) { textWidth.toDp() } + 54.dp
     }
-    val capsuleWidth by animateDpAsState(
-        targetValue = if (isFocused && titleOnFocus != null) expandedWidth else 38.dp,
-        animationSpec = tween(durationMillis = 280),
-        label = "toggleWidth",
-    )
     val titleAlpha by animateFloatAsState(
         targetValue = if (isFocused) 1f else 0f,
         animationSpec = tween(durationMillis = 180, delayMillis = if (isFocused) 60 else 0),
         label = "toggleTitleAlpha",
+    )
+    val showTitle = isFocused || titleAlpha > 0f
+    val capsuleWidth by animateDpAsState(
+        targetValue = if (showTitle && titleOnFocus != null) expandedWidth else 38.dp,
+        animationSpec = tween(durationMillis = 280),
+        label = "toggleWidth",
     )
 
     val shape = CircleShape
@@ -503,8 +504,8 @@ fun TvSquareToggleButton(
     ) {
         Row(
             modifier = Modifier
-                .then(if (titleOnFocus != null) Modifier.requiredWidth(if (isFocused) expandedWidth else 38.dp) else Modifier)
-                .padding(horizontal = if (isFocused && titleOnFocus != null) 14.dp else 0.dp),
+                .then(if (titleOnFocus != null) Modifier.requiredWidth(if (showTitle) expandedWidth else 38.dp) else Modifier)
+                .padding(horizontal = if (showTitle && titleOnFocus != null) 14.dp else 0.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(7.dp, Alignment.CenterHorizontally),
         ) {
@@ -514,7 +515,7 @@ fun TvSquareToggleButton(
                 tint = foreground,
                 modifier = Modifier.size(if (titleOnFocus != null) 19.dp else 16.dp),
             )
-            if (isFocused && titleOnFocus != null) {
+            if (showTitle && titleOnFocus != null) {
                 Text(
                     text = titleOnFocus,
                     color = foreground,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSquaredButtons.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvSquaredButtons.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -29,6 +30,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
@@ -120,6 +126,7 @@ fun TvPrimaryPillButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester? = null,
+    stableHero: Boolean = false,
 ) {
     SquaredPill(
         kind = PillKind.Primary,
@@ -128,6 +135,7 @@ fun TvPrimaryPillButton(
         onClick = onClick,
         modifier = modifier,
         focusRequester = focusRequester,
+        stableHero = stableHero,
     )
 }
 
@@ -165,17 +173,19 @@ private fun SquaredPill(
     onClick: () -> Unit,
     modifier: Modifier,
     focusRequester: FocusRequester?,
+    stableHero: Boolean = false,
 ) {
     val primary = kind == PillKind.Primary
     SquaredPillSurface(
         kind = kind,
         onClick = onClick,
-        modifier = modifier,
+        modifier = if (stableHero) modifier.height(38.dp) else modifier,
         focusRequester = focusRequester,
         capsule = true,
+        stableHero = stableHero,
         contentPadding = PaddingValues(
             horizontal = if (primary) 27.dp else 20.dp,
-            vertical = if (primary) 13.dp else 11.dp,
+            vertical = if (stableHero) 0.dp else if (primary) 13.dp else 11.dp,
         ),
     ) { foreground ->
         Row(
@@ -189,7 +199,7 @@ private fun SquaredPill(
             // pre-enlargement button height.
             Box(
                 modifier = Modifier
-                    .width(if (primary) 30.dp else 20.dp)
+                    .width(if (stableHero) 18.dp else if (primary) 30.dp else 20.dp)
                     .height(if (primary) 16.dp else 14.dp),
                 contentAlignment = Alignment.Center,
             ) {
@@ -197,14 +207,14 @@ private fun SquaredPill(
                     imageVector = icon,
                     contentDescription = null,
                     tint = foreground,
-                    modifier = Modifier.requiredSize(if (primary) 30.dp else 20.dp),
+                    modifier = Modifier.requiredSize(if (stableHero) 18.dp else if (primary) 30.dp else 20.dp),
                 )
             }
             Spacer(Modifier.width(if (primary) 9.dp else 8.dp))
             Text(
                 text = title,
                 style = MaterialTheme.typography.titleLarge.copy(
-                    fontSize = if (primary) 17.sp else 15.sp,
+                    fontSize = if (stableHero) 14.sp else if (primary) 17.sp else 15.sp,
                 ),
                 color = foreground,
                 maxLines = 1,
@@ -230,6 +240,7 @@ internal fun SquaredPillSurface(
     enabled: Boolean = true,
     /** Hero Play/Start Over use tvOS Capsule; selector triggers keep their approved squared shape. */
     capsule: Boolean = false,
+    stableHero: Boolean = false,
     contentPadding: PaddingValues,
     content: @Composable (foreground: Color) -> Unit,
 ) {
@@ -242,7 +253,9 @@ internal fun SquaredPillSurface(
 
     // --- Body visuals (per kind) ---
     val foreground by animateColorAsState(
-        targetValue = when (kind) {
+        targetValue = if (stableHero) {
+            if (isFocused) Color.Black else Color.White
+        } else when (kind) {
             // The Play pill remains the bright primary action at rest. Making
             // it use the same translucent treatment as the circular utility
             // buttons erased the hierarchy and made the whole action cluster
@@ -254,7 +267,9 @@ internal fun SquaredPillSurface(
         label = "pillForeground",
     )
     val fill by animateColorAsState(
-        targetValue = when (kind) {
+        targetValue = if (stableHero) {
+            if (isFocused) Color.White else Color.White.copy(alpha = 0.10f)
+        } else when (kind) {
             PillKind.Primary -> if (isFocused) Color.White else Color.White.copy(alpha = 0.76f)
             PillKind.Secondary -> if (isFocused) Color.White else Color.Black.copy(alpha = 0.52f)
         },
@@ -302,7 +317,7 @@ internal fun SquaredPillSurface(
     )
 
     val focusScale by animateFloatAsState(
-        targetValue = if (isFocused) 1.025f else 1f,
+        targetValue = if (isFocused && !stableHero) 1.025f else 1f,
         animationSpec = focusSpring(),
         label = "pillFocusScale",
     )
@@ -337,14 +352,14 @@ internal fun SquaredPillSurface(
             )
             // Compact focus outline, half-scale port of tvOS width 2.5 / inset 3.
             .focusRing(
-                visible = isFocused,
+                visible = isFocused && !stableHero,
                 color = focusOutlineColor,
                 width = 1.25.dp,
                 inset = 1.5.dp,
                 corner = if (capsule) 50.dp else TvControlCorner + 2.dp,
             )
             .background(fill, shape)
-            .border(innerBorderWidth, innerBorderColor, shape)
+            .then(if (stableHero) Modifier else Modifier.border(innerBorderWidth, innerBorderColor, shape))
             .then(focusRequester?.let { Modifier.focusRequester(it) } ?: Modifier)
             .onFocusChanged { isFocused = it.isFocused }
             .clickable(
@@ -361,12 +376,9 @@ internal fun SquaredPillSurface(
 }
 
 /**
- * 72×72 circular icon toggle (Favorite / Watchlist / Watched). Mirrors
- * `TVCircleActionButton` + `TVCircleButtonStyle`.
- *
- * Fill white@0.10 → focus white; icon white → focus black; swaps [icon] /
- * [iconActive] on [isActive]. Focus ring white@0.96 3dp inset −5, scale 1.10,
- * shadow black@0.34 r16 y6, glow onSurface@0.15 r10.
+ * Circular action with optional tvOS-style label expansion on focus.
+ * [titleOnFocus] uses a fixed-height capsule without a focus ring or scale;
+ * icon-only callers retain their existing toggle treatment.
  */
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -378,10 +390,29 @@ fun TvSquareToggleButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester? = null,
+    titleOnFocus: String? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     var isFocused by remember { mutableStateOf(false) }
+
+    val titleStyle = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+    val textMeasurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+    val expandedWidth = remember(titleOnFocus, textMeasurer, density) {
+        val textWidth = textMeasurer.measure(titleOnFocus.orEmpty(), titleStyle).size.width
+        with(density) { textWidth.toDp() } + 54.dp
+    }
+    val capsuleWidth by animateDpAsState(
+        targetValue = if (isFocused && titleOnFocus != null) expandedWidth else 38.dp,
+        animationSpec = tween(durationMillis = 280),
+        label = "toggleWidth",
+    )
+    val titleAlpha by animateFloatAsState(
+        targetValue = if (isFocused) 1f else 0f,
+        animationSpec = tween(durationMillis = 180, delayMillis = if (isFocused) 60 else 0),
+        label = "toggleTitleAlpha",
+    )
 
     val shape = CircleShape
 
@@ -407,7 +438,7 @@ fun TvSquareToggleButton(
     )
 
     val focusScale by animateFloatAsState(
-        targetValue = if (isFocused) 1.10f else 1f,
+        targetValue = if (isFocused && titleOnFocus == null) 1.10f else 1f,
         animationSpec = focusSpring(),
         label = "toggleFocusScale",
     )
@@ -422,8 +453,13 @@ fun TvSquareToggleButton(
 
     Box(
         modifier = modifier
-            // tvOS 72×72 ÷ 2 = 36dp, +4 per design review.
-            .size(40.dp)
+            .then(
+                if (titleOnFocus != null) {
+                    Modifier.width(capsuleWidth).height(38.dp)
+                } else {
+                    Modifier.size(40.dp)
+                },
+            )
             .graphicsLayer {
                 scaleX = scale
                 scaleY = scale
@@ -446,14 +482,15 @@ fun TvSquareToggleButton(
             )
             // Focus ring: white@0.96, 3dp, inset −2.5.
             .focusRing(
-                visible = isFocused,
+                visible = isFocused && titleOnFocus == null,
                 color = Color.White.copy(alpha = 0.96f),
                 width = 1.5.dp,
                 inset = 2.5.dp,
                 corner = 22.dp,
             )
             .background(fill, shape)
-            .border(innerBorderWidth, innerBorderColor, shape)
+            .then(if (titleOnFocus != null) Modifier.clip(shape) else Modifier)
+            .then(if (titleOnFocus == null) Modifier.border(innerBorderWidth, innerBorderColor, shape) else Modifier)
             .then(focusRequester?.let { Modifier.focusRequester(it) } ?: Modifier)
             .onFocusChanged { isFocused = it.isFocused }
             .semantics { this.contentDescription = contentDescription }
@@ -464,11 +501,28 @@ fun TvSquareToggleButton(
             ),
         contentAlignment = Alignment.Center,
     ) {
-        Icon(
-            imageVector = if (isActive) iconActive else icon,
-            contentDescription = null,
-            tint = foreground,
-            modifier = Modifier.size(16.dp),
-        )
+        Row(
+            modifier = Modifier
+                .then(if (titleOnFocus != null) Modifier.requiredWidth(if (isFocused) expandedWidth else 38.dp) else Modifier)
+                .padding(horizontal = if (isFocused && titleOnFocus != null) 14.dp else 0.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(7.dp, Alignment.CenterHorizontally),
+        ) {
+            Icon(
+                imageVector = if (isActive) iconActive else icon,
+                contentDescription = null,
+                tint = foreground,
+                modifier = Modifier.size(if (titleOnFocus != null) 19.dp else 16.dp),
+            )
+            if (isFocused && titleOnFocus != null) {
+                Text(
+                    text = titleOnFocus,
+                    color = foreground,
+                    style = titleStyle,
+                    modifier = Modifier.graphicsLayer { alpha = titleAlpha },
+                    maxLines = 1,
+                )
+            }
+        }
     }
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt
@@ -57,7 +57,9 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -158,6 +160,7 @@ internal fun TvDetailEpisodeRail(
 ) {
     if (episodes.isEmpty()) return
 
+    val layoutDirection = LocalLayoutDirection.current
     val listState = rememberLazyListState()
     val currentIndex = remember(currentContentId, episodes) {
         episodes.indexOfFirst { it.contentId == currentContentId }.takeIf { it >= 0 }
@@ -277,11 +280,7 @@ internal fun TvDetailEpisodeRail(
                         TvDetailHorizontalInset,
                     )
                     .onPreviewKeyEvent { event ->
-                        val direction = when (event.key) {
-                            Key.DirectionLeft -> -1
-                            Key.DirectionRight -> 1
-                            else -> 0
-                        }
+                        val direction = episodeCarouselDirection(event.key, layoutDirection)
                         if (direction == 0 || event.type != KeyEventType.KeyDown) {
                             false
                         } else if (usesSeriesGeometry && (
@@ -632,4 +631,14 @@ private fun EpisodeListItem.progressFraction(): Float? {
     val dur = user.durationSeconds ?: return null
     if (dur <= 0 || pos <= 0 || pos >= dur) return null
     return (pos / dur).toFloat().coerceIn(0f, 1f)
+}
+
+
+internal fun episodeCarouselDirection(key: Key, layoutDirection: LayoutDirection): Int {
+    val physicalDirection = when (key) {
+        Key.DirectionLeft -> -1
+        Key.DirectionRight -> 1
+        else -> 0
+    }
+    return if (layoutDirection == LayoutDirection.Rtl) -physicalDirection else physicalDirection
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt
@@ -36,9 +36,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
@@ -55,6 +57,8 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Icon
@@ -65,6 +69,7 @@ import org.siloserver.silo.model.catalog.EpisodeListItem
 import org.siloserver.silo.tv.ui.components.TvMediaCardActions
 import org.siloserver.silo.tv.ui.components.TvMediaCardContextMenu
 import org.siloserver.silo.tv.ui.components.tvEpisodeCardWidth
+import org.siloserver.silo.tv.ui.focus.requestFocusUntilObserved
 import org.siloserver.silo.tv.ui.theme.TvRailScrollBehavior
 import org.siloserver.silo.tv.ui.theme.tvRailPinOnFocus
 import org.siloserver.silo.tv.ui.theme.SiloOnSurface
@@ -73,6 +78,49 @@ import org.siloserver.silo.tv.ui.theme.DarkSurfaceElevated
 import org.siloserver.silo.tv.ui.theme.ProgressFill
 import org.siloserver.silo.tv.ui.theme.capsuleCaps
 import org.siloserver.silo.tv.ui.theme.cardScaled
+
+/** Includes the still, optional caption, and vertical rail padding from the first frame. */
+@Composable
+internal fun tvSeriesEpisodeRailHeight(): Dp {
+    val captionHeight = if (LocalCardPresentation.current.caption.showsTitle) {
+        7.dp + with(LocalDensity.current) { 14.sp.toDp() }
+    } else {
+        0.dp
+    }
+    return tvEpisodeCardWidth() * (9f / 16f) + captionHeight + 12.dp
+}
+
+@Composable
+internal fun TvSeriesEpisodeRailSkeleton() {
+    val cardWidth = tvEpisodeCardWidth()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(tvSeriesEpisodeRailHeight())
+            .clipToBounds()
+            .padding(horizontal = TvDetailHorizontalInset, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        repeat(5) {
+            Column(
+                modifier = Modifier.width(cardWidth),
+                verticalArrangement = Arrangement.spacedBy(7.dp),
+            ) {
+                Box(
+                    Modifier.width(cardWidth).height(cardWidth * (9f / 16f))
+                        .background(DarkSurfaceElevated, RoundedCornerShape(8.dp)),
+                )
+                if (LocalCardPresentation.current.caption.showsTitle) {
+                    Box(
+                        Modifier.fillMaxWidth(0.65f)
+                            .height(with(LocalDensity.current) { 14.sp.toDp() })
+                            .background(DarkSurfaceElevated, RoundedCornerShape(3.dp)),
+                    )
+                }
+            }
+        }
+    }
+}
 
 /**
  * Horizontal rail of episode cards for the series/season/episode detail
@@ -101,6 +149,12 @@ internal fun TvDetailEpisodeRail(
     onDirectionUp: (() -> Boolean)? = null,
     hidesEpisodeTitle: Boolean = false,
     usesSeriesGeometry: Boolean = false,
+    carouselJump: TvEpisodeCarouselJump? = null,
+    hasPreviousEpisodes: Boolean = false,
+    hasNextEpisodes: Boolean = false,
+    carouselLoadError: Boolean = false,
+    onCarouselEdgeRequested: (String, Int) -> Unit = { _, _ -> },
+    onCarouselFocusLost: () -> Unit = {},
 ) {
     if (episodes.isEmpty()) return
 
@@ -111,8 +165,8 @@ internal fun TvDetailEpisodeRail(
     // The first entry uses next-up/current. Once the viewer browses sideways,
     // retain that exact episode for every Up/Down round-trip through the
     // selector and supporting rails. Keying by the first episode resets this
-    // memory when a different season's rail replaces the current one.
-    val episodeSetKey = episodes.first().contentId
+    // memory on legacy routes. Series keeps it across prepends and appends.
+    val episodeSetKey = if (usesSeriesGeometry) "continuous-series" else episodes.first().contentId
     var rememberedFocusedContentId by remember(episodeSetKey) { mutableStateOf<String?>(null) }
     val entryIndex = remember(rememberedFocusedContentId, currentContentId, episodes) {
         val targetId = rememberedFocusedContentId
@@ -123,6 +177,23 @@ internal fun TvDetailEpisodeRail(
     // Default focus target: the remembered episode, falling back to current.
     // Mirrors tvOS's focusedEpisodeContentId plus its suggestedEpisode entry.
     val defaultFocusRequester = remember { FocusRequester() }
+    var observedFocusedContentId by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(carouselJump) {
+        val jump = carouselJump ?: return@LaunchedEffect
+        val index = episodes.indexOfFirst { it.contentId == jump.contentId }
+        if (index < 0) return@LaunchedEffect
+        rememberedFocusedContentId = jump.contentId
+        listState.scrollToItem(index + if (hasPreviousEpisodes) 1 else 0)
+        if (jump.requestFocus) {
+            requestFocusUntilObserved(
+                maxAttempts = 8,
+                awaitAttempt = { withFrameNanos { } },
+                requestFocus = defaultFocusRequester::requestFocus,
+                isFocused = { observedFocusedContentId == jump.contentId },
+            )
+        }
+    }
 
     // Auto-center the suggested episode ONCE when this season's rail appears
     // (parity with tvOS `scrollTo(..., anchor: .center)`). Do not key this on
@@ -132,9 +203,10 @@ internal fun TvDetailEpisodeRail(
     // even though focus reached the correct episode.
     LaunchedEffect(episodeSetKey) {
         val target = currentIndex ?: return@LaunchedEffect
-        listState.scrollToItem(target)
+        val itemIndex = target + if (hasPreviousEpisodes) 1 else 0
+        listState.scrollToItem(itemIndex)
         val info = listState.layoutInfo
-        val item = info.visibleItemsInfo.firstOrNull { it.index == target }
+        val item = info.visibleItemsInfo.firstOrNull { it.index == itemIndex }
             ?: return@LaunchedEffect
         val viewportCenter = (info.viewportStartOffset + info.viewportEndOffset) / 2f
         val itemCenter = item.offset + item.size / 2f
@@ -145,6 +217,7 @@ internal fun TvDetailEpisodeRail(
     LazyRow(
         modifier = modifier
             .fillMaxWidth()
+            .then(if (usesSeriesGeometry) Modifier.height(tvSeriesEpisodeRailHeight()) else Modifier)
             .then(
                 if (onDirectionUp != null) {
                     Modifier.onPreviewKeyEvent { event ->
@@ -158,6 +231,7 @@ internal fun TvDetailEpisodeRail(
                     Modifier
                 },
             )
+            .onFocusChanged { if (!it.hasFocus) onCarouselFocusLost() }
             .focusGroup()
             .then(
                 if (entryIndex != null) {
@@ -173,8 +247,13 @@ internal fun TvDetailEpisodeRail(
             // fixed primary viewport beneath the selector and season controls.
             vertical = if (usesSeriesGeometry) 6.dp else 16.dp,
         ),
-        horizontalArrangement = Arrangement.spacedBy(if (usesSeriesGeometry) 16.dp else 18.dp),
+        horizontalArrangement = Arrangement.spacedBy(if (usesSeriesGeometry) 20.dp else 18.dp),
     ) {
+        if (hasPreviousEpisodes) {
+            item(key = "previous-season-loading", contentType = "episode-loading") {
+                TvEpisodeBoundaryPlaceholder(carouselLoadError)
+            }
+        }
         itemsIndexed(
             episodes,
             key = { _, episode -> episode.contentId },
@@ -192,11 +271,37 @@ internal fun TvDetailEpisodeRail(
                 hidesEpisodeTitle = hidesEpisodeTitle,
                 usesSeriesGeometry = usesSeriesGeometry,
                 modifier = Modifier
-                    .tvRailPinOnFocus(listState, index, TvDetailHorizontalInset)
+                    .tvRailPinOnFocus(
+                        listState,
+                        index + if (hasPreviousEpisodes) 1 else 0,
+                        TvDetailHorizontalInset,
+                    )
+                    .onPreviewKeyEvent { event ->
+                        val direction = when (event.key) {
+                            Key.DirectionLeft -> -1
+                            Key.DirectionRight -> 1
+                            else -> 0
+                        }
+                        if (direction == 0 || event.type != KeyEventType.KeyDown) {
+                            false
+                        } else if (usesSeriesGeometry && (
+                            (direction == -1 && index == 0) ||
+                                (direction == 1 && index == episodes.lastIndex)
+                        )) {
+                            if ((direction < 0 && hasPreviousEpisodes) || (direction > 0 && hasNextEpisodes)) {
+                                onCarouselEdgeRequested(episode.contentId, direction)
+                            }
+                            // At the real series ends, horizontal input stays in this rail.
+                            true
+                        } else false
+                    }
                     .onFocusChanged { focusState ->
                         if (focusState.isFocused) {
+                            observedFocusedContentId = episode.contentId
                             rememberedFocusedContentId = episode.contentId
                             onEpisodeFocused?.invoke(episode)
+                        } else if (observedFocusedContentId == episode.contentId) {
+                            observedFocusedContentId = null
                         }
                     }
                     .then(
@@ -208,7 +313,32 @@ internal fun TvDetailEpisodeRail(
                     ),
             )
         }
+        if (hasNextEpisodes) {
+            item(key = "next-season-loading", contentType = "episode-loading") {
+                TvEpisodeBoundaryPlaceholder(carouselLoadError)
+            }
+        }
     }
+    }
+}
+
+@Composable
+private fun TvEpisodeBoundaryPlaceholder(failed: Boolean) {
+    Column(
+        modifier = Modifier.width(tvEpisodeCardWidth()),
+        verticalArrangement = Arrangement.spacedBy(7.dp),
+    ) {
+        Box(
+            Modifier.fillMaxWidth().height(tvEpisodeCardWidth() * (9f / 16f))
+                .background(DarkSurfaceElevated, RoundedCornerShape(8.dp)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = if (failed) "Press again to retry" else "Loading episodes…",
+                fontSize = 14.sp,
+                color = SiloSecondaryText,
+            )
+        }
     }
 }
 
@@ -371,7 +501,7 @@ private fun TvDetailEpisodeCard(
                     horizontalArrangement = Arrangement.spacedBy(5.dp),
                 ) {
                     Text(
-                        text = "EPISODE ${episode.episodeNumber}",
+                        text = if (usesSeriesGeometry) "S${episode.seasonNumber} · E${episode.episodeNumber}" else "EPISODE ${episode.episodeNumber}",
                         fontSize = eyebrowFontSize,
                         lineHeight = eyebrowLineHeight,
                         fontWeight = FontWeight.Bold,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt
@@ -14,11 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -32,9 +29,7 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -75,8 +70,8 @@ internal sealed class TvHeroFactToken {
  * the crisp top-trailing artwork and its alpha masks, so the image naturally
  * scrolls away with the hero instead of behaving like a fixed backdrop.
  *
- * The editorial and action stack is top-leading (50dp / 44dp = tvOS
- * 100pt / 88pt), while the artwork occupies the trailing 64 percent and
+ * The editorial and action stack is top-leading (50dp / 58dp = tvOS
+ * 100pt / 116pt), while the artwork occupies the trailing 64 percent and
  * dissolves into the page surface at its leading and lower edges. The action
  * cluster remains full-width and focus-grouped; Version and Subtitles live in
  * that same row as circular actions.
@@ -97,7 +92,7 @@ internal fun TvDetailHero(
     actions: @Composable () -> Unit,
     playbackSummary: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
-    /** Compact 580pt Series header while the standard 690pt artwork fade continues behind its mode row. */
+    /** Series reserves its editorial and disclosure slots as episodes change. */
     compactSeries: Boolean = false,
     // Optional description-translation affordance (Apple tvOS parity),
     // rendered as its own focus stop directly under the synopsis.
@@ -106,15 +101,7 @@ internal fun TvDetailHero(
     // tvOS 690pt on a 1080pt canvas. Android TV's 1920×1080 emulator reports
     // a 960×540dp layout canvas, so the same fraction produces 345dp.
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
-    val backdropHeight = screenHeight * HERO_HEIGHT_FRACTION
-    val heroHeight = if (compactSeries) {
-        screenHeight * SERIES_HERO_HEIGHT_FRACTION
-    } else {
-        backdropHeight
-    }
-    val heroTopInset = if (compactSeries) SERIES_HERO_TOP_INSET else HERO_TOP_INSET
-    val density = LocalDensity.current
-    var seriesOverviewEditorialHeightPx by remember { mutableIntStateOf(0) }
+    val heroHeight = screenHeight * HERO_HEIGHT_FRACTION
 
     BoxWithConstraints(
         modifier = modifier
@@ -123,7 +110,7 @@ internal fun TvDetailHero(
             .then(if (compactSeries) Modifier else Modifier.clipToBounds()),
     ) {
         val artworkWidth = maxWidth * ARTWORK_WIDTH_FRACTION
-        val artworkHeight = minOf(backdropHeight * ARTWORK_HEIGHT_FRACTION, artworkWidth * 9f / 16f)
+        val artworkHeight = maxWidth * 9f / 16f * ARTWORK_HEIGHT_FRACTION
 
         // Crisp artwork in the top-right. DstIn multiplies the horizontal and
         // vertical alpha ramps without painting black over the sampled page.
@@ -146,7 +133,7 @@ internal fun TvDetailHero(
                         drawRect(
                             brush = Brush.horizontalGradient(
                                 0.00f to Color.Transparent,
-                                0.54f to Color.Black,
+                                0.68f to Color.Black,
                                 1.00f to Color.Black,
                             ),
                             blendMode = BlendMode.DstIn,
@@ -154,8 +141,11 @@ internal fun TvDetailHero(
                         drawRect(
                             brush = Brush.verticalGradient(
                                 0.00f to Color.Black,
-                                0.70f to Color.Black,
-                                1.00f to Color.Transparent,
+                                0.38f to Color.Black,
+                                0.52f to Color.Black.copy(alpha = 0.88f),
+                                0.68f to Color.Black.copy(alpha = 0.58f),
+                                0.81f to Color.Black.copy(alpha = 0.24f),
+                                0.90f to Color.Transparent,
                             ),
                             size = Size(size.width, size.height),
                             blendMode = BlendMode.DstIn,
@@ -167,52 +157,27 @@ internal fun TvDetailHero(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = heroTopInset, start = TvDetailHorizontalInset, end = TvDetailHorizontalInset),
+                .padding(top = HERO_TOP_INSET, start = TvDetailHorizontalInset, end = TvDetailHorizontalInset),
             horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.spacedBy(HERO_CONTENT_SPACING),
+            verticalArrangement = Arrangement.spacedBy(if (compactSeries) 2.dp else HERO_CONTENT_SPACING),
         ) {
-            Box(
-                modifier = Modifier
-                    .then(
-                        if (compactSeries && seriesOverviewEditorialHeightPx > 0) {
-                            Modifier.height(with(density) { seriesOverviewEditorialHeightPx.toDp() })
-                        } else {
-                            Modifier
-                        },
-                    )
-                    .then(if (compactSeries) Modifier.clipToBounds() else Modifier)
-                    .onSizeChanged { size ->
-                        // The Show overview is the approved reference shown in
-                        // the design. Capture it once, then give every focused
-                        // episode that exact editorial footprint so changing
-                        // title/overview text cannot move the action row.
-                        if (
-                            compactSeries &&
-                            seriesTitle == null &&
-                            seriesOverviewEditorialHeightPx == 0
-                        ) {
-                            seriesOverviewEditorialHeightPx = size.height
-                        }
-                    },
-            ) {
-                EditorialColumn(
-                    title = title,
-                    seriesTitle = seriesTitle,
-                    logoUrl = logoUrl,
-                    sourceTokens = sourceTokens,
-                    ratingChip = ratingChip,
-                    overview = overview,
-                    tagline = tagline,
-                    factsLine = factsLine,
-                    directorText = directorText,
-                    contentMaxWidth = HERO_CONTENT_MAX_WIDTH,
-                    verticalSpacing = EDITORIAL_SPACING,
-                    collapsedSynopsisLines = 2,
-                    compactSeries = compactSeries,
-                    translation = translation,
-                    playbackSummary = playbackSummary,
-                )
-            }
+            EditorialColumn(
+                title = title,
+                seriesTitle = seriesTitle,
+                logoUrl = logoUrl,
+                sourceTokens = sourceTokens,
+                ratingChip = ratingChip,
+                overview = overview,
+                tagline = tagline,
+                factsLine = factsLine,
+                directorText = directorText,
+                contentMaxWidth = HERO_CONTENT_MAX_WIDTH,
+                verticalSpacing = EDITORIAL_SPACING,
+                collapsedSynopsisLines = 3,
+                compactSeries = compactSeries,
+                translation = translation,
+                playbackSummary = playbackSummary,
+            )
 
             Box(
                 modifier = Modifier
@@ -247,132 +212,106 @@ private fun EditorialColumn(
 ) {
     val isCombinedSeriesEpisode = compactSeries && !seriesTitle.isNullOrBlank()
     Column(
-        modifier = Modifier.widthIn(max = contentMaxWidth),
+        modifier = Modifier.widthIn(max = contentMaxWidth)
+            // tvOS reserves 435pt for Series editorial content and its disclosure block.
+            .then(if (compactSeries) Modifier.height(217.5.dp) else Modifier),
         horizontalAlignment = Alignment.Start,
-        verticalArrangement = Arrangement.spacedBy(verticalSpacing),
+        verticalArrangement = Arrangement.spacedBy(if (compactSeries) 2.dp else verticalSpacing),
     ) {
-        TitleBlock(
-            // A focused episode must not shrink or move the Show identity.
-            // Its name belongs to the bounded synopsis slot below instead.
-            title = if (isCombinedSeriesEpisode) seriesTitle!! else title,
-            seriesTitle = seriesTitle.takeUnless { isCombinedSeriesEpisode },
-            logoUrl = logoUrl,
-        )
+        Column(
+            modifier = if (compactSeries) Modifier.weight(1f).clipToBounds() else Modifier,
+            verticalArrangement = Arrangement.spacedBy(verticalSpacing),
+        ) {
+            TitleBlock(
+                // A focused episode must not shrink or move the Show identity.
+                // Its name belongs to the bounded synopsis slot below instead.
+                title = if (isCombinedSeriesEpisode) seriesTitle!! else title,
+                seriesTitle = seriesTitle.takeUnless { isCombinedSeriesEpisode },
+                logoUrl = logoUrl,
+            )
 
-        // Movies keep their separate editorial identity line. The combined
-        // Series page follows tvOS's single metadata line instead: episode date
-        // and runtime, then Season / Episode context, then the rating chip.
-        if (!compactSeries && sourceTokens.isNotEmpty()) SourceRow(tokens = sourceTokens)
-        val hasMetadata = factsLine.isNotEmpty() ||
-            !ratingChip.isNullOrBlank() ||
-            (compactSeries && sourceTokens.isNotEmpty())
-        if (compactSeries) {
-            // Episode focus may swap a full Show facts row for a shorter date /
-            // runtime row. Keep the approved facts baseline and the margin
-            // below it fixed so the synopsis and action row cannot follow the
-            // newly measured text up or down.
-            Box(
-                modifier = Modifier
-                    .height(SERIES_METADATA_SLOT_HEIGHT)
-                    .clipToBounds(),
-                contentAlignment = Alignment.CenterStart,
-            ) {
-                if (hasMetadata) {
-                    MetadataRow(
-                        tokens = factsLine,
-                        sourceTokens = sourceTokens,
-                        ratingChip = ratingChip,
-                        compactRating = true,
-                    )
+            val hasEpisodeHierarchy = !compactSeries && !seriesTitle.isNullOrBlank()
+            if (hasEpisodeHierarchy && sourceTokens.isNotEmpty()) SourceRow(tokens = sourceTokens)
+            val metadataSourceTokens = sourceTokens.takeUnless { hasEpisodeHierarchy }.orEmpty()
+            val hasMetadata = factsLine.isNotEmpty() || !ratingChip.isNullOrBlank() || metadataSourceTokens.isNotEmpty()
+            if (compactSeries || hasMetadata) {
+                Box(
+                    modifier = Modifier.height(SERIES_METADATA_SLOT_HEIGHT).clipToBounds(),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    if (hasMetadata) {
+                        MetadataRow(
+                            tokens = factsLine,
+                            sourceTokens = metadataSourceTokens,
+                            ratingChip = ratingChip,
+                            compactRating = true,
+                        )
+                    }
                 }
             }
-        } else if (hasMetadata) {
-            // Keep the standard hero's established metadata footprint while
-            // giving movie ratings the same compact tvOS badge used by Series.
-            Box(
-                modifier = Modifier
-                    .height(SERIES_METADATA_SLOT_HEIGHT)
-                    .clipToBounds(),
-                contentAlignment = Alignment.CenterStart,
-            ) {
-                MetadataRow(
-                    tokens = factsLine,
-                    sourceTokens = emptyList(),
-                    ratingChip = ratingChip,
-                    compactRating = true,
-                )
-            }
-        }
 
-        // Synopsis slot — the hero's only text focus stop. A focusable leaf
-        // that clamps the overview to the current height budget and, on
-        // OK/Select, expands with the tagline revealed above it.
-        if (compactSeries) {
-            // Reserve the exact two-line Show synopsis footprint even when an
-            // episode has no description yet. This also covers direct entry
-            // from Continue Watching, where the Show overview was never
-            // composed first and therefore cannot be used as a measured lock.
-            Box(
-                modifier = Modifier
-                    .height(SERIES_EPISODE_SYNOPSIS_HEIGHT)
-                    .clipToBounds(),
-            ) {
+            // The synopsis opens its full text without resizing the hero.
+            if (compactSeries) {
+                // Reserve three lines even when the focused episode has no synopsis.
+                Box(
+                    modifier = Modifier
+                        .height(SERIES_EPISODE_SYNOPSIS_HEIGHT)
+                        .clipToBounds(),
+                ) {
+                    overview?.takeIf { it.isNotBlank() }?.let { line ->
+                        TvExpandableSynopsis(
+                            overview = line,
+                            tagline = tagline.takeUnless { isCombinedSeriesEpisode },
+                            collapsedMaxLines = 3,
+                            dialogTitle = title,
+                            previewText = if (isCombinedSeriesEpisode) "$title · $line" else line,
+                        )
+                    }
+                }
+            } else {
                 overview?.takeIf { it.isNotBlank() }?.let { line ->
                     TvExpandableSynopsis(
                         overview = line,
-                        tagline = tagline.takeUnless { isCombinedSeriesEpisode },
-                        collapsedMaxLines = 2,
+                        tagline = tagline,
+                        collapsedMaxLines = collapsedSynopsisLines,
                         dialogTitle = title,
-                        previewText = if (isCombinedSeriesEpisode) "$title · $line" else line,
                     )
                 }
             }
-        } else {
-            overview?.takeIf { it.isNotBlank() }?.let { line ->
-                TvExpandableSynopsis(
-                    overview = line,
-                    tagline = tagline,
-                    collapsedMaxLines = collapsedSynopsisLines,
-                    dialogTitle = title,
-                )
-            }
+            translation?.invoke()
         }
-        translation?.invoke()
-
-        if (compactSeries) {
-            // Keep this slot mounted even while episode data changes so the
-            // playback readout and action row remain completely locked.
-            Box(
-                modifier = Modifier
-                    .height(SERIES_CREDIT_SLOT_HEIGHT)
-                    .clipToBounds(),
-                contentAlignment = Alignment.CenterStart,
-            ) {
+        // Bottom-lock the credit and playback readout independently of synopsis length.
+        Column(verticalArrangement = Arrangement.spacedBy(if (compactSeries) 4.dp else verticalSpacing)) {
+            if (compactSeries) {
+                // Keep this slot mounted even while episode data changes so the
+                // playback readout and action row remain completely locked.
+                Box(
+                    modifier = Modifier
+                        .height(SERIES_CREDIT_SLOT_HEIGHT)
+                        .clipToBounds(),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    directorText?.takeIf { it.isNotBlank() }?.let { line ->
+                        HeroCreditLine(line)
+                    }
+                }
+            } else {
                 directorText?.takeIf { it.isNotBlank() }?.let { line ->
                     HeroCreditLine(line)
                 }
             }
-        } else {
-            directorText?.takeIf { it.isNotBlank() }?.let { line ->
-                HeroCreditLine(line)
-            }
+            playbackSummary?.invoke()
         }
-        // Both movie and Series heroes now share the same footer hierarchy:
-        // synopsis, credit, then Version / Audio / Subtitles directly above
-        // the action row. Reordering these existing children does not change
-        // the standard hero's total measured height.
-        playbackSummary?.invoke()
     }
 }
 
 @Composable
 private fun HeroCreditLine(line: String) {
-    // 14sp = the ten-foot metadata floor; the quieter alpha lets a Starring or
-    // Directed-by line read as supporting credit rather than another synopsis.
     Text(
         text = line,
         fontWeight = FontWeight.Medium,
-        fontSize = 14.sp,
+        fontSize = 12.sp,
+        lineHeight = 14.sp,
         color = Color.White.copy(alpha = 0.62f),
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
@@ -525,6 +464,9 @@ private fun MetadataRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(7.dp),
     ) {
+        ratingChip?.takeIf { it.isNotBlank() }?.let { rating ->
+            RatingChip(text = rating, compact = compactRating)
+        }
         tokens.forEachIndexed { index, token ->
             if (index > 0) MetadataDivider()
             when (token) {
@@ -574,10 +516,7 @@ private fun MetadataRow(
                 maxLines = 1,
             )
         }
-        ratingChip?.takeIf { it.isNotBlank() }?.let { rating ->
-            if (tokens.isNotEmpty() || sourceTokens.isNotEmpty()) MetadataDivider()
-            RatingChip(text = rating, compact = compactRating)
-        }
+
     }
 }
 
@@ -639,21 +578,15 @@ private fun splitDisplayTitle(raw: String): Pair<String, String?> {
 
 /** Approved tvOS detail geometry mapped onto Android TV's half-scale canvas. */
 private const val HERO_HEIGHT_FRACTION = 690f / 1080f
-// The full Series hierarchy (single metadata row, synopsis, fixed Starring and
-// playback readout, then 72pt controls) needs 610pt. This remains compact next
-// to the 690pt movie artwork while keeping the body from painting over the
-// controls or their focus treatment.
-private const val SERIES_HERO_HEIGHT_FRACTION = 610f / 1080f
 private const val ARTWORK_WIDTH_FRACTION = 0.64f
-private const val ARTWORK_HEIGHT_FRACTION = 0.94f
-private val HERO_TOP_INSET = 44.dp
-private val SERIES_HERO_TOP_INSET = 23.dp
+private const val ARTWORK_HEIGHT_FRACTION = 0.70f
+private val HERO_TOP_INSET = 58.dp
 private val HERO_CONTENT_MAX_WIDTH = 540.dp
 private val HERO_CONTENT_SPACING = 9.dp
 private val EDITORIAL_SPACING = 7.dp
-private val SERIES_METADATA_SLOT_HEIGHT = 24.dp
-private val SERIES_EPISODE_SYNOPSIS_HEIGHT = 52.dp
-private val SERIES_CREDIT_SLOT_HEIGHT = 18.dp
+private val SERIES_METADATA_SLOT_HEIGHT = 18.dp
+private val SERIES_EPISODE_SYNOPSIS_HEIGHT = 56.dp
+private val SERIES_CREDIT_SLOT_HEIGHT = 14.dp
 
 /**
  * Condensed family for the hero display title. tvOS renders the title in SF

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt
@@ -175,7 +175,7 @@ internal fun TvDetailHero(
                 verticalSpacing = EDITORIAL_SPACING,
                 collapsedSynopsisLines = 3,
                 compactSeries = compactSeries,
-                translation = translation,
+                translation = translation.takeUnless { compactSeries },
                 playbackSummary = playbackSummary,
             )
 
@@ -186,7 +186,14 @@ internal fun TvDetailHero(
                     .focusGroup(),
                 contentAlignment = Alignment.CenterStart,
             ) {
-                actions()
+                if (compactSeries && translation != null) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(Modifier.weight(1f)) { actions() }
+                        translation()
+                    }
+                } else {
+                    actions()
+                }
             }
         }
     }
@@ -474,6 +481,7 @@ private fun MetadataRow(
                     text = token.value,
                     fontWeight = FontWeight.Medium,
                     fontSize = 14.sp,
+                    lineHeight = 16.sp,
                     color = Color.White.copy(alpha = 0.88f),
                     maxLines = 1,
                 )
@@ -491,6 +499,7 @@ private fun MetadataRow(
                         text = token.value,
                         fontWeight = FontWeight.Medium,
                         fontSize = 14.sp,
+                        lineHeight = 16.sp,
                         color = Color.White.copy(alpha = 0.88f),
                         maxLines = 1,
                     )
@@ -499,6 +508,7 @@ private fun MetadataRow(
                     text = homeStyleFormatLabel(token.value),
                     fontWeight = FontWeight.Medium,
                     fontSize = 14.sp,
+                    lineHeight = 16.sp,
                     fontFamily = FontFamily.Monospace,
                     letterSpacing = 0.52.sp,
                     color = Color.White.copy(alpha = 0.55f),
@@ -512,6 +522,7 @@ private fun MetadataRow(
                 text = token,
                 fontWeight = FontWeight.Medium,
                 fontSize = 14.sp,
+                lineHeight = 16.sp,
                 color = Color.White.copy(alpha = 0.90f),
                 maxLines = 1,
             )
@@ -526,6 +537,7 @@ private fun MetadataDivider() {
         text = "·",
         fontWeight = FontWeight.SemiBold,
         fontSize = 14.sp,
+        lineHeight = 16.sp,
         color = Color.White.copy(alpha = 0.45f),
     )
 }
@@ -550,6 +562,7 @@ private fun RatingChip(text: String, compact: Boolean) {
             text = text,
             fontWeight = FontWeight.Black,
             fontSize = if (compact) 10.5.sp else 14.sp,
+            lineHeight = if (compact) 12.sp else 16.sp,
             letterSpacing = if (compact) 0.35.sp else 0.5.sp,
             color = Color.White,
             maxLines = 1,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvEpisodeWindow.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvEpisodeWindow.kt
@@ -1,0 +1,57 @@
+package org.siloserver.silo.tv.ui.screens.detail
+
+import org.siloserver.silo.model.catalog.EpisodeListItem
+import org.siloserver.silo.model.catalog.Season
+import org.siloserver.silo.model.catalog.isSpecialsForDisplay
+
+/** A bounded cache; missing seasons never silently join two nonadjacent episode runs. */
+internal class TvEpisodeWindow {
+    private val pages = mutableMapOf<Int, List<EpisodeListItem>>()
+
+    fun get(season: Int): List<EpisodeListItem>? = pages[season]
+
+    fun put(season: Int, episodes: List<EpisodeListItem>) {
+        pages[season] = episodes.sortedBy { it.episodeNumber }
+    }
+
+    fun orderedSeasons(seasons: List<Season>): List<Int> =
+        seasons.sortedWith(compareBy<Season> { it.isSpecialsForDisplay() }.thenBy { it.seasonNumber })
+            .map { it.seasonNumber }.distinct()
+
+    fun retainNear(seasons: List<Season>, selected: Int) {
+        val order = orderedSeasons(seasons)
+        val index = order.indexOf(selected)
+        if (index < 0) return
+        val keep = pages.keys.filter { pages[it].orEmpty().isNotEmpty() }
+            .sortedBy { kotlin.math.abs(order.indexOf(it) - index) }.take(5).toSet()
+        pages.keys.removeAll { pages[it].orEmpty().isNotEmpty() && it !in keep }
+    }
+
+    fun snapshot(seasons: List<Season>, selected: Int): EpisodeWindowSnapshot {
+        val order = orderedSeasons(seasons)
+        val index = order.indexOf(selected)
+        if (index < 0 || selected !in pages) return EpisodeWindowSnapshot()
+        var first = index
+        var last = index
+        while (first > 0 && order[first - 1] in pages) first--
+        while (last < order.lastIndex && order[last + 1] in pages) last++
+        return EpisodeWindowSnapshot(
+            episodes = order.subList(first, last + 1).flatMap { pages.getValue(it) }
+                .distinctBy { it.contentId },
+            previousSeason = order.getOrNull(first - 1),
+            nextSeason = order.getOrNull(last + 1),
+        )
+    }
+}
+
+internal data class EpisodeWindowSnapshot(
+    val episodes: List<EpisodeListItem> = emptyList(),
+    val previousSeason: Int? = null,
+    val nextSeason: Int? = null,
+)
+
+data class TvEpisodeCarouselJump(
+    val contentId: String,
+    val revision: Int,
+    val requestFocus: Boolean = false,
+)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvExpandableSynopsis.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvExpandableSynopsis.kt
@@ -107,20 +107,16 @@ internal fun TvExpandableSynopsis(
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
-            ) { showFullSynopsis = true }
-            // Keep the synopsis text on the same leading edge as the title,
-            // episode hierarchy, and metadata rows. The old 10dp horizontal
-            // inset made the description visibly drift right.
-            .padding(vertical = 7.dp),
+            ) { showFullSynopsis = true },
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.Top,
     ) {
-        // tvOS: 26pt regular → 13sp, +2 per design review (2026-07-11).
+        // Match tvOS's three-line synopsis inside the reserved hero slot.
         Text(
             text = previewText,
             fontWeight = FontWeight.Normal,
-            fontSize = 15.sp,
-            lineHeight = 19.sp,
+            fontSize = 13.sp,
+            lineHeight = 17.5.sp,
             color = Color.White.copy(alpha = 0.82f),
             textAlign = TextAlign.Start,
             maxLines = collapsedMaxLines,

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -4,11 +4,6 @@ import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.SizeTransform
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
@@ -50,6 +45,7 @@ import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -80,6 +76,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -560,16 +557,15 @@ private fun TvDetailContent(
     val isEpisodicType = detail.type in setOf("series", "season", "episode")
     val showsEpisodeRail = isEpisodicType && state.episodes.isNotEmpty()
     val showsSeasonChips = isEpisodicType && if (isSeriesDetail) {
-        state.seasons.isNotEmpty()
+        true
     } else {
         state.seasons.size > 1
     }
     // Keep the whole Episodes section — and, crucially, the season chips —
     // mounted whenever the series has seasons, so selecting an empty or failed
     // season can't unmount the chips and strand the user (T15). The rail itself
-    // still renders only when there are episodes; otherwise the section shows a
-    // loading spinner or a "No episodes available" empty state.
-    val showsEpisodesSection = isEpisodicType && (state.seasons.isNotEmpty() || state.episodes.isNotEmpty())
+    // reserves its footprint from the first Series frame, before seasons arrive.
+    val showsEpisodesSection = isEpisodicType && (isSeriesDetail || state.seasons.isNotEmpty() || state.episodes.isNotEmpty())
     // Whether a focusable episode-navigation element (the rail or the season
     // chips) sits above the cast / similar rails — drives their
     // Up-return-to-hero fallback.
@@ -1045,6 +1041,8 @@ private fun TvDetailContent(
                                         viewModel.onSeriesEpisodeActivated(episode.contentId)
                                     }
                                 },
+                                onCarouselEdgeRequested = viewModel::onCarouselEdgeRequested,
+                                onCarouselFocusLost = viewModel::onCarouselFocusLost,
                                 onSetEpisodeWatched = viewModel::onSetEpisodeWatched,
                                 onSetEpisodeFavorite = viewModel::onSetEpisodeFavorite,
                             )
@@ -1346,24 +1344,38 @@ private fun TvDetailPlaybackSelectionSummary(
         ).replace("Auto - ", "Auto · ")
     }
 
+    // Retain presentation only while the next episode resolves. Playback and
+    // selector actions continue to use the live, identity-checked state.
+    val resolvedValues = Triple(versionValue, audioValue, subtitleValue)
+    var previousValues by remember(detail.contentId) {
+        mutableStateOf<Triple<String?, String?, String?>?>(null)
+    }
+    val transitioning = usesNextUp && (
+        state.isLoadingNextUpPlaybackDetail || state.episodesLoading || state.seasonsLoading
+    )
+    val displayedValues = if (transitioning) previousValues ?: resolvedValues else resolvedValues
+    SideEffect {
+        if (!transitioning) previousValues = resolvedValues
+    }
+
     Row(
         modifier = Modifier.height(TV_PLAYBACK_SUMMARY_HEIGHT),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         TvPlaybackSummaryItem(
             label = "VERSION",
-            value = versionValue,
+            value = displayedValues.first,
             itemWidth = TV_PLAYBACK_VERSION_ITEM_WIDTH,
         )
         TvPlaybackSummaryItem(
             label = "AUDIO",
-            value = audioValue,
+            value = displayedValues.second,
             itemWidth = TV_PLAYBACK_AUDIO_ITEM_WIDTH,
         )
         TvPlaybackSummaryItem(
             label = "SUBTITLES",
-            value = subtitleValue,
+            value = displayedValues.third,
             itemWidth = TV_PLAYBACK_SUBTITLE_ITEM_WIDTH,
         )
     }
@@ -1375,18 +1387,34 @@ private fun TvPlaybackSummaryItem(
     value: String?,
     itemWidth: androidx.compose.ui.unit.Dp,
 ) {
-    // Items size to their text instead of a fixed width so long audio or
-    // subtitle labels are never cut off. The skeleton keeps a fixed width so
-    // the loading row stays stable until the values arrive.
+    val valueStyle = MaterialTheme.typography.bodyMedium.copy(
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.5.sp,
+        lineHeight = 14.sp,
+        color = Color.White.copy(alpha = 0.82f),
+    )
+    val textMeasurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+    val valueScale = remember(value, label, itemWidth, valueStyle, textMeasurer, density) {
+        val labelWidth = textMeasurer.measure(
+            label,
+            valueStyle.copy(fontWeight = FontWeight.Bold, letterSpacing = 0.5.sp),
+        ).size.width
+        val valueWidth = textMeasurer.measure(value.orEmpty(), valueStyle).size.width
+        val availableWidth = with(density) { (itemWidth - 4.dp).toPx() } - labelWidth
+        (availableWidth / valueWidth.coerceAtLeast(1)).coerceIn(0.75f, 1f)
+    }
+    // Stable columns keep Audio and Subtitles aligned while episode data loads.
     Row(
-        modifier = if (value == null) Modifier.width(itemWidth) else Modifier,
+        modifier = Modifier.width(itemWidth),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Text(
             text = label,
             fontWeight = FontWeight.Bold,
-            fontSize = 11.sp,
+            fontSize = 11.5.sp,
+            lineHeight = 14.sp,
             letterSpacing = 0.5.sp,
             color = Color.White.copy(alpha = 0.48f),
             maxLines = 1,
@@ -1396,9 +1424,9 @@ private fun TvPlaybackSummaryItem(
         } else {
             Text(
                 text = value,
-                fontWeight = FontWeight.Medium,
-                fontSize = 11.5.sp,
-                color = Color.White.copy(alpha = 0.82f),
+                modifier = Modifier.weight(1f),
+                style = valueStyle.copy(fontSize = valueStyle.fontSize * valueScale),
+                overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
             )
         }
@@ -1417,10 +1445,10 @@ private fun TvPlaybackSummarySkeleton(modifier: Modifier = Modifier) {
     )
 }
 
-private val TV_PLAYBACK_SUMMARY_HEIGHT = 20.dp
-private val TV_PLAYBACK_VERSION_ITEM_WIDTH = 120.dp
-private val TV_PLAYBACK_AUDIO_ITEM_WIDTH = 160.dp
-private val TV_PLAYBACK_SUBTITLE_ITEM_WIDTH = 130.dp
+private val TV_PLAYBACK_SUMMARY_HEIGHT = 22.dp
+private val TV_PLAYBACK_VERSION_ITEM_WIDTH = 156.5.dp
+private val TV_PLAYBACK_AUDIO_ITEM_WIDTH = 182.dp
+private val TV_PLAYBACK_SUBTITLE_ITEM_WIDTH = 169.dp
 
 internal fun seriesStarringCredit(detail: ItemDetail): String? {
     val names = detail.cast
@@ -1581,8 +1609,7 @@ private fun HeroActionRow(
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         // Action row — approved tvOS `HStack(spacing: 18)` mapped through the
         // half-scale dp port as the button internals. Version and Subtitles use
-        // the same circular chrome as the utility actions, so this cluster never
-        // changes shape while focus moves across it.
+        // circular chrome at rest and widen to reveal their labels on focus.
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -1600,6 +1627,7 @@ private fun HeroActionRow(
                 horizontalArrangement = Arrangement.spacedBy(9.dp),
             ) {
                 TvPrimaryPillButton(
+                    stableHero = true,
                     icon = Icons.Filled.PlayArrow,
                     title = playButtonLabel(
                         isSeriesOrSeason = isSeriesOrSeason,
@@ -1627,6 +1655,32 @@ private fun HeroActionRow(
                     modifier = if (detail.type == "series") Modifier.width(170.dp) else Modifier,
                     focusRequester = playFocus,
                 )
+
+
+                if (hasResume) {
+                    // tvOS Start Over uses `backward.end.fill` (skip-to-start),
+                    // not a replay arrow. It is an icon-only circular companion
+                    // to the primary Play/Resume pill.
+                    TvSquareToggleButton(
+                        icon = Icons.Filled.SkipPrevious,
+                        iconActive = Icons.Filled.SkipPrevious,
+                        contentDescription = "Start Over",
+                        titleOnFocus = "Start Over",
+                        isActive = false,
+                        onClick = {
+                            if (playReady && !playLaunchPending) {
+                                playLaunchPending = true
+                                onPlay(
+                                    playContentId, playFileId,
+                                    selectorAudioIndex ?: automaticAudioTrackOrdinal,
+                                    selectorAudioPicked,
+                                    subtitleLaunchSelection,
+                                    playType, 0.0,
+                                )
+                            }
+                        },
+                    )
+                }
 
                 TvPlaybackActionSelectors(
                     versions = selectorVersions,
@@ -1657,30 +1711,6 @@ private fun HeroActionRow(
                     versionFocusRequester = selectorFocus,
                 )
 
-                if (hasResume) {
-                    // tvOS Start Over uses `backward.end.fill` (skip-to-start),
-                    // not a replay arrow. It is an icon-only circular companion
-                    // to the primary Play/Resume pill.
-                    TvSquareToggleButton(
-                        icon = Icons.Filled.SkipPrevious,
-                        iconActive = Icons.Filled.SkipPrevious,
-                        contentDescription = "Start Over",
-                        isActive = false,
-                        onClick = {
-                            if (playReady && !playLaunchPending) {
-                                playLaunchPending = true
-                                onPlay(
-                                    playContentId, playFileId,
-                                    selectorAudioIndex ?: automaticAudioTrackOrdinal,
-                                    selectorAudioPicked,
-                                    subtitleLaunchSelection,
-                                    playType, 0.0,
-                                )
-                            }
-                        },
-                    )
-                }
-
                 TvSquareToggleButton(
                     icon = Icons.Filled.BookmarkBorder,
                     iconActive = Icons.Filled.Bookmark,
@@ -1691,6 +1721,7 @@ private fun HeroActionRow(
                         "Add to watchlist"
                     },
                     onClick = viewModel::onToggleWatchlist,
+                    titleOnFocus = "Watchlist",
                 )
 
                 TvSquareToggleButton(
@@ -1698,6 +1729,7 @@ private fun HeroActionRow(
                     iconActive = Icons.Filled.MoreHoriz,
                     isActive = false,
                     contentDescription = "More options",
+                    titleOnFocus = "More",
                     onClick = { moreOpen = true },
                 )
             }
@@ -1938,29 +1970,6 @@ private fun watchedUnmarkLabel(detail: ItemDetail): String = when (detail.type) 
 }
 
 /** Tiny breathing room between the fixed hero controls and the series modes. */
-private val SeriesSeasonPickerTopPadding = 3.dp
-
-private data class SeriesEpisodeRailPage(
-    val seasonNumber: Int,
-    val episodes: List<EpisodeListItem>,
-)
-
-private const val SERIES_EPISODE_CAROUSEL_DURATION_MS = 360
-
-internal fun seriesEpisodeCarouselDirection(
-    fromSeasonNumber: Int,
-    toSeasonNumber: Int,
-    seasons: List<Season>,
-): Int {
-    if (fromSeasonNumber == toSeasonNumber) return 0
-    val fromIndex = seasons.indexOfFirst { it.seasonNumber == fromSeasonNumber }
-    val toIndex = seasons.indexOfFirst { it.seasonNumber == toSeasonNumber }
-    return if (fromIndex >= 0 && toIndex >= 0) {
-        if (toIndex > fromIndex) 1 else -1
-    } else {
-        if (toSeasonNumber > fromSeasonNumber) 1 else -1
-    }
-}
 
 @Composable
 private fun EpisodesSection(
@@ -1975,10 +1984,13 @@ private fun EpisodesSection(
     onSeasonSelected: (org.siloserver.silo.model.catalog.Season) -> Unit,
     onEpisodeSelected: (EpisodeListItem) -> Unit,
     onEpisodeFocused: (EpisodeListItem) -> Unit = {},
+    onCarouselEdgeRequested: (String, Int) -> Unit,
+    onCarouselFocusLost: () -> Unit,
     onSetEpisodeWatched: (contentId: String, watched: Boolean) -> Unit,
     onSetEpisodeFavorite: (contentId: String, favorite: Boolean) -> Unit,
 ) {
     val isSeries = detail.type == "series"
+    val railEpisodes = if (isSeries) state.carouselEpisodes.ifEmpty { state.episodes } else state.episodes
     Column(verticalArrangement = Arrangement.spacedBy(if (isSeries) 7.dp else 20.dp)) {
         if (!isSeries) {
             Row(
@@ -2014,9 +2026,6 @@ private fun EpisodesSection(
                     selectedSeason = state.selectedSeason,
                     onShowSelected = onShowSelected,
                     onSeasonSelected = onSeasonSelected,
-                    // Keep the approved row geometry, adding only the small
-                    // requested breathing room below the compact hero.
-                    modifier = Modifier.padding(top = SeriesSeasonPickerTopPadding),
                     // Return to the circular Version control in the hero; if
                     // it is not attached yet, fall back to Play.
                     onDirectionUp = onReturnToSeriesSelector ?: onReturnToHero,
@@ -2037,20 +2046,19 @@ private fun EpisodesSection(
         // loads (and for empty seasons), so the spinner/empty states don't
         // collapse the section and flash Cast & Crew up into the viewport.
         var railHeightPx by remember { mutableStateOf(0) }
-        val railMinHeight = with(LocalDensity.current) { railHeightPx.toDp() }
+        val measuredRailHeight = with(LocalDensity.current) { railHeightPx.toDp() }
+        val railMinHeight = if (isSeries) maxOf(measuredRailHeight, tvSeriesEpisodeRailHeight()) else measuredRailHeight
         Box(
             modifier = Modifier
-                .heightIn(min = railMinHeight)
-                // Keep a small separation from Seasons while reclaiming the
-                // space previously occupied by the selector band.
-                .padding(top = if (isSeries && showsSeasonChips) 10.dp else 0.dp),
+                .heightIn(min = railMinHeight),
         ) {
             when {
-                // The first season still gets a loading indicator. Once a Series rail
-                // exists, retain it until the requested season is ready so the two
-                // complete rails can perform the directional carousel hand-off below.
-                // Non-Series detail routes retain their established spinner behavior.
-                state.episodesLoading && (!isSeries || state.episodes.isEmpty()) -> {
+                isSeries && railEpisodes.isEmpty() &&
+                    (state.isLoading || state.seasonsLoading || state.episodesLoading) -> {
+                    TvSeriesEpisodeRailSkeleton()
+                }
+                // Keep the loaded rail mounted during season jumps. Legacy routes use a spinner.
+                state.episodesLoading && (!isSeries || railEpisodes.isEmpty()) -> {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -2064,7 +2072,7 @@ private fun EpisodesSection(
                 // and left nothing to show): keep the section and chips mounted and
                 // say so, rather than unmounting everything and stranding the user
                 // (T15a).
-                state.episodes.isEmpty() -> {
+                railEpisodes.isEmpty() -> {
                     Text(
                         text = "No episodes available",
                         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Medium),
@@ -2091,52 +2099,17 @@ private fun EpisodesSection(
                             onDirectionUp = if (showsSeasonChips) null else onReturnToHero,
                             hidesEpisodeTitle = isSeries,
                             usesSeriesGeometry = isSeries,
+                            carouselJump = state.carouselJump.takeIf { isSeries },
+                            hasPreviousEpisodes = isSeries && state.carouselPreviousSeason != null,
+                            hasNextEpisodes = isSeries && state.carouselNextSeason != null,
+                            carouselLoadError = state.carouselLoadError,
+                            onCarouselEdgeRequested = onCarouselEdgeRequested,
+                            onCarouselFocusLost = onCarouselFocusLost,
                             modifier = Modifier.onSizeChanged { railHeightPx = it.height },
                         )
                     }
 
-                    if (isSeries) {
-                        // Retain the outgoing season while the next one loads,
-                        // then move both complete rails as one viewport-wide
-                        // carousel page. Card geometry and each rail's own
-                        // focus/scroll state remain entirely unchanged.
-                        val railPage = SeriesEpisodeRailPage(
-                            seasonNumber = state.episodes.first().seasonNumber,
-                            episodes = state.episodes,
-                        )
-                        AnimatedContent(
-                            targetState = railPage,
-                            contentKey = { it.seasonNumber },
-                            transitionSpec = {
-                                val direction = seriesEpisodeCarouselDirection(
-                                    fromSeasonNumber = initialState.seasonNumber,
-                                    toSeasonNumber = targetState.seasonNumber,
-                                    seasons = state.seasons,
-                                )
-                                (
-                                    slideInHorizontally(
-                                        animationSpec = tween(
-                                            durationMillis = SERIES_EPISODE_CAROUSEL_DURATION_MS,
-                                            easing = FastOutSlowInEasing,
-                                        ),
-                                        initialOffsetX = { width -> width * direction },
-                                    ) togetherWith slideOutHorizontally(
-                                        animationSpec = tween(
-                                            durationMillis = SERIES_EPISODE_CAROUSEL_DURATION_MS,
-                                            easing = FastOutSlowInEasing,
-                                        ),
-                                        targetOffsetX = { width -> -width * direction },
-                                    )
-                                ).using(SizeTransform(clip = false))
-                            },
-                            label = "seriesEpisodeCarousel",
-                            modifier = Modifier.fillMaxWidth(),
-                        ) { page ->
-                            renderEpisodeRail(page.episodes)
-                        }
-                    } else {
-                        renderEpisodeRail(state.episodes)
-                    }
+                    renderEpisodeRail(railEpisodes)
                 }
             }
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -379,30 +379,6 @@ class TvItemDetailViewModel(
     val translationPhase: StateFlow<org.siloserver.silo.metadata.DescriptionTranslationPhase> =
         descriptionTranslation.phase
 
-    init {
-        viewModelScope.launch {
-            identityTransitions.transitions.collect { transition ->
-                if (transition.phase == IdentityTransitionPhase.WILL_CHANGE) {
-                    pendingNextUpSelectionHandoff = null
-                }
-            }
-        }
-        observePreferredQuality()
-        capabilityDetector?.let(::observeAutomaticAudioPolicy)
-        if (contentId.isNotBlank()) {
-            // Restore this title's pre-play track choices (QA 2026-07-08: a
-            // manual subtitle selection reset on every return to the page —
-            // season switches and detail re-entry build a fresh ViewModel).
-            TvDetailTrackSelectionSession.recall(contentId)?.let { saved ->
-                _uiState.update {
-                    it.copy(
-                        selectedFileId = saved.fileId,
-                    )
-                }
-            }
-            loadAll()
-        }
-    }
 
     /**
      * Loads the cascaded subtitle preferences that annotate the selector row's
@@ -1082,8 +1058,13 @@ class TvItemDetailViewModel(
         val active = state.episodes.firstOrNull { it.contentId == contentId }
         _uiState.update { it.copy(entryEpisodeSelectionApplied = true) }
         if (active != null) {
+            pendingCarouselSeasonJump = null
+            pendingCarouselEdge = null
             activeSeriesEpisodeContentId = active.contentId
             updateNextUp(active)
+            _uiState.update {
+                it.copy(carouselJump = TvEpisodeCarouselJump(active.contentId, ++carouselJumpRevision))
+            }
         }
     }
 
@@ -1094,7 +1075,7 @@ class TvItemDetailViewModel(
     private var pendingCarouselEdge: Pair<String, Int>? = null
 
     private fun recordCarouselSeason(season: Int, episodes: List<EpisodeListItem>) {
-        if (_uiState.value.detail?.type != "series") return
+        if (_uiState.value.detail?.type?.lowercase() != "series") return
         episodeWindow.put(season, episodes)
         publishCarousel()
         if (pendingCarouselSeasonJump == season) {
@@ -1112,7 +1093,7 @@ class TvItemDetailViewModel(
 
     private fun publishCarousel() {
         val state = _uiState.value
-        if (state.detail?.type != "series") return
+        if (state.detail?.type?.lowercase() != "series") return
         val selected = state.selectedSeason ?: return
         // Preserve optimistic watched-state edits on the active page.
         if (state.episodes.firstOrNull()?.seasonNumber == selected) {
@@ -1144,7 +1125,7 @@ class TvItemDetailViewModel(
 
     private fun prefetchCarouselNeighbors() {
         val state = _uiState.value
-        if (state.detail?.type != "series") return
+        if (state.detail?.type?.lowercase() != "series") return
         val order = episodeWindow.orderedSeasons(state.seasons)
         val selectedIndex = order.indexOf(state.selectedSeason)
         if (selectedIndex < 0) return
@@ -1163,7 +1144,7 @@ class TvItemDetailViewModel(
 
     private fun loadCarouselNeighbor(season: Int) {
         val state = _uiState.value
-        val series = state.detail?.takeIf { it.type == "series" } ?: return
+        val series = state.detail?.takeIf { it.type.lowercase() == "series" } ?: return
         if (episodeWindow.get(season) != null || carouselLoads[season]?.isActive == true) return
         carouselLoads[season] = viewModelScope.launch {
             _uiState.update { it.copy(carouselLoadError = false) }
@@ -2058,6 +2039,32 @@ class TvItemDetailViewModel(
             }
         }
     }
+    // Start observers only after every cache and request field is initialized.
+    init {
+        viewModelScope.launch {
+            identityTransitions.transitions.collect { transition ->
+                if (transition.phase == IdentityTransitionPhase.WILL_CHANGE) {
+                    pendingNextUpSelectionHandoff = null
+                }
+            }
+        }
+        observePreferredQuality()
+        capabilityDetector?.let(::observeAutomaticAudioPolicy)
+        if (contentId.isNotBlank()) {
+            // Restore this title's pre-play track choices (QA 2026-07-08: a
+            // manual subtitle selection reset on every return to the page —
+            // season switches and detail re-entry build a fresh ViewModel).
+            TvDetailTrackSelectionSession.recall(contentId)?.let { saved ->
+                _uiState.update {
+                    it.copy(
+                        selectedFileId = saved.fileId,
+                    )
+                }
+            }
+            loadAll()
+        }
+    }
+
 }
 
 private fun ItemDetail.withWatchedPlaybackState(watched: Boolean): ItemDetail {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -81,6 +81,11 @@ data class TvItemDetailUiState(
     val seasons: List<Season> = emptyList(),
     val selectedSeason: Int? = null,
     val episodes: List<EpisodeListItem> = emptyList(),
+    val carouselEpisodes: List<EpisodeListItem> = emptyList(),
+    val carouselPreviousSeason: Int? = null,
+    val carouselNextSeason: Int? = null,
+    val carouselJump: TvEpisodeCarouselJump? = null,
+    val carouselLoadError: Boolean = false,
     val episodeFavoriteStates: Map<String, Boolean> = emptyMap(),
     /** The route's one-shot episode target has been applied (or safely rejected). */
     val entryEpisodeSelectionApplied: Boolean = false,
@@ -592,6 +597,7 @@ class TvItemDetailViewModel(
         }
         if (_uiState.value.selectedSeason != seasonNumber) return false
         refreshNextUp(episodes)
+        recordCarouselSeason(seasonNumber, episodes)
         return true
     }
 
@@ -614,6 +620,7 @@ class TvItemDetailViewModel(
                         it.copy(
                             isLoading = false,
                             detail = detail,
+                            seasonsLoading = detail.type.lowercase() == "series" || it.seasonsLoading,
                             userRating = detail.userRating,
                             isWatched = detail.userData?.played == true,
                             error = null,
@@ -1001,6 +1008,8 @@ class TvItemDetailViewModel(
     fun onSeasonSelected(seasonNumber: Int) {
         if (_uiState.value.selectedSeason == seasonNumber) return
         seasonSelectionGeneration += 1
+        pendingCarouselEdge = null
+        pendingCarouselSeasonJump = seasonNumber
         // A focused episode belongs to the old season. The newly loaded rail
         // chooses its own suggested/current episode, exactly like tvOS.
         activeSeriesEpisodeContentId = null
@@ -1031,9 +1040,35 @@ class TvItemDetailViewModel(
     fun onSeriesEpisodeActivated(contentId: String?) {
         val state = _uiState.value
         if (state.detail?.type?.lowercase() != "series") return
-        val active = contentId?.let { id -> state.episodes.firstOrNull { it.contentId == id } }
+        val active = contentId?.let { id ->
+            (state.carouselEpisodes.ifEmpty { state.episodes }).firstOrNull { it.contentId == id }
+        }
+        pendingCarouselEdge = null
+        if (active != null) {
+            pendingCarouselSeasonJump = null
+            _uiState.update { it.copy(carouselJump = null) }
+        }
+        if (active != null && active.seasonNumber != state.selectedSeason) {
+            seasonSelectionGeneration += 1
+            episodeLoadRequestGeneration += 1
+            episodeLoadJob?.cancel()
+            loadedSeason = active.seasonNumber
+            episodeListGeneration += 1
+            _uiState.update {
+                it.copy(
+                    selectedSeason = active.seasonNumber,
+                    episodes = episodeWindow.get(active.seasonNumber).orEmpty(),
+                    episodesLoading = false,
+                )
+            }
+        }
         activeSeriesEpisodeContentId = active?.contentId
-        updateNextUp(active ?: resolveNextUpEpisode(state.episodes))
+        updateNextUp(active ?: resolveNextUpEpisode(_uiState.value.episodes))
+        if (active != null) {
+            if (active.seasonNumber != state.selectedSeason) publishCarousel()
+            prefetchCarouselNeighbors()
+            viewModelScope.launch { refreshEpisodeFavoriteStates(listOf(active)) }
+        }
     }
 
     /**
@@ -1049,6 +1084,115 @@ class TvItemDetailViewModel(
         if (active != null) {
             activeSeriesEpisodeContentId = active.contentId
             updateNextUp(active)
+        }
+    }
+
+    private val episodeWindow = TvEpisodeWindow()
+    private val carouselLoads = mutableMapOf<Int, Job>()
+    private var carouselJumpRevision = 0
+    private var pendingCarouselSeasonJump: Int? = null
+    private var pendingCarouselEdge: Pair<String, Int>? = null
+
+    private fun recordCarouselSeason(season: Int, episodes: List<EpisodeListItem>) {
+        if (_uiState.value.detail?.type != "series") return
+        episodeWindow.put(season, episodes)
+        publishCarousel()
+        if (pendingCarouselSeasonJump == season) {
+            pendingCarouselSeasonJump = null
+            episodes.firstOrNull()?.let { first ->
+                activeSeriesEpisodeContentId = first.contentId
+                updateNextUp(first)
+                _uiState.update {
+                    it.copy(carouselJump = TvEpisodeCarouselJump(first.contentId, ++carouselJumpRevision))
+                }
+            }
+        }
+        prefetchCarouselNeighbors()
+    }
+
+    private fun publishCarousel() {
+        val state = _uiState.value
+        if (state.detail?.type != "series") return
+        val selected = state.selectedSeason ?: return
+        // Preserve optimistic watched-state edits on the active page.
+        if (state.episodes.firstOrNull()?.seasonNumber == selected) {
+            episodeWindow.put(selected, state.episodes)
+        }
+        episodeWindow.retainNear(state.seasons, selected)
+        val snapshot = episodeWindow.snapshot(state.seasons, selected)
+        _uiState.update {
+            it.copy(
+                carouselEpisodes = snapshot.episodes,
+                carouselPreviousSeason = snapshot.previousSeason,
+                carouselNextSeason = snapshot.nextSeason,
+            )
+        }
+        val pending = pendingCarouselEdge ?: return
+        val index = snapshot.episodes.indexOfFirst { it.contentId == pending.first }
+        val target = snapshot.episodes.getOrNull(index + pending.second).takeIf { index >= 0 }
+        if (target != null) {
+            pendingCarouselEdge = null
+            _uiState.update {
+                it.copy(carouselJump = TvEpisodeCarouselJump(target.contentId, ++carouselJumpRevision, true))
+            }
+        }
+    }
+
+    fun onCarouselFocusLost() {
+        pendingCarouselEdge = null
+    }
+
+    private fun prefetchCarouselNeighbors() {
+        val state = _uiState.value
+        if (state.detail?.type != "series") return
+        val order = episodeWindow.orderedSeasons(state.seasons)
+        val selectedIndex = order.indexOf(state.selectedSeason)
+        if (selectedIndex < 0) return
+        listOfNotNull(order.getOrNull(selectedIndex - 1), order.getOrNull(selectedIndex + 1))
+            .forEach(::loadCarouselNeighbor)
+    }
+
+    /** Called only at a loaded edge; holding Right never skips an unloaded season. */
+    fun onCarouselEdgeRequested(contentId: String, direction: Int) {
+        if (direction != -1 && direction != 1) return
+        pendingCarouselEdge = contentId to direction
+        val state = _uiState.value
+        val season = if (direction < 0) state.carouselPreviousSeason else state.carouselNextSeason
+        season?.let(::loadCarouselNeighbor)
+    }
+
+    private fun loadCarouselNeighbor(season: Int) {
+        val state = _uiState.value
+        val series = state.detail?.takeIf { it.type == "series" } ?: return
+        if (episodeWindow.get(season) != null || carouselLoads[season]?.isActive == true) return
+        carouselLoads[season] = viewModelScope.launch {
+            _uiState.update { it.copy(carouselLoadError = false) }
+            try {
+                val result = catalogRepository.getEpisodes(series.contentId, season)
+                if (result is ApiResult.Success) {
+                    val episodes = withLocalProgress(result.data.episodes)
+                    // A distant season jump can make this prefetch obsolete.
+                    val live = _uiState.value
+                    val order = episodeWindow.orderedSeasons(live.seasons)
+                    val distance = kotlin.math.abs(order.indexOf(season) - order.indexOf(live.selectedSeason))
+                    val edge = episodeWindow.snapshot(live.seasons, live.selectedSeason ?: return@launch)
+                    if (distance <= 2 || season == edge.previousSeason || season == edge.nextSeason) {
+                        episodeWindow.put(season, episodes)
+                        publishCarousel()
+                        // Empty seasons are traversed, never mistaken for the end of the series.
+                        if (episodes.isEmpty()) {
+                            val snapshot = episodeWindow.snapshot(live.seasons, live.selectedSeason ?: return@launch)
+                            val before = order.indexOf(season) < order.indexOf(live.selectedSeason)
+                            (if (before) snapshot.previousSeason else snapshot.nextSeason)
+                                ?.let(::loadCarouselNeighbor)
+                        }
+                    }
+                } else {
+                    _uiState.update { it.copy(carouselLoadError = true) }
+                }
+            } finally {
+                carouselLoads.remove(season)
+            }
         }
     }
 
@@ -1077,6 +1221,7 @@ class TvItemDetailViewModel(
                             seasonsLoading = false,
                             seasons = plan.seasons,
                             selectedSeason = selectedSeasonNumber,
+                            episodesLoading = it.episodesLoading || (!preservesNewerSelection && selectedSeasonNumber != null),
                         )
                     }
                     if (!preservesNewerSelection) {
@@ -1182,6 +1327,7 @@ class TvItemDetailViewModel(
                     episodeListGeneration += 1
                     _uiState.update { it.copy(episodesLoading = false, episodes = episodes) }
                     refreshNextUp(episodes)
+                    recordCarouselSeason(seasonNumber, episodes)
                     val revalidationComplete =
                         refreshEpisodeFavoriteStates(episodes, revalidate = revalidateFavorites)
                     // Caught up only now, and only if every id we were asked to
@@ -1306,6 +1452,7 @@ class TvItemDetailViewModel(
             if (episode.contentId == episodeContentId) episode.withWatchedPlaybackState(watched) else episode
         }
         _uiState.update { it.copy(episodes = updatedEpisodes) }
+        publishCarousel()
         refreshNextUp(updatedEpisodes)
 
         viewModelScope.launch {
@@ -1323,6 +1470,7 @@ class TvItemDetailViewModel(
                             if (episode.contentId == episodeContentId) previousEpisode else episode
                         }
                         if (_uiState.compareAndSet(live, live.copy(episodes = restored))) {
+                            publishCarousel()
                             refreshNextUp(restored)
                         }
                     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/theme/Layout.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/theme/Layout.kt
@@ -17,6 +17,11 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import androidx.compose.ui.unit.Dp
@@ -126,13 +131,11 @@ fun rememberTvGridBringIntoViewSpec(topInset: Dp): BringIntoViewSpec {
  * it spun a new scroll job per frame. Measured on the Shield as p90 121ms and
  * near-frozen vertical navigation.
  *
- * Fast-out/slow-in at 480ms (tuned on the Shield): quick to start so rapid
- * presses feel connected, long enough to settle that a card-step reads as a
- * glide; a chain of presses retargets the running animation from its current
- * position, so it never stutters.
+ * Shared 100 ms card steps, tuned on the Shield. Horizontal repeats wait
+ * for the current step to settle so focus never outruns the visible cards.
  */
 val TvRailScrollSpec: AnimationSpec<Float> = tween(
-    durationMillis = 480,
+    durationMillis = 100,
     easing = FastOutSlowInEasing,
 )
 
@@ -210,10 +213,20 @@ private const val NEAR_EDGE_ITEMS = 2
  * [leading] is the row's start content padding.
  */
 @Composable
-fun Modifier.tvRailPinOnFocus(state: LazyListState, index: Int, leading: Dp): Modifier {
+fun Modifier.tvRailPinOnFocus(
+    state: LazyListState,
+    index: Int,
+    leading: Dp,
+): Modifier {
     val leadingPx = with(LocalDensity.current) { leading.toPx() }
     val scope = rememberCoroutineScope()
-    return onFocusChanged { focusState ->
+    return onPreviewKeyEvent { event ->
+        // Drop repeats during a card step rather than restarting its animation
+        // or queuing movement that would continue after the remote is released.
+        event.type == KeyEventType.KeyDown &&
+            (event.key == Key.DirectionLeft || event.key == Key.DirectionRight) &&
+            state.isScrollInProgress
+    }.onFocusChanged { focusState ->
         if (focusState.isFocused) scope.launch { state.tvRailPinItem(index, leadingPx) }
     }
 }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailFocusPolicyTest.kt
@@ -42,7 +42,6 @@ class TvDetailFocusPolicyTest {
         assertTrue(seasons >= 0)
         assertTrue(episodes >= 0)
         assertTrue(seasons < episodes)
-        assertTrue(episodesSection.contains("padding(top = SeriesSeasonPickerTopPadding)"))
         assertFalse(source.contains("if (!isSeriesDetail || isShowingSeriesOverview)"))
         assertFalse(source.contains("onItemDetail(episode.contentId)"))
     }
@@ -120,28 +119,27 @@ class TvDetailFocusPolicyTest {
         assertTrue(facts < synopsis)
         assertTrue(synopsis < credit)
         assertTrue(credit < playback)
-        assertTrue(heroSource.contains("if (!compactSeries && sourceTokens.isNotEmpty())"))
-        assertTrue(heroSource.contains("sourceTokens = sourceTokens"))
+        assertTrue(heroSource.contains("if (hasEpisodeHierarchy && sourceTokens.isNotEmpty())"))
+        assertTrue(heroSource.contains("sourceTokens = metadataSourceTokens"))
         assertTrue(heroSource.contains("compactRating = true"))
         assertFalse(editorial.contains("if (!compactSeries) playbackSummary?.invoke()"))
         assertTrue(editorial.lastIndexOf("HeroCreditLine(line)") < playback)
         assertTrue(heroSource.contains("fontSize = if (compact) 10.5.sp else 14.sp"))
-        assertTrue(heroSource.contains("SERIES_HERO_HEIGHT_FRACTION = 610f / 1080f"))
+        assertTrue(heroSource.contains("HERO_HEIGHT_FRACTION = 690f / 1080f"))
         assertTrue(detailSource.contains("label = \"VERSION\""))
         assertTrue(detailSource.contains("label = \"AUDIO\""))
         assertTrue(detailSource.contains("label = \"SUBTITLES\""))
         assertTrue(detailSource.contains("includePlaybackFormats = false"))
         assertTrue(playbackReadout.contains("Modifier.weight(1f)"))
-        assertTrue(playbackReadout.contains("Arrangement.spacedBy(6.dp)"))
+        assertTrue(playbackReadout.contains("Arrangement.spacedBy(4.dp)"))
         assertTrue(playbackReadout.contains("Modifier.height(TV_PLAYBACK_SUMMARY_HEIGHT)"))
         assertTrue(playbackReadout.contains("TvPlaybackSummarySkeleton(modifier = Modifier.weight(1f))"))
-        // Loaded values size to their text so long audio / subtitle labels never
-        // truncate; only the skeleton keeps the fixed per-item width.
-        assertTrue(playbackReadout.contains("modifier = if (value == null) Modifier.width(itemWidth) else Modifier"))
-        assertFalse(playbackReadout.contains("overflow = TextOverflow.Ellipsis"))
-        assertTrue(playbackReadout.contains("TV_PLAYBACK_VERSION_ITEM_WIDTH = 120.dp"))
-        assertTrue(playbackReadout.contains("TV_PLAYBACK_AUDIO_ITEM_WIDTH = 160.dp"))
-        assertTrue(playbackReadout.contains("TV_PLAYBACK_SUBTITLE_ITEM_WIDTH = 130.dp"))
+        // Loaded and loading values retain the same column starts.
+        assertTrue(playbackReadout.contains("modifier = Modifier.width(itemWidth)"))
+        assertTrue(playbackReadout.contains("overflow = TextOverflow.Ellipsis"))
+        assertTrue(playbackReadout.contains("TV_PLAYBACK_VERSION_ITEM_WIDTH = 156.5.dp"))
+        assertTrue(playbackReadout.contains("TV_PLAYBACK_AUDIO_ITEM_WIDTH = 182.dp"))
+        assertTrue(playbackReadout.contains("TV_PLAYBACK_SUBTITLE_ITEM_WIDTH = 169.dp"))
         assertFalse(playbackReadout.contains("Spacer(modifier = Modifier.size"))
     }
 
@@ -151,9 +149,9 @@ class TvDetailFocusPolicyTest {
             "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt",
         ).readText()
 
-        assertTrue(heroSource.contains("seriesOverviewEditorialHeightPx"))
-        assertTrue(heroSource.contains("seriesTitle == null"))
-        assertTrue(heroSource.contains("Modifier.height(with(density)"))
+        assertTrue(heroSource.contains("Modifier.height(217.5.dp)"))
+        assertTrue(heroSource.contains("Modifier.weight(1f).clipToBounds()"))
+        assertFalse(heroSource.contains("seriesOverviewEditorialHeightPx"))
         assertTrue(heroSource.contains("isCombinedSeriesEpisode"))
         assertTrue(heroSource.contains("SERIES_METADATA_SLOT_HEIGHT"))
         assertTrue(heroSource.contains("SERIES_EPISODE_SYNOPSIS_HEIGHT"))
@@ -181,37 +179,6 @@ class TvDetailFocusPolicyTest {
         assertTrue(seriesPicker.contains("listState.animateScrollBy(itemCenter - viewportCenter)"))
         assertTrue(modeTab.contains("if (focusState.isFocused && !isSelected) onActivated()"))
         assertTrue(modeTab.contains("onClick = onActivated"))
-    }
-
-    @Test
-    fun seriesEpisodesSlideAsOneDirectionalSeasonCarousel() {
-        val source = File(
-            "src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt",
-        ).readText()
-        val episodesSection = source
-            .substringAfter("private fun EpisodesSection(")
-            .substringBefore("private fun currentEpisodeRailContentId")
-        val seasons = listOf(
-            Season(contentId = "season-1", seasonNumber = 1),
-            Season(contentId = "season-2", seasonNumber = 2),
-            Season(contentId = "specials", seasonNumber = 0, isSpecials = true),
-        )
-
-        assertEquals(1, seriesEpisodeCarouselDirection(1, 2, seasons))
-        assertEquals(-1, seriesEpisodeCarouselDirection(2, 1, seasons))
-        assertEquals(1, seriesEpisodeCarouselDirection(2, 0, seasons))
-        assertTrue(episodesSection.contains("AnimatedContent("))
-        assertTrue(episodesSection.contains("contentKey = { it.seasonNumber }"))
-        assertTrue(episodesSection.contains("slideInHorizontally("))
-        assertTrue(episodesSection.contains("slideOutHorizontally("))
-        assertTrue(episodesSection.contains("SizeTransform(clip = false)"))
-        assertTrue(source.contains("SERIES_EPISODE_CAROUSEL_DURATION_MS = 360"))
-        assertFalse(episodesSection.contains("durationMillis = 280"))
-        assertTrue(
-            episodesSection.contains(
-                "state.episodesLoading && (!isSeries || state.episodes.isEmpty())",
-            ),
-        )
     }
 
     @Test

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvEpisodeWindowTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvEpisodeWindowTest.kt
@@ -1,0 +1,71 @@
+package org.siloserver.silo.tv.ui.screens.detail
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.siloserver.silo.model.catalog.EpisodeListItem
+import org.siloserver.silo.model.catalog.Season
+
+class TvEpisodeWindowTest {
+    private fun seasons(count: Int) = (1..count).map { Season("season-$it", it) }
+    private fun episodes(season: Int, count: Int = 2) =
+        (1..count).map { EpisodeListItem("$season-$it", season, it) }
+
+    @Test
+    fun adjacentPagesPrependWithoutChangingEpisodeIdentities() {
+        val window = TvEpisodeWindow()
+        window.put(2, episodes(2))
+        window.put(3, episodes(3))
+        assertEquals(listOf("2-1", "2-2", "3-1", "3-2"), window.snapshot(seasons(3), 2).episodes.map { it.contentId })
+        window.put(1, episodes(1).reversed())
+        val snapshot = window.snapshot(seasons(3), 2)
+        assertEquals((1..3).flatMap { episodes(it) }, snapshot.episodes)
+        assertNull(snapshot.previousSeason)
+        assertNull(snapshot.nextSeason)
+    }
+
+    @Test
+    fun missingSeasonIsAnEdgeUntilItLoadsEvenAfterDistantJump() {
+        val window = TvEpisodeWindow()
+        window.put(1, episodes(1))
+        window.put(3, episodes(3))
+        assertEquals(episodes(1), window.snapshot(seasons(3), 1).episodes)
+        assertEquals(2, window.snapshot(seasons(3), 1).nextSeason)
+        assertEquals(episodes(3), window.snapshot(seasons(3), 3).episodes)
+        assertEquals(2, window.snapshot(seasons(3), 3).previousSeason)
+        window.put(2, emptyList())
+        assertEquals(episodes(1) + episodes(3), window.snapshot(seasons(3), 3).episodes)
+    }
+
+    @Test
+    fun specialsFollowRegularSeasonsRegardlessOfInputOrder() {
+        val window = TvEpisodeWindow()
+        val seasons = listOf(Season("special", 0, isSpecials = true)) + seasons(2).reversed()
+        (0..2).forEach { window.put(it, episodes(it)) }
+        assertEquals(listOf(1, 2, 0), window.orderedSeasons(seasons))
+        assertEquals(episodes(1) + episodes(2) + episodes(0), window.snapshot(seasons, 2).episodes)
+    }
+
+    @Test
+    fun thousandsOfEpisodesKeepAtMostFiveLoadedPages() {
+        val window = TvEpisodeWindow()
+        val seasons = seasons(100)
+        for (season in 1..100) {
+            window.put(season, episodes(season, 100))
+            window.retainNear(seasons, season)
+        }
+        assertEquals(500, window.snapshot(seasons, 100).episodes.size)
+        assertNull(window.get(1))
+        assertEquals(episodes(100, 100), window.get(100))
+    }
+
+    @Test
+    fun emptySeasonsDoNotBreakTheWindowOrEvictTheActivePage() {
+        val window = TvEpisodeWindow()
+        window.put(1, episodes(1))
+        (2..9).forEach { window.put(it, emptyList()) }
+        window.put(10, episodes(10))
+        window.retainNear(seasons(10), 1)
+        assertEquals(episodes(1) + episodes(10), window.snapshot(seasons(10), 1).episodes)
+    }
+}

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvEpisodeWindowTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvEpisodeWindowTest.kt
@@ -1,5 +1,7 @@
 package org.siloserver.silo.tv.ui.screens.detail
 
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.unit.LayoutDirection
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -10,6 +12,15 @@ class TvEpisodeWindowTest {
     private fun seasons(count: Int) = (1..count).map { Season("season-$it", it) }
     private fun episodes(season: Int, count: Int = 2) =
         (1..count).map { EpisodeListItem("$season-$it", season, it) }
+
+    @Test
+    fun episodeBoundaryDirectionFollowsLayoutDirection() {
+        assertEquals(-1, episodeCarouselDirection(Key.DirectionLeft, LayoutDirection.Ltr))
+        assertEquals(1, episodeCarouselDirection(Key.DirectionRight, LayoutDirection.Ltr))
+        assertEquals(1, episodeCarouselDirection(Key.DirectionLeft, LayoutDirection.Rtl))
+        assertEquals(-1, episodeCarouselDirection(Key.DirectionRight, LayoutDirection.Rtl))
+        assertEquals(0, episodeCarouselDirection(Key.DirectionUp, LayoutDirection.Rtl))
+    }
 
     @Test
     fun adjacentPagesPrependWithoutChangingEpisodeIdentities() {

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
@@ -71,6 +71,29 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvNextUpSelectionHandoffTest {
     @Test
+    fun routedEpisodeReplacesAnEarlierSeasonJump() = runDetailTest {
+        val scenario = Scenario(suffix = "-routed-season-jump")
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onSeasonSelected(2)
+        awaitEpisode(fixture.viewModel, scenario.seasonTwoEpisodeId)
+        fixture.viewModel.onSeasonSelected(1)
+        awaitCondition { fixture.viewModel.uiState.value.carouselJump?.contentId == scenario.episodeOneId }
+        fixture.viewModel.onEntrySeriesEpisodeRequested(scenario.episodeTwoId)
+        awaitEpisode(fixture.viewModel, scenario.episodeTwoId)
+        assertEquals(scenario.episodeTwoId, fixture.viewModel.uiState.value.carouselJump?.contentId)
+    }
+
+    @Test
+    fun mixedCaseSeriesPublishesAndPrefetchesTheCarousel() = runDetailTest {
+        val scenario = Scenario(suffix = "-mixed-case", seriesType = "Series")
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        awaitCondition { fixture.viewModel.uiState.value.carouselEpisodes.size == 3 }
+        assertEquals(1, fixture.viewModel.uiState.value.selectedSeason)
+    }
+
+    @Test
     fun returningToLoadedEpisodeCancelsPendingSeasonJump() = runDetailTest {
         val scenario = Scenario(suffix = "-continuous-cancel-jump")
         scenario.seasonTwoEpisodesGate = CompletableDeferred()
@@ -759,6 +782,7 @@ class TvNextUpSelectionHandoffTest {
 
     private class Scenario(
         val suffix: String = "",
+        val seriesType: String = "series",
         val oldVersions: List<VersionFixture> = listOf(version(101, "1080p")),
         val newVersions: List<VersionFixture> = listOf(version(201, "1080p")),
         val oldLastFileId: Int? = null,
@@ -791,7 +815,7 @@ class TvNextUpSelectionHandoffTest {
                 )
                 when (request.url.encodedPath) {
                     "/api/v1/catalog/items/$seriesId" -> json(
-                        """{"content_id":"$seriesId","type":"series","title":"Series"}""",
+                        """{"content_id":"$seriesId","type":"$seriesType","title":"Series"}""",
                     )
                     "/api/v1/catalog/series/$seriesId/seasons" -> {
                         seasonsRequests.incrementAndGet()

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvNextUpSelectionHandoffTest.kt
@@ -71,6 +71,68 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvNextUpSelectionHandoffTest {
     @Test
+    fun returningToLoadedEpisodeCancelsPendingSeasonJump() = runDetailTest {
+        val scenario = Scenario(suffix = "-continuous-cancel-jump")
+        scenario.seasonTwoEpisodesGate = CompletableDeferred()
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onSeasonSelected(2)
+        fixture.viewModel.onSeriesEpisodeActivated(scenario.episodeTwoId)
+        scenario.seasonTwoEpisodesGate?.complete(Unit)
+        awaitCondition { fixture.viewModel.uiState.value.carouselEpisodes.size == 3 }
+        assertEquals(1, fixture.viewModel.uiState.value.selectedSeason)
+        assertEquals(null, fixture.viewModel.uiState.value.carouselJump)
+        awaitEpisode(fixture.viewModel, scenario.episodeTwoId)
+    }
+
+    @Test
+    fun prefetchedSeasonExtendsRailWithoutChangingPlayTarget() = runDetailTest {
+        val scenario = Scenario(suffix = "-continuous-prefetch")
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        awaitCondition { fixture.viewModel.uiState.value.carouselEpisodes.size == 3 }
+        assertEquals(1, fixture.viewModel.uiState.value.selectedSeason)
+        assertEquals(scenario.episodeOneId, fixture.viewModel.uiState.value.nextUpEpisode?.contentId)
+
+        fixture.viewModel.onSeriesEpisodeActivated(scenario.seasonTwoEpisodeId)
+        awaitEpisode(fixture.viewModel, scenario.seasonTwoEpisodeId)
+        assertEquals(2, fixture.viewModel.uiState.value.selectedSeason)
+        assertEquals(listOf(scenario.seasonTwoEpisodeId), fixture.viewModel.uiState.value.episodes.map { it.contentId })
+
+        fixture.viewModel.onSeriesEpisodeActivated(scenario.episodeTwoId)
+        awaitEpisode(fixture.viewModel, scenario.episodeTwoId)
+        assertEquals(1, fixture.viewModel.uiState.value.selectedSeason)
+    }
+
+    @Test
+    fun delayedEdgeRequestsFocusOnlyAfterItsPageArrives() = runDetailTest {
+        val scenario = Scenario(suffix = "-continuous-delayed")
+        scenario.seasonTwoEpisodesGate = CompletableDeferred()
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onSeriesEpisodeActivated(scenario.episodeTwoId)
+        fixture.viewModel.onCarouselEdgeRequested(scenario.episodeTwoId, 1)
+        assertEquals(null, fixture.viewModel.uiState.value.carouselJump)
+        scenario.seasonTwoEpisodesGate?.complete(Unit)
+        awaitCondition { fixture.viewModel.uiState.value.carouselJump != null }
+        assertEquals(scenario.seasonTwoEpisodeId, fixture.viewModel.uiState.value.carouselJump?.contentId)
+        assertTrue(fixture.viewModel.uiState.value.carouselJump?.requestFocus == true)
+    }
+
+    @Test
+    fun leavingRailCancelsPendingEdgeFocus() = runDetailTest {
+        val scenario = Scenario(suffix = "-continuous-focus-cancel")
+        scenario.seasonTwoEpisodesGate = CompletableDeferred()
+        val fixture = createFixture(scenario)
+        awaitEpisode(fixture.viewModel, scenario.episodeOneId)
+        fixture.viewModel.onCarouselEdgeRequested(scenario.episodeTwoId, 1)
+        fixture.viewModel.onCarouselFocusLost()
+        scenario.seasonTwoEpisodesGate?.complete(Unit)
+        awaitCondition { fixture.viewModel.uiState.value.carouselEpisodes.size == 3 }
+        assertEquals(null, fixture.viewModel.uiState.value.carouselJump)
+    }
+
+    @Test
     fun cancelledPriorSeasonCannotEndReplacementLoad() = runDetailTest {
         val scenario = Scenario(suffix = "-cancelled-season-owner")
         val fixture = createFixture(scenario)

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/theme/TvTypographyReadabilityTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/theme/TvTypographyReadabilityTest.kt
@@ -13,6 +13,7 @@ class TvTypographyReadabilityTest {
     private val source = File(
         "src/androidMain/kotlin/org/siloserver/silo/tv/ui/theme/Type.kt",
     ).readText()
+    // One expected entry per matching source line, including duplicates.
     private val tvOsMappedCompactTextLines = listOf(
         "org/siloserver/silo/tv/ui/screens/detail/TvExpandableSynopsis.kt|fontSize = 13.sp,",
         "org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt|fontSize = 12.sp,",

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/theme/TvTypographyReadabilityTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/theme/TvTypographyReadabilityTest.kt
@@ -14,8 +14,11 @@ class TvTypographyReadabilityTest {
         "src/androidMain/kotlin/org/siloserver/silo/tv/ui/theme/Type.kt",
     ).readText()
     private val tvOsMappedCompactTextLines = listOf(
+        "org/siloserver/silo/tv/ui/screens/detail/TvExpandableSynopsis.kt|fontSize = 13.sp,",
+        "org/siloserver/silo/tv/ui/screens/detail/TvDetailHero.kt|fontSize = 12.sp,",
+        "org/siloserver/silo/tv/ui/components/TvSquaredButtons.kt|val titleStyle = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.SemiBold)",
         "org/siloserver/silo/tv/ui/screens/detail/TvDetailEpisodeRail.kt|fontSize = 11.5.sp,",
-        "org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt|fontSize = 11.sp,",
+        "org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt|fontSize = 11.5.sp,",
         "org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt|fontSize = 11.5.sp,",
     )
 
@@ -56,7 +59,7 @@ class TvTypographyReadabilityTest {
 
     @Test
     fun tvScreensAvoidHardcodedTinyTextOutsideTheTheme() {
-        // Normal TV copy honours a 14sp metadata floor. These three exact
+        // Normal TV copy honours a 14sp metadata floor. These exact
         // assignments are approved half-scale mappings of compact tvOS chrome;
         // the matched-count assertion keeps this exception line-specific and
         // prevents it from becoming a file-wide escape hatch.


### PR DESCRIPTION
TV detail pages had inconsistent hero and episode placement, loading shifts, and season-by-season carousels that interrupted browsing. Rapid remote repeats could outrun the scroll animation and cause focus to bounce.

Align the hero, title, episode rail, and expanding selector controls with the tvOS layout. Reserve the episode section during initial loading and retain the last resolved version/audio/subtitle summary while the next episode loads. Episodes now browse continuously across seasons, with season shortcuts, adjacent-season prefetch, and a cache of up to five populated seasons. Shared TV carousels use 100 ms scroll steps and discard horizontal repeats while a step is running.

Validation:
- All 1,115 Android TV debug unit tests passed, including delayed loading, focus cancellation, season-boundary selection, and a synthetic 10,000-episode cache case.
- Optimized release build and release lint passed using `:androidTvApp:assembleRelease -PallowDebugReleaseSigning=true`.
- Installed the optimized ARM64 build on an NVIDIA Shield and checked season shortcuts, navigation across season boundaries in both directions, held Left/Right input, stopping after release, and Home carousel navigation.
- `git diff --check` passed.

Loading still uses whole-season API requests. A single season with thousands of episodes would benefit from server-side pagination. The faster horizontal scrolling applies to shared TV media rows, including Home, recommendations, cast, trailers, and episode rails.

AI disclosure: Implemented with OpenAI `gpt-6-astra` through the Codex desktop agent harness. Automated Codex and CodeRabbit review feedback informed the follow-up fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smoother episode browsing across seasons, including adjacent-season loading, boundary navigation, retry states, and focus preservation.
  * Added conditional Start Over actions and focused labels for watchlist and additional controls.
  * Improved loading continuity and playback summary presentation on series detail screens.

* **UI Improvements**
  * Refined hero layouts, episode rails, synopsis text, button styling, and TV focus behavior.
  * Reduced rail scrolling delays and prevented repeated navigation from queuing unwanted movement.

* **Tests**
  * Added coverage for episode windowing, season transitions, loading behavior, and focus handoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
