### PR TITLE
fix: report HDR mode from the selected video decoder

### DIFF
--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackAnalyticsListener.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlaybackAnalyticsListener.kt
@@ -41,6 +41,7 @@ class PlaybackAnalyticsListener : AnalyticsListener {
         ) : Event()
         data class AudioDecoderInitialized(val decoderName: String) : Event()
         data class VideoFormatChanged(val format: Format) : Event()
+        data class VideoOutputFormatChanged(val format: Format, val decoderMimeType: String?) : Event()
         data class AudioFormatChanged(val format: Format) : Event()
         data class DroppedFrames(val count: Int, val elapsedMs: Long) : Event()
         object AudioUnderrun : Event()
@@ -130,6 +131,10 @@ class PlaybackAnalyticsListener : AnalyticsListener {
             hdrMode = null,
         )
         emit(Event.VideoFormatChanged(format))
+    }
+
+    fun onVideoOutputFormatChanged(format: Format, decoderMimeType: String?) {
+        emit(Event.VideoOutputFormatChanged(format, decoderMimeType))
     }
 
     override fun onAudioInputFormatChanged(

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshot.kt
@@ -2,6 +2,7 @@ package org.siloserver.silo.common.player
 
 import androidx.media3.common.C
 import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 
 /**
@@ -75,9 +76,12 @@ fun reducePlayerStats(
             current.resolution
         },
         frameRate = if (event.format.frameRate > 0f) event.format.frameRate else current.frameRate,
-        hdrMode = describeHdrMode(event.format) ?: current.hdrMode,
+        hdrMode = null, // Wait for the decoder output, including after format changes.
         colorTransfer = describeColorTransfer(event.format) ?: current.colorTransfer,
         colorRange = describeColorRange(event.format) ?: current.colorRange,
+    )
+    is PlaybackAnalyticsListener.Event.VideoOutputFormatChanged -> current.copy(
+        hdrMode = describeHdrMode(event.format, event.decoderMimeType),
     )
     is PlaybackAnalyticsListener.Event.AudioFormatChanged ->
         current.copy(audioCodec = event.format.codecs ?: event.format.sampleMimeType)
@@ -179,9 +183,9 @@ private fun describeColorRange(format: Format): String? = when (format.colorInfo
     else -> null
 }
 
-private fun describeHdrMode(format: Format): String? {
-    val codecs = format.codecs.orEmpty()
-    if (codecs.contains("dvh", ignoreCase = true) || codecs.contains("dvhe", ignoreCase = true)) {
+private fun describeHdrMode(format: Format, decoderMimeType: String?): String? {
+    if (decoderMimeType == null) return null
+    if (decoderMimeType.equals(MimeTypes.VIDEO_DOLBY_VISION, ignoreCase = true)) {
         return "Dolby Vision"
     }
     val colorInfo = format.colorInfo ?: return null

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/SiloPlayerFactory.kt
@@ -82,6 +82,7 @@ class SiloPlayerFactory(
     private val delayProcessor: DelayAudioProcessor,
     private val subtitleOffsetHolder: SubtitleOffsetHolder,
     private val libassBridge: LibassBridge,
+    private val playbackAnalytics: PlaybackAnalyticsListener,
 ) {
     val isTv: Boolean = TvModeDetector.isTv(context)
 
@@ -246,6 +247,11 @@ class SiloPlayerFactory(
                     eventHandler = eventHandler,
                     eventListener = eventListener,
                     runtimeCorrectionEnabled = runtimeCorrectionState::isEnabled,
+                    onVideoOutputFormatChanged = { format, decoderMimeType ->
+                        eventHandler.post {
+                            playbackAnalytics.onVideoOutputFormatChanged(format, decoderMimeType)
+                        }
+                    },
                     onBaseLayerDecoderMismatch = { decoderName ->
                         baseLayerDecoderMismatch.value = decoderName
                     },

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/SiloMediaCodecVideoRenderer.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/player/video/SiloMediaCodecVideoRenderer.kt
@@ -1,6 +1,7 @@
 package org.siloserver.silo.common.player.video
 
 import android.content.Context
+import android.media.MediaFormat
 import android.os.Handler
 import androidx.media3.common.Format
 import androidx.media3.common.MimeTypes
@@ -35,6 +36,7 @@ internal class SiloMediaCodecVideoRenderer(
      * replan instead of playing with an unverified presentation.
      */
     private val onBaseLayerDecoderMismatch: (String) -> Unit = {},
+    private val onVideoOutputFormatChanged: (Format, String?) -> Unit = { _, _ -> },
 ) : MediaCodecVideoRenderer(
     MediaCodecVideoRenderer.Builder(context)
         .setCodecAdapterFactory(codecAdapterFactory)
@@ -105,6 +107,13 @@ internal class SiloMediaCodecVideoRenderer(
         val result = super.onInputFormatChanged(formatHolder)
         profile8Input = formatHolder.format?.let(::isDolbyVisionProfile8) == true
         return result
+    }
+
+    override fun onOutputFormatChanged(format: Format, mediaFormat: MediaFormat?) {
+        super.onOutputFormatChanged(format, mediaFormat)
+        // The input can remain dvhe.08 even when Media3 opens an HEVC decoder.
+        // Report the selected decoder MIME, not the source codec identity.
+        onVideoOutputFormatChanged(format, codecInfo?.codecMimeType)
     }
 
     override fun onQueueInputBuffer(buffer: DecoderInputBuffer) {

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshotReducerTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/player/PlayerStatsSnapshotReducerTest.kt
@@ -14,6 +14,49 @@ import org.junit.Test
 class PlayerStatsSnapshotReducerTest {
 
     @Test
+    fun `Dolby Vision source reports the selected decoder base range`() {
+        for ((transfer, expected) in listOf(
+            C.COLOR_TRANSFER_ST2084 to "HDR10",
+            C.COLOR_TRANSFER_HLG to "HLG",
+            C.COLOR_TRANSFER_SDR to "SDR",
+        )) {
+            val format = Format.Builder()
+                .setSampleMimeType("video/dolby-vision")
+                .setCodecs("dvhe.08.06")
+                .setColorInfo(ColorInfo.Builder().setColorTransfer(transfer).build())
+                .build()
+            val input = reducePlayerStats(
+                PlayerStatsSnapshot(hdrMode = "Dolby Vision"),
+                PlaybackAnalyticsListener.Event.VideoFormatChanged(format),
+            )
+            assertEquals(null, input.hdrMode)
+            val output = reducePlayerStats(
+                input,
+                PlaybackAnalyticsListener.Event.VideoOutputFormatChanged(format, "video/hevc"),
+            )
+            assertEquals(expected, output.hdrMode)
+            assertEquals("dvhe.08.06", output.videoCodec)
+            val nativeOutput = reducePlayerStats(
+                output,
+                PlaybackAnalyticsListener.Event.VideoOutputFormatChanged(format, "video/dolby-vision"),
+            )
+            assertEquals("Dolby Vision", nativeOutput.hdrMode)
+        }
+    }
+
+    @Test
+    fun `unknown output clears the previous HDR mode`() {
+        val format = Format.Builder().setCodecs("dvhe.08.06").build()
+        for (mime in listOf(null, "video/hevc")) {
+            val output = reducePlayerStats(
+                PlayerStatsSnapshot(hdrMode = "Dolby Vision"),
+                PlaybackAnalyticsListener.Event.VideoOutputFormatChanged(format, mime),
+            )
+            assertEquals(null, output.hdrMode)
+        }
+    }
+
+    @Test
     fun `VideoFormatChanged fills resolution codec frame rate and hdr`() {
         val format = Format.Builder()
             .setSampleMimeType("video/avc")
@@ -36,7 +79,7 @@ class PlayerStatsSnapshotReducerTest {
         assertEquals("avc1.640028", result.videoCodec)
         assertEquals("1920x1080", result.resolution)
         assertEquals(23.976f, result.frameRate)
-        assertEquals("HDR10", result.hdrMode)
+        assertEquals(null, result.hdrMode)
         assertEquals("video/avc", result.videoMimeType)
         assertEquals(1920, result.videoWidth)
         assertEquals(1080, result.videoHeight)
@@ -148,7 +191,7 @@ class PlayerStatsSnapshotReducerTest {
     }
 
     @Test
-    fun `Dolby Vision codec produces Dolby Vision HDR mode`() {
+    fun `Dolby Vision input waits for decoder output`() {
         val format = Format.Builder()
             .setSampleMimeType("video/dolby-vision")
             .setCodecs("dvhe.05.06")
@@ -160,7 +203,7 @@ class PlayerStatsSnapshotReducerTest {
             PlaybackAnalyticsListener.Event.VideoFormatChanged(format),
         )
 
-        assertEquals("Dolby Vision", result.hdrMode)
+        assertEquals(null, result.hdrMode)
     }
 
     @Test

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -254,6 +254,7 @@ val androidModule = module {
             delayProcessor = get(),
             subtitleOffsetHolder = get(),
             libassBridge = get(),
+            playbackAnalytics = get(),
         )
     }
     single { PlaybackSessionManager(get(), get(), get()) }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -183,6 +183,7 @@ val androidTvModule = module {
             delayProcessor = get(),
             subtitleOffsetHolder = get(),
             libassBridge = get(),
+            playbackAnalytics = get(),
         )
     }
     single { PlaybackSessionManager(get(), get(), get()) }

--- a/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/PlayerStatsSnapshotReducerTest.kt
+++ b/androidTvApp/src/androidUnitTest/kotlin/org/siloserver/silo/tv/ui/screens/player/PlayerStatsSnapshotReducerTest.kt
@@ -35,7 +35,7 @@ class PlayerStatsSnapshotReducerTest {
         assertEquals("avc1.640028", result.videoCodec)
         assertEquals("1920x1080", result.resolution)
         assertEquals(23.976f, result.frameRate)
-        assertEquals("HDR10", result.hdrMode)
+        assertEquals(null, result.hdrMode)
     }
 
     @Test
@@ -90,7 +90,7 @@ class PlayerStatsSnapshotReducerTest {
     }
 
     @Test
-    fun `Dolby Vision codec produces 'Dolby Vision' HDR mode`() {
+    fun `Dolby Vision input waits for decoder output`() {
         val format = Format.Builder()
             .setSampleMimeType("video/dolby-vision")
             .setCodecs("dvhe.05.06")
@@ -100,7 +100,7 @@ class PlayerStatsSnapshotReducerTest {
             PlayerStatsSnapshot(),
             PlaybackAnalyticsListener.Event.VideoFormatChanged(format),
         )
-        assertEquals("Dolby Vision", result.hdrMode)
+        assertEquals(null, result.hdrMode)
     }
 
     @Test


### PR DESCRIPTION
The player stats reported Dolby Vision whenever the input codec was `dvhe`, including Profile 8 playback through an HEVC base-layer decoder with Dolby Vision disabled.

Report HDR mode after the renderer receives its output format, using the selected decoder MIME and color transfer. Keep the source codec visible separately and clear the previous HDR label when the input changes. Phone and TV share this reporting path.

Validation:
- Shared Android unit suite: 1,461 tests passed. TV stats suite: eight tests passed.
- TV debug APK assembled and phone debug Kotlin compilation passed.
- Verified on NVIDIA Shield: Dolby Vision Off, source `dvhe.08.06`, decoder `OMX.Nvidia.h265.decode`, and HDR mode HDR10. Repeated after a fresh original-quality playback start; playback advanced with zero dropped frames in the final sample. NVIDIA HDMI output reported 10-bit Rec.2020 HDR without the DV flag.
- Regression coverage includes HDR10/HLG/SDR base ranges, native Dolby Vision, and stale/unknown output metadata.

Native Dolby Vision was verified in unit tests only; the test display configuration exposed HDR10 only. The HDR label describes decoder presentation, not an independent HDMI measurement. Playback routing is unchanged.

AI disclosure: Implemented and validated with OpenAI `gpt-6-astra` through the Codex desktop agent harness. No other AI tooling was used.
