### PR TITLE
docs: allow wordplay names in trademark policy

### DIFF
--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -66,6 +66,12 @@ need written permission:
 Repository and package names such as `silo-plugin-trakt` are fine when "silo"
 only describes what the code plugs into.
 
+**Wordplay is fine.** A name such as "Siloette" or "Silodeon" contains the mark
+but reads as its own word, not as an official product, so it needs no
+permission. The test is whether a reasonable user would think the Silo team
+made it. Keep a tagline that says what the project is ("Siloette, a Silo
+client"), use your own logo, and do not describe the project as official.
+
 ## Writing the name
 
 - Prose and UI text: **Silo**, capital S, one word. The server product is

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -119,7 +119,9 @@ The only official Silo software comes from:
 - official app-store listings published by **Silo Media L.L.C.**
 
 Any app-store listing, download, or "Silo" app that does not originate from the
-above is **not** official and is **not** authorized to use the Silo marks.
+above is **not** official and is **not** authorized to present itself as Silo.
+Third-party projects that follow *Naming your project*, including wordplay
+names, are unaffected.
 
 ## Requesting permission / reporting misuse
 

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -41,8 +41,9 @@ marks.** This reservation is expressly permitted by AGPL-3.0 §7(e).
 - **Publishing an app to any app store** — Apple App Store, Google Play,
   F-Droid, or similar — under the Silo name, logo, or a confusingly similar
   identity.
-- Using the marks in a **company, product, domain, or app name**, or in any way
-  that implies Silo Media operates or endorses your offering.
+- Using the marks in a **company, product, domain, or app name** in a way that
+  reads as official (see *Naming your project*; wordplay is exempt), or in any
+  way that implies Silo Media operates or endorses your offering.
 - **Merchandise**, or using the logo or wordmark to sell your own product
   beyond a referential "works with Silo" placement.
 
@@ -58,7 +59,8 @@ Official products use "Silo" alone, **Silo Server**, or "Silo" joined to a
 product word (**SiloRemote**, **SiloMac**). Those patterns are reserved and
 need written permission:
 
-- "Silo" on its own, or as the first word of a product name
+- "Silo" on its own, or as the first word of a product name, including
+  generic descriptors used as the name such as "Silo Client" or "Silo Player"
 - "Silo[word]" names such as SiloTV or SiloPlay, which read as official apps
 - "[word]Silo" names such as OpenSilo or MySilo, which read as the project
 - misspellings and look-alikes such as Sylo or Si1o
@@ -66,11 +68,14 @@ need written permission:
 Repository and package names such as `silo-plugin-trakt` are fine when "silo"
 only describes what the code plugs into.
 
-**Wordplay is fine.** A name such as "Siloette" or "Silodeon" contains the mark
-but reads as its own word, not as an official product, so it needs no
-permission. The test is whether a reasonable user would think the Silo team
-made it. Keep a tagline that says what the project is ("Siloette, a Silo
-client"), use your own logo, and do not describe the project as official.
+**Wordplay is fine, and is the exception to the rules above.** A name such as
+"Siloette" or "Silodeon" contains the mark but reads as its own word, not as an
+official product, so it needs no permission, wherever you publish it, including
+app stores and commercial offerings. The test is whether a reasonable user would
+think the Silo team made it. Keep a description that says what the project is
+("Siloette, a Silo client"), use your own logo, and do not describe the project
+as official. Describing your project as "a Silo client" is fine; naming it
+"Silo Client" is not.
 
 ## Writing the name
 


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Sync of the canonical trademark policy. The naming section now says wordplay such as "Siloette" needs no permission, keyed on whether a reasonable user would think the Silo team made it.

## Approach

Copy `TRADEMARK.md` verbatim from the siloserver.org PR branch. Merge after that PR.

## Validation

```
$ diff TRADEMARK.md <siloserver.org docs/brand-wordplay>/TRADEMARK.md && echo identical
identical
```

## Risks

None identified.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Claude Code (Claude Agent SDK) running inside T3 Code
- Tool(s): Claude Code
- Model(s): claude-fable-5-1
- Involvement: Fully AI-generated, human verified
- Adversarial review: n/a — documentation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified trademark guidance for project names incorporating wordplay based on the Silo mark.
  - Added recommendations to use descriptive taglines, distinct logos, and avoid implying official affiliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->