### PR TITLE
docs: sync trademark policy with siloserver.org

### DIFF
--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -43,7 +43,8 @@ marks.** This reservation is expressly permitted by AGPL-3.0 §7(e).
   identity.
 - Using the marks in a **company, product, domain, or app name**, or in any way
   that implies Silo Media operates or endorses your offering.
-- **Merchandise** or other commercial use of the logo or wordmark.
+- **Merchandise**, or using the logo or wordmark to sell your own product
+  beyond a referential "works with Silo" placement.
 
 Never use the marks to promote piracy or to impersonate the project.
 
@@ -53,8 +54,9 @@ Give your client, plugin, or fork its own name, then mention Silo in the
 tagline or description: "Bramble — a Silo client for Android TV," "Trakt sync
 plugin for Silo." That is referential use and needs no permission.
 
-Official products use "Silo" alone or join it to a product word with no space
-(**SiloRemote**, **SiloMac**), so those patterns are reserved. Please avoid:
+Official products use "Silo" alone, **Silo Server**, or "Silo" joined to a
+product word (**SiloRemote**, **SiloMac**). Those patterns are reserved and
+need written permission:
 
 - "Silo" on its own, or as the first word of a product name
 - "Silo[word]" names such as SiloTV or SiloPlay, which read as official apps
@@ -76,8 +78,8 @@ only describes what the code plugs into.
 ## Colors and motif
 
 You may use the Silo colors, and the three-bar motif from the website, in your
-own interface. The logo itself is what we reserve, so keep your own logo a
-different shape and do not build the Silo mark into it.
+own interface. The logo, wordmark, and icons are what we reserve, so keep your
+own logo a different shape and do not build the Silo mark into it.
 
 ## Forks must rebrand
 
@@ -113,8 +115,11 @@ or email **trademark@siloserver.org**. We answer quickly and usually say yes.
 The goal of this policy is only to prevent user confusion and unauthorized
 "official-looking" releases.
 
-This file is the canonical policy. The brand page at <https://siloserver.org/brand>
-is the practical guide and asset library, and follows this file.
+The canonical copy of this policy is the one in the siloserver.org repository:
+<https://github.com/Silo-Server/siloserver.org/blob/main/TRADEMARK.md>. Other
+Silo repositories carry synchronized copies. The brand page at
+<https://siloserver.org/brand> is the practical guide and asset library, and
+follows the canonical file.
 
 ---
 

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -70,7 +70,9 @@ only describes what the code plugs into.
 
 - Prose and UI text: **Silo**, capital S, one word. The server product is
   **Silo Server**.
-- Repositories, packages, and binaries: lowercase `silo` (`silo-server`).
+- Repositories, packages, and command-line binaries: lowercase `silo`
+  (`silo-server`). App bundles and product names keep the display form
+  (`Silo`, `SiloTV`).
 - Paths and config directories: follow the platform convention
   (`/var/lib/silo`, `~/Library/Application Support/Silo`).
 - Never SILO, SiLo, or a typeset "Silo" in place of the supplied wordmark.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -45,6 +45,40 @@ marks.** This reservation is expressly permitted by AGPL-3.0 §7(e).
   that implies Silo Media operates or endorses your offering.
 - **Merchandise** or other commercial use of the logo or wordmark.
 
+Never use the marks to promote piracy or to impersonate the project.
+
+## Naming your project
+
+Give your client, plugin, or fork its own name, then mention Silo in the
+tagline or description: "Bramble — a Silo client for Android TV," "Trakt sync
+plugin for Silo." That is referential use and needs no permission.
+
+Official products use "Silo" alone or join it to a product word with no space
+(**SiloRemote**, **SiloMac**), so those patterns are reserved. Please avoid:
+
+- "Silo" on its own, or as the first word of a product name
+- "Silo[word]" names such as SiloTV or SiloPlay, which read as official apps
+- "[word]Silo" names such as OpenSilo or MySilo, which read as the project
+- misspellings and look-alikes such as Sylo or Si1o
+
+Repository and package names such as `silo-plugin-trakt` are fine when "silo"
+only describes what the code plugs into.
+
+## Writing the name
+
+- Prose and UI text: **Silo**, capital S, one word. The server product is
+  **Silo Server**.
+- Repositories, packages, and binaries: lowercase `silo` (`silo-server`).
+- Paths and config directories: follow the platform convention
+  (`/var/lib/silo`, `~/Library/Application Support/Silo`).
+- Never SILO, SiLo, or a typeset "Silo" in place of the supplied wordmark.
+
+## Colors and motif
+
+You may use the Silo colors, and the three-bar motif from the website, in your
+own interface. The logo itself is what we reserve, so keep your own logo a
+different shape and do not build the Silo mark into it.
+
 ## Forks must rebrand
 
 You may fork Silo — that is your right under the AGPL. But a **distributed** fork
@@ -74,9 +108,13 @@ above is **not** official and is **not** authorized to use the Silo marks.
 
 ## Requesting permission / reporting misuse
 
-Email **trademark@siloserver.org** with the details. We're generally glad to
-grant reasonable requests — the goal of this policy is only to prevent user
-confusion and unauthorized "official-looking" releases.
+Not sure whether your use is fine? Ask in Discord (<https://discord.gg/siloserver>)
+or email **trademark@siloserver.org**. We answer quickly and usually say yes.
+The goal of this policy is only to prevent user confusion and unauthorized
+"official-looking" releases.
+
+This file is the canonical policy. The brand page at <https://siloserver.org/brand>
+is the practical guide and asset library, and follows this file.
 
 ---
 


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Six repositories carry a byte-identical copy of `TRADEMARK.md`. Silo-Server/siloserver.org#16 rewrites that file to lead with what needs no permission and adds naming, writing-the-name, and colour guidance for third parties, and declares the copy in that repository canonical. Without a sync, this copy goes stale and contradicts the brand page.

## Approach

Copy the updated file verbatim from the siloserver.org PR branch. The legal position is unchanged; the additions are the new sections and a closing note that points at the canonical file. Merge after #16 so the canonical link resolves to the new text.

## Validation

```
$ diff TRADEMARK.md <siloserver.org feat/brand-usage-guidance>/TRADEMARK.md && echo identical
identical
```

No code, build, or tests touched.

## Risks

None identified.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Claude Code (Claude Agent SDK) running inside T3 Code
- Tool(s): Claude Code
- Model(s): claude-fable-5-1
- Involvement: Fully AI-generated, human verified
- Adversarial review: n/a — documentation-only change; the copied file was diffed byte-for-byte against the source branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded branding guidance for project naming, “Silo” usage, colors, and visual motifs.
  - Clarified how to request permission to use the brand, including Discord contact details.
  - Identified the policy as the canonical reference.
  - Added a link to the brand page for practical guidance and access to brand assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->