### PR TITLE
feat(detail): mark a season watched from its chip on phone and TV

### DIFF
--- a/android-shared/schemas/org.siloserver.silo.common.data.db.SiloDatabase/9.json
+++ b/android-shared/schemas/org.siloserver.silo.common.data.db.SiloDatabase/9.json
@@ -1,0 +1,883 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "9d4d6817bd19219ea8d34269e0636b9d",
+    "entities": [
+      {
+        "tableName": "user_item_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `profileId` TEXT NOT NULL, `contentId` TEXT NOT NULL, `fileId` INTEGER NOT NULL, `positionSeconds` REAL NOT NULL, `durationSeconds` REAL, `audioFingerprint` TEXT, `subtitleFingerprint` TEXT, `cfi` TEXT, `readProgress` REAL, `clientUpdatedAtMs` INTEGER NOT NULL, `serverUpdatedAtMs` INTEGER, PRIMARY KEY(`serverId`, `profileId`, `contentId`, `fileId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentId",
+            "columnName": "contentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "fileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSeconds",
+            "columnName": "positionSeconds",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "audioFingerprint",
+            "columnName": "audioFingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitleFingerprint",
+            "columnName": "subtitleFingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readProgress",
+            "columnName": "readProgress",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "clientUpdatedAtMs",
+            "columnName": "clientUpdatedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverUpdatedAtMs",
+            "columnName": "serverUpdatedAtMs",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "profileId",
+            "contentId",
+            "fileId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_item_state_serverId_profileId_contentId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "profileId",
+              "contentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_item_state_serverId_profileId_contentId` ON `${TABLE_NAME}` (`serverId`, `profileId`, `contentId`)"
+          },
+          {
+            "name": "index_user_item_state_serverId_profileId_clientUpdatedAtMs",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "profileId",
+              "clientUpdatedAtMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_item_state_serverId_profileId_clientUpdatedAtMs` ON `${TABLE_NAME}` (`serverId`, `profileId`, `clientUpdatedAtMs`)"
+          }
+        ]
+      },
+      {
+        "tableName": "content_item_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `profileId` TEXT NOT NULL, `contentId` TEXT NOT NULL, `watched` INTEGER, `ratingValue` INTEGER, `favorite` INTEGER, `clientUpdatedAtMs` INTEGER NOT NULL, `serverUpdatedAtMs` INTEGER, `watchedIntentAtMs` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`serverId`, `profileId`, `contentId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentId",
+            "columnName": "contentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watched",
+            "columnName": "watched",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "ratingValue",
+            "columnName": "ratingValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "clientUpdatedAtMs",
+            "columnName": "clientUpdatedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverUpdatedAtMs",
+            "columnName": "serverUpdatedAtMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "watchedIntentAtMs",
+            "columnName": "watchedIntentAtMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "profileId",
+            "contentId"
+          ]
+        }
+      },
+      {
+        "tableName": "dirty_operations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `opKind` TEXT NOT NULL, `serverId` TEXT NOT NULL, `profileId` TEXT NOT NULL, `targetContentId` TEXT NOT NULL, `targetFileId` INTEGER, `coalesceKey` TEXT NOT NULL, `idempotencyKey` TEXT NOT NULL, `opVersion` INTEGER NOT NULL, `payloadJson` TEXT NOT NULL, `state` TEXT NOT NULL, `createdAtMs` INTEGER NOT NULL, `attemptCount` INTEGER NOT NULL, `lastAttemptAtMs` INTEGER, `nextAttemptAtMs` INTEGER NOT NULL, `lastError` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "opKind",
+            "columnName": "opKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetContentId",
+            "columnName": "targetContentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetFileId",
+            "columnName": "targetFileId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coalesceKey",
+            "columnName": "coalesceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "idempotencyKey",
+            "columnName": "idempotencyKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "opVersion",
+            "columnName": "opVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "createdAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAtMs",
+            "columnName": "lastAttemptAtMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextAttemptAtMs",
+            "columnName": "nextAttemptAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dirty_operations_idempotencyKey",
+            "unique": true,
+            "columnNames": [
+              "idempotencyKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_dirty_operations_idempotencyKey` ON `${TABLE_NAME}` (`idempotencyKey`)"
+          },
+          {
+            "name": "index_dirty_operations_coalesceKey",
+            "unique": false,
+            "columnNames": [
+              "coalesceKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dirty_operations_coalesceKey` ON `${TABLE_NAME}` (`coalesceKey`)"
+          },
+          {
+            "name": "index_dirty_operations_nextAttemptAtMs_id",
+            "unique": false,
+            "columnNames": [
+              "nextAttemptAtMs",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dirty_operations_nextAttemptAtMs_id` ON `${TABLE_NAME}` (`nextAttemptAtMs`, `id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `profileId` TEXT NOT NULL, `mediaFileId` INTEGER NOT NULL, `recordId` TEXT NOT NULL, `contentId` TEXT NOT NULL, `title` TEXT NOT NULL, `subtitle` TEXT, `posterUrl` TEXT, `posterThumbhash` TEXT, `year` INTEGER, `seriesTitle` TEXT, `seriesContentId` TEXT, `seasonNumber` INTEGER, `episodeNumber` INTEGER, `fileName` TEXT, `container` TEXT, `localUri` TEXT, `mediaType` TEXT NOT NULL, `overview` TEXT, `author` TEXT, `narrator` TEXT, `durationSeconds` REAL, `chaptersJson` TEXT, `status` TEXT NOT NULL, `kind` TEXT NOT NULL, `fileSize` INTEGER NOT NULL, `bytesSent` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `completedAt` TEXT, `updatedAtMs` INTEGER NOT NULL, `resumeValidator` TEXT, `quality` TEXT, `effectiveQuality` TEXT, PRIMARY KEY(`serverId`, `profileId`, `mediaFileId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaFileId",
+            "columnName": "mediaFileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordId",
+            "columnName": "recordId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentId",
+            "columnName": "contentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "posterThumbhash",
+            "columnName": "posterThumbhash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seriesTitle",
+            "columnName": "seriesTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesContentId",
+            "columnName": "seriesContentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "container",
+            "columnName": "container",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUri",
+            "columnName": "localUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "narrator",
+            "columnName": "narrator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytesSent",
+            "columnName": "bytesSent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAtMs",
+            "columnName": "updatedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumeValidator",
+            "columnName": "resumeValidator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "effectiveQuality",
+            "columnName": "effectiveQuality",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "profileId",
+            "mediaFileId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_serverId_profileId_status",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "profileId",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_serverId_profileId_status` ON `${TABLE_NAME}` (`serverId`, `profileId`, `status`)"
+          },
+          {
+            "name": "index_downloads_serverId_profileId_contentId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "profileId",
+              "contentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_serverId_profileId_contentId` ON `${TABLE_NAME}` (`serverId`, `profileId`, `contentId`)"
+          },
+          {
+            "name": "index_downloads_recordId",
+            "unique": true,
+            "columnNames": [
+              "recordId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_downloads_recordId` ON `${TABLE_NAME}` (`recordId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "legacy_imports",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceKind` TEXT NOT NULL, `sourcePath` TEXT NOT NULL, `sourceHash` TEXT NOT NULL, `sourceMtimeMs` INTEGER NOT NULL, `importedAtMs` INTEGER NOT NULL, `importVersion` INTEGER NOT NULL, `status` TEXT NOT NULL, `error` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceKind",
+            "columnName": "sourceKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePath",
+            "columnName": "sourcePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceHash",
+            "columnName": "sourceHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceMtimeMs",
+            "columnName": "sourceMtimeMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "importedAtMs",
+            "columnName": "importedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "importVersion",
+            "columnName": "importVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_legacy_imports_sourceKind_sourcePath",
+            "unique": true,
+            "columnNames": [
+              "sourceKind",
+              "sourcePath"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_legacy_imports_sourceKind_sourcePath` ON `${TABLE_NAME}` (`sourceKind`, `sourcePath`)"
+          }
+        ]
+      },
+      {
+        "tableName": "home_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `profileId` TEXT NOT NULL, `sectionsJson` TEXT NOT NULL, `cachedAtMs` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `profileId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sectionsJson",
+            "columnName": "sectionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAtMs",
+            "columnName": "cachedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "profileId"
+          ]
+        }
+      },
+      {
+        "tableName": "catalog_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `profileId` TEXT NOT NULL, `cacheKey` TEXT NOT NULL, `json` TEXT NOT NULL, `cachedAtMs` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `profileId`, `cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAtMs",
+            "columnName": "cachedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "profileId",
+            "cacheKey"
+          ]
+        }
+      },
+      {
+        "tableName": "download_deletions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `profileId` TEXT NOT NULL, `recordId` TEXT NOT NULL, `mediaFileId` INTEGER, `enqueuedAtMs` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `profileId`, `recordId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordId",
+            "columnName": "recordId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaFileId",
+            "columnName": "mediaFileId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "enqueuedAtMs",
+            "columnName": "enqueuedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "profileId",
+            "recordId"
+          ]
+        }
+      },
+      {
+        "tableName": "download_subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `profileId` TEXT NOT NULL, `targetType` TEXT NOT NULL, `targetId` TEXT NOT NULL, `displayTitle` TEXT NOT NULL, `mediaKind` TEXT NOT NULL, `quality` TEXT NOT NULL, `wifiOnly` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `includeExisting` INTEGER NOT NULL, `keepUnwatchedLimit` INTEGER NOT NULL, `deleteWatchedAfterDays` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastEvaluatedAt` INTEGER, `lastError` TEXT, PRIMARY KEY(`serverId`, `profileId`, `id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetType",
+            "columnName": "targetType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetId",
+            "columnName": "targetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayTitle",
+            "columnName": "displayTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaKind",
+            "columnName": "mediaKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiOnly",
+            "columnName": "wifiOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeExisting",
+            "columnName": "includeExisting",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keepUnwatchedLimit",
+            "columnName": "keepUnwatchedLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleteWatchedAfterDays",
+            "columnName": "deleteWatchedAfterDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEvaluatedAt",
+            "columnName": "lastEvaluatedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "profileId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_subscriptions_serverId_profileId_enabled",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "profileId",
+              "enabled"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_subscriptions_serverId_profileId_enabled` ON `${TABLE_NAME}` (`serverId`, `profileId`, `enabled`)"
+          },
+          {
+            "name": "index_download_subscriptions_serverId_profileId_targetType_targetId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "profileId",
+              "targetType",
+              "targetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_download_subscriptions_serverId_profileId_targetType_targetId` ON `${TABLE_NAME}` (`serverId`, `profileId`, `targetType`, `targetId`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9d4d6817bd19219ea8d34269e0636b9d')"
+    ]
+  }
+}

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/db/SiloDatabase.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/db/SiloDatabase.kt
@@ -49,7 +49,7 @@ import org.siloserver.silo.common.data.db.entity.UserItemStateEntity
         DownloadDeletionEntity::class,
         DownloadSubscriptionEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
@@ -59,6 +59,7 @@ import org.siloserver.silo.common.data.db.entity.UserItemStateEntity
         AutoMigration(from = 5, to = 6),
         AutoMigration(from = 6, to = 7),
         AutoMigration(from = 7, to = 8),
+        AutoMigration(from = 8, to = 9),
     ],
 )
 abstract class SiloDatabase : RoomDatabase() {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/db/dao/ContentItemStateDao.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/db/dao/ContentItemStateDao.kt
@@ -38,7 +38,12 @@ interface ContentItemStateDao {
 
     // Revert a single optimistic field to "unknown" after its outbox op is dropped
     // (terminal server rejection) — the overlay then defers to server state.
-    @Query("UPDATE content_item_state SET watched = NULL WHERE serverId = :serverId AND profileId = :profileId AND contentId = :contentId")
+    // A rejected watched intent is no longer an intent: its stamp must not
+    // shield the row from a later container confirmation.
+    @Query(
+        "UPDATE content_item_state SET watched = NULL, watchedIntentAtMs = 0 " +
+            "WHERE serverId = :serverId AND profileId = :profileId AND contentId = :contentId",
+    )
     suspend fun clearWatched(serverId: String, profileId: String, contentId: String)
 
     @Query("UPDATE content_item_state SET favorite = NULL WHERE serverId = :serverId AND profileId = :profileId AND contentId = :contentId")

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/db/dao/ContentItemStateDao.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/db/dao/ContentItemStateDao.kt
@@ -49,4 +49,8 @@ interface ContentItemStateDao {
 
     @Query("DELETE FROM content_item_state WHERE serverId = :serverId AND profileId = :profileId AND contentId = :contentId")
     suspend fun delete(serverId: String, profileId: String, contentId: String)
+
+    /** Highest watched-intent stamp ever persisted; seeds the monotonic sequence after a restart. */
+    @Query("SELECT COALESCE(MAX(watchedIntentAtMs), 0) FROM content_item_state")
+    suspend fun maxWatchedIntentAtMs(): Long
 }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/db/entity/ContentItemStateEntity.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/db/entity/ContentItemStateEntity.kt
@@ -1,5 +1,6 @@
 package org.siloserver.silo.common.data.db.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 
 /**
@@ -30,4 +31,10 @@ data class ContentItemStateEntity(
     val favorite: Boolean?,
     val clientUpdatedAtMs: Long,
     val serverUpdatedAtMs: Long?,
+    /**
+     * When the user last set [watched] on this exact item. A container
+     * (season) confirmation skips children whose own intent is newer than the
+     * container action, even after that intent's outbox op has drained.
+     */
+    @ColumnInfo(defaultValue = "0") val watchedIntentAtMs: Long = 0L,
 )

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -10,6 +10,8 @@ import org.siloserver.silo.common.data.sync.OutboxSyncScheduler
 import org.siloserver.silo.common.data.sync.revertForTerminalOp
 import org.siloserver.silo.common.data.sync.restorePlaybackProgressForTerminalOp
 import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.DefaultIdentityTransitionBarrier
+import org.siloserver.silo.network.IdentityTransitionBarrier
 import org.siloserver.silo.repository.port.EbookLocalProgress
 import org.siloserver.silo.repository.port.LocalContentState
 import org.siloserver.silo.repository.port.LocalPlaybackProgress
@@ -20,6 +22,8 @@ import org.siloserver.silo.repository.port.TrackSelectionFingerprintUpdate
 import org.siloserver.silo.repository.port.UserItemStatePort
 import org.siloserver.silo.repository.port.WatchedContainerChildren
 import org.siloserver.silo.repository.port.WriteOutcome
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonPrimitive
 import java.util.UUID
 
@@ -49,6 +53,8 @@ class RoomUserItemStateRepository(
     private val syncScheduler: OutboxSyncScheduler = OutboxSyncScheduler.NONE,
     private val now: () -> Long = { System.currentTimeMillis() },
     private val idGenerator: () -> String = { UUID.randomUUID().toString() },
+    /** Gates drain-time child confirmations against the identity that captured them. */
+    private val identityTransitions: IdentityTransitionBarrier = DefaultIdentityTransitionBarrier(),
 ) : UserItemStatePort {
 
     private val contentDao = db.contentItemStateDao()
@@ -58,13 +64,17 @@ class RoomUserItemStateRepository(
     /**
      * Strictly increasing stamp for watched actions. Wall-clock millisecond
      * ticks can tie, and a child action issued after a container action in
-     * the same millisecond must still order after it. Issue order breaks
-     * the tie: every stamp is at least one greater than the last issued.
+     * the same millisecond must still order after it. Issue order breaks the
+     * tie: every stamp is at least one greater than the last issued. The
+     * floor is seeded from the highest stamp already persisted, so a clock
+     * that moved backwards across a restart cannot hand out a stamp below
+     * an intent recorded by the previous process.
      */
-    private val intentStampLock = Any()
-    private var lastIntentStampMs = 0L
-    private fun nextIntentStamp(): Long = synchronized(intentStampLock) {
-        val stamp = maxOf(now(), lastIntentStampMs + 1)
+    private val intentStampMutex = Mutex()
+    private var lastIntentStampMs: Long? = null
+    private suspend fun nextIntentStamp(): Long = intentStampMutex.withLock {
+        val floor = lastIntentStampMs ?: contentDao.maxWatchedIntentAtMs()
+        val stamp = maxOf(now(), floor + 1)
         lastIntentStampMs = stamp
         stamp
     }
@@ -516,17 +526,36 @@ class RoomUserItemStateRepository(
      * in-flight-position replay all behave the same.
      */
     suspend fun confirmContainerChild(
+        scope: AuthScopeSnapshot,
+        contentId: String,
+        watched: Boolean,
+        containerAtMs: Long,
+    ) {
+        val serverId = scope.serverId
+        val profileId = scope.profileId ?: return
+        // The drain captured this scope before the container was acknowledged.
+        // A sign-out or profile switch since then must not let an old
+        // identity's confirmation land on rows the new identity now owns.
+        // withCurrentGeneration also holds the identity mutex for the write.
+        val applied = identityTransitions.withCurrentGeneration(scope.identityGeneration) {
+            confirmContainerChildUnchecked(scope, serverId, profileId, contentId, watched, containerAtMs)
+        }
+        if (applied == true) syncScheduler.requestSync()
+    }
+
+    /** Returns true when a queued replay needs the drain woken. */
+    private suspend fun confirmContainerChildUnchecked(
+        localScope: AuthScopeSnapshot,
         serverId: String,
         profileId: String,
         contentId: String,
         watched: Boolean,
         containerAtMs: Long,
-    ) {
+    ): Boolean {
         var replays = false
         db.withTransaction {
             val row = contentDao.get(serverId, profileId, contentId)
             val ownIntentAtMs = row?.watchedIntentAtMs ?: 0L
-            val localScope = AuthScopeSnapshot(serverId, profileId, "", null)
             if (ownIntentAtMs > containerAtMs) {
                 // The user's own newer intent wins locally, but the season
                 // fan-out may have landed on the server after it. Replay that
@@ -569,7 +598,7 @@ class RoomUserItemStateRepository(
                 resolve(handle, WriteOutcome.SYNCED)
             }
         }
-        if (replays) syncScheduler.requestSync()
+        return replays
     }
 
     private suspend fun DirtyOperationEntity.hasQueuedReconciliation(): Boolean =

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -18,6 +18,7 @@ import org.siloserver.silo.repository.port.OutboxHandle
 import org.siloserver.silo.repository.port.PlaybackWriteScope
 import org.siloserver.silo.repository.port.TrackSelectionFingerprintUpdate
 import org.siloserver.silo.repository.port.UserItemStatePort
+import org.siloserver.silo.repository.port.WatchedContainerChildren
 import org.siloserver.silo.repository.port.WriteOutcome
 import kotlinx.serialization.json.JsonPrimitive
 import java.util.UUID
@@ -60,6 +61,7 @@ class RoomUserItemStateRepository(
             OutboxOperation.SET_WATCHED,
             JsonPrimitive(watched).toString(),
             clearPlaybackProgress = true,
+            stampsIntent = true,
         ) {
             it.copy(watched = watched)
         }
@@ -424,32 +426,80 @@ class RoomUserItemStateRepository(
         }
     }
 
-    override suspend fun recordConfirmedWatched(contentIds: List<String>, watched: Boolean) {
-        val snapshot = snapshotProvider() ?: return
+    override suspend fun recordContainerWatched(
+        contentId: String,
+        watched: Boolean,
+        children: WatchedContainerChildren,
+    ): OutboxHandle {
+        val snapshot = snapshotProvider() ?: return OutboxHandle.NONE
         val serverId = snapshot.serverId
-        val profileId = snapshot.profileId ?: return
-        // Reuse the single-item path so each child gets the same care: the
-        // projection flips, resume rows and pending position writes clear,
-        // and an in-flight position leaves the watched op queued for one
-        // idempotent replay. Resolving as synced immediately means no network
-        // request is sent unless that replay is required.
-        contentIds.distinct().forEach { contentId ->
-            // One transaction per child: the intent check, the record, and the
-            // synced resolve must not interleave with a child-level write that
-            // lands between them, or that newer intent would be coalesced away.
-            db.withTransaction {
-                // A child the user toggled on its own while the container
-                // write was pending carries a newer intent. Leave its
-                // projection and its queued write alone; the server-resolved
-                // page refresh shows the final answer either way.
-                val ownIntent = outboxDao.getLatestByCoalesceKey(
-                    "$serverId|$profileId|$contentId|${OutboxOperation.SET_WATCHED}",
-                )
-                if (ownIntent == null) {
-                    val handle = recordWatched(contentId, watched)
-                    resolve(handle, WriteOutcome.SYNCED)
-                }
+        val profileId = snapshot.profileId ?: return OutboxHandle.NONE
+        var handle = OutboxHandle.NONE
+        db.withTransaction {
+            handle = recordWatched(contentId, watched)
+            if (handle.opId < 0) return@withTransaction
+            // Queue the child reconciliation behind the container op. Per-item
+            // FIFO in the drain holds it until the container write is
+            // acknowledged, and it stays queued through failures until the
+            // catalog lookup succeeds, so leaving the screen or losing the
+            // network cannot strand the children's resume rows.
+            val nowMs = now()
+            outboxDao.enqueueCoalescing(
+                DirtyOperationEntity(
+                    opKind = OutboxOperation.RECONCILE_WATCHED_CHILDREN,
+                    serverId = serverId,
+                    profileId = profileId,
+                    targetContentId = contentId,
+                    targetFileId = null,
+                    coalesceKey = "$serverId|$profileId|$contentId|${OutboxOperation.RECONCILE_WATCHED_CHILDREN}",
+                    idempotencyKey = idGenerator(),
+                    payloadJson = OutboxOperation.encodeReconcilePayload(
+                        OutboxOperation.ReconcileWatchedChildrenPayload(
+                            watched = watched,
+                            seriesId = children.seriesId,
+                            seasonNumber = children.seasonNumber,
+                            knownChildIds = children.knownChildIds,
+                            containerAtMs = nowMs,
+                        ),
+                    ),
+                    createdAtMs = nowMs,
+                    nextAttemptAtMs = nowMs,
+                ),
+            )
+        }
+        return handle
+    }
+
+    /**
+     * Confirm one child of an acknowledged container write. Runs as one
+     * transaction so a child-level write cannot interleave with the check.
+     * The child keeps its own state when its intent is newer than the
+     * container action, whether that intent is still queued or already
+     * drained. Otherwise it is recorded exactly like a confirmed single-item
+     * watched write: projection, resume rows, pending positions, and the
+     * in-flight-position replay all behave the same.
+     */
+    suspend fun confirmContainerChild(
+        serverId: String,
+        profileId: String,
+        contentId: String,
+        watched: Boolean,
+        containerAtMs: Long,
+    ) {
+        db.withTransaction {
+            val ownIntentAtMs = contentDao.get(serverId, profileId, contentId)?.watchedIntentAtMs ?: 0L
+            if (ownIntentAtMs > containerAtMs) return@withTransaction
+            val handle = record(
+                contentId,
+                OutboxOperation.SET_WATCHED,
+                JsonPrimitive(watched).toString(),
+                clearPlaybackProgress = true,
+                scopeOverride = AuthScopeSnapshot(serverId, profileId, "", null),
+                stampsIntent = false,
+            ) {
+                it.copy(watched = watched)
             }
+            resolve(handle, WriteOutcome.SYNCED)
         }
     }
 
@@ -466,9 +516,13 @@ class RoomUserItemStateRepository(
         opKind: String,
         payloadJson: String,
         clearPlaybackProgress: Boolean = false,
+        /** Pin to a captured identity instead of the live one (outbox drain). */
+        scopeOverride: AuthScopeSnapshot? = null,
+        /** A direct user watched action; container confirmations leave it untouched. */
+        stampsIntent: Boolean = false,
         applyField: (ContentItemStateEntity) -> ContentItemStateEntity,
     ): OutboxHandle {
-        val snapshot = snapshotProvider() ?: return OutboxHandle.NONE
+        val snapshot = scopeOverride ?: snapshotProvider() ?: return OutboxHandle.NONE
         val serverId = snapshot.serverId
         val profileId = snapshot.profileId ?: return OutboxHandle.NONE
         val nowMs = now()
@@ -488,7 +542,12 @@ class RoomUserItemStateRepository(
                     clientUpdatedAtMs = nowMs,
                     serverUpdatedAtMs = null,
                 )
-            contentDao.upsert(applyField(existing).copy(clientUpdatedAtMs = nowMs))
+            contentDao.upsert(
+                applyField(existing).copy(
+                    clientUpdatedAtMs = nowMs,
+                    watchedIntentAtMs = if (stampsIntent) nowMs else existing.watchedIntentAtMs,
+                ),
+            )
 
             var operationPayload = payloadJson
             if (clearPlaybackProgress) {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -529,22 +529,24 @@ class RoomUserItemStateRepository(
      * watched write: projection, resume rows, pending positions, and the
      * in-flight-position replay all behave the same.
      */
+    /** Returns false when the captured identity is no longer current; nothing was written. */
     suspend fun confirmContainerChild(
         scope: AuthScopeSnapshot,
         contentId: String,
         watched: Boolean,
         containerAtMs: Long,
-    ) {
+    ): Boolean {
         val serverId = scope.serverId
-        val profileId = scope.profileId ?: return
+        val profileId = scope.profileId ?: return true
         // The drain captured this scope before the container was acknowledged.
         // A sign-out or profile switch since then must not let an old
         // identity's confirmation land on rows the new identity now owns.
         // withCurrentGeneration also holds the identity mutex for the write.
-        val applied = identityTransitions.withCurrentGeneration(scope.identityGeneration) {
+        val replays = identityTransitions.withCurrentGeneration(scope.identityGeneration) {
             confirmContainerChildUnchecked(scope, serverId, profileId, contentId, watched, containerAtMs)
-        }
-        if (applied == true) syncScheduler.requestSync()
+        } ?: return false
+        if (replays) syncScheduler.requestSync()
+        return true
     }
 
     /** Returns true when a queued replay needs the drain woken. */

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -434,16 +434,22 @@ class RoomUserItemStateRepository(
         // idempotent replay. Resolving as synced immediately means no network
         // request is sent unless that replay is required.
         contentIds.distinct().forEach { contentId ->
-            // A child the user toggled on its own while the container write
-            // was pending carries a newer intent. Leave its projection and its
-            // queued write alone; the server-resolved page refresh shows the
-            // final answer either way.
-            val ownIntent = outboxDao.getLatestByCoalesceKey(
-                "$serverId|$profileId|$contentId|${OutboxOperation.SET_WATCHED}",
-            )
-            if (ownIntent != null) return@forEach
-            val handle = recordWatched(contentId, watched)
-            resolve(handle, WriteOutcome.SYNCED)
+            // One transaction per child: the intent check, the record, and the
+            // synced resolve must not interleave with a child-level write that
+            // lands between them, or that newer intent would be coalesced away.
+            db.withTransaction {
+                // A child the user toggled on its own while the container
+                // write was pending carries a newer intent. Leave its
+                // projection and its queued write alone; the server-resolved
+                // page refresh shows the final answer either way.
+                val ownIntent = outboxDao.getLatestByCoalesceKey(
+                    "$serverId|$profileId|$contentId|${OutboxOperation.SET_WATCHED}",
+                )
+                if (ownIntent == null) {
+                    val handle = recordWatched(contentId, watched)
+                    resolve(handle, WriteOutcome.SYNCED)
+                }
+            }
         }
     }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -443,7 +443,18 @@ class RoomUserItemStateRepository(
         val profileId = snapshot.profileId ?: return OutboxHandle.NONE
         var handle = OutboxHandle.NONE
         db.withTransaction {
-            handle = recordWatched(contentId, watched)
+            // Both ops and the returned handle share this one snapshot, so a
+            // scope change mid-call cannot split the write from its children.
+            handle = record(
+                contentId,
+                OutboxOperation.SET_WATCHED,
+                JsonPrimitive(watched).toString(),
+                clearPlaybackProgress = true,
+                scopeOverride = snapshot,
+                stampsIntent = true,
+            ) {
+                it.copy(watched = watched)
+            }
             if (handle.opId < 0) return@withTransaction
             // Queue the child reconciliation behind the container op. Per-item
             // FIFO in the drain holds it until the container write is
@@ -495,12 +506,32 @@ class RoomUserItemStateRepository(
     ) {
         var replays = false
         db.withTransaction {
-            val ownIntentAtMs = contentDao.get(serverId, profileId, contentId)?.watchedIntentAtMs ?: 0L
-            if (ownIntentAtMs > containerAtMs) return@withTransaction
-            // An older child write may still be on the wire (its op is pending
-            // while the inline request runs, or claimed by a drain). It can
-            // land after the season fan-out and restore the older value on the
-            // server, so the corrective write must actually be sent after it.
+            val row = contentDao.get(serverId, profileId, contentId)
+            val ownIntentAtMs = row?.watchedIntentAtMs ?: 0L
+            val localScope = AuthScopeSnapshot(serverId, profileId, "", null)
+            if (ownIntentAtMs > containerAtMs) {
+                // The user's own newer intent wins locally, but the season
+                // fan-out may have landed on the server after it. Replay that
+                // intent, queued (not resolved), so it is sent after the
+                // container settled and after any in-flight write of its own.
+                val newerValue = row?.watched ?: return@withTransaction
+                record(
+                    contentId,
+                    OutboxOperation.SET_WATCHED,
+                    JsonPrimitive(newerValue).toString(),
+                    scopeOverride = localScope,
+                    coalesces = false,
+                ) {
+                    it.copy(watched = newerValue)
+                }
+                replays = true
+                return@withTransaction
+            }
+            // An older child write may still be on the wire: its op is pending
+            // while the inline request runs, or claimed by a drain. It can land
+            // after the season fan-out and restore the older value on the
+            // server, so the corrective write must be sent after it. Inserting
+            // without coalescing keeps that older row as a FIFO barrier.
             val olderWriteInFlight = outboxDao.getLatestByCoalesceKey(
                 "$serverId|$profileId|$contentId|${OutboxOperation.SET_WATCHED}",
             ) != null
@@ -509,14 +540,12 @@ class RoomUserItemStateRepository(
                 OutboxOperation.SET_WATCHED,
                 JsonPrimitive(watched).toString(),
                 clearPlaybackProgress = true,
-                scopeOverride = AuthScopeSnapshot(serverId, profileId, "", null),
-                stampsIntent = false,
+                scopeOverride = localScope,
+                coalesces = !olderWriteInFlight,
             ) {
                 it.copy(watched = watched)
             }
             if (olderWriteInFlight) {
-                // Leave the corrective op queued; per-item FIFO holds it behind
-                // a claimed older op, and coalescing has replaced a pending one.
                 replays = true
             } else {
                 resolve(handle, WriteOutcome.SYNCED)
@@ -552,6 +581,11 @@ class RoomUserItemStateRepository(
         scopeOverride: AuthScopeSnapshot? = null,
         /** A direct user watched action; container confirmations leave it untouched. */
         stampsIntent: Boolean = false,
+        /**
+         * False keeps an older pending op for the same key in place as a
+         * per-item FIFO barrier instead of replacing it.
+         */
+        coalesces: Boolean = true,
         applyField: (ContentItemStateEntity) -> ContentItemStateEntity,
     ): OutboxHandle {
         val snapshot = scopeOverride ?: snapshotProvider() ?: return OutboxHandle.NONE
@@ -624,20 +658,19 @@ class RoomUserItemStateRepository(
                 )
             }
 
-            opId = outboxDao.enqueueCoalescing(
-                DirtyOperationEntity(
-                    opKind = opKind,
-                    serverId = serverId,
-                    profileId = profileId,
-                    targetContentId = contentId,
-                    targetFileId = null,
-                    coalesceKey = "$serverId|$profileId|$contentId|$opKind",
-                    idempotencyKey = idGenerator(),
-                    payloadJson = operationPayload,
-                    createdAtMs = nowMs,
-                    nextAttemptAtMs = nowMs,
-                ),
+            val op = DirtyOperationEntity(
+                opKind = opKind,
+                serverId = serverId,
+                profileId = profileId,
+                targetContentId = contentId,
+                targetFileId = null,
+                coalesceKey = "$serverId|$profileId|$contentId|$opKind",
+                idempotencyKey = idGenerator(),
+                payloadJson = operationPayload,
+                createdAtMs = nowMs,
+                nextAttemptAtMs = nowMs,
             )
+            opId = if (coalesces) outboxDao.enqueueCoalescing(op) else outboxDao.insert(op)
         }
         return OutboxHandle(opId, snapshot)
     }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -424,6 +424,27 @@ class RoomUserItemStateRepository(
         }
     }
 
+    override suspend fun clearPlaybackProgress(contentIds: List<String>) {
+        if (contentIds.isEmpty()) return
+        val snapshot = snapshotProvider() ?: return
+        val serverId = snapshot.serverId
+        val profileId = snapshot.profileId ?: return
+        val nowMs = now()
+        db.withTransaction {
+            contentIds.distinct().forEach { contentId ->
+                // A queued position write for a child would otherwise drain
+                // after the confirmed watched mutation and reopen the episode.
+                outboxDao.deletePendingForTargetKind(
+                    serverId = serverId,
+                    profileId = profileId,
+                    contentId = contentId,
+                    opKind = OutboxOperation.SET_POSITION,
+                )
+                userStateDao.clearPlaybackProgress(serverId, profileId, contentId, nowMs)
+            }
+        }
+    }
+
     override suspend fun localContentStates(contentIds: List<String>): Map<String, LocalContentState> {
         if (contentIds.isEmpty()) return emptyMap()
         val snapshot = snapshotProvider() ?: return emptyMap()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -407,16 +407,23 @@ class RoomUserItemStateRepository(
                     ?: false
                 if (requiresReplay) syncScheduler.requestSync()
                 else outboxDao.deleteById(handle.opId)
+                // An acknowledged container write leaves its child reconciliation
+                // queued; nothing else would wake the drain on this happy path.
+                if (op != null && op.opKind == OutboxOperation.SET_WATCHED && op.hasQueuedReconciliation()) {
+                    syncScheduler.requestSync()
+                }
             }
             // Rejected for good: drop the op AND revert the optimistic projection
             // field so the card overlay defers to server state (no fake local state
-            // across cold starts).
+            // across cold starts). A container's dependent reconciliation goes
+            // with it, or a later drain would confirm children the server refused.
             WriteOutcome.TERMINAL -> db.withTransaction {
                 outboxDao.getById(handle.opId)?.let {
                     if (outboxDao.countNewerPending(it.coalesceKey, it.id) == 0) {
                         contentDao.revertForTerminalOp(it)
                         userStateDao.restorePlaybackProgressForTerminalOp(it)
                     }
+                    if (it.opKind == OutboxOperation.SET_WATCHED) it.deleteQueuedReconciliation()
                 }
                 outboxDao.deleteById(handle.opId)
             }
@@ -486,9 +493,17 @@ class RoomUserItemStateRepository(
         watched: Boolean,
         containerAtMs: Long,
     ) {
+        var replays = false
         db.withTransaction {
             val ownIntentAtMs = contentDao.get(serverId, profileId, contentId)?.watchedIntentAtMs ?: 0L
             if (ownIntentAtMs > containerAtMs) return@withTransaction
+            // An older child write may still be on the wire (its op is pending
+            // while the inline request runs, or claimed by a drain). It can
+            // land after the season fan-out and restore the older value on the
+            // server, so the corrective write must actually be sent after it.
+            val olderWriteInFlight = outboxDao.getLatestByCoalesceKey(
+                "$serverId|$profileId|$contentId|${OutboxOperation.SET_WATCHED}",
+            ) != null
             val handle = record(
                 contentId,
                 OutboxOperation.SET_WATCHED,
@@ -499,9 +514,26 @@ class RoomUserItemStateRepository(
             ) {
                 it.copy(watched = watched)
             }
-            resolve(handle, WriteOutcome.SYNCED)
+            if (olderWriteInFlight) {
+                // Leave the corrective op queued; per-item FIFO holds it behind
+                // a claimed older op, and coalescing has replaced a pending one.
+                replays = true
+            } else {
+                resolve(handle, WriteOutcome.SYNCED)
+            }
         }
+        if (replays) syncScheduler.requestSync()
     }
+
+    private suspend fun DirtyOperationEntity.hasQueuedReconciliation(): Boolean =
+        outboxDao.getLatestByCoalesceKey(reconciliationKey()) != null
+
+    private suspend fun DirtyOperationEntity.deleteQueuedReconciliation() {
+        outboxDao.deletePendingByCoalesceKey(reconciliationKey())
+    }
+
+    private fun DirtyOperationEntity.reconciliationKey(): String =
+        "$serverId|$profileId|$targetContentId|${OutboxOperation.RECONCILE_WATCHED_CHILDREN}"
 
     override suspend fun localContentStates(contentIds: List<String>): Map<String, LocalContentState> {
         if (contentIds.isEmpty()) return emptyMap()

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -55,6 +55,20 @@ class RoomUserItemStateRepository(
     private val userStateDao = db.userItemStateDao()
     private val outboxDao = db.dirtyOperationDao()
 
+    /**
+     * Strictly increasing stamp for watched actions. Wall-clock millisecond
+     * ticks can tie, and a child action issued after a container action in
+     * the same millisecond must still order after it. Issue order breaks
+     * the tie: every stamp is at least one greater than the last issued.
+     */
+    private val intentStampLock = Any()
+    private var lastIntentStampMs = 0L
+    private fun nextIntentStamp(): Long = synchronized(intentStampLock) {
+        val stamp = maxOf(now(), lastIntentStampMs + 1)
+        lastIntentStampMs = stamp
+        stamp
+    }
+
     override suspend fun recordWatched(contentId: String, watched: Boolean): OutboxHandle =
         record(
             contentId,
@@ -456,6 +470,10 @@ class RoomUserItemStateRepository(
                 it.copy(watched = watched)
             }
             if (handle.opId < 0) return@withTransaction
+            // The container action's stamp is the one just issued to its row;
+            // it comes from the same monotonic sequence as child intents, so
+            // same-millisecond actions compare by issue order.
+            val containerAtMs = contentDao.get(serverId, profileId, contentId)?.watchedIntentAtMs ?: now()
             // Queue the child reconciliation behind the container op. Per-item
             // FIFO in the drain holds it until the container write is
             // acknowledged, and it stays queued through failures until the
@@ -477,7 +495,7 @@ class RoomUserItemStateRepository(
                             seriesId = children.seriesId,
                             seasonNumber = children.seasonNumber,
                             knownChildIds = children.knownChildIds,
-                            containerAtMs = nowMs,
+                            containerAtMs = containerAtMs,
                         ),
                     ),
                     createdAtMs = nowMs,
@@ -592,6 +610,7 @@ class RoomUserItemStateRepository(
         val serverId = snapshot.serverId
         val profileId = snapshot.profileId ?: return OutboxHandle.NONE
         val nowMs = now()
+        val intentStamp = if (stampsIntent) nextIntentStamp() else 0L
 
         var opId = OutboxHandle.NONE.opId
         db.withTransaction {
@@ -611,7 +630,7 @@ class RoomUserItemStateRepository(
             contentDao.upsert(
                 applyField(existing).copy(
                     clientUpdatedAtMs = nowMs,
-                    watchedIntentAtMs = if (stampsIntent) nowMs else existing.watchedIntentAtMs,
+                    watchedIntentAtMs = if (stampsIntent) intentStamp else existing.watchedIntentAtMs,
                 ),
             )
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -424,24 +424,15 @@ class RoomUserItemStateRepository(
         }
     }
 
-    override suspend fun clearPlaybackProgress(contentIds: List<String>) {
-        if (contentIds.isEmpty()) return
-        val snapshot = snapshotProvider() ?: return
-        val serverId = snapshot.serverId
-        val profileId = snapshot.profileId ?: return
-        val nowMs = now()
-        db.withTransaction {
-            contentIds.distinct().forEach { contentId ->
-                // A queued position write for a child would otherwise drain
-                // after the confirmed watched mutation and reopen the episode.
-                outboxDao.deletePendingForTargetKind(
-                    serverId = serverId,
-                    profileId = profileId,
-                    contentId = contentId,
-                    opKind = OutboxOperation.SET_POSITION,
-                )
-                userStateDao.clearPlaybackProgress(serverId, profileId, contentId, nowMs)
-            }
+    override suspend fun recordConfirmedWatched(contentIds: List<String>, watched: Boolean) {
+        // Reuse the single-item path so each child gets the same care: the
+        // projection flips, resume rows and pending position writes clear,
+        // and an in-flight position leaves the watched op queued for one
+        // idempotent replay. Resolving as synced immediately means no network
+        // request is sent unless that replay is required.
+        contentIds.distinct().forEach { contentId ->
+            val handle = recordWatched(contentId, watched)
+            resolve(handle, WriteOutcome.SYNCED)
         }
     }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -425,12 +425,23 @@ class RoomUserItemStateRepository(
     }
 
     override suspend fun recordConfirmedWatched(contentIds: List<String>, watched: Boolean) {
+        val snapshot = snapshotProvider() ?: return
+        val serverId = snapshot.serverId
+        val profileId = snapshot.profileId ?: return
         // Reuse the single-item path so each child gets the same care: the
         // projection flips, resume rows and pending position writes clear,
         // and an in-flight position leaves the watched op queued for one
         // idempotent replay. Resolving as synced immediately means no network
         // request is sent unless that replay is required.
         contentIds.distinct().forEach { contentId ->
+            // A child the user toggled on its own while the container write
+            // was pending carries a newer intent. Leave its projection and its
+            // queued write alone; the server-resolved page refresh shows the
+            // final answer either way.
+            val ownIntent = outboxDao.getLatestByCoalesceKey(
+                "$serverId|$profileId|$contentId|${OutboxOperation.SET_WATCHED}",
+            )
+            if (ownIntent != null) return@forEach
             val handle = recordWatched(contentId, watched)
             resolve(handle, WriteOutcome.SYNCED)
         }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepository.kt
@@ -457,10 +457,13 @@ class RoomUserItemStateRepository(
         }
     }
 
+    override suspend fun reserveWatchedIntentStamp(): Long = nextIntentStamp()
+
     override suspend fun recordContainerWatched(
         contentId: String,
         watched: Boolean,
         children: WatchedContainerChildren,
+        intentStamp: Long,
     ): OutboxHandle {
         val snapshot = snapshotProvider() ?: return OutboxHandle.NONE
         val serverId = snapshot.serverId
@@ -476,13 +479,14 @@ class RoomUserItemStateRepository(
                 clearPlaybackProgress = true,
                 scopeOverride = snapshot,
                 stampsIntent = true,
+                intentStampOverride = intentStamp.takeIf { it > 0L },
             ) {
                 it.copy(watched = watched)
             }
             if (handle.opId < 0) return@withTransaction
-            // The container action's stamp is the one just issued to its row;
-            // it comes from the same monotonic sequence as child intents, so
-            // same-millisecond actions compare by issue order.
+            // The container action's stamp is the one on its row: reserved when
+            // the user acted, or issued just now. Either way it comes from the
+            // same monotonic sequence as child intents.
             val containerAtMs = contentDao.get(serverId, profileId, contentId)?.watchedIntentAtMs ?: now()
             // Queue the child reconciliation behind the container op. Per-item
             // FIFO in the drain holds it until the container write is
@@ -633,13 +637,15 @@ class RoomUserItemStateRepository(
          * per-item FIFO barrier instead of replacing it.
          */
         coalesces: Boolean = true,
+        /** A stamp reserved earlier at action time, so it orders as of then. */
+        intentStampOverride: Long? = null,
         applyField: (ContentItemStateEntity) -> ContentItemStateEntity,
     ): OutboxHandle {
         val snapshot = scopeOverride ?: snapshotProvider() ?: return OutboxHandle.NONE
         val serverId = snapshot.serverId
         val profileId = snapshot.profileId ?: return OutboxHandle.NONE
         val nowMs = now()
-        val intentStamp = if (stampsIntent) nextIntentStamp() else 0L
+        val intentStamp = if (stampsIntent) intentStampOverride ?: nextIntentStamp() else 0L
 
         var opId = OutboxHandle.NONE.opId
         db.withTransaction {

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/sync/OutboxOperation.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/sync/OutboxOperation.kt
@@ -52,9 +52,25 @@ data class OutboxOperation(
         val requiresReplay: Boolean = false,
     )
 
+    /**
+     * Payload for [RECONCILE_WATCHED_CHILDREN]. Queued next to a container's
+     * SET_WATCHED op and drained after it: confirms [knownChildIds], then
+     * discovers the rest from the catalog. [containerAtMs] orders the
+     * container action against child-level intents.
+     */
+    @Serializable
+    data class ReconcileWatchedChildrenPayload(
+        val watched: Boolean,
+        val seriesId: String,
+        val seasonNumber: Int,
+        val knownChildIds: List<String>,
+        val containerAtMs: Long,
+    )
+
     companion object {
         const val SET_POSITION = "SET_POSITION"
         const val SET_WATCHED = "SET_WATCHED"
+        const val RECONCILE_WATCHED_CHILDREN = "RECONCILE_WATCHED_CHILDREN"
         const val SET_RATING = "SET_RATING"
         const val SET_FAVORITE = "SET_FAVORITE"
         const val SET_EBOOK_PROGRESS = "SET_EBOOK_PROGRESS"
@@ -103,6 +119,11 @@ data class OutboxOperation(
             return if (element is JsonPrimitive) WatchedPayload(watched = element.boolean)
             else json.decodeFromJsonElement(element)
         }
+
+        fun encodeReconcilePayload(payload: ReconcileWatchedChildrenPayload): String = json.encodeToString(payload)
+
+        fun decodeReconcilePayload(payloadJson: String): ReconcileWatchedChildrenPayload =
+            json.decodeFromString(payloadJson)
 
         /** Rating payload is the int value, or null for "clear rating". */
         fun decodeRatingPayload(payloadJson: String): Int? =

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/sync/SyncEngine.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/sync/SyncEngine.kt
@@ -134,6 +134,13 @@ class SyncEngine(
                         if (dao.countNewerPending(op.coalesceKey, op.id) == 0) {
                             contentDao.revertForTerminalOp(op)
                             userStateDao.restorePlaybackProgressForTerminalOp(op)
+                            // A rejected container write must not leave its child
+                            // reconciliation eligible to drain.
+                            if (op.opKind == OutboxOperation.SET_WATCHED) {
+                                dao.deletePendingByCoalesceKey(
+                                    "${op.serverId}|${op.profileId}|${op.targetContentId}|${OutboxOperation.RECONCILE_WATCHED_CHILDREN}",
+                                )
+                            }
                         }
                         dao.deleteById(op.id)
                         dropped++

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/sync/SyncEngine.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/sync/SyncEngine.kt
@@ -8,6 +8,7 @@ import org.siloserver.silo.model.personal.SyncProgressItem
 import org.siloserver.silo.model.personal.SyncProgressRequest
 import org.siloserver.silo.network.ApiResult
 import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.api.CatalogApi
 import org.siloserver.silo.network.api.EbookReaderApi
 import org.siloserver.silo.network.api.PersonalDataApi
 import org.siloserver.silo.repository.port.WriteOutcome
@@ -43,10 +44,25 @@ class SyncEngine(
     private val snapshotProvider: suspend () -> AuthScopeSnapshot?,
     private val now: () -> Long = { System.currentTimeMillis() },
     private val batchLimit: Int = 50,
+    /** Needed only for RECONCILE_WATCHED_CHILDREN; null drops those ops terminally. */
+    private val catalogApi: CatalogApi? = null,
+    /** Local confirmation sink for RECONCILE_WATCHED_CHILDREN; null drops those ops terminally. */
+    private val childConfirmer: WatchedChildConfirmer? = null,
 ) {
     private val dao = db.dirtyOperationDao()
     private val contentDao = db.contentItemStateDao()
     private val userStateDao = db.userItemStateDao()
+
+    /** Applies one acknowledged container write to one child, locally only. */
+    fun interface WatchedChildConfirmer {
+        suspend fun confirm(
+            serverId: String,
+            profileId: String,
+            contentId: String,
+            watched: Boolean,
+            containerAtMs: Long,
+        )
+    }
 
     data class DrainResult(
         val synced: Int = 0,
@@ -207,6 +223,8 @@ class SyncEngine(
 
             OutboxOperation.SET_EBOOK_PROGRESS -> return dispatchEbookProgress(op, contentId, scope)
 
+            OutboxOperation.RECONCILE_WATCHED_CHILDREN -> return dispatchReconcileWatchedChildren(op, scope)
+
             else -> {
                 // This engine version cannot send this kind. Drop it rather than
                 // retry forever.
@@ -250,6 +268,38 @@ class SyncEngine(
                 } else {
                     server.toWriteOutcome()
                 }
+        }
+    }
+
+    /**
+     * Confirm a season's episodes after the season's own SET_WATCHED drained.
+     * Known children are confirmed first so a lookup failure never loses them;
+     * the catalog lookup then discovers the rest. A transient lookup failure
+     * keeps the op queued with backoff, so discovery is retried rather than
+     * abandoned. Every confirmation is pinned to the drain's captured scope.
+     */
+    private suspend fun dispatchReconcileWatchedChildren(
+        op: DirtyOperationEntity,
+        scope: AuthScopeSnapshot,
+    ): WriteOutcome {
+        val api = catalogApi ?: return WriteOutcome.TERMINAL
+        val confirmer = childConfirmer ?: return WriteOutcome.TERMINAL
+        val profileId = scope.profileId ?: return WriteOutcome.TERMINAL
+        val payload = OutboxOperation.decodeReconcilePayload(op.payloadJson)
+        payload.knownChildIds.forEach { childId ->
+            confirmer.confirm(scope.serverId, profileId, childId, payload.watched, payload.containerAtMs)
+        }
+        return when (val page = api.getEpisodes(payload.seriesId, payload.seasonNumber, scope)) {
+            is ApiResult.Success -> {
+                page.data.episodes
+                    .map { it.contentId }
+                    .filterNot { it in payload.knownChildIds }
+                    .forEach { childId ->
+                        confirmer.confirm(scope.serverId, profileId, childId, payload.watched, payload.containerAtMs)
+                    }
+                WriteOutcome.SYNCED
+            }
+            else -> page.toWriteOutcome()
         }
     }
 

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/sync/SyncEngine.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/sync/SyncEngine.kt
@@ -53,11 +53,14 @@ class SyncEngine(
     private val contentDao = db.contentItemStateDao()
     private val userStateDao = db.userItemStateDao()
 
-    /** Applies one acknowledged container write to one child, locally only. */
+    /**
+     * Applies one acknowledged container write to one child, locally only.
+     * Receives the drain's captured [AuthScopeSnapshot] so the confirmation
+     * can be gated against the identity that accepted the container write.
+     */
     fun interface WatchedChildConfirmer {
         suspend fun confirm(
-            serverId: String,
-            profileId: String,
+            scope: AuthScopeSnapshot,
             contentId: String,
             watched: Boolean,
             containerAtMs: Long,
@@ -291,10 +294,10 @@ class SyncEngine(
     ): WriteOutcome {
         val api = catalogApi ?: return WriteOutcome.TERMINAL
         val confirmer = childConfirmer ?: return WriteOutcome.TERMINAL
-        val profileId = scope.profileId ?: return WriteOutcome.TERMINAL
+        if (scope.profileId == null) return WriteOutcome.TERMINAL
         val payload = OutboxOperation.decodeReconcilePayload(op.payloadJson)
         payload.knownChildIds.forEach { childId ->
-            confirmer.confirm(scope.serverId, profileId, childId, payload.watched, payload.containerAtMs)
+            confirmer.confirm(scope, childId, payload.watched, payload.containerAtMs)
         }
         return when (val page = api.getEpisodes(payload.seriesId, payload.seasonNumber, scope)) {
             is ApiResult.Success -> {
@@ -302,7 +305,7 @@ class SyncEngine(
                     .map { it.contentId }
                     .filterNot { it in payload.knownChildIds }
                     .forEach { childId ->
-                        confirmer.confirm(scope.serverId, profileId, childId, payload.watched, payload.containerAtMs)
+                        confirmer.confirm(scope, childId, payload.watched, payload.containerAtMs)
                     }
                 WriteOutcome.SYNCED
             }

--- a/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/sync/SyncEngine.kt
+++ b/android-shared/src/androidMain/kotlin/org/siloserver/silo/common/data/sync/SyncEngine.kt
@@ -59,12 +59,13 @@ class SyncEngine(
      * can be gated against the identity that accepted the container write.
      */
     fun interface WatchedChildConfirmer {
+        /** Returns false when the captured identity is no longer current and nothing was written. */
         suspend fun confirm(
             scope: AuthScopeSnapshot,
             contentId: String,
             watched: Boolean,
             containerAtMs: Long,
-        )
+        ): Boolean
     }
 
     data class DrainResult(
@@ -296,17 +297,18 @@ class SyncEngine(
         val confirmer = childConfirmer ?: return WriteOutcome.TERMINAL
         if (scope.profileId == null) return WriteOutcome.TERMINAL
         val payload = OutboxOperation.decodeReconcilePayload(op.payloadJson)
-        payload.knownChildIds.forEach { childId ->
-            confirmer.confirm(scope, childId, payload.watched, payload.containerAtMs)
+        // A confirmation declined by the identity gate means the captured
+        // identity moved on mid-drain. Keep the op queued for that identity's
+        // next drain instead of deleting it as done.
+        for (childId in payload.knownChildIds) {
+            if (!confirmer.confirm(scope, childId, payload.watched, payload.containerAtMs)) return WriteOutcome.RETRIABLE
         }
         return when (val page = api.getEpisodes(payload.seriesId, payload.seasonNumber, scope)) {
             is ApiResult.Success -> {
-                page.data.episodes
-                    .map { it.contentId }
-                    .filterNot { it in payload.knownChildIds }
-                    .forEach { childId ->
-                        confirmer.confirm(scope, childId, payload.watched, payload.containerAtMs)
-                    }
+                val discovered = page.data.episodes.map { it.contentId }.filterNot { it in payload.knownChildIds }
+                for (childId in discovered) {
+                    if (!confirmer.confirm(scope, childId, payload.watched, payload.containerAtMs)) return WriteOutcome.RETRIABLE
+                }
                 WriteOutcome.SYNCED
             }
             else -> page.toWriteOutcome()

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/db/SiloDatabaseMigrationTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/db/SiloDatabaseMigrationTest.kt
@@ -68,4 +68,22 @@ class SiloDatabaseMigrationTest {
     private companion object {
         const val DATABASE_NAME = "migration-7-to-8"
     }
+
+    @Test
+    fun migration8To9AddsWatchedIntentTimestampDefaultingToZero() {
+        migrationHelper.createDatabase(DATABASE_NAME, 8).use { database ->
+            database.execSQL(
+                "INSERT INTO content_item_state (serverId, profileId, contentId, watched, clientUpdatedAtMs) VALUES (?, ?, ?, ?, ?)",
+                arrayOf<Any?>("server-a", "profile-a", "content-a", 1, 1234L),
+            )
+        }
+
+        migrationHelper.runMigrationsAndValidate(DATABASE_NAME, 9, true).use { database ->
+            database.query("SELECT watched, watchedIntentAtMs FROM content_item_state").use { cursor ->
+                assertEquals(true, cursor.moveToFirst())
+                assertEquals(1, cursor.getInt(0))
+                assertEquals(0L, cursor.getLong(1))
+            }
+        }
+    }
 }

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -73,6 +73,61 @@ class RoomUserItemStateRepositoryTest {
         assertEquals(listOf(handle.opId), heads.map { it.id })
     }
 
+    /** Acknowledging the season write must wake the drain for its queued reconciliation. */
+    @Test
+    fun resolvingContainerWriteSyncedRequestsADrainForTheReconciliation() = runTest {
+        var syncRequests = 0
+        val scheduled = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = { currentSnapshot },
+            syncScheduler = OutboxSyncScheduler { syncRequests += 1 },
+            now = { 1000L },
+            idGenerator = { "sched-${nextId++}" },
+        )
+        val handle = scheduled.recordContainerWatched("season-1", watched = true, children = children)
+        scheduled.resolve(handle, WriteOutcome.SYNCED)
+        assertEquals(1, syncRequests)
+        val remaining = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
+        assertEquals(listOf(OutboxOperation.RECONCILE_WATCHED_CHILDREN), remaining.map { it.opKind })
+    }
+
+    /** A rejected season write takes its reconciliation with it. */
+    @Test
+    fun resolvingContainerWriteTerminalDropsTheReconciliation() = runTest {
+        val handle = repo.recordContainerWatched("season-1", watched = true, children = children)
+        repo.resolve(handle, WriteOutcome.TERMINAL)
+        assertEquals(0, db.dirtyOperationDao().count())
+        assertNull(db.contentItemStateDao().get("s1", "p1", "season-1")?.watched)
+    }
+
+    /**
+     * A child whose own older write is still on the wire gets a corrective
+     * op that stays queued for the drain instead of being resolved locally,
+     * so the season value is sent after that older request.
+     */
+    @Test
+    fun confirmContainerChildKeepsCorrectiveWriteQueuedBehindAnOlderChildWrite() = runTest {
+        var syncRequests = 0
+        val scheduled = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = { currentSnapshot },
+            syncScheduler = OutboxSyncScheduler { syncRequests += 1 },
+            now = { 1000L },
+            idGenerator = { "sched-${nextId++}" },
+        )
+        // Older child write, inline request still in progress (op pending).
+        scheduled.recordWatched("e1", watched = false)
+
+        scheduled.confirmContainerChild("s1", "p1", "e1", watched = true, containerAtMs = 5_000L)
+
+        val queued = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
+            .filter { it.opKind == OutboxOperation.SET_WATCHED && it.targetContentId == "e1" }
+        assertEquals(1, queued.size)
+        assertEquals(true, OutboxOperation.decodeBooleanPayload(queued.single().payloadJson))
+        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
+        assertEquals(1, syncRequests)
+    }
+
     /**
      * Confirming a child behaves like a confirmed single-item write: the
      * projection flips, resume rows and pending positions clear, and nothing

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -249,6 +249,28 @@ class RoomUserItemStateRepositoryTest {
         assertEquals(true, db.contentItemStateDao().get("s1", "p1", "child")?.watched)
     }
 
+    /**
+     * A season action queued behind an earlier write reserves its stamp when
+     * the user acts. An episode toggled after that, but before the season
+     * write records, still ranks newer than the season action.
+     */
+    @Test
+    fun reservedContainerStampOrdersBeforeALaterChildToggle() = runTest {
+        val reserved = repo.reserveWatchedIntentStamp()
+        // User toggles a child after the (still waiting) season action.
+        repo.resolve(repo.recordWatched("e1", watched = false), WriteOutcome.SYNCED)
+        // The season write finally records with the stamp reserved earlier.
+        repo.recordContainerWatched("season-1", watched = true, children = children, intentStamp = reserved)
+        val containerAtMs = db.dirtyOperationDao()
+            .dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
+            .first { it.opKind == OutboxOperation.RECONCILE_WATCHED_CHILDREN }
+            .let { OutboxOperation.decodeReconcilePayload(it.payloadJson).containerAtMs }
+        assertEquals(reserved, containerAtMs)
+
+        repo.confirmContainerChild(scopeS1, "e1", watched = true, containerAtMs = containerAtMs)
+        assertEquals(false, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
+    }
+
     /** Both container ops and the returned handle must share the scope captured once. */
     @Test
     fun recordContainerWatchedUsesOneScopeForBothOperations() = runTest {

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -163,6 +163,36 @@ class RoomUserItemStateRepositoryTest {
         assertEquals(1, syncRequests)
     }
 
+    /**
+     * Wall-clock stamps tie inside one millisecond. A child action issued
+     * after the container action in that same millisecond must still order
+     * after it; one issued before it must not.
+     */
+    @Test
+    fun childActionInTheSameMillisecondOrdersByIssueOrder() = runTest {
+        val frozen = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = { currentSnapshot },
+            now = { 5_000L },
+            idGenerator = { "frozen-${nextId++}" },
+        )
+        // Child "before" toggled, then the season, then child "after": all at now()=5000.
+        frozen.resolve(frozen.recordWatched("before", watched = false), WriteOutcome.SYNCED)
+        val container = frozen.recordContainerWatched("season-1", watched = true, children = children)
+        frozen.resolve(frozen.recordWatched("after", watched = false), WriteOutcome.SYNCED)
+        val containerAtMs = db.dirtyOperationDao()
+            .dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
+            .first { it.opKind == OutboxOperation.RECONCILE_WATCHED_CHILDREN }
+            .let { OutboxOperation.decodeReconcilePayload(it.payloadJson).containerAtMs }
+        frozen.resolve(container, WriteOutcome.SYNCED)
+
+        frozen.confirmContainerChild("s1", "p1", "before", watched = true, containerAtMs = containerAtMs)
+        frozen.confirmContainerChild("s1", "p1", "after", watched = true, containerAtMs = containerAtMs)
+
+        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "before")?.watched)
+        assertEquals(false, db.contentItemStateDao().get("s1", "p1", "after")?.watched)
+    }
+
     /** Both container ops and the returned handle must share the scope captured once. */
     @Test
     fun recordContainerWatchedUsesOneScopeForBothOperations() = runTest {

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -9,6 +9,7 @@ import org.siloserver.silo.network.AuthScopeSnapshot
 import org.siloserver.silo.repository.port.OutboxHandle
 import org.siloserver.silo.repository.port.PlaybackWriteScope
 import org.siloserver.silo.repository.port.TrackSelectionFingerprintUpdate
+import org.siloserver.silo.repository.port.WatchedContainerChildren
 import org.siloserver.silo.repository.port.WriteOutcome
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
@@ -47,81 +48,75 @@ class RoomUserItemStateRepositoryTest {
     @AfterTest
     fun tearDown() = db.close()
 
+    private val children = WatchedContainerChildren(seriesId = "series-1", seasonNumber = 2, knownChildIds = listOf("e1"))
+
     /**
-     * A season-level watched mutation is recorded against the season id only.
-     * The episodes it fans out to keep their local resume rows unless the
-     * caller confirms them, which would resurrect Resume on a played episode.
+     * A season write queues its own SET_WATCHED plus a reconciliation op for
+     * the children, behind it, so the drain confirms children only after the
+     * server has acknowledged the container.
      */
     @Test
-    fun recordConfirmedWatchedDropsChildResumeRowsAndQueuedPositionsWithoutQueuingRequests() = runTest {
-        repo.recordPosition("e1", fileId = 7, positionSeconds = 456.0, durationSeconds = 3600.0)
-        repo.recordPosition("e2", fileId = 8, positionSeconds = 120.0, durationSeconds = 3600.0)
-        assertNotNull(repo.localPlaybackProgress("e1"))
-        assertNotNull(repo.localPlaybackProgress("e2"))
+    fun recordContainerWatchedQueuesReconciliationBehindTheContainerWrite() = runTest {
+        val handle = repo.recordContainerWatched("season-1", watched = true, children = children)
+        assertTrue(handle.opId >= 0)
 
-        repo.recordConfirmedWatched(listOf("e1", "e2"), watched = true)
+        val ops = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 2000L, limit = 10)
+        assertEquals(listOf(OutboxOperation.SET_WATCHED, OutboxOperation.RECONCILE_WATCHED_CHILDREN), ops.map { it.opKind })
+        assertEquals(handle.opId, ops[0].id)
+        val payload = OutboxOperation.decodeReconcilePayload(ops[1].payloadJson)
+        assertEquals(true, payload.watched)
+        assertEquals("series-1", payload.seriesId)
+        assertEquals(2, payload.seasonNumber)
+        assertEquals(listOf("e1"), payload.knownChildIds)
+        // Only the season head is due first: the reconciliation waits behind it.
+        val heads = db.dirtyOperationDao().dueTargetHeads("s1", "p1", nowMs = 2000L, limit = 10)
+        assertEquals(listOf(handle.opId), heads.map { it.id })
+    }
+
+    /**
+     * Confirming a child behaves like a confirmed single-item write: the
+     * projection flips, resume rows and pending positions clear, and nothing
+     * is left queued for the network.
+     */
+    @Test
+    fun confirmContainerChildDropsResumeRowsAndQueuedPositionsWithoutQueuingRequests() = runTest {
+        repo.recordPosition("e1", fileId = 7, positionSeconds = 456.0, durationSeconds = 3600.0)
+        assertNotNull(repo.localPlaybackProgress("e1"))
+
+        repo.confirmContainerChild("s1", "p1", "e1", watched = true, containerAtMs = 5_000L)
 
         assertNull(repo.localPlaybackProgress("e1"))
-        assertNull(repo.localPlaybackProgress("e2"))
-        assertTrue(repo.localPlaybackProgressForContent(listOf("e1", "e2")).isEmpty())
         assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
-        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e2")?.watched)
-        // Nothing left to send: the server already applied the season write.
         assertTrue(db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10).isEmpty())
     }
 
     /**
-     * A child the user toggled on its own while the season write was pending
-     * carries a newer intent; the container confirmation must not overwrite
-     * its projection or coalesce away its queued write.
+     * A child the user toggled after the container action carries a newer
+     * intent, whether or not its outbox op has drained already. An older
+     * intent (a stale queued op from before the action) does not protect it.
      */
     @Test
-    fun recordConfirmedWatchedLeavesChildrenWithTheirOwnPendingIntentAlone() = runTest {
-        val own = repo.recordWatched("e1", watched = false)
-        assertTrue(own.opId >= 0)
-
-        repo.recordConfirmedWatched(listOf("e1", "e2"), watched = true)
-
-        assertEquals(false, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
-        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e2")?.watched)
-        assertNotNull(db.dirtyOperationDao().getById(own.opId))
-    }
-
-    /**
-     * The per-child confirmation must be atomic. Simulate a child-level write
-     * landing between the intent check and the record by issuing it from a
-     * second repository on the same database while the first is mid-loop.
-     * With per-child transactions the second write either waits and is then
-     * seen as the newer intent, or lands after and coalesces normally; in
-     * both cases the child's own pending op survives.
-     */
-    @Test
-    fun recordConfirmedWatchedDoesNotDropAChildWriteThatLandsDuringConfirmation() = runTest {
-        val other = RoomUserItemStateRepository(
+    fun confirmContainerChildKeepsIntentsNewerThanTheContainerActionOnly() = runTest {
+        var clock = 1000L
+        val clocked = RoomUserItemStateRepository(
             db = db,
             snapshotProvider = { currentSnapshot },
-            now = { 1000L },
-            idGenerator = { "other-${nextId++}" },
+            now = { clock },
+            idGenerator = { "clocked-${nextId++}" },
         )
-        // Confirm a first child, then race a user toggle on the second child
-        // against its confirmation.
-        val own = kotlinx.coroutines.coroutineScope {
-            val confirmation = async(kotlinx.coroutines.Dispatchers.IO) {
-                repo.recordConfirmedWatched(listOf("e1", "e2"), watched = true)
-            }
-            val handle = other.recordWatched("e2", watched = false)
-            confirmation.await()
-            handle
-        }
+        // Stale intent from before the container action: superseded.
+        val stale = clocked.recordWatched("old", watched = false)
+        clocked.resolve(stale, WriteOutcome.SYNCED)
+        // Newer intent, already drained (no outbox row left to inspect).
+        clock = 9_000L
+        val newer = clocked.recordWatched("new", watched = false)
+        clocked.resolve(newer, WriteOutcome.SYNCED)
 
-        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
-        // Whichever order the two writes serialized in, the user's own intent
-        // for e2 is what remains queued.
-        val queued = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
-            .filter { it.opKind == OutboxOperation.SET_WATCHED && it.targetContentId == "e2" }
-        assertEquals(1, queued.size)
-        assertEquals(own.opId, queued.single().id)
-        assertEquals(false, db.contentItemStateDao().get("s1", "p1", "e2")?.watched)
+        clocked.confirmContainerChild("s1", "p1", "old", watched = true, containerAtMs = 5_000L)
+        clocked.confirmContainerChild("s1", "p1", "new", watched = true, containerAtMs = 5_000L)
+
+        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "old")?.watched)
+        assertEquals(false, db.contentItemStateDao().get("s1", "p1", "new")?.watched)
     }
 
     /**
@@ -130,7 +125,7 @@ class RoomUserItemStateRepositoryTest {
      * position cannot land last and reopen the episode on the server.
      */
     @Test
-    fun recordConfirmedWatchedKeepsReplayForChildWithInFlightPosition() = runTest {
+    fun confirmContainerChildKeepsReplayForChildWithInFlightPosition() = runTest {
         repo.recordPosition("e1", fileId = 7, positionSeconds = 456.0, durationSeconds = 3600.0)
         val position = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 2000L, limit = 10).single()
         assertEquals(1, db.dirtyOperationDao().claim(position.id))
@@ -143,7 +138,7 @@ class RoomUserItemStateRepositoryTest {
             idGenerator = { "guarded-${nextId++}" },
         )
 
-        guardedRepo.recordConfirmedWatched(listOf("e1", "e2"), watched = true)
+        guardedRepo.confirmContainerChild("s1", "p1", "e1", watched = true, containerAtMs = 5_000L)
 
         assertNull(guardedRepo.localPlaybackProgress("e1"))
         val queuedWatched = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -70,6 +70,23 @@ class RoomUserItemStateRepositoryTest {
     }
 
     /**
+     * A child the user toggled on its own while the season write was pending
+     * carries a newer intent; the container confirmation must not overwrite
+     * its projection or coalesce away its queued write.
+     */
+    @Test
+    fun recordConfirmedWatchedLeavesChildrenWithTheirOwnPendingIntentAlone() = runTest {
+        val own = repo.recordWatched("e1", watched = false)
+        assertTrue(own.opId >= 0)
+
+        repo.recordConfirmedWatched(listOf("e1", "e2"), watched = true)
+
+        assertEquals(false, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
+        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e2")?.watched)
+        assertNotNull(db.dirtyOperationDao().getById(own.opId))
+    }
+
+    /**
      * A child whose position write is already in flight cannot have that
      * write deleted. Its watched op must stay queued for one replay so the
      * position cannot land last and reopen the episode on the server.

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -49,24 +49,52 @@ class RoomUserItemStateRepositoryTest {
     /**
      * A season-level watched mutation is recorded against the season id only.
      * The episodes it fans out to keep their local resume rows unless the
-     * caller clears them, which would resurrect Resume on a played episode.
+     * caller confirms them, which would resurrect Resume on a played episode.
      */
     @Test
-    fun clearPlaybackProgressDropsChildResumeRowsAndQueuedPositions() = runTest {
+    fun recordConfirmedWatchedDropsChildResumeRowsAndQueuedPositionsWithoutQueuingRequests() = runTest {
         repo.recordPosition("e1", fileId = 7, positionSeconds = 456.0, durationSeconds = 3600.0)
         repo.recordPosition("e2", fileId = 8, positionSeconds = 120.0, durationSeconds = 3600.0)
         assertNotNull(repo.localPlaybackProgress("e1"))
         assertNotNull(repo.localPlaybackProgress("e2"))
 
-        repo.clearPlaybackProgress(listOf("e1", "e2"))
+        repo.recordConfirmedWatched(listOf("e1", "e2"), watched = true)
 
         assertNull(repo.localPlaybackProgress("e1"))
         assertNull(repo.localPlaybackProgress("e2"))
         assertTrue(repo.localPlaybackProgressForContent(listOf("e1", "e2")).isEmpty())
-        val pendingPositions = db.dirtyOperationDao()
-            .dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
-            .filter { it.opKind == OutboxOperation.SET_POSITION }
-        assertTrue(pendingPositions.isEmpty())
+        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
+        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e2")?.watched)
+        // Nothing left to send: the server already applied the season write.
+        assertTrue(db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10).isEmpty())
+    }
+
+    /**
+     * A child whose position write is already in flight cannot have that
+     * write deleted. Its watched op must stay queued for one replay so the
+     * position cannot land last and reopen the episode on the server.
+     */
+    @Test
+    fun recordConfirmedWatchedKeepsReplayForChildWithInFlightPosition() = runTest {
+        repo.recordPosition("e1", fileId = 7, positionSeconds = 456.0, durationSeconds = 3600.0)
+        val position = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 2000L, limit = 10).single()
+        assertEquals(1, db.dirtyOperationDao().claim(position.id))
+        var syncRequests = 0
+        val guardedRepo = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = { AuthScopeSnapshot("s1", "p1", "https://s1.example", "pt") },
+            syncScheduler = OutboxSyncScheduler { syncRequests += 1 },
+            now = { 1000L },
+            idGenerator = { "guarded-${nextId++}" },
+        )
+
+        guardedRepo.recordConfirmedWatched(listOf("e1", "e2"), watched = true)
+
+        assertNull(guardedRepo.localPlaybackProgress("e1"))
+        val queuedWatched = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
+            .filter { it.opKind == OutboxOperation.SET_WATCHED }
+        assertEquals(listOf("e1"), queuedWatched.map { it.targetContentId })
+        assertEquals(1, syncRequests)
     }
 
     @Test

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -46,6 +46,29 @@ class RoomUserItemStateRepositoryTest {
     @AfterTest
     fun tearDown() = db.close()
 
+    /**
+     * A season-level watched mutation is recorded against the season id only.
+     * The episodes it fans out to keep their local resume rows unless the
+     * caller clears them, which would resurrect Resume on a played episode.
+     */
+    @Test
+    fun clearPlaybackProgressDropsChildResumeRowsAndQueuedPositions() = runTest {
+        repo.recordPosition("e1", fileId = 7, positionSeconds = 456.0, durationSeconds = 3600.0)
+        repo.recordPosition("e2", fileId = 8, positionSeconds = 120.0, durationSeconds = 3600.0)
+        assertNotNull(repo.localPlaybackProgress("e1"))
+        assertNotNull(repo.localPlaybackProgress("e2"))
+
+        repo.clearPlaybackProgress(listOf("e1", "e2"))
+
+        assertNull(repo.localPlaybackProgress("e1"))
+        assertNull(repo.localPlaybackProgress("e2"))
+        assertTrue(repo.localPlaybackProgressForContent(listOf("e1", "e2")).isEmpty())
+        val pendingPositions = db.dirtyOperationDao()
+            .dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
+            .filter { it.opKind == OutboxOperation.SET_POSITION }
+        assertTrue(pendingPositions.isEmpty())
+    }
+
     @Test
     fun recordWatchedWritesProjectionAndContentScopedOutboxOp() = runTest {
         val handle = repo.recordWatched("c1", watched = true)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -49,6 +49,7 @@ class RoomUserItemStateRepositoryTest {
     fun tearDown() = db.close()
 
     private val children = WatchedContainerChildren(seriesId = "series-1", seasonNumber = 2, knownChildIds = listOf("e1"))
+    private val scopeS1 = AuthScopeSnapshot("s1", "p1", "https://s1.example", "pt")
 
     /**
      * A season write queues its own SET_WATCHED plus a reconciliation op for
@@ -119,7 +120,7 @@ class RoomUserItemStateRepositoryTest {
         // Older child write, inline request still in progress (op pending).
         val older = scheduled.recordWatched("e1", watched = false)
 
-        scheduled.confirmContainerChild("s1", "p1", "e1", watched = true, containerAtMs = 5_000L)
+        scheduled.confirmContainerChild(scopeS1, "e1", watched = true, containerAtMs = 5_000L)
 
         val queued = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
             .filter { it.opKind == OutboxOperation.SET_WATCHED && it.targetContentId == "e1" }
@@ -154,7 +155,7 @@ class RoomUserItemStateRepositoryTest {
         clocked.resolve(newer, WriteOutcome.SYNCED)
         assertEquals(0, db.dirtyOperationDao().count())
 
-        clocked.confirmContainerChild("s1", "p1", "e1", watched = true, containerAtMs = 5_000L)
+        clocked.confirmContainerChild(scopeS1, "e1", watched = true, containerAtMs = 5_000L)
 
         assertEquals(false, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
         val replay = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10).single()
@@ -186,11 +187,66 @@ class RoomUserItemStateRepositoryTest {
             .let { OutboxOperation.decodeReconcilePayload(it.payloadJson).containerAtMs }
         frozen.resolve(container, WriteOutcome.SYNCED)
 
-        frozen.confirmContainerChild("s1", "p1", "before", watched = true, containerAtMs = containerAtMs)
-        frozen.confirmContainerChild("s1", "p1", "after", watched = true, containerAtMs = containerAtMs)
+        frozen.confirmContainerChild(scopeS1, "before", watched = true, containerAtMs = containerAtMs)
+        frozen.confirmContainerChild(scopeS1, "after", watched = true, containerAtMs = containerAtMs)
 
         assertEquals(true, db.contentItemStateDao().get("s1", "p1", "before")?.watched)
         assertEquals(false, db.contentItemStateDao().get("s1", "p1", "after")?.watched)
+    }
+
+    /**
+     * A confirmation carries the identity that accepted the container write.
+     * Once that identity has moved on, the confirmation must not land.
+     */
+    @Test
+    fun confirmContainerChildIsSkippedAfterAnIdentityTransition() = runTest {
+        val barrier = org.siloserver.silo.network.DefaultIdentityTransitionBarrier()
+        val gated = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = { currentSnapshot },
+            now = { 1000L },
+            idGenerator = { "gated-${nextId++}" },
+            identityTransitions = barrier,
+        )
+        val captured = scopeS1.copy(identityGeneration = barrier.generation.value, isIdentityGenerationStamped = true)
+        barrier.changing(org.siloserver.silo.network.IdentityTransitionKind.SIGN_OUT) { }
+
+        gated.confirmContainerChild(captured, "e1", watched = true, containerAtMs = 5_000L)
+
+        assertNull(db.contentItemStateDao().get("s1", "p1", "e1"))
+    }
+
+    /**
+     * The monotonic stamp floor is seeded from persisted rows, so a clock
+     * that moved backwards across a restart cannot issue a stamp below an
+     * intent the previous process recorded.
+     */
+    @Test
+    fun intentStampsNeverFallBelowPersistedStampsAfterRestart() = runTest {
+        val earlier = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = { currentSnapshot },
+            now = { 9_000L },
+            idGenerator = { "earlier-${nextId++}" },
+        )
+        earlier.resolve(earlier.recordWatched("child", watched = false), WriteOutcome.SYNCED)
+
+        // "Restart" with a clock that went backwards.
+        val restarted = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = { currentSnapshot },
+            now = { 3_000L },
+            idGenerator = { "restarted-${nextId++}" },
+        )
+        restarted.recordContainerWatched("season-1", watched = true, children = children)
+        val containerAtMs = db.dirtyOperationDao()
+            .dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
+            .first { it.opKind == OutboxOperation.RECONCILE_WATCHED_CHILDREN }
+            .let { OutboxOperation.decodeReconcilePayload(it.payloadJson).containerAtMs }
+        assertTrue(containerAtMs > 9_000L)
+
+        restarted.confirmContainerChild(scopeS1, "child", watched = true, containerAtMs = containerAtMs)
+        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "child")?.watched)
     }
 
     /** Both container ops and the returned handle must share the scope captured once. */
@@ -224,7 +280,7 @@ class RoomUserItemStateRepositoryTest {
         repo.recordPosition("e1", fileId = 7, positionSeconds = 456.0, durationSeconds = 3600.0)
         assertNotNull(repo.localPlaybackProgress("e1"))
 
-        repo.confirmContainerChild("s1", "p1", "e1", watched = true, containerAtMs = 5_000L)
+        repo.confirmContainerChild(scopeS1, "e1", watched = true, containerAtMs = 5_000L)
 
         assertNull(repo.localPlaybackProgress("e1"))
         assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
@@ -253,8 +309,8 @@ class RoomUserItemStateRepositoryTest {
         val newer = clocked.recordWatched("new", watched = false)
         clocked.resolve(newer, WriteOutcome.SYNCED)
 
-        clocked.confirmContainerChild("s1", "p1", "old", watched = true, containerAtMs = 5_000L)
-        clocked.confirmContainerChild("s1", "p1", "new", watched = true, containerAtMs = 5_000L)
+        clocked.confirmContainerChild(scopeS1, "old", watched = true, containerAtMs = 5_000L)
+        clocked.confirmContainerChild(scopeS1, "new", watched = true, containerAtMs = 5_000L)
 
         assertEquals(true, db.contentItemStateDao().get("s1", "p1", "old")?.watched)
         assertEquals(false, db.contentItemStateDao().get("s1", "p1", "new")?.watched)
@@ -283,7 +339,7 @@ class RoomUserItemStateRepositoryTest {
             idGenerator = { "guarded-${nextId++}" },
         )
 
-        guardedRepo.confirmContainerChild("s1", "p1", "e1", watched = true, containerAtMs = 5_000L)
+        guardedRepo.confirmContainerChild(scopeS1, "e1", watched = true, containerAtMs = 5_000L)
 
         assertNull(guardedRepo.localPlaybackProgress("e1"))
         val queuedWatched = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -10,6 +10,7 @@ import org.siloserver.silo.repository.port.OutboxHandle
 import org.siloserver.silo.repository.port.PlaybackWriteScope
 import org.siloserver.silo.repository.port.TrackSelectionFingerprintUpdate
 import org.siloserver.silo.repository.port.WriteOutcome
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -84,6 +85,43 @@ class RoomUserItemStateRepositoryTest {
         assertEquals(false, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
         assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e2")?.watched)
         assertNotNull(db.dirtyOperationDao().getById(own.opId))
+    }
+
+    /**
+     * The per-child confirmation must be atomic. Simulate a child-level write
+     * landing between the intent check and the record by issuing it from a
+     * second repository on the same database while the first is mid-loop.
+     * With per-child transactions the second write either waits and is then
+     * seen as the newer intent, or lands after and coalesces normally; in
+     * both cases the child's own pending op survives.
+     */
+    @Test
+    fun recordConfirmedWatchedDoesNotDropAChildWriteThatLandsDuringConfirmation() = runTest {
+        val other = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = { currentSnapshot },
+            now = { 1000L },
+            idGenerator = { "other-${nextId++}" },
+        )
+        // Confirm a first child, then race a user toggle on the second child
+        // against its confirmation.
+        val own = kotlinx.coroutines.coroutineScope {
+            val confirmation = async(kotlinx.coroutines.Dispatchers.IO) {
+                repo.recordConfirmedWatched(listOf("e1", "e2"), watched = true)
+            }
+            val handle = other.recordWatched("e2", watched = false)
+            confirmation.await()
+            handle
+        }
+
+        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
+        // Whichever order the two writes serialized in, the user's own intent
+        // for e2 is what remains queued.
+        val queued = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
+            .filter { it.opKind == OutboxOperation.SET_WATCHED && it.targetContentId == "e2" }
+        assertEquals(1, queued.size)
+        assertEquals(own.opId, queued.single().id)
+        assertEquals(false, db.contentItemStateDao().get("s1", "p1", "e2")?.watched)
     }
 
     /**

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -102,11 +102,12 @@ class RoomUserItemStateRepositoryTest {
 
     /**
      * A child whose own older write is still on the wire gets a corrective
-     * op that stays queued for the drain instead of being resolved locally,
-     * so the season value is sent after that older request.
+     * op inserted behind it, not coalesced over it. The older row stays as a
+     * per-item FIFO barrier, so the drain cannot send the correction until
+     * that older request has resolved.
      */
     @Test
-    fun confirmContainerChildKeepsCorrectiveWriteQueuedBehindAnOlderChildWrite() = runTest {
+    fun confirmContainerChildQueuesCorrectiveWriteBehindAnOlderInFlightChildWrite() = runTest {
         var syncRequests = 0
         val scheduled = RoomUserItemStateRepository(
             db = db,
@@ -116,16 +117,71 @@ class RoomUserItemStateRepositoryTest {
             idGenerator = { "sched-${nextId++}" },
         )
         // Older child write, inline request still in progress (op pending).
-        scheduled.recordWatched("e1", watched = false)
+        val older = scheduled.recordWatched("e1", watched = false)
 
         scheduled.confirmContainerChild("s1", "p1", "e1", watched = true, containerAtMs = 5_000L)
 
         val queued = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
             .filter { it.opKind == OutboxOperation.SET_WATCHED && it.targetContentId == "e1" }
-        assertEquals(1, queued.size)
-        assertEquals(true, OutboxOperation.decodeBooleanPayload(queued.single().payloadJson))
+        assertEquals(listOf(false, true), queued.map { OutboxOperation.decodeBooleanPayload(it.payloadJson) })
         assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
         assertEquals(1, syncRequests)
+        // Only the older write is a due head; the correction waits behind it.
+        assertEquals(listOf(older.opId), db.dirtyOperationDao().dueTargetHeads("s1", "p1", 40_000L, 10).map { it.id })
+        // Once the older inline request is acknowledged, the correction is next.
+        scheduled.resolve(older, WriteOutcome.SYNCED)
+        val head = db.dirtyOperationDao().dueTargetHeads("s1", "p1", 40_000L, 10).single()
+        assertEquals(true, OutboxOperation.decodeBooleanPayload(head.payloadJson))
+    }
+
+    /**
+     * A child the user toggled after the container action keeps its value
+     * locally and re-sends it, queued, so the server ends up with the newer
+     * intent even when the season fan-out landed after it.
+     */
+    @Test
+    fun confirmContainerChildReplaysANewerChildIntentAfterTheContainer() = runTest {
+        var clock = 9_000L
+        var syncRequests = 0
+        val clocked = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = { currentSnapshot },
+            syncScheduler = OutboxSyncScheduler { syncRequests += 1 },
+            now = { clock },
+            idGenerator = { "clocked-${nextId++}" },
+        )
+        val newer = clocked.recordWatched("e1", watched = false)
+        clocked.resolve(newer, WriteOutcome.SYNCED)
+        assertEquals(0, db.dirtyOperationDao().count())
+
+        clocked.confirmContainerChild("s1", "p1", "e1", watched = true, containerAtMs = 5_000L)
+
+        assertEquals(false, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
+        val replay = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10).single()
+        assertEquals(OutboxOperation.SET_WATCHED, replay.opKind)
+        assertEquals(false, OutboxOperation.decodeBooleanPayload(replay.payloadJson))
+        assertEquals(1, syncRequests)
+    }
+
+    /** Both container ops and the returned handle must share the scope captured once. */
+    @Test
+    fun recordContainerWatchedUsesOneScopeForBothOperations() = runTest {
+        var calls = 0
+        val switching = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = {
+                calls += 1
+                if (calls == 1) AuthScopeSnapshot("s1", "p1", "https://s1.example", "pt")
+                else AuthScopeSnapshot("s2", "p2", "https://s2.example", "pt")
+            },
+            now = { 1000L },
+            idGenerator = { "switch-${nextId++}" },
+        )
+        val handle = switching.recordContainerWatched("season-1", watched = true, children = children)
+        assertEquals("s1", handle.scope?.serverId)
+        val ops = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 2000L, limit = 10)
+        assertEquals(listOf(OutboxOperation.SET_WATCHED, OutboxOperation.RECONCILE_WATCHED_CHILDREN), ops.map { it.opKind })
+        assertEquals(0, db.dirtyOperationDao().countForScope("s2", "p2"))
     }
 
     /**
@@ -172,6 +228,10 @@ class RoomUserItemStateRepositoryTest {
 
         assertEquals(true, db.contentItemStateDao().get("s1", "p1", "old")?.watched)
         assertEquals(false, db.contentItemStateDao().get("s1", "p1", "new")?.watched)
+        // The stale child is confirmed locally with nothing queued; the newer
+        // child's intent is queued for replay after the container.
+        val queued = db.dirtyOperationDao().dueBatch("s1", "p1", nowMs = 40_000L, limit = 10)
+        assertEquals(listOf("new"), queued.map { it.targetContentId })
     }
 
     /**

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/repository/RoomUserItemStateRepositoryTest.kt
@@ -211,9 +211,34 @@ class RoomUserItemStateRepositoryTest {
         val captured = scopeS1.copy(identityGeneration = barrier.generation.value, isIdentityGenerationStamped = true)
         barrier.changing(org.siloserver.silo.network.IdentityTransitionKind.SIGN_OUT) { }
 
-        gated.confirmContainerChild(captured, "e1", watched = true, containerAtMs = 5_000L)
+        val applied = gated.confirmContainerChild(captured, "e1", watched = true, containerAtMs = 5_000L)
 
+        assertFalse(applied)
         assertNull(db.contentItemStateDao().get("s1", "p1", "e1"))
+    }
+
+    /**
+     * A child intent the server rejected is no intent at all. Its stamp must
+     * not shield the row from the season confirmation that did succeed.
+     */
+    @Test
+    fun rejectedChildIntentDoesNotBlockContainerConfirmation() = runTest {
+        var clock = 9_000L
+        val clocked = RoomUserItemStateRepository(
+            db = db,
+            snapshotProvider = { currentSnapshot },
+            now = { clock },
+            idGenerator = { "clocked-${nextId++}" },
+        )
+        clocked.recordPosition("e1", fileId = 7, positionSeconds = 456.0, durationSeconds = 3600.0)
+        val rejected = clocked.recordWatched("e1", watched = false)
+        clocked.resolve(rejected, WriteOutcome.TERMINAL)
+        assertEquals(0L, db.contentItemStateDao().get("s1", "p1", "e1")?.watchedIntentAtMs)
+
+        clocked.confirmContainerChild(scopeS1, "e1", watched = true, containerAtMs = 5_000L)
+
+        assertEquals(true, db.contentItemStateDao().get("s1", "p1", "e1")?.watched)
+        assertNull(clocked.localPlaybackProgress("e1"))
     }
 
     /**

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/sync/SyncEngineTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/sync/SyncEngineTest.kt
@@ -135,6 +135,20 @@ class SyncEngineTest {
         assertTrue(confirmed.isEmpty())
     }
 
+    /** A season write rejected during the drain must not leave its reconciliation to run later. */
+    @Test
+    fun terminalContainerWriteDropsItsQueuedReconciliation() = runTest {
+        db.dirtyOperationDao().insert(
+            op(idempotencyKey = "season", targetContentId = "season-1", coalesceKey = "s1|p1|season-1|SET_WATCHED"),
+        )
+        db.dirtyOperationDao().insert(reconcileOp("r1"))
+        status = HttpStatusCode.Forbidden
+        val result = reconcilingEngine().drainOnce()
+        assertEquals(1, result.dropped)
+        assertEquals(0, db.dirtyOperationDao().count())
+        assertTrue(confirmed.isEmpty())
+    }
+
     /** An engine without a catalog API cannot honour the op; drop rather than spin. */
     @Test
     fun reconcileWatchedChildrenIsDroppedWhenNoCatalogApiIsBound() = runTest {

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/sync/SyncEngineTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/sync/SyncEngineTest.kt
@@ -59,6 +59,91 @@ class SyncEngineTest {
         batchLimit = batchLimit,
     )
 
+    private val confirmed = mutableListOf<String>()
+    private var episodesStatus = HttpStatusCode.OK
+    private fun reconcilingEngine() = SyncEngine(
+        db = db,
+        personalDataApi = api,
+        ebookReaderApi = ebookApi,
+        snapshotProvider = { snapshot },
+        now = { clock },
+        catalogApi = org.siloserver.silo.network.api.CatalogApi(
+            HttpClient(
+                MockEngine {
+                    respond(
+                        """{"episodes":[{"content_id":"e1","season_number":2,"episode_number":1},{"content_id":"e2","season_number":2,"episode_number":2}]}""",
+                        episodesStatus,
+                        headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                },
+            ) { install(ContentNegotiation) { json(SiloJson) } },
+        ),
+        childConfirmer = SyncEngine.WatchedChildConfirmer { _, _, contentId, watched, _ -> confirmed += "$contentId=$watched" },
+    )
+
+    private fun reconcileOp(idempotencyKey: String) = DirtyOperationEntity(
+        opKind = OutboxOperation.RECONCILE_WATCHED_CHILDREN,
+        serverId = "s1",
+        profileId = "p1",
+        targetContentId = "season-1",
+        targetFileId = null,
+        coalesceKey = "s1|p1|season-1|${OutboxOperation.RECONCILE_WATCHED_CHILDREN}",
+        idempotencyKey = idempotencyKey,
+        payloadJson = OutboxOperation.encodeReconcilePayload(
+            OutboxOperation.ReconcileWatchedChildrenPayload(
+                watched = true, seriesId = "series-1", seasonNumber = 2,
+                knownChildIds = listOf("e1"), containerAtMs = 500L,
+            ),
+        ),
+        createdAtMs = 1L,
+        nextAttemptAtMs = 0L,
+    )
+
+    /** Known children first, then every episode the catalog reports, once. */
+    @Test
+    fun reconcileWatchedChildrenConfirmsKnownThenDiscoveredEpisodes() = runTest {
+        db.dirtyOperationDao().insert(reconcileOp("r1"))
+        val result = reconcilingEngine().drainOnce()
+        assertEquals(1, result.synced)
+        assertEquals(listOf("e1=true", "e2=true"), confirmed)
+        assertEquals(0, db.dirtyOperationDao().count())
+    }
+
+    /**
+     * A transient lookup failure keeps the op queued with backoff instead of
+     * abandoning discovery; the known children were still confirmed.
+     */
+    @Test
+    fun reconcileWatchedChildrenRetriesDiscoveryOnTransientFailure() = runTest {
+        db.dirtyOperationDao().insert(reconcileOp("r1"))
+        episodesStatus = HttpStatusCode.ServiceUnavailable
+        val result = reconcilingEngine().drainOnce()
+        assertEquals(1, result.retriable)
+        assertEquals(listOf("e1=true"), confirmed)
+        assertEquals(1, db.dirtyOperationDao().count())
+    }
+
+    /** The reconciliation waits behind its container's own write (per-item FIFO). */
+    @Test
+    fun reconcileWatchedChildrenWaitsForTheContainerWrite() = runTest {
+        db.dirtyOperationDao().insert(
+            op(idempotencyKey = "season", targetContentId = "season-1", coalesceKey = "s1|p1|season-1|SET_WATCHED", nextAttemptAtMs = 10_000L),
+        )
+        db.dirtyOperationDao().insert(reconcileOp("r1"))
+        val result = reconcilingEngine().drainOnce()
+        assertEquals(0, result.synced)
+        assertTrue(confirmed.isEmpty())
+    }
+
+    /** An engine without a catalog API cannot honour the op; drop rather than spin. */
+    @Test
+    fun reconcileWatchedChildrenIsDroppedWhenNoCatalogApiIsBound() = runTest {
+        db.dirtyOperationDao().insert(reconcileOp("r1"))
+        val result = engine().drainOnce()
+        assertEquals(1, result.dropped)
+        assertEquals(0, db.dirtyOperationDao().count())
+    }
+
     @AfterTest
     fun tearDown() = db.close()
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/sync/SyncEngineTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/sync/SyncEngineTest.kt
@@ -60,6 +60,7 @@ class SyncEngineTest {
     )
 
     private val confirmed = mutableListOf<String>()
+    private val confirmedScopes = mutableListOf<AuthScopeSnapshot>()
     private var episodesStatus = HttpStatusCode.OK
     private fun reconcilingEngine() = SyncEngine(
         db = db,
@@ -78,7 +79,10 @@ class SyncEngineTest {
                 },
             ) { install(ContentNegotiation) { json(SiloJson) } },
         ),
-        childConfirmer = SyncEngine.WatchedChildConfirmer { _, _, contentId, watched, _ -> confirmed += "$contentId=$watched" },
+        childConfirmer = SyncEngine.WatchedChildConfirmer { scope, contentId, watched, _ ->
+            confirmedScopes += scope
+            confirmed += "$contentId=$watched"
+        },
     )
 
     private fun reconcileOp(idempotencyKey: String) = DirtyOperationEntity(
@@ -99,13 +103,14 @@ class SyncEngineTest {
         nextAttemptAtMs = 0L,
     )
 
-    /** Known children first, then every episode the catalog reports, once. */
+    /** Known children first, then every episode the catalog reports, once, all pinned to the drain scope. */
     @Test
     fun reconcileWatchedChildrenConfirmsKnownThenDiscoveredEpisodes() = runTest {
         db.dirtyOperationDao().insert(reconcileOp("r1"))
         val result = reconcilingEngine().drainOnce()
         assertEquals(1, result.synced)
         assertEquals(listOf("e1=true", "e2=true"), confirmed)
+        assertTrue(confirmedScopes.all { it == snapshot })
         assertEquals(0, db.dirtyOperationDao().count())
     }
 

--- a/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/sync/SyncEngineTest.kt
+++ b/android-shared/src/androidUnitTest/kotlin/org/siloserver/silo/common/data/sync/SyncEngineTest.kt
@@ -61,6 +61,7 @@ class SyncEngineTest {
 
     private val confirmed = mutableListOf<String>()
     private val confirmedScopes = mutableListOf<AuthScopeSnapshot>()
+    private var confirmApplies = true
     private var episodesStatus = HttpStatusCode.OK
     private fun reconcilingEngine() = SyncEngine(
         db = db,
@@ -82,6 +83,7 @@ class SyncEngineTest {
         childConfirmer = SyncEngine.WatchedChildConfirmer { scope, contentId, watched, _ ->
             confirmedScopes += scope
             confirmed += "$contentId=$watched"
+            confirmApplies
         },
     )
 
@@ -138,6 +140,16 @@ class SyncEngineTest {
         val result = reconcilingEngine().drainOnce()
         assertEquals(0, result.synced)
         assertTrue(confirmed.isEmpty())
+    }
+
+    /** A confirmation declined by the identity gate keeps the op queued for that identity. */
+    @Test
+    fun reconcileWatchedChildrenStaysQueuedWhenConfirmationIsGated() = runTest {
+        db.dirtyOperationDao().insert(reconcileOp("r1"))
+        confirmApplies = false
+        val result = reconcilingEngine().drainOnce()
+        assertEquals(1, result.retriable)
+        assertEquals(1, db.dirtyOperationDao().count())
     }
 
     /** A season write rejected during the drain must not leave its reconciliation to run later. */

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -164,11 +164,17 @@ val androidModule = module {
     }
     single {
         val tokenManager: TokenManager = get()
+        val userItemState: org.siloserver.silo.repository.port.UserItemStatePort = get()
         org.siloserver.silo.common.data.sync.SyncEngine(
             db = get(),
             personalDataApi = get(),
             ebookReaderApi = get(),
             snapshotProvider = { tokenManager.snapshotCurrentScope() },
+            catalogApi = get(),
+            childConfirmer = (userItemState as? org.siloserver.silo.common.data.repository.RoomUserItemStateRepository)
+                ?.let { repository ->
+                    org.siloserver.silo.common.data.sync.SyncEngine.WatchedChildConfirmer(repository::confirmContainerChild)
+                },
         )
     }
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/di/AndroidModule.kt
@@ -136,6 +136,7 @@ val androidModule = module {
         org.siloserver.silo.common.data.repository.RoomUserItemStateRepository(
             db = get(),
             snapshotProvider = { tokenManager.snapshotCurrentScope() },
+            identityTransitions = get(),
             // Drain is requested only when a write is left pending (resolve RETRIABLE).
             syncScheduler = get(),
         )

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
@@ -3,6 +3,8 @@ package org.siloserver.silo.android.ui.screens.detail
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -37,6 +39,7 @@ import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.AlertDialog
@@ -1259,12 +1262,18 @@ fun SectionHeader(
 
 // ── Season chips ──────────────────────────────────────────────
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SeasonChips(
     seasons: List<Season>,
     selectedSeasonNumber: Int,
     onSeasonSelected: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    /**
+     * Long-press action. When set, every chip offers "Mark Season N as
+     * Watched / Unwatched" for its own season, mirroring the iOS chips.
+     */
+    onSetSeasonWatched: ((season: Season, watched: Boolean) -> Unit)? = null,
 ) {
     // The series overview deliberately keeps its single selected chip. iOS
     // renders "Season 1" even when there is no alternative season because it
@@ -1310,33 +1319,62 @@ fun SeasonChips(
         ) { season ->
             val isSelected = season.seasonNumber == selectedSeasonNumber
             val label = phoneSeasonLabel(season)
+            var menuExpanded by remember(season.contentId) { mutableStateOf(false) }
+            val isPlayed = season.userData?.played == true
             // iOS PhoneSeasonChips: 14pt (semibold selected / medium
             // unselected), hpad 16, height 36, unselected fill white-0.06.
-            Surface(
-                shape = PillShape,
-                color = if (isSelected) Color.White else Color.White.copy(alpha = 0.06f),
-                border = if (isSelected) {
-                    null
-                } else {
-                    androidx.compose.foundation.BorderStroke(1.dp, Color.White.copy(alpha = 0.25f))
-                },
-                modifier = Modifier
-                    .height(36.dp)
-                    .clickable { onSeasonSelected(season.seasonNumber) },
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Text(
-                        text = label,
-                        fontSize = 14.sp,
-                        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
-                        color = if (isSelected) Color.Black else Color.White,
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                    )
+            Box {
+                Surface(
+                    shape = PillShape,
+                    color = if (isSelected) Color.White else Color.White.copy(alpha = 0.06f),
+                    border = if (isSelected) {
+                        null
+                    } else {
+                        androidx.compose.foundation.BorderStroke(1.dp, Color.White.copy(alpha = 0.25f))
+                    },
+                    modifier = Modifier
+                        .height(36.dp)
+                        .combinedClickable(
+                            onClick = { onSeasonSelected(season.seasonNumber) },
+                            onLongClick = onSetSeasonWatched?.let { { menuExpanded = true } },
+                        ),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Text(
+                            text = label,
+                            fontSize = 14.sp,
+                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+                            color = if (isSelected) Color.Black else Color.White,
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                        )
+                    }
+                }
+                if (onSetSeasonWatched != null) {
+                    DropdownMenu(
+                        expanded = menuExpanded,
+                        onDismissRequest = { menuExpanded = false },
+                    ) {
+                        // Name the season by number even when the chip shows
+                        // a custom title such as "Series 2".
+                        val target = phoneSeasonWatchedTargetLabel(season)
+                        DropdownMenuItem(
+                            text = {
+                                Text(if (isPlayed) "Mark $target as Unwatched" else "Mark $target as Watched")
+                            },
+                            onClick = {
+                                menuExpanded = false
+                                onSetSeasonWatched(season, !isPlayed)
+                            },
+                        )
+                    }
                 }
             }
         }
     }
 }
+
+internal fun phoneSeasonWatchedTargetLabel(season: Season): String =
+    if (season.isSpecialsForDisplay() || season.seasonNumber == 0) "Specials" else "Season ${season.seasonNumber}"
 
 // ── Hero metadata helpers (mirror PhoneHeroMetadata.swift) ────
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/DetailSharedComponents.kt
@@ -1374,7 +1374,7 @@ fun SeasonChips(
 }
 
 internal fun phoneSeasonWatchedTargetLabel(season: Season): String =
-    if (season.isSpecialsForDisplay() || season.seasonNumber == 0) "Specials" else "Season ${season.seasonNumber}"
+    if (season.isSpecialsForDisplay()) "Specials" else "Season ${season.seasonNumber}"
 
 // ── Hero metadata helpers (mirror PhoneHeroMetadata.swift) ────
 

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
@@ -885,6 +885,9 @@ fun ItemDetailScreen(
                             onEpisodeWatchedChange = { episodeContentId, watched ->
                                 viewModel.setEpisodeWatched(episodeContentId, watched)
                             },
+                            onSeasonWatchedChange = { season, watched ->
+                                viewModel.setSeasonWatched(season, watched)
+                            },
                             isDownloaded = downloadState.isDownloaded,
                             downloadProgress = downloadState.progress,
                             playOnDeviceLabel = PLAY_ON_DEVICE_LABEL,

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailScreen.kt
@@ -683,6 +683,9 @@ fun ItemDetailScreen(
                             onEpisodeWatchedChange = { episodeContentId, watched ->
                                 viewModel.setEpisodeWatched(episodeContentId, watched)
                             },
+                            onSeasonWatchedChange = { season, watched ->
+                                viewModel.setSeasonWatched(season, watched)
+                            },
                             onSeasonSelected = { viewModel.selectSeason(it) },
                             onFavoriteClick = { viewModel.toggleFavorite() },
                             onWatchlistClick = { viewModel.toggleWatchlist() },

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -1169,7 +1169,6 @@ class ItemDetailViewModel(
         }
         val generationStartedAt = ++episodeMutationClock
 
-        val previousEpisodesLoaded = state.episodesBySeason[seasonNumber] != null
         val generation = (seasonWatchedMutationGenerations[seasonNumber] ?: 0) + 1
         seasonWatchedMutationGenerations[seasonNumber] = generation
         // Optimistic: flip the chip and any loaded page for this season.
@@ -1181,6 +1180,10 @@ class ItemDetailViewModel(
         )
         val previousWrite = seasonWatchedWrites[seasonNumber]
         seasonWatchedWrites[seasonNumber] = viewModelScope.launch {
+            // Reserve this action's ordering stamp now, before waiting on an
+            // earlier write, so an episode toggled after this action still
+            // ranks as newer than it.
+            val intentStamp = personalDataRepository.reserveWatchedIntentStamp()
             // Serialize with the previous write for this season so a quick
             // reversal cannot reach the server before the request it reverses.
             previousWrite?.join()
@@ -1194,6 +1197,7 @@ class ItemDetailViewModel(
                 seriesId = seriesId,
                 seasonNumber = seasonNumber,
                 knownEpisodeIds = baseline.episodes.orEmpty().map { it.contentId },
+                intentStamp = intentStamp,
             )
             completeWatchedWrite(result)
             val refreshTicket = beginWatchedRefresh()
@@ -1230,9 +1234,10 @@ class ItemDetailViewModel(
             if (!refreshStillOwned(refreshTicket)) return@launch
             if (_uiState.value.selectedSeasonNumber == seasonNumber) {
                 loadEpisodes(seriesId, seasonNumber, forceRefresh = true, freshOnly = true, refreshTicket = refreshTicket)
-            } else if (previousEpisodesLoaded) {
+            } else if (_uiState.value.episodesBySeason[seasonNumber] != null) {
                 // Refresh the cached pager page in place so a later swipe
-                // shows server-resolved progress, not a skeleton.
+                // shows server-resolved progress, not a skeleton. Checked live:
+                // the download roll-up may have cached this page during the write.
                 val page = catalogRepository.refreshEpisodes(seriesId, seasonNumber)
                 if (!refreshStillOwned(refreshTicket)) return@launch
                 if (page is ApiResult.Success) {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -180,10 +180,16 @@ class ItemDetailViewModel(
     private val seasonWatchedBaselines = mutableMapOf<Int, SeasonWatchBaseline>()
 
     /**
-     * Bumped by every watched mutation (season or episode). A refresh captured
-     * before the bump must not publish its result afterwards.
+     * Refresh ownership follows server completion order, not start order: a
+     * post-write refresh publishes only if no other watched write completed
+     * after it began. The last write to finish is the one whose refresh
+     * carries the final server rollup.
      */
-    private var watchedStateRevision = 0L
+    private var lastWatchedCompletion = 0L
+    private var nextWatchedCompletion = 0L
+    private fun beginWatchedRefresh(): Long = lastWatchedCompletion
+    private fun completeWatchedWrite() { lastWatchedCompletion = ++nextWatchedCompletion }
+    private fun refreshStillOwned(startedAfterCompletion: Long) = lastWatchedCompletion == startedAfterCompletion
 
     private val descriptionTranslation = DescriptionTranslationController(
         repository = metadataAiRepository,
@@ -1127,9 +1133,10 @@ class ItemDetailViewModel(
      * the last confirmed state if the server refuses.
      *
      * Writes for one season run strictly in order so the latest intent is the
-     * last write the server sees. Post-write refreshes are guarded by
-     * [watchedStateRevision] and use fresh-only reads, so neither a newer
-     * mutation nor a stale cache fallback can undo the optimistic state.
+     * last write the server sees. Post-write refreshes publish only while no
+     * other watched write has completed since they began, and use fresh-only
+     * reads, so neither a later completion nor a stale cache fallback can
+     * undo the optimistic state.
      */
     fun setSeasonWatched(season: Season, watched: Boolean) {
         val state = _uiState.value
@@ -1141,12 +1148,16 @@ class ItemDetailViewModel(
         val baseline = seasonWatchedBaselines.getOrPut(seasonNumber) {
             SeasonWatchBaseline(
                 season = state.seasons.firstOrNull { it.seasonNumber == seasonNumber } ?: season,
-                episodes = state.episodesBySeason[seasonNumber],
+                // An episode with its own write in flight shows that write's
+                // optimistic value; the baseline must hold its confirmed value.
+                episodes = state.episodesBySeason[seasonNumber]?.map { episode ->
+                    episodeConfirmedStates[episode.contentId] ?: episode
+                },
             )
         }
+        val generationStartedAt = ++episodeMutationClock
 
         val previousEpisodesLoaded = state.episodesBySeason[seasonNumber] != null
-        val revision = ++watchedStateRevision
         val generation = (seasonWatchedMutationGenerations[seasonNumber] ?: 0) + 1
         seasonWatchedMutationGenerations[seasonNumber] = generation
         // Optimistic: flip the chip and any loaded page for this season.
@@ -1161,18 +1172,19 @@ class ItemDetailViewModel(
             // Serialize with the previous write for this season so a quick
             // reversal cannot reach the server before the request it reverses.
             previousWrite?.join()
-            val knownEpisodes = baseline.episodes.orEmpty().map { it.contentId }
-            // The repository confirms the children on its own scope, so
-            // leaving this screen cannot strand their durable resume rows.
-            val result = personalDataRepository.setContainerWatched(
-                itemId = season.contentId,
+            // The port queues a durable child reconciliation next to this
+            // write, so leaving this screen cannot strand the episodes'
+            // resume rows. Known episodes are confirmed first; the rest are
+            // discovered by the sync engine and retried until the lookup succeeds.
+            val result = personalDataRepository.setSeasonWatched(
+                seasonId = season.contentId,
                 watched = watched,
-                knownChildIds = knownEpisodes,
-                resolveChildIds = {
-                    val page = catalogRepository.refreshEpisodes(seriesId, seasonNumber)
-                    (page as? ApiResult.Success)?.data?.episodes?.map { it.contentId }
-                },
+                seriesId = seriesId,
+                seasonNumber = seasonNumber,
+                knownEpisodeIds = baseline.episodes.orEmpty().map { it.contentId },
             )
+            completeWatchedWrite()
+            val refreshTicket = beginWatchedRefresh()
             val isCurrentMutation = seasonWatchedMutationGenerations[seasonNumber] == generation
             // Read the live baseline: an earlier serialized write for this
             // season may have advanced it after this write captured its own.
@@ -1184,7 +1196,10 @@ class ItemDetailViewModel(
                 if (!isCurrentMutation) return@launch
                 seasonWatchedMutationGenerations.remove(seasonNumber)
                 seasonWatchedBaselines.remove(seasonNumber)
-                applySeasonWatchState(confirmed)
+                // Episodes the user toggled on their own after this season
+                // write began keep their newer state; only untouched
+                // episodes return to the confirmed baseline.
+                applySeasonWatchState(confirmed.withoutEpisodes(episodesTouchedSince(generationStartedAt)))
                 return@launch
             }
 
@@ -1199,18 +1214,18 @@ class ItemDetailViewModel(
 
             // Fresh-only reads: a cached pre-mutation list would undo the
             // optimistic state.
-            refreshSeasonUserData(seriesId, revision)
-            if (revision != watchedStateRevision) return@launch
+            refreshSeasonUserData(seriesId, refreshTicket)
+            if (!refreshStillOwned(refreshTicket)) return@launch
             if (_uiState.value.selectedSeasonNumber == seasonNumber) {
                 loadEpisodes(seriesId, seasonNumber, forceRefresh = true, freshOnly = true)
             } else if (previousEpisodesLoaded) {
                 // Refresh the cached pager page in place so a later swipe
                 // shows server-resolved progress, not a skeleton.
                 val page = catalogRepository.refreshEpisodes(seriesId, seasonNumber)
-                if (revision != watchedStateRevision) return@launch
+                if (!refreshStillOwned(refreshTicket)) return@launch
                 if (page is ApiResult.Success) {
                     val episodes = withLocalProgress(page.data.episodes.sortedBy { it.episodeNumber })
-                    if (revision != watchedStateRevision) return@launch
+                    if (!refreshStillOwned(refreshTicket)) return@launch
                     _uiState.update {
                         if (it.detail?.contentId != seriesId) it else it.copy(
                             episodesBySeason = it.episodesBySeason + (seasonNumber to episodes),
@@ -1230,7 +1245,24 @@ class ItemDetailViewModel(
             season = season.withSeasonWatchedState(watched),
             episodes = episodes?.map { it.withSeasonWatchedState(watched) },
         )
+
+        /** Drop [contentIds] from the restore so newer episode state survives. */
+        fun withoutEpisodes(contentIds: Set<String>) = if (contentIds.isEmpty()) this else copy(
+            episodes = episodes?.filterNot { it.contentId in contentIds },
+        )
     }
+
+    /**
+     * Confirmed (pre-optimistic) episode state while an episode write is in
+     * flight, and the logical time each episode write started. A season
+     * baseline reads confirmed values from here; a season rollback leaves
+     * alone any episode touched after the season write began.
+     */
+    private val episodeConfirmedStates = mutableMapOf<String, EpisodeListItem>()
+    private val episodeMutationStartedAt = mutableMapOf<String, Long>()
+    private var episodeMutationClock = 0L
+    private fun episodesTouchedSince(clock: Long): Set<String> =
+        episodeMutationStartedAt.filterValues { it > clock }.keys
 
     /**
      * Publish one season's state: the chip, its cached pager page, and any rail
@@ -1241,15 +1273,21 @@ class ItemDetailViewModel(
     private fun applySeasonWatchState(target: SeasonWatchBaseline) {
         val seasonNumber = target.season.seasonNumber
         val byId = target.episodes.orEmpty().associateBy { it.contentId }
+        fun List<EpisodeListItem>.merged() = map { episode -> byId[episode.contentId] ?: episode }
         _uiState.update { state ->
+            val page = state.episodesBySeason[seasonNumber]
             state.copy(
                 seasons = state.seasons.map { season ->
                     if (season.seasonNumber == seasonNumber) target.season else season
                 },
-                episodesBySeason = target.episodes
-                    ?.let { state.episodesBySeason + (seasonNumber to it) }
-                    ?: (state.episodesBySeason - seasonNumber),
-                episodes = state.episodes.map { episode -> byId[episode.contentId] ?: episode },
+                // Merge into the existing page when one is loaded so episodes
+                // deliberately left out of [target] keep their current state.
+                episodesBySeason = when {
+                    page != null -> state.episodesBySeason + (seasonNumber to page.merged())
+                    target.episodes != null -> state.episodesBySeason + (seasonNumber to target.episodes)
+                    else -> state.episodesBySeason
+                },
+                episodes = state.episodes.merged(),
             )
         }
     }
@@ -1257,11 +1295,11 @@ class ItemDetailViewModel(
     /**
      * Reload only the season list, preserving order and the current selection.
      * Fresh-only: a cached pre-mutation list would undo the optimistic state.
-     * Published only while [revision] is still the latest watched mutation.
+     * Published only if no other watched write completed since [refreshTicket].
      */
-    private suspend fun refreshSeasonUserData(seriesId: String, revision: Long) {
+    private suspend fun refreshSeasonUserData(seriesId: String, refreshTicket: Long) {
         val result = catalogRepository.refreshSeasons(seriesId)
-        if (revision != watchedStateRevision) return
+        if (!refreshStillOwned(refreshTicket)) return
         if (result !is ApiResult.Success) return
         val byNumber = result.data.seasons.associateBy { it.seasonNumber }
         _uiState.update { state ->
@@ -1282,21 +1320,33 @@ class ItemDetailViewModel(
             ?: false
         if (previous == watched) return
 
-        val revision = ++watchedStateRevision
         val generation = (episodeWatchedMutationGenerations[episodeContentId] ?: 0) + 1
         episodeWatchedMutationGenerations[episodeContentId] = generation
+        episodeMutationStartedAt[episodeContentId] = ++episodeMutationClock
+        // Remember the confirmed value only for the first of a run of writes,
+        // so a season baseline captured mid-run still sees the server state.
+        episodeConfirmedStates.getOrPut(episodeContentId) {
+            state.episodesBySeason.values.asSequence().flatten()
+                .firstOrNull { it.contentId == episodeContentId }
+                ?: state.episodes.first { it.contentId == episodeContentId }
+        }
         updateEpisodePlayedState(episodeContentId, watched)
         viewModelScope.launch {
-            when (personalDataRepository.setWatched(episodeContentId, watched)) {
+            val result = personalDataRepository.setWatched(episodeContentId, watched)
+            completeWatchedWrite()
+            val refreshTicket = beginWatchedRefresh()
+            val isCurrentMutation = episodeWatchedMutationGenerations[episodeContentId] == generation
+            if (isCurrentMutation) episodeConfirmedStates.remove(episodeContentId)
+            when (result) {
                 is ApiResult.Success -> {
                     // One episode can complete or reopen its season, so the
                     // season chip's watched flag must follow.
                     val seriesId = _uiState.value.detail?.let { detail ->
                         if (detail.type == "series") detail.contentId else detail.seriesId
                     }
-                    if (!seriesId.isNullOrBlank()) refreshSeasonUserData(seriesId, revision)
+                    if (!seriesId.isNullOrBlank()) refreshSeasonUserData(seriesId, refreshTicket)
                 }
-                else -> if (episodeWatchedMutationGenerations[episodeContentId] == generation) {
+                else -> if (isCurrentMutation) {
                     updateEpisodePlayedState(episodeContentId, previous)
                 }
             }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -803,8 +803,13 @@ class ItemDetailViewModel(
                 is ApiResult.Success -> {
                     val episodes = withLocalProgress(result.data.episodes)
                     // A watched write that completed while this reload was in
-                    // flight owns the next refresh; this page is stale.
-                    if (refreshTicket != null && !refreshStillOwned(refreshTicket)) return@launch
+                    // flight owns the next refresh; this page is stale. Drop
+                    // only the page: the loading flag this load raised must
+                    // still come down, or the pager shows its skeleton forever.
+                    if (refreshTicket != null && !refreshStillOwned(refreshTicket)) {
+                        _uiState.update { it.copy(isLoadingEpisodes = false) }
+                        return@launch
+                    }
                     loadedSeasonNumber = seasonNumber
                     _uiState.update {
                         val cache = it.episodesBySeason + (seasonNumber to episodes)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -9,6 +9,7 @@ import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.catalog.LeafItemUserData
 import org.siloserver.silo.model.catalog.Season
+import org.siloserver.silo.model.catalog.SeasonUserData
 import org.siloserver.silo.model.catalog.initialSeasonDisplayPlan
 import org.siloserver.silo.model.catalog.sortedForDisplay
 import org.siloserver.silo.model.download.DownloadCapability
@@ -174,6 +175,7 @@ class ItemDetailViewModel(
 
     private var watchedMutationGeneration = 0
     private val episodeWatchedMutationGenerations = mutableMapOf<String, Int>()
+    private val seasonWatchedMutationGenerations = mutableMapOf<Int, Int>()
 
     private val descriptionTranslation = DescriptionTranslationController(
         repository = metadataAiRepository,
@@ -1108,6 +1110,109 @@ class ItemDetailViewModel(
         }
     }
 
+    /**
+     * Marks a whole season from its chip's long-press menu. The server fans
+     * the mutation out to the season's episodes; the local season flag and any
+     * loaded episode page for that season flip immediately and roll back if
+     * the server refuses. Success re-reads the season list so counts agree.
+     */
+    fun setSeasonWatched(season: Season, watched: Boolean) {
+        val state = _uiState.value
+        val seriesId = state.detail?.takeIf { it.type == "series" }?.contentId ?: return
+        val previousSeason = state.seasons.firstOrNull { it.seasonNumber == season.seasonNumber } ?: season
+        val previousEpisodes = state.episodesBySeason[season.seasonNumber]
+
+        val generation = (seasonWatchedMutationGenerations[season.seasonNumber] ?: 0) + 1
+        seasonWatchedMutationGenerations[season.seasonNumber] = generation
+        updateSeasonPlayedState(season.seasonNumber, watched)
+        viewModelScope.launch {
+            when (personalDataRepository.setWatched(season.contentId, watched)) {
+                is ApiResult.Success -> {
+                    if (seasonWatchedMutationGenerations[season.seasonNumber] != generation) return@launch
+                    refreshSeasonUserData(seriesId)
+                    if (_uiState.value.selectedSeasonNumber == season.seasonNumber) {
+                        loadEpisodes(seriesId, season.seasonNumber, forceRefresh = true)
+                    } else if (previousEpisodes != null) {
+                        // Refresh the cached pager page in place so a later
+                        // swipe shows server-resolved progress, not a skeleton.
+                        val page = catalogRepository.getEpisodes(seriesId, season.seasonNumber)
+                        if (page is ApiResult.Success) {
+                            val episodes = page.data.episodes.sortedBy { it.episodeNumber }
+                            _uiState.update {
+                                if (it.detail?.contentId != seriesId) it else it.copy(
+                                    episodesBySeason = it.episodesBySeason + (season.seasonNumber to episodes),
+                                )
+                            }
+                        }
+                    }
+                }
+                else -> if (seasonWatchedMutationGenerations[season.seasonNumber] == generation) {
+                    _uiState.update { live ->
+                        live.copy(
+                            seasons = live.seasons.map {
+                                if (it.seasonNumber == season.seasonNumber) previousSeason else it
+                            },
+                            episodesBySeason = if (previousEpisodes != null) {
+                                live.episodesBySeason + (season.seasonNumber to previousEpisodes)
+                            } else {
+                                live.episodesBySeason
+                            },
+                            episodes = if (live.selectedSeasonNumber == season.seasonNumber && previousEpisodes != null) {
+                                previousEpisodes
+                            } else {
+                                live.episodes
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateSeasonPlayedState(seasonNumber: Int, played: Boolean) {
+        fun EpisodeListItem.updated(): EpisodeListItem =
+            copy(
+                userData = (userData ?: LeafItemUserData()).copy(
+                    played = played,
+                    isInProgress = false,
+                    positionSeconds = null,
+                ),
+            )
+
+        _uiState.update { state ->
+            val page = state.episodesBySeason[seasonNumber]?.map { it.updated() }
+            state.copy(
+                seasons = state.seasons.map { season ->
+                    if (season.seasonNumber != seasonNumber) season else {
+                        val current = season.userData ?: SeasonUserData()
+                        val total = current.watchedCount + current.unplayedCount
+                        season.copy(
+                            userData = current.copy(
+                                played = played,
+                                watchedCount = if (played) total else 0,
+                                unplayedCount = if (played) 0 else total,
+                                inProgressCount = 0,
+                            ),
+                        )
+                    }
+                },
+                episodesBySeason = if (page != null) state.episodesBySeason + (seasonNumber to page) else state.episodesBySeason,
+                episodes = if (state.selectedSeasonNumber == seasonNumber) state.episodes.map { it.updated() } else state.episodes,
+            )
+        }
+    }
+
+    /** Reload only the season list, preserving order and the current selection. */
+    private suspend fun refreshSeasonUserData(seriesId: String) {
+        val result = catalogRepository.getSeasons(seriesId)
+        if (result !is ApiResult.Success) return
+        val byNumber = result.data.seasons.associateBy { it.seasonNumber }
+        _uiState.update { state ->
+            if (state.detail?.contentId != seriesId) return@update state
+            state.copy(seasons = state.seasons.map { byNumber[it.seasonNumber] ?: it })
+        }
+    }
+
     /** Marks one episode from the in-page rail without navigating away. */
     fun setEpisodeWatched(episodeContentId: String, watched: Boolean) {
         val state = _uiState.value
@@ -1125,7 +1230,14 @@ class ItemDetailViewModel(
         updateEpisodePlayedState(episodeContentId, watched)
         viewModelScope.launch {
             when (personalDataRepository.setWatched(episodeContentId, watched)) {
-                is ApiResult.Success -> Unit
+                is ApiResult.Success -> {
+                    // One episode can complete or reopen its season, so the
+                    // season chip's watched flag must follow.
+                    val seriesId = _uiState.value.detail?.let { detail ->
+                        if (detail.type == "series") detail.contentId else detail.seriesId
+                    }
+                    if (!seriesId.isNullOrBlank()) refreshSeasonUserData(seriesId)
+                }
                 else -> if (episodeWatchedMutationGenerations[episodeContentId] == generation) {
                     updateEpisodePlayedState(episodeContentId, previous)
                 }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -188,7 +188,10 @@ class ItemDetailViewModel(
     private var lastWatchedCompletion = 0L
     private var nextWatchedCompletion = 0L
     private fun beginWatchedRefresh(): Long = lastWatchedCompletion
-    private fun completeWatchedWrite() { lastWatchedCompletion = ++nextWatchedCompletion }
+    /** Only a write the server accepted can change what the server reports. */
+    private fun completeWatchedWrite(result: ApiResult<Unit>) {
+        if (result is ApiResult.Success) lastWatchedCompletion = ++nextWatchedCompletion
+    }
     private fun refreshStillOwned(startedAfterCompletion: Long) = lastWatchedCompletion == startedAfterCompletion
 
     private val descriptionTranslation = DescriptionTranslationController(
@@ -755,6 +758,8 @@ class ItemDetailViewModel(
         preferPrefetched: Boolean = false,
         /** Post-mutation reloads must not be satisfied by a stale cache fallback. */
         freshOnly: Boolean = false,
+        /** A post-write reload publishes only while it still owns the refresh. */
+        refreshTicket: Long? = null,
     ) {
         episodeLoadJob?.cancel()
         val cachedEpisodes = _uiState.value.episodesBySeason[seasonNumber]
@@ -797,6 +802,9 @@ class ItemDetailViewModel(
             when (result) {
                 is ApiResult.Success -> {
                     val episodes = withLocalProgress(result.data.episodes)
+                    // A watched write that completed while this reload was in
+                    // flight owns the next refresh; this page is stale.
+                    if (refreshTicket != null && !refreshStillOwned(refreshTicket)) return@launch
                     loadedSeasonNumber = seasonNumber
                     _uiState.update {
                         val cache = it.episodesBySeason + (seasonNumber to episodes)
@@ -1187,7 +1195,7 @@ class ItemDetailViewModel(
                 seasonNumber = seasonNumber,
                 knownEpisodeIds = baseline.episodes.orEmpty().map { it.contentId },
             )
-            completeWatchedWrite()
+            completeWatchedWrite(result)
             val refreshTicket = beginWatchedRefresh()
             val isCurrentMutation = seasonWatchedMutationGenerations[seasonNumber] == generation
             // Read the live baseline: an earlier serialized write for this
@@ -1221,7 +1229,7 @@ class ItemDetailViewModel(
             refreshSeasonUserData(seriesId, refreshTicket)
             if (!refreshStillOwned(refreshTicket)) return@launch
             if (_uiState.value.selectedSeasonNumber == seasonNumber) {
-                loadEpisodes(seriesId, seasonNumber, forceRefresh = true, freshOnly = true)
+                loadEpisodes(seriesId, seasonNumber, forceRefresh = true, freshOnly = true, refreshTicket = refreshTicket)
             } else if (previousEpisodesLoaded) {
                 // Refresh the cached pager page in place so a later swipe
                 // shows server-resolved progress, not a skeleton.
@@ -1307,7 +1315,9 @@ class ItemDetailViewModel(
         if (result !is ApiResult.Success) return
         val byNumber = result.data.seasons.associateBy { it.seasonNumber }
         _uiState.update { state ->
-            if (state.detail?.contentId != seriesId) return@update state
+            // The page may be the series itself or one of its seasons or
+            // episodes; all of them own this season list.
+            if (state.detail?.let { it.contentId == seriesId || it.seriesId == seriesId } != true) return@update state
             state.copy(seasons = state.seasons.map { byNumber[it.seasonNumber] ?: it })
         }
     }
@@ -1337,7 +1347,7 @@ class ItemDetailViewModel(
         updateEpisodePlayedState(episodeContentId, watched)
         viewModelScope.launch {
             val result = personalDataRepository.setWatched(episodeContentId, watched)
-            completeWatchedWrite()
+            completeWatchedWrite(result)
             val refreshTicket = beginWatchedRefresh()
             val isCurrentMutation = episodeWatchedMutationGenerations[episodeContentId] == generation
             if (isCurrentMutation) episodeConfirmedStates.remove(episodeContentId)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -1140,7 +1140,11 @@ class ItemDetailViewModel(
      */
     fun setSeasonWatched(season: Season, watched: Boolean) {
         val state = _uiState.value
-        val seriesId = state.detail?.takeIf { it.type == "series" }?.contentId ?: return
+        val detail = state.detail ?: return
+        // Series pages own the series id; season and episode pages carry it
+        // as a parent reference. All three show season chips.
+        val seriesId = (if (detail.type == "series") detail.contentId else detail.seriesId)
+            ?.takeIf { it.isNotBlank() } ?: return
         val seasonNumber = season.seasonNumber
         // The baseline is the last confirmed state. A second write that starts
         // while the first is pending inherits it instead of snapshotting the
@@ -1338,6 +1342,9 @@ class ItemDetailViewModel(
             val isCurrentMutation = episodeWatchedMutationGenerations[episodeContentId] == generation
             if (isCurrentMutation) episodeConfirmedStates.remove(episodeContentId)
             when (result) {
+                // A superseded success still completed on the server, possibly
+                // last, so it refreshes too; the completion ticket decides who
+                // publishes.
                 is ApiResult.Success -> {
                     // One episode can complete or reopen its season, so the
                     // season chip's watched flag must follow.

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -1145,6 +1145,7 @@ class ItemDetailViewModel(
             )
         }
 
+        val previousEpisodesLoaded = state.episodesBySeason[seasonNumber] != null
         val revision = ++watchedStateRevision
         val generation = (seasonWatchedMutationGenerations[seasonNumber] ?: 0) + 1
         seasonWatchedMutationGenerations[seasonNumber] = generation
@@ -1154,9 +1155,22 @@ class ItemDetailViewModel(
             // Serialize with the previous write for this season so a quick
             // reversal cannot reach the server before the request it reverses.
             previousWrite?.join()
-            val result = personalDataRepository.setWatched(season.contentId, watched)
-            val isCurrentMutation = seasonWatchedMutationGenerations[seasonNumber] == generation
             val knownEpisodes = baseline.episodes.orEmpty().map { it.contentId }
+            // The repository confirms the children on its own scope, so
+            // leaving this screen cannot strand their durable resume rows.
+            val result = personalDataRepository.setContainerWatched(
+                itemId = season.contentId,
+                watched = watched,
+                knownChildIds = knownEpisodes,
+                resolveChildIds = {
+                    val page = catalogRepository.refreshEpisodes(seriesId, seasonNumber)
+                    (page as? ApiResult.Success)?.data?.episodes?.map { it.contentId }
+                },
+            )
+            val isCurrentMutation = seasonWatchedMutationGenerations[seasonNumber] == generation
+            // Read the live baseline: an earlier serialized write for this
+            // season may have advanced it after this write captured its own.
+            val confirmed = seasonWatchedBaselines[seasonNumber] ?: baseline
 
             if (result !is ApiResult.Success) {
                 // A superseded failure changes nothing: the newer write will
@@ -1165,10 +1179,10 @@ class ItemDetailViewModel(
                 seasonWatchedMutationGenerations.remove(seasonNumber)
                 seasonWatchedBaselines.remove(seasonNumber)
                 _uiState.update { live ->
-                    val restoredPage = baseline.episodes
+                    val restoredPage = confirmed.episodes
                     live.copy(
                         seasons = live.seasons.map {
-                            if (it.seasonNumber == seasonNumber) baseline.season else it
+                            if (it.seasonNumber == seasonNumber) confirmed.season else it
                         },
                         episodesBySeason = if (restoredPage != null) {
                             live.episodesBySeason + (seasonNumber to restoredPage)
@@ -1191,40 +1205,34 @@ class ItemDetailViewModel(
                 return@launch
             }
 
-            // The server resolved the season to its episodes. Confirm the ones
-            // this screen knows about right away so their local resume rows
-            // cannot offer Resume on an episode the server now reports played.
-            if (knownEpisodes.isNotEmpty()) userItemState.recordConfirmedWatched(knownEpisodes, watched)
             if (!isCurrentMutation) {
                 // Superseded but confirmed: the newer pending write must roll
                 // back to this state, not to the one before it.
-                seasonWatchedBaselines[seasonNumber] = baseline.applied(watched)
+                seasonWatchedBaselines[seasonNumber] = confirmed.applied(watched)
                 return@launch
             }
             seasonWatchedMutationGenerations.remove(seasonNumber)
             seasonWatchedBaselines.remove(seasonNumber)
 
             // Fresh-only reads: a cached pre-mutation list would undo the
-            // optimistic state. The episode page is always fetched so children
-            // this screen never loaded are confirmed too.
+            // optimistic state.
             refreshSeasonUserData(seriesId, revision)
-            val page = catalogRepository.refreshEpisodes(seriesId, seasonNumber)
-            if (page is ApiResult.Success) {
-                val unconfirmed = page.data.episodes.map { it.contentId }.filterNot { it in knownEpisodes }
-                if (unconfirmed.isNotEmpty()) userItemState.recordConfirmedWatched(unconfirmed, watched)
-            }
             if (revision != watchedStateRevision) return@launch
             if (_uiState.value.selectedSeasonNumber == seasonNumber) {
                 loadEpisodes(seriesId, seasonNumber, forceRefresh = true, freshOnly = true)
-            } else if (page is ApiResult.Success) {
+            } else if (previousEpisodesLoaded) {
                 // Refresh the cached pager page in place so a later swipe
                 // shows server-resolved progress, not a skeleton.
-                val episodes = withLocalProgress(page.data.episodes.sortedBy { it.episodeNumber })
+                val page = catalogRepository.refreshEpisodes(seriesId, seasonNumber)
                 if (revision != watchedStateRevision) return@launch
-                _uiState.update {
-                    if (it.detail?.contentId != seriesId) it else it.copy(
-                        episodesBySeason = it.episodesBySeason + (seasonNumber to episodes),
-                    )
+                if (page is ApiResult.Success) {
+                    val episodes = withLocalProgress(page.data.episodes.sortedBy { it.episodeNumber })
+                    if (revision != watchedStateRevision) return@launch
+                    _uiState.update {
+                        if (it.detail?.contentId != seriesId) it else it.copy(
+                            episodesBySeason = it.episodesBySeason + (seasonNumber to episodes),
+                        )
+                    }
                 }
             }
         }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -176,6 +176,13 @@ class ItemDetailViewModel(
     private var watchedMutationGeneration = 0
     private val episodeWatchedMutationGenerations = mutableMapOf<String, Int>()
     private val seasonWatchedMutationGenerations = mutableMapOf<Int, Int>()
+    private val seasonWatchedWrites = mutableMapOf<Int, Job>()
+
+    /**
+     * Bumped by every watched mutation (season or episode). A refresh captured
+     * before the bump must not publish its result afterwards.
+     */
+    private var watchedStateRevision = 0L
 
     private val descriptionTranslation = DescriptionTranslationController(
         repository = metadataAiRepository,
@@ -739,6 +746,8 @@ class ItemDetailViewModel(
         seasonsForDownloadRollup: List<Season>? = null,
         forceRefresh: Boolean = false,
         preferPrefetched: Boolean = false,
+        /** Post-mutation reloads must not be satisfied by a stale cache fallback. */
+        freshOnly: Boolean = false,
     ) {
         episodeLoadJob?.cancel()
         val cachedEpisodes = _uiState.value.episodesBySeason[seasonNumber]
@@ -773,10 +782,10 @@ class ItemDetailViewModel(
                     },
                 )
             }
-            val result = if (!forceRefresh && preferPrefetched) {
-                catalogRepository.getEpisodesForPrefetch(seriesId, seasonNumber)
-            } else {
-                catalogRepository.getEpisodes(seriesId, seasonNumber)
+            val result = when {
+                freshOnly -> catalogRepository.refreshEpisodes(seriesId, seasonNumber)
+                !forceRefresh && preferPrefetched -> catalogRepository.getEpisodesForPrefetch(seriesId, seasonNumber)
+                else -> catalogRepository.getEpisodes(seriesId, seasonNumber)
             }
             when (result) {
                 is ApiResult.Success -> {
@@ -1115,6 +1124,11 @@ class ItemDetailViewModel(
      * the mutation out to the season's episodes; the local season flag and any
      * loaded episode page for that season flip immediately and roll back if
      * the server refuses. Success re-reads the season list so counts agree.
+     *
+     * Writes for one season run strictly in order so the latest intent is the
+     * last write the server sees. Post-write refreshes are guarded by
+     * [watchedStateRevision] and use fresh-only reads, so neither a newer
+     * mutation nor a stale cache fallback can undo the optimistic state.
      */
     fun setSeasonWatched(season: Season, watched: Boolean) {
         val state = _uiState.value
@@ -1122,22 +1136,36 @@ class ItemDetailViewModel(
         val previousSeason = state.seasons.firstOrNull { it.seasonNumber == season.seasonNumber } ?: season
         val previousEpisodes = state.episodesBySeason[season.seasonNumber]
 
+        val revision = ++watchedStateRevision
         val generation = (seasonWatchedMutationGenerations[season.seasonNumber] ?: 0) + 1
         seasonWatchedMutationGenerations[season.seasonNumber] = generation
         updateSeasonPlayedState(season.seasonNumber, watched)
-        viewModelScope.launch {
+        val previousWrite = seasonWatchedWrites[season.seasonNumber]
+        seasonWatchedWrites[season.seasonNumber] = viewModelScope.launch {
+            // Serialize with the previous write for this season so a quick
+            // reversal cannot reach the server before the request it reverses.
+            previousWrite?.join()
             when (personalDataRepository.setWatched(season.contentId, watched)) {
                 is ApiResult.Success -> {
                     if (seasonWatchedMutationGenerations[season.seasonNumber] != generation) return@launch
-                    refreshSeasonUserData(seriesId)
+                    // The server resolved the season to its episodes; drop
+                    // their local resume positions so the overlay cannot offer
+                    // Resume on an episode the server now reports as played.
+                    val knownEpisodes = previousEpisodes.orEmpty().map { it.contentId }
+                    if (knownEpisodes.isNotEmpty()) userItemState.clearPlaybackProgress(knownEpisodes)
+
+                    refreshSeasonUserData(seriesId, revision)
+                    if (revision != watchedStateRevision) return@launch
                     if (_uiState.value.selectedSeasonNumber == season.seasonNumber) {
-                        loadEpisodes(seriesId, season.seasonNumber, forceRefresh = true)
+                        loadEpisodes(seriesId, season.seasonNumber, forceRefresh = true, freshOnly = true)
                     } else if (previousEpisodes != null) {
                         // Refresh the cached pager page in place so a later
                         // swipe shows server-resolved progress, not a skeleton.
-                        val page = catalogRepository.getEpisodes(seriesId, season.seasonNumber)
+                        val page = catalogRepository.refreshEpisodes(seriesId, season.seasonNumber)
+                        if (revision != watchedStateRevision) return@launch
                         if (page is ApiResult.Success) {
-                            val episodes = page.data.episodes.sortedBy { it.episodeNumber }
+                            val episodes = withLocalProgress(page.data.episodes.sortedBy { it.episodeNumber })
+                            if (revision != watchedStateRevision) return@launch
                             _uiState.update {
                                 if (it.detail?.contentId != seriesId) it else it.copy(
                                     episodesBySeason = it.episodesBySeason + (season.seasonNumber to episodes),
@@ -1202,9 +1230,14 @@ class ItemDetailViewModel(
         }
     }
 
-    /** Reload only the season list, preserving order and the current selection. */
-    private suspend fun refreshSeasonUserData(seriesId: String) {
-        val result = catalogRepository.getSeasons(seriesId)
+    /**
+     * Reload only the season list, preserving order and the current selection.
+     * Fresh-only: a cached pre-mutation list would undo the optimistic state.
+     * Published only while [revision] is still the latest watched mutation.
+     */
+    private suspend fun refreshSeasonUserData(seriesId: String, revision: Long) {
+        val result = catalogRepository.refreshSeasons(seriesId)
+        if (revision != watchedStateRevision) return
         if (result !is ApiResult.Success) return
         val byNumber = result.data.seasons.associateBy { it.seasonNumber }
         _uiState.update { state ->
@@ -1225,6 +1258,7 @@ class ItemDetailViewModel(
             ?: false
         if (previous == watched) return
 
+        val revision = ++watchedStateRevision
         val generation = (episodeWatchedMutationGenerations[episodeContentId] ?: 0) + 1
         episodeWatchedMutationGenerations[episodeContentId] = generation
         updateEpisodePlayedState(episodeContentId, watched)
@@ -1236,7 +1270,7 @@ class ItemDetailViewModel(
                     val seriesId = _uiState.value.detail?.let { detail ->
                         if (detail.type == "series") detail.contentId else detail.seriesId
                     }
-                    if (!seriesId.isNullOrBlank()) refreshSeasonUserData(seriesId)
+                    if (!seriesId.isNullOrBlank()) refreshSeasonUserData(seriesId, revision)
                 }
                 else -> if (episodeWatchedMutationGenerations[episodeContentId] == generation) {
                     updateEpisodePlayedState(episodeContentId, previous)

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -177,6 +177,7 @@ class ItemDetailViewModel(
     private val episodeWatchedMutationGenerations = mutableMapOf<String, Int>()
     private val seasonWatchedMutationGenerations = mutableMapOf<Int, Int>()
     private val seasonWatchedWrites = mutableMapOf<Int, Job>()
+    private val seasonWatchedBaselines = mutableMapOf<Int, SeasonWatchBaseline>()
 
     /**
      * Bumped by every watched mutation (season or episode). A refresh captured
@@ -1122,8 +1123,8 @@ class ItemDetailViewModel(
     /**
      * Marks a whole season from its chip's long-press menu. The server fans
      * the mutation out to the season's episodes; the local season flag and any
-     * loaded episode page for that season flip immediately and roll back if
-     * the server refuses. Success re-reads the season list so counts agree.
+     * loaded episode page for that season flip immediately and roll back to
+     * the last confirmed state if the server refuses.
      *
      * Writes for one season run strictly in order so the latest intent is the
      * last write the server sees. Post-write refreshes are guarded by
@@ -1133,99 +1134,126 @@ class ItemDetailViewModel(
     fun setSeasonWatched(season: Season, watched: Boolean) {
         val state = _uiState.value
         val seriesId = state.detail?.takeIf { it.type == "series" }?.contentId ?: return
-        val previousSeason = state.seasons.firstOrNull { it.seasonNumber == season.seasonNumber } ?: season
-        val previousEpisodes = state.episodesBySeason[season.seasonNumber]
+        val seasonNumber = season.seasonNumber
+        // The baseline is the last confirmed state. A second write that starts
+        // while the first is pending inherits it instead of snapshotting the
+        // first write's optimistic values.
+        val baseline = seasonWatchedBaselines.getOrPut(seasonNumber) {
+            SeasonWatchBaseline(
+                season = state.seasons.firstOrNull { it.seasonNumber == seasonNumber } ?: season,
+                episodes = state.episodesBySeason[seasonNumber],
+            )
+        }
 
         val revision = ++watchedStateRevision
-        val generation = (seasonWatchedMutationGenerations[season.seasonNumber] ?: 0) + 1
-        seasonWatchedMutationGenerations[season.seasonNumber] = generation
-        updateSeasonPlayedState(season.seasonNumber, watched)
-        val previousWrite = seasonWatchedWrites[season.seasonNumber]
-        seasonWatchedWrites[season.seasonNumber] = viewModelScope.launch {
+        val generation = (seasonWatchedMutationGenerations[seasonNumber] ?: 0) + 1
+        seasonWatchedMutationGenerations[seasonNumber] = generation
+        updateSeasonPlayedState(seasonNumber, watched)
+        val previousWrite = seasonWatchedWrites[seasonNumber]
+        seasonWatchedWrites[seasonNumber] = viewModelScope.launch {
             // Serialize with the previous write for this season so a quick
             // reversal cannot reach the server before the request it reverses.
             previousWrite?.join()
-            when (personalDataRepository.setWatched(season.contentId, watched)) {
-                is ApiResult.Success -> {
-                    if (seasonWatchedMutationGenerations[season.seasonNumber] != generation) return@launch
-                    // The server resolved the season to its episodes; drop
-                    // their local resume positions so the overlay cannot offer
-                    // Resume on an episode the server now reports as played.
-                    val knownEpisodes = previousEpisodes.orEmpty().map { it.contentId }
-                    if (knownEpisodes.isNotEmpty()) userItemState.clearPlaybackProgress(knownEpisodes)
+            val result = personalDataRepository.setWatched(season.contentId, watched)
+            val isCurrentMutation = seasonWatchedMutationGenerations[seasonNumber] == generation
+            val knownEpisodes = baseline.episodes.orEmpty().map { it.contentId }
 
-                    refreshSeasonUserData(seriesId, revision)
-                    if (revision != watchedStateRevision) return@launch
-                    if (_uiState.value.selectedSeasonNumber == season.seasonNumber) {
-                        loadEpisodes(seriesId, season.seasonNumber, forceRefresh = true, freshOnly = true)
-                    } else if (previousEpisodes != null) {
-                        // Refresh the cached pager page in place so a later
-                        // swipe shows server-resolved progress, not a skeleton.
-                        val page = catalogRepository.refreshEpisodes(seriesId, season.seasonNumber)
-                        if (revision != watchedStateRevision) return@launch
-                        if (page is ApiResult.Success) {
-                            val episodes = withLocalProgress(page.data.episodes.sortedBy { it.episodeNumber })
-                            if (revision != watchedStateRevision) return@launch
-                            _uiState.update {
-                                if (it.detail?.contentId != seriesId) it else it.copy(
-                                    episodesBySeason = it.episodesBySeason + (season.seasonNumber to episodes),
-                                )
+            if (result !is ApiResult.Success) {
+                // A superseded failure changes nothing: the newer write will
+                // roll back to the same confirmed baseline if it also fails.
+                if (!isCurrentMutation) return@launch
+                seasonWatchedMutationGenerations.remove(seasonNumber)
+                seasonWatchedBaselines.remove(seasonNumber)
+                _uiState.update { live ->
+                    val restoredPage = baseline.episodes
+                    live.copy(
+                        seasons = live.seasons.map {
+                            if (it.seasonNumber == seasonNumber) baseline.season else it
+                        },
+                        episodesBySeason = if (restoredPage != null) {
+                            live.episodesBySeason + (seasonNumber to restoredPage)
+                        } else {
+                            live.episodesBySeason - seasonNumber
+                        },
+                        episodes = if (live.selectedSeasonNumber == seasonNumber) {
+                            restoredPage ?: live.episodes.map { episode ->
+                                if (episode.seasonNumber == seasonNumber) {
+                                    episode.copy(userData = (episode.userData ?: LeafItemUserData()).copy(played = !watched))
+                                } else {
+                                    episode
+                                }
                             }
-                        }
-                    }
+                        } else {
+                            live.episodes
+                        },
+                    )
                 }
-                else -> if (seasonWatchedMutationGenerations[season.seasonNumber] == generation) {
-                    _uiState.update { live ->
-                        live.copy(
-                            seasons = live.seasons.map {
-                                if (it.seasonNumber == season.seasonNumber) previousSeason else it
-                            },
-                            episodesBySeason = if (previousEpisodes != null) {
-                                live.episodesBySeason + (season.seasonNumber to previousEpisodes)
-                            } else {
-                                live.episodesBySeason
-                            },
-                            episodes = if (live.selectedSeasonNumber == season.seasonNumber && previousEpisodes != null) {
-                                previousEpisodes
-                            } else {
-                                live.episodes
-                            },
-                        )
-                    }
+                return@launch
+            }
+
+            // The server resolved the season to its episodes. Confirm the ones
+            // this screen knows about right away so their local resume rows
+            // cannot offer Resume on an episode the server now reports played.
+            if (knownEpisodes.isNotEmpty()) userItemState.recordConfirmedWatched(knownEpisodes, watched)
+            if (!isCurrentMutation) {
+                // Superseded but confirmed: the newer pending write must roll
+                // back to this state, not to the one before it.
+                seasonWatchedBaselines[seasonNumber] = baseline.applied(watched)
+                return@launch
+            }
+            seasonWatchedMutationGenerations.remove(seasonNumber)
+            seasonWatchedBaselines.remove(seasonNumber)
+
+            // Fresh-only reads: a cached pre-mutation list would undo the
+            // optimistic state. The episode page is always fetched so children
+            // this screen never loaded are confirmed too.
+            refreshSeasonUserData(seriesId, revision)
+            val page = catalogRepository.refreshEpisodes(seriesId, seasonNumber)
+            if (page is ApiResult.Success) {
+                val unconfirmed = page.data.episodes.map { it.contentId }.filterNot { it in knownEpisodes }
+                if (unconfirmed.isNotEmpty()) userItemState.recordConfirmedWatched(unconfirmed, watched)
+            }
+            if (revision != watchedStateRevision) return@launch
+            if (_uiState.value.selectedSeasonNumber == seasonNumber) {
+                loadEpisodes(seriesId, seasonNumber, forceRefresh = true, freshOnly = true)
+            } else if (page is ApiResult.Success) {
+                // Refresh the cached pager page in place so a later swipe
+                // shows server-resolved progress, not a skeleton.
+                val episodes = withLocalProgress(page.data.episodes.sortedBy { it.episodeNumber })
+                if (revision != watchedStateRevision) return@launch
+                _uiState.update {
+                    if (it.detail?.contentId != seriesId) it else it.copy(
+                        episodesBySeason = it.episodesBySeason + (seasonNumber to episodes),
+                    )
                 }
             }
         }
     }
 
-    private fun updateSeasonPlayedState(seasonNumber: Int, played: Boolean) {
-        fun EpisodeListItem.updated(): EpisodeListItem =
-            copy(
-                userData = (userData ?: LeafItemUserData()).copy(
-                    played = played,
-                    isInProgress = false,
-                    positionSeconds = null,
-                ),
-            )
+    /** Last server-confirmed state of one season while a write for it is pending. */
+    private data class SeasonWatchBaseline(
+        val season: Season,
+        val episodes: List<EpisodeListItem>?,
+    ) {
+        fun applied(watched: Boolean) = SeasonWatchBaseline(
+            season = season.withSeasonWatchedState(watched),
+            episodes = episodes?.map { it.withSeasonWatchedState(watched) },
+        )
+    }
 
+    private fun updateSeasonPlayedState(seasonNumber: Int, played: Boolean) {
         _uiState.update { state ->
-            val page = state.episodesBySeason[seasonNumber]?.map { it.updated() }
+            val page = state.episodesBySeason[seasonNumber]?.map { it.withSeasonWatchedState(played) }
             state.copy(
                 seasons = state.seasons.map { season ->
-                    if (season.seasonNumber != seasonNumber) season else {
-                        val current = season.userData ?: SeasonUserData()
-                        val total = current.watchedCount + current.unplayedCount
-                        season.copy(
-                            userData = current.copy(
-                                played = played,
-                                watchedCount = if (played) total else 0,
-                                unplayedCount = if (played) 0 else total,
-                                inProgressCount = 0,
-                            ),
-                        )
-                    }
+                    if (season.seasonNumber == seasonNumber) season.withSeasonWatchedState(played) else season
                 },
                 episodesBySeason = if (page != null) state.episodesBySeason + (seasonNumber to page) else state.episodesBySeason,
-                episodes = if (state.selectedSeasonNumber == seasonNumber) state.episodes.map { it.updated() } else state.episodes,
+                // Flip only cards that belong to this season; the rail may still
+                // show another season while a switch is loading.
+                episodes = state.episodes.map { episode ->
+                    if (episode.seasonNumber == seasonNumber) episode.withSeasonWatchedState(played) else episode
+                },
             )
         }
     }
@@ -1315,3 +1343,25 @@ class ItemDetailViewModel(
         }
     }
 }
+
+private fun Season.withSeasonWatchedState(played: Boolean): Season {
+    val current = userData ?: SeasonUserData()
+    val total = current.watchedCount + current.unplayedCount
+    return copy(
+        userData = current.copy(
+            played = played,
+            watchedCount = if (played) total else 0,
+            unplayedCount = if (played) 0 else total,
+            inProgressCount = 0,
+        ),
+    )
+}
+
+private fun EpisodeListItem.withSeasonWatchedState(played: Boolean): EpisodeListItem =
+    copy(
+        userData = (userData ?: LeafItemUserData()).copy(
+            played = played,
+            isInProgress = false,
+            positionSeconds = null,
+        ),
+    )

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -1369,6 +1369,9 @@ class ItemDetailViewModel(
                     if (!seriesId.isNullOrBlank()) refreshSeasonUserData(seriesId, refreshTicket)
                 }
                 else -> if (isCurrentMutation) {
+                    // The rejected write no longer counts as a newer intent, so
+                    // a season rollback may restore this episode again.
+                    episodeMutationStartedAt.remove(episodeContentId)
                     updateEpisodePlayedState(episodeContentId, previous)
                 }
             }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/ItemDetailViewModel.kt
@@ -1149,7 +1149,13 @@ class ItemDetailViewModel(
         val revision = ++watchedStateRevision
         val generation = (seasonWatchedMutationGenerations[seasonNumber] ?: 0) + 1
         seasonWatchedMutationGenerations[seasonNumber] = generation
-        updateSeasonPlayedState(seasonNumber, watched)
+        // Optimistic: flip the chip and any loaded page for this season.
+        applySeasonWatchState(
+            SeasonWatchBaseline(
+                season = baseline.season,
+                episodes = state.episodesBySeason[seasonNumber],
+            ).applied(watched),
+        )
         val previousWrite = seasonWatchedWrites[seasonNumber]
         seasonWatchedWrites[seasonNumber] = viewModelScope.launch {
             // Serialize with the previous write for this season so a quick
@@ -1178,30 +1184,7 @@ class ItemDetailViewModel(
                 if (!isCurrentMutation) return@launch
                 seasonWatchedMutationGenerations.remove(seasonNumber)
                 seasonWatchedBaselines.remove(seasonNumber)
-                _uiState.update { live ->
-                    val restoredPage = confirmed.episodes
-                    live.copy(
-                        seasons = live.seasons.map {
-                            if (it.seasonNumber == seasonNumber) confirmed.season else it
-                        },
-                        episodesBySeason = if (restoredPage != null) {
-                            live.episodesBySeason + (seasonNumber to restoredPage)
-                        } else {
-                            live.episodesBySeason - seasonNumber
-                        },
-                        episodes = if (live.selectedSeasonNumber == seasonNumber) {
-                            restoredPage ?: live.episodes.map { episode ->
-                                if (episode.seasonNumber == seasonNumber) {
-                                    episode.copy(userData = (episode.userData ?: LeafItemUserData()).copy(played = !watched))
-                                } else {
-                                    episode
-                                }
-                            }
-                        } else {
-                            live.episodes
-                        },
-                    )
-                }
+                applySeasonWatchState(confirmed)
                 return@launch
             }
 
@@ -1249,19 +1232,24 @@ class ItemDetailViewModel(
         )
     }
 
-    private fun updateSeasonPlayedState(seasonNumber: Int, played: Boolean) {
+    /**
+     * Publish one season's state: the chip, its cached pager page, and any rail
+     * card that belongs to it. Used for both the optimistic edit and its
+     * rollback. The rail is matched by content id so a placeholder rail from
+     * another season is never touched.
+     */
+    private fun applySeasonWatchState(target: SeasonWatchBaseline) {
+        val seasonNumber = target.season.seasonNumber
+        val byId = target.episodes.orEmpty().associateBy { it.contentId }
         _uiState.update { state ->
-            val page = state.episodesBySeason[seasonNumber]?.map { it.withSeasonWatchedState(played) }
             state.copy(
                 seasons = state.seasons.map { season ->
-                    if (season.seasonNumber == seasonNumber) season.withSeasonWatchedState(played) else season
+                    if (season.seasonNumber == seasonNumber) target.season else season
                 },
-                episodesBySeason = if (page != null) state.episodesBySeason + (seasonNumber to page) else state.episodesBySeason,
-                // Flip only cards that belong to this season; the rail may still
-                // show another season while a switch is loading.
-                episodes = state.episodes.map { episode ->
-                    if (episode.seasonNumber == seasonNumber) episode.withSeasonWatchedState(played) else episode
-                },
+                episodesBySeason = target.episodes
+                    ?.let { state.episodesBySeason + (seasonNumber to it) }
+                    ?: (state.episodesBySeason - seasonNumber),
+                episodes = state.episodes.map { episode -> byId[episode.contentId] ?: episode },
             )
         }
     }

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/MovieDetailContent.kt
@@ -90,6 +90,8 @@ fun MovieDetailContent(
     onSeasonSelected: (Int) -> Unit = {},
     onEpisodeDetailClick: (String) -> Unit = {},
     onEpisodeWatchedChange: (String, Boolean) -> Unit = { _, _ -> },
+    /** Long-press on a season chip. Targets that chip's season. */
+    onSeasonWatchedChange: ((Season, Boolean) -> Unit)? = null,
     isDownloaded: Boolean = false,
     downloadProgress: Float? = null,
     playOnDeviceLabel: String = "Play on device",
@@ -289,6 +291,7 @@ fun MovieDetailContent(
                             seasons = seasons,
                             selectedSeasonNumber = selectedSeasonNumber,
                             onSeasonSelected = onSeasonSelected,
+                            onSetSeasonWatched = onSeasonWatchedChange,
                         )
                     }
                     val selectedSeason = seasons.firstOrNull {

--- a/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
+++ b/androidApp/src/androidMain/kotlin/org/siloserver/silo/android/ui/screens/detail/SeriesDetailContent.kt
@@ -66,6 +66,8 @@ fun SeriesDetailContent(
     onEpisodePlayClick: (String, Double?) -> Unit,
     onEpisodeDetailClick: (String) -> Unit,
     onEpisodeWatchedChange: (String, Boolean) -> Unit,
+    /** Long-press on a season chip. Targets that chip's season. */
+    onSeasonWatchedChange: (Season, Boolean) -> Unit,
     onSeasonSelected: (Int) -> Unit,
     onFavoriteClick: () -> Unit,
     onWatchlistClick: () -> Unit,
@@ -165,6 +167,7 @@ fun SeriesDetailContent(
                     seasons = seasons,
                     selectedSeasonNumber = selectedSeasonNumber,
                     onSeasonSelected = onSeasonSelected,
+                    onSetSeasonWatched = onSeasonWatchedChange,
                 )
             }
             if (showsEpisodeDetails) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -135,11 +135,17 @@ val androidTvModule = module {
     }
     single {
         val tokenManager: TokenManager = get()
+        val userItemState: org.siloserver.silo.repository.port.UserItemStatePort = get()
         org.siloserver.silo.common.data.sync.SyncEngine(
             db = get(),
             personalDataApi = get(),
             ebookReaderApi = get(),
             snapshotProvider = { tokenManager.snapshotCurrentScope() },
+            catalogApi = get(),
+            childConfirmer = (userItemState as? org.siloserver.silo.common.data.repository.RoomUserItemStateRepository)
+                ?.let { repository ->
+                    org.siloserver.silo.common.data.sync.SyncEngine.WatchedChildConfirmer(repository::confirmContainerChild)
+                },
         )
     }
 

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/di/AndroidTvModule.kt
@@ -111,6 +111,7 @@ val androidTvModule = module {
         org.siloserver.silo.common.data.repository.RoomUserItemStateRepository(
             db = get(),
             snapshotProvider = { tokenManager.snapshotCurrentScope() },
+            identityTransitions = get(),
             syncScheduler = get(),
         )
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCardActions.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/components/TvMediaCardActions.kt
@@ -73,6 +73,9 @@ data class TvMediaCardActions(
     val onPlay: (() -> Unit)? = null,
     val playLabel: String = "Play",
     val onSetWatched: ((watched: Boolean) -> Unit)? = null,
+    /** Row text while the item is unwatched / watched. Defaults name no target. */
+    val watchedLabel: String = "Mark as Watched",
+    val unwatchedLabel: String = "Mark as Unwatched",
     val onToggleFavorite: ((favorite: Boolean) -> Unit)? = null,
     val onToggleWatchlist: ((inWatchlist: Boolean) -> Unit)? = null,
     val onRemoveFromContinueWatching: (() -> Unit)? = null,
@@ -196,7 +199,7 @@ private fun TvMediaCardMenuRows(
     }
     actions.onSetWatched?.let { setWatched ->
         TvMenuRow(
-            text = if (isPlayed) "Mark as Unwatched" else "Mark as Watched",
+            text = if (isPlayed) actions.unwatchedLabel else actions.watchedLabel,
             icon = if (isPlayed) Icons.Default.VisibilityOff else Icons.Default.Check,
             onClick = {
                 setWatched(!isPlayed)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -2041,6 +2041,7 @@ private fun EpisodesSection(
                     onSeasonSelected = onSeasonSelected,
                     onDirectionUp = onReturnToHero,
                     horizontalContentPadding = TvDetailHorizontalInset,
+                    onSetSeasonWatched = onSetSeasonWatched,
                 )
             }
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailScreen.kt
@@ -1044,6 +1044,7 @@ private fun TvDetailContent(
                                 onCarouselEdgeRequested = viewModel::onCarouselEdgeRequested,
                                 onCarouselFocusLost = viewModel::onCarouselFocusLost,
                                 onSetEpisodeWatched = viewModel::onSetEpisodeWatched,
+                                onSetSeasonWatched = viewModel::onSetSeasonWatched,
                                 onSetEpisodeFavorite = viewModel::onSetEpisodeFavorite,
                             )
                             }
@@ -1988,6 +1989,7 @@ private fun EpisodesSection(
     onCarouselFocusLost: () -> Unit,
     onSetEpisodeWatched: (contentId: String, watched: Boolean) -> Unit,
     onSetEpisodeFavorite: (contentId: String, favorite: Boolean) -> Unit,
+    onSetSeasonWatched: ((season: org.siloserver.silo.model.catalog.Season, watched: Boolean) -> Unit)? = null,
 ) {
     val isSeries = detail.type == "series"
     val railEpisodes = if (isSeries) state.carouselEpisodes.ifEmpty { state.episodes } else state.episodes
@@ -2030,6 +2032,7 @@ private fun EpisodesSection(
                     // it is not attached yet, fall back to Play.
                     onDirectionUp = onReturnToSeriesSelector ?: onReturnToHero,
                     horizontalContentPadding = TvDetailHorizontalInset,
+                    onSetSeasonWatched = onSetSeasonWatched,
                 )
             } else {
                 TvSeasonPicker(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -23,6 +23,7 @@ import org.siloserver.silo.model.catalog.FileVersion
 import org.siloserver.silo.model.catalog.ItemDetail
 import org.siloserver.silo.model.catalog.LeafItemUserData
 import org.siloserver.silo.model.catalog.Season
+import org.siloserver.silo.model.catalog.SeasonUserData
 import org.siloserver.silo.model.catalog.isAudiobookItemType
 import org.siloserver.silo.model.catalog.initialSeasonDisplayPlan
 import org.siloserver.silo.model.playback.combinedSubtitleSelectionIndexes
@@ -800,6 +801,104 @@ class TvItemDetailViewModel(
         }
     }
 
+    /**
+     * Long-press action on a season tab. Targets that tab's season, which need
+     * not be the selected page. The server fans a season mutation out to its
+     * episodes; the season list and the affected episode page are re-read so
+     * every checkmark and the next-up target agree afterward.
+     */
+    fun onSetSeasonWatched(season: Season, watched: Boolean) {
+        val current = _uiState.value
+        if (current.detail?.type?.lowercase() != "series") return
+        val seriesContentId = current.detail.contentId
+        val previousSeason = current.seasons.firstOrNull { it.seasonNumber == season.seasonNumber } ?: season
+        val previousEpisodes = current.episodes.takeIf { current.selectedSeason == season.seasonNumber }
+        val previousWindowPage = episodeWindow.get(season.seasonNumber)
+        val mutationGeneration = ++nextSeasonWatchMutationGeneration
+        seasonWatchMutationGenerations[season.seasonNumber] = mutationGeneration
+
+        // Optimistic: flip the tab's season state, the rail when it shows this
+        // season, and the cached carousel page so neighbouring cards agree.
+        _uiState.update {
+            it.copy(
+                seasons = it.seasons.map { entry ->
+                    if (entry.seasonNumber == season.seasonNumber) entry.withWatchedState(watched) else entry
+                },
+                episodes = if (it.selectedSeason == season.seasonNumber) {
+                    it.episodes.map { episode -> episode.withWatchedPlaybackState(watched) }
+                } else {
+                    it.episodes
+                },
+            )
+        }
+        previousWindowPage?.let { page ->
+            episodeWindow.put(season.seasonNumber, page.map { it.withWatchedPlaybackState(watched) })
+        }
+        publishCarousel()
+        if (current.selectedSeason == season.seasonNumber) refreshNextUp(_uiState.value.episodes)
+
+        viewModelScope.launch {
+            val result = personalDataRepository.setWatched(season.contentId, watched)
+            val isCurrentMutation =
+                seasonWatchMutationGenerations[season.seasonNumber] == mutationGeneration
+            if (!isCurrentMutation) return@launch
+            seasonWatchMutationGenerations.remove(season.seasonNumber)
+            if (result !is ApiResult.Success) {
+                // Roll back only this season; restore the rail when it still
+                // shows the season we mutated.
+                _uiState.update {
+                    it.copy(
+                        seasons = it.seasons.map { entry ->
+                            if (entry.seasonNumber == season.seasonNumber) previousSeason else entry
+                        },
+                        episodes = if (previousEpisodes != null && it.selectedSeason == season.seasonNumber) {
+                            previousEpisodes
+                        } else {
+                            it.episodes
+                        },
+                    )
+                }
+                previousWindowPage?.let { episodeWindow.put(season.seasonNumber, it) }
+                publishCarousel()
+                if (_uiState.value.selectedSeason == season.seasonNumber) refreshNextUp(_uiState.value.episodes)
+                return@launch
+            }
+            // Re-read server-resolved state. The season list carries the
+            // authoritative per-season flag; the affected episode page is
+            // refreshed in place so the continuous carousel keeps its shape.
+            refreshSeasonUserData(seriesContentId)
+            val selected = _uiState.value.selectedSeason
+            if (selected == season.seasonNumber) {
+                loadEpisodes(seriesContentId, season.seasonNumber, quiet = true)
+            } else if (episodeWindow.get(season.seasonNumber) != null) {
+                val page = catalogRepository.getEpisodes(seriesContentId, season.seasonNumber)
+                if (page is ApiResult.Success && _uiState.value.detail?.contentId == seriesContentId) {
+                    episodeWindow.put(season.seasonNumber, withLocalProgress(page.data.episodes))
+                    publishCarousel()
+                }
+            }
+        }
+    }
+
+    /** Reload only the season list, keeping the current selection and rail. */
+    private suspend fun refreshSeasonUserData(seriesContentId: String) {
+        val result = catalogRepository.getSeasons(seriesContentId)
+        if (result !is ApiResult.Success) return
+        val refreshed = result.data.seasons
+        _uiState.update { state ->
+            if (state.detail?.contentId != seriesContentId) return@update state
+            val order = state.seasons.map { it.seasonNumber }
+            val byNumber = refreshed.associateBy { it.seasonNumber }
+            state.copy(
+                seasons = state.seasons.map { entry -> byNumber[entry.seasonNumber] ?: entry }
+                    .let { merged ->
+                        // Keep display order stable; append any new seasons.
+                        merged + refreshed.filter { it.seasonNumber !in order }
+                    },
+            )
+        }
+    }
+
     fun onSetRating(stars: Int) {
         val current = _uiState.value
         if (current.isTogglingRating) return
@@ -1421,6 +1520,9 @@ class TvItemDetailViewModel(
         )
     }
 
+    private var nextSeasonWatchMutationGeneration = 0L
+    private val seasonWatchMutationGenerations = mutableMapOf<Int, Long>()
+
     fun onSetEpisodeWatched(episodeContentId: String, watched: Boolean) {
         val current = _uiState.value
         val previousEpisodes = current.episodes
@@ -1470,6 +1572,9 @@ class TvItemDetailViewModel(
                 val season = _uiState.value.selectedSeason
                 if (!seriesId.isNullOrBlank() && season != null) {
                     loadEpisodes(seriesId, season, quiet = true)
+                    // One episode can complete or reopen its season, so the
+                    // season tab's watched flag must follow.
+                    refreshSeasonUserData(seriesId)
                 }
             }
         }
@@ -2074,6 +2179,19 @@ private fun ItemDetail.withWatchedPlaybackState(watched: Boolean): ItemDetail {
             played = watched,
             isInProgress = if (watched) false else current.isInProgress,
             positionSeconds = if (watched) null else current.positionSeconds,
+        ),
+    )
+}
+
+private fun Season.withWatchedState(watched: Boolean): Season {
+    val current = userData ?: SeasonUserData()
+    val total = current.watchedCount + current.unplayedCount
+    return copy(
+        userData = current.copy(
+            played = watched,
+            watchedCount = if (watched) total else 0,
+            unplayedCount = if (watched) 0 else total,
+            inProgressCount = 0,
         ),
     )
 }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -872,7 +872,7 @@ class TvItemDetailViewModel(
                 seasonNumber = seasonNumber,
                 knownEpisodeIds = (baseline.windowPage ?: baseline.episodes).map { it.contentId },
             )
-            completeWatchedWrite()
+            completeWatchedWrite(result)
             val refreshTicket = beginWatchedRefresh()
             val isCurrentMutation = seasonWatchMutationGenerations[seasonNumber] == mutationGeneration
             // Read the live baseline: an earlier serialized write for this
@@ -907,7 +907,7 @@ class TvItemDetailViewModel(
             if (!refreshStillOwned(refreshTicket)) return@launch
             if (seasonsResult is ApiResult.Success) applySeasonUserData(seriesContentId, seasonsResult.data.seasons)
             if (_uiState.value.selectedSeason == seasonNumber) {
-                loadEpisodes(seriesContentId, seasonNumber, quiet = true, freshOnly = true)
+                loadEpisodes(seriesContentId, seasonNumber, quiet = true, freshOnly = true, refreshTicket = refreshTicket)
             } else if (episodeWindow.get(seasonNumber) != null) {
                 val page = catalogRepository.refreshEpisodes(seriesContentId, seasonNumber)
                 if (!refreshStillOwned(refreshTicket)) return@launch
@@ -930,7 +930,10 @@ class TvItemDetailViewModel(
     private var lastWatchedCompletion = 0L
     private var nextWatchedCompletion = 0L
     private fun beginWatchedRefresh(): Long = lastWatchedCompletion
-    private fun completeWatchedWrite() { lastWatchedCompletion = ++nextWatchedCompletion }
+    /** Only a write the server accepted can change what the server reports. */
+    private fun completeWatchedWrite(result: ApiResult<Unit>) {
+        if (result is ApiResult.Success) lastWatchedCompletion = ++nextWatchedCompletion
+    }
     private fun refreshStillOwned(startedAfterCompletion: Long) = lastWatchedCompletion == startedAfterCompletion
 
     /**
@@ -1000,7 +1003,11 @@ class TvItemDetailViewModel(
 
     private fun applySeasonUserData(seriesContentId: String, refreshed: List<Season>) {
         _uiState.update { state ->
-            if (state.detail?.contentId != seriesContentId) return@update state
+            // The page may be the series itself or one of its seasons or
+            // episodes; all of them own this season list.
+            if (state.detail?.let { it.contentId == seriesContentId || it.seriesId == seriesContentId } != true) {
+                return@update state
+            }
             val order = state.seasons.map { it.seasonNumber }
             val byNumber = refreshed.associateBy { it.seasonNumber }
             state.copy(
@@ -1491,6 +1498,8 @@ class TvItemDetailViewModel(
         favoritesVersion: Long? = null,
         /** Post-mutation reloads must not be satisfied by a stale cache fallback. */
         freshOnly: Boolean = false,
+        /** A post-write reload publishes only while it still owns the refresh. */
+        refreshTicket: Long? = null,
     ) {
         // Cancel any in-flight episode load so a slower response for a
         // previously-selected season can't overwrite episodes/next-up for the
@@ -1505,7 +1514,10 @@ class TvItemDetailViewModel(
         episodeLoadJob = viewModelScope.launch {
             fun ownsRequest(): Boolean =
                 requestGeneration == episodeLoadRequestGeneration &&
-                    _uiState.value.selectedSeason == seasonNumber
+                    _uiState.value.selectedSeason == seasonNumber &&
+                    // A watched write that completed while this reload was in
+                    // flight owns the next refresh; this page is stale.
+                    (refreshTicket == null || refreshStillOwned(refreshTicket))
 
             if (!ownsRequest()) return@launch
             if (!quiet) _uiState.update { it.copy(episodesLoading = true) }
@@ -1664,7 +1676,7 @@ class TvItemDetailViewModel(
 
         viewModelScope.launch {
             val result = personalDataRepository.setWatched(episodeContentId, watched)
-            completeWatchedWrite()
+            completeWatchedWrite(result)
             val refreshTicket = beginWatchedRefresh()
             val isCurrentMutation = episodeWatchMutationGenerations[episodeContentId] == mutationGeneration
             if (isCurrentMutation) episodeConfirmedStates.remove(episodeContentId)
@@ -1702,7 +1714,7 @@ class TvItemDetailViewModel(
                 }
                 val season = _uiState.value.selectedSeason
                 if (!seriesId.isNullOrBlank() && season != null) {
-                    loadEpisodes(seriesId, season, quiet = true, freshOnly = true)
+                    loadEpisodes(seriesId, season, quiet = true, freshOnly = true, refreshTicket = refreshTicket)
                     // One episode can complete or reopen its season, so the
                     // season tab's watched flag must follow.
                     refreshSeasonUserData(seriesId, refreshTicket)

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -810,9 +810,9 @@ class TvItemDetailViewModel(
      * Requests for one season run strictly in order so the latest intent is
      * always the last write the server sees. Rollback always returns to the
      * last server-confirmed state, not to an earlier pending intent. Every
-     * post-write refresh is guarded by [watchedStateRevision]: any watched
-     * mutation that starts while a refresh is suspended makes that refresh's
-     * result stale.
+     * post-write refresh publishes only while no other watched write has
+     * completed since it began, so the last write to finish owns the final
+     * server rollup.
      */
     fun onSetSeasonWatched(season: Season, watched: Boolean) {
         val current = _uiState.value
@@ -822,16 +822,19 @@ class TvItemDetailViewModel(
         // The baseline is the last confirmed state. A second write that starts
         // while the first is pending inherits it instead of snapshotting the
         // first write's optimistic values.
+        // An episode with its own write in flight shows that write's
+        // optimistic value; the baseline must hold its confirmed value.
+        fun List<EpisodeListItem>.confirmed() = map { episodeConfirmedStates[it.contentId] ?: it }
         val baseline = seasonWatchBaselines.getOrPut(seasonNumber) {
             TvSeasonWatchBaseline(
                 season = current.seasons.firstOrNull { it.seasonNumber == seasonNumber } ?: season,
                 // During a season switch the rail still shows the previous
                 // season as a placeholder; only episodes of this season count.
-                episodes = current.episodes.filter { it.seasonNumber == seasonNumber },
-                windowPage = episodeWindow.get(seasonNumber),
+                episodes = current.episodes.filter { it.seasonNumber == seasonNumber }.confirmed(),
+                windowPage = episodeWindow.get(seasonNumber)?.confirmed(),
             )
         }
-        val revision = ++watchedStateRevision
+        val generationStartedAt = ++episodeMutationClock
         val mutationGeneration = ++nextSeasonWatchMutationGeneration
         seasonWatchMutationGenerations[seasonNumber] = mutationGeneration
 
@@ -852,18 +855,19 @@ class TvItemDetailViewModel(
             // Serialize with the previous write for this season so a quick
             // reversal cannot reach the server before the request it reverses.
             previousWrite?.join()
-            val knownEpisodes = (baseline.windowPage ?: baseline.episodes).map { it.contentId }
-            // The repository confirms the children on its own scope, so
-            // leaving this screen cannot strand their durable resume rows.
-            val result = personalDataRepository.setContainerWatched(
-                itemId = season.contentId,
+            // The port queues a durable child reconciliation next to this
+            // write, so leaving this screen cannot strand the episodes'
+            // resume rows. Known episodes are confirmed first; the rest are
+            // discovered by the sync engine and retried until the lookup succeeds.
+            val result = personalDataRepository.setSeasonWatched(
+                seasonId = season.contentId,
                 watched = watched,
-                knownChildIds = knownEpisodes,
-                resolveChildIds = {
-                    val page = catalogRepository.refreshEpisodes(seriesContentId, seasonNumber)
-                    (page as? ApiResult.Success)?.data?.episodes?.map { it.contentId }
-                },
+                seriesId = seriesContentId,
+                seasonNumber = seasonNumber,
+                knownEpisodeIds = (baseline.windowPage ?: baseline.episodes).map { it.contentId },
             )
+            completeWatchedWrite()
+            val refreshTicket = beginWatchedRefresh()
             val isCurrentMutation = seasonWatchMutationGenerations[seasonNumber] == mutationGeneration
             // Read the live baseline: an earlier serialized write for this
             // season may have advanced it after this write captured its own.
@@ -875,7 +879,10 @@ class TvItemDetailViewModel(
                 if (!isCurrentMutation) return@launch
                 seasonWatchMutationGenerations.remove(seasonNumber)
                 seasonWatchBaselines.remove(seasonNumber)
-                applySeasonWatchState(confirmed)
+                // Episodes the user toggled on their own after this season
+                // write began keep their newer state; only untouched
+                // episodes return to the confirmed baseline.
+                applySeasonWatchState(confirmed.withoutEpisodes(episodesTouchedSince(generationStartedAt)))
                 return@launch
             }
 
@@ -891,16 +898,16 @@ class TvItemDetailViewModel(
             // Fresh-only reads: a cached pre-mutation list would undo the
             // optimistic state.
             val seasonsResult = catalogRepository.refreshSeasons(seriesContentId)
-            if (revision != watchedStateRevision) return@launch
+            if (!refreshStillOwned(refreshTicket)) return@launch
             if (seasonsResult is ApiResult.Success) applySeasonUserData(seriesContentId, seasonsResult.data.seasons)
             if (_uiState.value.selectedSeason == seasonNumber) {
                 loadEpisodes(seriesContentId, seasonNumber, quiet = true, freshOnly = true)
             } else if (episodeWindow.get(seasonNumber) != null) {
                 val page = catalogRepository.refreshEpisodes(seriesContentId, seasonNumber)
-                if (revision != watchedStateRevision) return@launch
+                if (!refreshStillOwned(refreshTicket)) return@launch
                 if (page is ApiResult.Success && _uiState.value.detail?.contentId == seriesContentId) {
                     val refreshed = withLocalProgress(page.data.episodes)
-                    if (revision != watchedStateRevision) return@launch
+                    if (!refreshStillOwned(refreshTicket)) return@launch
                     episodeWindow.put(seasonNumber, refreshed)
                     publishCarousel()
                 }
@@ -909,10 +916,29 @@ class TvItemDetailViewModel(
     }
 
     /**
-     * Bumped by every watched mutation (season or episode). A refresh captured
-     * before the bump must not publish its result afterwards.
+     * Refresh ownership follows server completion order, not start order: a
+     * post-write refresh publishes only if no other watched write completed
+     * after it began. The last write to finish is the one whose refresh
+     * carries the final server rollup.
      */
-    private var watchedStateRevision = 0L
+    private var lastWatchedCompletion = 0L
+    private var nextWatchedCompletion = 0L
+    private fun beginWatchedRefresh(): Long = lastWatchedCompletion
+    private fun completeWatchedWrite() { lastWatchedCompletion = ++nextWatchedCompletion }
+    private fun refreshStillOwned(startedAfterCompletion: Long) = lastWatchedCompletion == startedAfterCompletion
+
+    /**
+     * Confirmed (pre-optimistic) episode state while an episode write is in
+     * flight, and the logical time each episode write started. A season
+     * baseline reads confirmed values from here; a season rollback leaves
+     * alone any episode touched after the season write began.
+     */
+    private val episodeConfirmedStates = mutableMapOf<String, EpisodeListItem>()
+    private val episodeMutationStartedAt = mutableMapOf<String, Long>()
+    private var episodeMutationClock = 0L
+    private fun episodesTouchedSince(clock: Long): Set<String> =
+        episodeMutationStartedAt.filterValues { it > clock }.keys
+
     private val seasonWatchWrites = mutableMapOf<Int, Job>()
     private val seasonWatchBaselines = mutableMapOf<Int, TvSeasonWatchBaseline>()
 
@@ -923,16 +949,19 @@ class TvItemDetailViewModel(
      */
     private fun applySeasonWatchState(state: TvSeasonWatchBaseline) {
         val seasonNumber = state.season.seasonNumber
-        val byId = state.episodes.associateBy { it.contentId }
+        val byId = (state.windowPage ?: state.episodes).associateBy { it.contentId }
+        fun List<EpisodeListItem>.merged() = map { episode -> byId[episode.contentId] ?: episode }
         _uiState.update {
             it.copy(
                 seasons = it.seasons.map { entry ->
                     if (entry.seasonNumber == seasonNumber) state.season else entry
                 },
-                episodes = it.episodes.map { episode -> byId[episode.contentId] ?: episode },
+                episodes = it.episodes.merged(),
             )
         }
-        state.windowPage?.let { episodeWindow.put(seasonNumber, it) }
+        // Merge into the cached page so episodes deliberately left out of
+        // [state] keep their current state.
+        episodeWindow.get(seasonNumber)?.let { episodeWindow.put(seasonNumber, it.merged()) }
         publishCarousel()
         if (_uiState.value.selectedSeason == seasonNumber) refreshNextUp(_uiState.value.episodes)
     }
@@ -948,12 +977,18 @@ class TvItemDetailViewModel(
             episodes = episodes.map { it.withWatchedPlaybackState(watched) },
             windowPage = windowPage?.map { it.withWatchedPlaybackState(watched) },
         )
+
+        /** Drop [contentIds] from the restore so newer episode state survives. */
+        fun withoutEpisodes(contentIds: Set<String>) = if (contentIds.isEmpty()) this else copy(
+            episodes = episodes.filterNot { it.contentId in contentIds },
+            windowPage = windowPage?.filterNot { it.contentId in contentIds },
+        )
     }
 
-    /** Reload only the season list; publish it only if no newer mutation began. */
-    private suspend fun refreshSeasonUserData(seriesContentId: String, revision: Long) {
+    /** Reload only the season list; publish it only if no other watched write completed since. */
+    private suspend fun refreshSeasonUserData(seriesContentId: String, refreshTicket: Long) {
         val result = catalogRepository.refreshSeasons(seriesContentId)
-        if (revision != watchedStateRevision) return
+        if (!refreshStillOwned(refreshTicket)) return
         if (result is ApiResult.Success) applySeasonUserData(seriesContentId, result.data.seasons)
     }
 
@@ -1608,9 +1643,12 @@ class TvItemDetailViewModel(
         val previousEpisode = previousEpisodes.firstOrNull { it.contentId == episodeContentId }
         val mutationSeason = current.selectedSeason
         val listGeneration = episodeListGeneration
-        val revision = ++watchedStateRevision
         val mutationGeneration = ++nextEpisodeWatchMutationGeneration
         episodeWatchMutationGenerations[episodeContentId] = mutationGeneration
+        episodeMutationStartedAt[episodeContentId] = ++episodeMutationClock
+        // Remember the confirmed value only for the first of a run of writes,
+        // so a season baseline captured mid-run still sees the server state.
+        if (previousEpisode != null) episodeConfirmedStates.getOrPut(episodeContentId) { previousEpisode }
         val updatedEpisodes = previousEpisodes.map { episode ->
             if (episode.contentId == episodeContentId) episode.withWatchedPlaybackState(watched) else episode
         }
@@ -1620,7 +1658,10 @@ class TvItemDetailViewModel(
 
         viewModelScope.launch {
             val result = personalDataRepository.setWatched(episodeContentId, watched)
+            completeWatchedWrite()
+            val refreshTicket = beginWatchedRefresh()
             val isCurrentMutation = episodeWatchMutationGenerations[episodeContentId] == mutationGeneration
+            if (isCurrentMutation) episodeConfirmedStates.remove(episodeContentId)
             if (result !is ApiResult.Success) {
                 if (
                     isCurrentMutation &&
@@ -1654,7 +1695,7 @@ class TvItemDetailViewModel(
                     loadEpisodes(seriesId, season, quiet = true, freshOnly = true)
                     // One episode can complete or reopen its season, so the
                     // season tab's watched flag must follow.
-                    refreshSeasonUserData(seriesId, revision)
+                    refreshSeasonUserData(seriesId, refreshTicket)
                 }
             }
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -858,9 +858,22 @@ class TvItemDetailViewModel(
             // Serialize with the previous write for this season so a quick
             // reversal cannot reach the server before the request it reverses.
             previousWrite?.join()
-            val result = personalDataRepository.setWatched(season.contentId, watched)
-            val isCurrentMutation = seasonWatchMutationGenerations[seasonNumber] == mutationGeneration
             val knownEpisodes = (baseline.windowPage ?: baseline.episodes).map { it.contentId }
+            // The repository confirms the children on its own scope, so
+            // leaving this screen cannot strand their durable resume rows.
+            val result = personalDataRepository.setContainerWatched(
+                itemId = season.contentId,
+                watched = watched,
+                knownChildIds = knownEpisodes,
+                resolveChildIds = {
+                    val page = catalogRepository.refreshEpisodes(seriesContentId, seasonNumber)
+                    (page as? ApiResult.Success)?.data?.episodes?.map { it.contentId }
+                },
+            )
+            val isCurrentMutation = seasonWatchMutationGenerations[seasonNumber] == mutationGeneration
+            // Read the live baseline: an earlier serialized write for this
+            // season may have advanced it after this write captured its own.
+            val confirmed = seasonWatchBaselines[seasonNumber] ?: baseline
 
             if (result !is ApiResult.Success) {
                 // A superseded failure changes nothing: the newer write will
@@ -871,51 +884,44 @@ class TvItemDetailViewModel(
                 _uiState.update {
                     it.copy(
                         seasons = it.seasons.map { entry ->
-                            if (entry.seasonNumber == seasonNumber) baseline.season else entry
+                            if (entry.seasonNumber == seasonNumber) confirmed.season else entry
                         },
                         episodes = it.episodes.map { episode ->
-                            baseline.episodes.firstOrNull { it.contentId == episode.contentId } ?: episode
+                            confirmed.episodes.firstOrNull { it.contentId == episode.contentId } ?: episode
                         },
                     )
                 }
-                baseline.windowPage?.let { episodeWindow.put(seasonNumber, it) }
+                confirmed.windowPage?.let { episodeWindow.put(seasonNumber, it) }
                 publishCarousel()
                 if (_uiState.value.selectedSeason == seasonNumber) refreshNextUp(_uiState.value.episodes)
                 return@launch
             }
 
-            // The server resolved the season to its episodes. Confirm the ones
-            // this screen knows about right away so their local resume rows
-            // cannot offer Resume on an episode the server now reports played.
-            if (knownEpisodes.isNotEmpty()) userItemState.recordConfirmedWatched(knownEpisodes, watched)
             if (!isCurrentMutation) {
                 // Superseded but confirmed: the newer pending write must roll
                 // back to this state, not to the one before it.
-                seasonWatchBaselines[seasonNumber] = baseline.applied(watched)
+                seasonWatchBaselines[seasonNumber] = confirmed.applied(watched)
                 return@launch
             }
             seasonWatchMutationGenerations.remove(seasonNumber)
             seasonWatchBaselines.remove(seasonNumber)
 
             // Fresh-only reads: a cached pre-mutation list would undo the
-            // optimistic state. The episode page is always fetched so children
-            // this screen never loaded are confirmed too.
+            // optimistic state.
             val seasonsResult = catalogRepository.refreshSeasons(seriesContentId)
-            val page = catalogRepository.refreshEpisodes(seriesContentId, seasonNumber)
-            if (page is ApiResult.Success) {
-                val unconfirmed = page.data.episodes.map { it.contentId }.filterNot { it in knownEpisodes }
-                if (unconfirmed.isNotEmpty()) userItemState.recordConfirmedWatched(unconfirmed, watched)
-            }
             if (revision != watchedStateRevision) return@launch
             if (seasonsResult is ApiResult.Success) applySeasonUserData(seriesContentId, seasonsResult.data.seasons)
             if (_uiState.value.selectedSeason == seasonNumber) {
                 loadEpisodes(seriesContentId, seasonNumber, quiet = true, freshOnly = true)
-            } else if (page is ApiResult.Success && episodeWindow.get(seasonNumber) != null) {
-                if (_uiState.value.detail?.contentId != seriesContentId) return@launch
-                val refreshed = withLocalProgress(page.data.episodes)
+            } else if (episodeWindow.get(seasonNumber) != null) {
+                val page = catalogRepository.refreshEpisodes(seriesContentId, seasonNumber)
                 if (revision != watchedStateRevision) return@launch
-                episodeWindow.put(seasonNumber, refreshed)
-                publishCarousel()
+                if (page is ApiResult.Success && _uiState.value.detail?.contentId == seriesContentId) {
+                    val refreshed = withLocalProgress(page.data.episodes)
+                    if (revision != watchedStateRevision) return@launch
+                    episodeWindow.put(seasonNumber, refreshed)
+                    publishCarousel()
+                }
             }
         }
     }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -858,6 +858,10 @@ class TvItemDetailViewModel(
 
         val previousWrite = seasonWatchWrites[seasonNumber]
         seasonWatchWrites[seasonNumber] = viewModelScope.launch {
+            // Reserve this action's ordering stamp now, before waiting on an
+            // earlier write, so an episode toggled after this action still
+            // ranks as newer than it.
+            val intentStamp = personalDataRepository.reserveWatchedIntentStamp()
             // Serialize with the previous write for this season so a quick
             // reversal cannot reach the server before the request it reverses.
             previousWrite?.join()
@@ -871,6 +875,7 @@ class TvItemDetailViewModel(
                 seriesId = seriesContentId,
                 seasonNumber = seasonNumber,
                 knownEpisodeIds = (baseline.windowPage ?: baseline.episodes).map { it.contentId },
+                intentStamp = intentStamp,
             )
             completeWatchedWrite(result)
             val refreshTicket = beginWatchedRefresh()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -816,8 +816,14 @@ class TvItemDetailViewModel(
      */
     fun onSetSeasonWatched(season: Season, watched: Boolean) {
         val current = _uiState.value
-        if (current.detail?.type?.lowercase() != "series") return
-        val seriesContentId = current.detail.contentId
+        val detail = current.detail ?: return
+        // Series pages own the series id; season and episode pages carry it
+        // as a parent reference. All three show season chips.
+        val seriesContentId = when (detail.type.lowercase()) {
+            "series" -> detail.contentId
+            "season", "episode" -> detail.seriesId
+            else -> null
+        }?.takeIf { it.isNotBlank() } ?: return
         val seasonNumber = season.seasonNumber
         // The baseline is the last confirmed state. A second write that starts
         // while the first is pending inherits it instead of snapshotting the
@@ -1680,8 +1686,12 @@ class TvItemDetailViewModel(
                     }
                 }
                 if (isCurrentMutation) episodeWatchMutationGenerations.remove(episodeContentId)
-            } else if (isCurrentMutation) {
-                episodeWatchMutationGenerations.remove(episodeContentId)
+            } else {
+                // A superseded success still completed on the server, possibly
+                // last. It owns the refresh from here unless something newer
+                // completes, so the rail cannot settle on a stale optimistic
+                // value. Only the current mutation clears its generation.
+                if (isCurrentMutation) episodeWatchMutationGenerations.remove(episodeContentId)
                 // Re-read the server-resolved season state without collapsing
                 // the rail or flashing its loading placeholder.
                 val detail = _uiState.value.detail

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -806,6 +806,11 @@ class TvItemDetailViewModel(
      * not be the selected page. The server fans a season mutation out to its
      * episodes; the season list and the affected episode page are re-read so
      * every checkmark and the next-up target agree afterward.
+     *
+     * Requests for one season run strictly in order so the latest intent is
+     * always the last write the server sees. Every post-write refresh is
+     * guarded by [watchedStateRevision]: any watched mutation that starts
+     * while a refresh is suspended makes that refresh's result stale.
      */
     fun onSetSeasonWatched(season: Season, watched: Boolean) {
         val current = _uiState.value
@@ -814,6 +819,7 @@ class TvItemDetailViewModel(
         val previousSeason = current.seasons.firstOrNull { it.seasonNumber == season.seasonNumber } ?: season
         val previousEpisodes = current.episodes.takeIf { current.selectedSeason == season.seasonNumber }
         val previousWindowPage = episodeWindow.get(season.seasonNumber)
+        val revision = ++watchedStateRevision
         val mutationGeneration = ++nextSeasonWatchMutationGeneration
         seasonWatchMutationGenerations[season.seasonNumber] = mutationGeneration
 
@@ -837,7 +843,11 @@ class TvItemDetailViewModel(
         publishCarousel()
         if (current.selectedSeason == season.seasonNumber) refreshNextUp(_uiState.value.episodes)
 
-        viewModelScope.launch {
+        val previousWrite = seasonWatchWrites[season.seasonNumber]
+        seasonWatchWrites[season.seasonNumber] = viewModelScope.launch {
+            // Serialize with the previous write for this season so a quick
+            // reversal cannot reach the server before the request it reverses.
+            previousWrite?.join()
             val result = personalDataRepository.setWatched(season.contentId, watched)
             val isCurrentMutation =
                 seasonWatchMutationGenerations[season.seasonNumber] == mutationGeneration
@@ -863,28 +873,51 @@ class TvItemDetailViewModel(
                 if (_uiState.value.selectedSeason == season.seasonNumber) refreshNextUp(_uiState.value.episodes)
                 return@launch
             }
-            // Re-read server-resolved state. The season list carries the
-            // authoritative per-season flag; the affected episode page is
-            // refreshed in place so the continuous carousel keeps its shape.
-            refreshSeasonUserData(seriesContentId)
+            // The server resolved the season to its episodes; drop any local
+            // resume positions for those episodes so the overlay cannot offer
+            // Resume on an episode the server now reports as played.
+            val knownEpisodes = (previousWindowPage ?: previousEpisodes).orEmpty().map { it.contentId }
+            if (knownEpisodes.isNotEmpty()) userItemState.clearPlaybackProgress(knownEpisodes)
+
+            // Re-read server-resolved state, but only while this is still the
+            // latest watched mutation. A fresh-only read is required: a cached
+            // pre-mutation list would undo the optimistic state.
+            val seasonsResult = catalogRepository.refreshSeasons(seriesContentId)
+            if (revision != watchedStateRevision) return@launch
+            if (seasonsResult is ApiResult.Success) applySeasonUserData(seriesContentId, seasonsResult.data.seasons)
             val selected = _uiState.value.selectedSeason
             if (selected == season.seasonNumber) {
-                loadEpisodes(seriesContentId, season.seasonNumber, quiet = true)
+                loadEpisodes(seriesContentId, season.seasonNumber, quiet = true, freshOnly = true)
             } else if (episodeWindow.get(season.seasonNumber) != null) {
-                val page = catalogRepository.getEpisodes(seriesContentId, season.seasonNumber)
+                val page = catalogRepository.refreshEpisodes(seriesContentId, season.seasonNumber)
+                if (revision != watchedStateRevision) return@launch
                 if (page is ApiResult.Success && _uiState.value.detail?.contentId == seriesContentId) {
+                    if (knownEpisodes.isEmpty()) {
+                        userItemState.clearPlaybackProgress(page.data.episodes.map { it.contentId })
+                    }
                     episodeWindow.put(season.seasonNumber, withLocalProgress(page.data.episodes))
+                    if (revision != watchedStateRevision) return@launch
                     publishCarousel()
                 }
             }
         }
     }
 
-    /** Reload only the season list, keeping the current selection and rail. */
-    private suspend fun refreshSeasonUserData(seriesContentId: String) {
-        val result = catalogRepository.getSeasons(seriesContentId)
-        if (result !is ApiResult.Success) return
-        val refreshed = result.data.seasons
+    /**
+     * Bumped by every watched mutation (season or episode). A refresh captured
+     * before the bump must not publish its result afterwards.
+     */
+    private var watchedStateRevision = 0L
+    private val seasonWatchWrites = mutableMapOf<Int, kotlinx.coroutines.Job>()
+
+    /** Reload only the season list; publish it only if no newer mutation began. */
+    private suspend fun refreshSeasonUserData(seriesContentId: String, revision: Long) {
+        val result = catalogRepository.refreshSeasons(seriesContentId)
+        if (revision != watchedStateRevision) return
+        if (result is ApiResult.Success) applySeasonUserData(seriesContentId, result.data.seasons)
+    }
+
+    private fun applySeasonUserData(seriesContentId: String, refreshed: List<Season>) {
         _uiState.update { state ->
             if (state.detail?.contentId != seriesContentId) return@update state
             val order = state.seasons.map { it.seasonNumber }
@@ -1375,6 +1408,8 @@ class TvItemDetailViewModel(
         quiet: Boolean = false,
         revalidateFavorites: Set<String>? = emptySet(),
         favoritesVersion: Long? = null,
+        /** Post-mutation reloads must not be satisfied by a stale cache fallback. */
+        freshOnly: Boolean = false,
     ) {
         // Cancel any in-flight episode load so a slower response for a
         // previously-selected season can't overwrite episodes/next-up for the
@@ -1393,9 +1428,13 @@ class TvItemDetailViewModel(
 
             if (!ownsRequest()) return@launch
             if (!quiet) _uiState.update { it.copy(episodesLoading = true) }
-            seedCachedEpisodes(seriesContentId, seasonNumber)
+            if (!freshOnly) seedCachedEpisodes(seriesContentId, seasonNumber)
             if (!ownsRequest()) return@launch
-            val result = catalogRepository.getEpisodes(seriesContentId, seasonNumber)
+            val result = if (freshOnly) {
+                catalogRepository.refreshEpisodes(seriesContentId, seasonNumber)
+            } else {
+                catalogRepository.getEpisodes(seriesContentId, seasonNumber)
+            }
             if (!ownsRequest()) return@launch
             when (result) {
                 is ApiResult.Success -> {
@@ -1529,6 +1568,7 @@ class TvItemDetailViewModel(
         val previousEpisode = previousEpisodes.firstOrNull { it.contentId == episodeContentId }
         val mutationSeason = current.selectedSeason
         val listGeneration = episodeListGeneration
+        val revision = ++watchedStateRevision
         val mutationGeneration = ++nextEpisodeWatchMutationGeneration
         episodeWatchMutationGenerations[episodeContentId] = mutationGeneration
         val updatedEpisodes = previousEpisodes.map { episode ->
@@ -1571,10 +1611,10 @@ class TvItemDetailViewModel(
                 }
                 val season = _uiState.value.selectedSeason
                 if (!seriesId.isNullOrBlank() && season != null) {
-                    loadEpisodes(seriesId, season, quiet = true)
+                    loadEpisodes(seriesId, season, quiet = true, freshOnly = true)
                     // One episode can complete or reopen its season, so the
                     // season tab's watched flag must follow.
-                    refreshSeasonUserData(seriesId)
+                    refreshSeasonUserData(seriesId, revision)
                 }
             }
         }

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -1702,7 +1702,12 @@ class TvItemDetailViewModel(
                         }
                     }
                 }
-                if (isCurrentMutation) episodeWatchMutationGenerations.remove(episodeContentId)
+                if (isCurrentMutation) {
+                    episodeWatchMutationGenerations.remove(episodeContentId)
+                    // The rejected write no longer counts as a newer intent, so
+                    // a season rollback may restore this episode again.
+                    episodeMutationStartedAt.remove(episodeContentId)
+                }
             } else {
                 // A superseded success still completed on the server, possibly
                 // last. It owns the refresh from here unless something newer

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -837,21 +837,15 @@ class TvItemDetailViewModel(
 
         // Optimistic: flip the tab's season state, the rail cards that belong
         // to this season, and the cached carousel page so neighbours agree.
-        _uiState.update {
-            it.copy(
-                seasons = it.seasons.map { entry ->
-                    if (entry.seasonNumber == seasonNumber) entry.withWatchedState(watched) else entry
-                },
-                episodes = it.episodes.map { episode ->
-                    if (episode.seasonNumber == seasonNumber) episode.withWatchedPlaybackState(watched) else episode
-                },
-            )
-        }
-        episodeWindow.get(seasonNumber)?.let { page ->
-            episodeWindow.put(seasonNumber, page.map { it.withWatchedPlaybackState(watched) })
-        }
-        publishCarousel()
-        if (current.selectedSeason == seasonNumber) refreshNextUp(_uiState.value.episodes)
+        // Built from current state, not the baseline: a superseded write may
+        // already have flipped the rail, and this edit must start from that.
+        applySeasonWatchState(
+            TvSeasonWatchBaseline(
+                season = baseline.season,
+                episodes = current.episodes.filter { it.seasonNumber == seasonNumber },
+                windowPage = episodeWindow.get(seasonNumber),
+            ).applied(watched),
+        )
 
         val previousWrite = seasonWatchWrites[seasonNumber]
         seasonWatchWrites[seasonNumber] = viewModelScope.launch {
@@ -881,19 +875,7 @@ class TvItemDetailViewModel(
                 if (!isCurrentMutation) return@launch
                 seasonWatchMutationGenerations.remove(seasonNumber)
                 seasonWatchBaselines.remove(seasonNumber)
-                _uiState.update {
-                    it.copy(
-                        seasons = it.seasons.map { entry ->
-                            if (entry.seasonNumber == seasonNumber) confirmed.season else entry
-                        },
-                        episodes = it.episodes.map { episode ->
-                            confirmed.episodes.firstOrNull { it.contentId == episode.contentId } ?: episode
-                        },
-                    )
-                }
-                confirmed.windowPage?.let { episodeWindow.put(seasonNumber, it) }
-                publishCarousel()
-                if (_uiState.value.selectedSeason == seasonNumber) refreshNextUp(_uiState.value.episodes)
+                applySeasonWatchState(confirmed)
                 return@launch
             }
 
@@ -931,8 +913,29 @@ class TvItemDetailViewModel(
      * before the bump must not publish its result afterwards.
      */
     private var watchedStateRevision = 0L
-    private val seasonWatchWrites = mutableMapOf<Int, kotlinx.coroutines.Job>()
+    private val seasonWatchWrites = mutableMapOf<Int, Job>()
     private val seasonWatchBaselines = mutableMapOf<Int, TvSeasonWatchBaseline>()
+
+    /**
+     * Publish one season's state (tab, rail cards of that season, cached
+     * carousel page) and re-derive the carousel and next-up from it. Used for
+     * both the optimistic edit and its rollback.
+     */
+    private fun applySeasonWatchState(state: TvSeasonWatchBaseline) {
+        val seasonNumber = state.season.seasonNumber
+        val byId = state.episodes.associateBy { it.contentId }
+        _uiState.update {
+            it.copy(
+                seasons = it.seasons.map { entry ->
+                    if (entry.seasonNumber == seasonNumber) state.season else entry
+                },
+                episodes = it.episodes.map { episode -> byId[episode.contentId] ?: episode },
+            )
+        }
+        state.windowPage?.let { episodeWindow.put(seasonNumber, it) }
+        publishCarousel()
+        if (_uiState.value.selectedSeason == seasonNumber) refreshNextUp(_uiState.value.episodes)
+    }
 
     /** Last server-confirmed state of one season while a write for it is pending. */
     private data class TvSeasonWatchBaseline(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvItemDetailViewModel.kt
@@ -808,97 +808,114 @@ class TvItemDetailViewModel(
      * every checkmark and the next-up target agree afterward.
      *
      * Requests for one season run strictly in order so the latest intent is
-     * always the last write the server sees. Every post-write refresh is
-     * guarded by [watchedStateRevision]: any watched mutation that starts
-     * while a refresh is suspended makes that refresh's result stale.
+     * always the last write the server sees. Rollback always returns to the
+     * last server-confirmed state, not to an earlier pending intent. Every
+     * post-write refresh is guarded by [watchedStateRevision]: any watched
+     * mutation that starts while a refresh is suspended makes that refresh's
+     * result stale.
      */
     fun onSetSeasonWatched(season: Season, watched: Boolean) {
         val current = _uiState.value
         if (current.detail?.type?.lowercase() != "series") return
         val seriesContentId = current.detail.contentId
-        val previousSeason = current.seasons.firstOrNull { it.seasonNumber == season.seasonNumber } ?: season
-        val previousEpisodes = current.episodes.takeIf { current.selectedSeason == season.seasonNumber }
-        val previousWindowPage = episodeWindow.get(season.seasonNumber)
+        val seasonNumber = season.seasonNumber
+        // The baseline is the last confirmed state. A second write that starts
+        // while the first is pending inherits it instead of snapshotting the
+        // first write's optimistic values.
+        val baseline = seasonWatchBaselines.getOrPut(seasonNumber) {
+            TvSeasonWatchBaseline(
+                season = current.seasons.firstOrNull { it.seasonNumber == seasonNumber } ?: season,
+                // During a season switch the rail still shows the previous
+                // season as a placeholder; only episodes of this season count.
+                episodes = current.episodes.filter { it.seasonNumber == seasonNumber },
+                windowPage = episodeWindow.get(seasonNumber),
+            )
+        }
         val revision = ++watchedStateRevision
         val mutationGeneration = ++nextSeasonWatchMutationGeneration
-        seasonWatchMutationGenerations[season.seasonNumber] = mutationGeneration
+        seasonWatchMutationGenerations[seasonNumber] = mutationGeneration
 
-        // Optimistic: flip the tab's season state, the rail when it shows this
-        // season, and the cached carousel page so neighbouring cards agree.
+        // Optimistic: flip the tab's season state, the rail cards that belong
+        // to this season, and the cached carousel page so neighbours agree.
         _uiState.update {
             it.copy(
                 seasons = it.seasons.map { entry ->
-                    if (entry.seasonNumber == season.seasonNumber) entry.withWatchedState(watched) else entry
+                    if (entry.seasonNumber == seasonNumber) entry.withWatchedState(watched) else entry
                 },
-                episodes = if (it.selectedSeason == season.seasonNumber) {
-                    it.episodes.map { episode -> episode.withWatchedPlaybackState(watched) }
-                } else {
-                    it.episodes
+                episodes = it.episodes.map { episode ->
+                    if (episode.seasonNumber == seasonNumber) episode.withWatchedPlaybackState(watched) else episode
                 },
             )
         }
-        previousWindowPage?.let { page ->
-            episodeWindow.put(season.seasonNumber, page.map { it.withWatchedPlaybackState(watched) })
+        episodeWindow.get(seasonNumber)?.let { page ->
+            episodeWindow.put(seasonNumber, page.map { it.withWatchedPlaybackState(watched) })
         }
         publishCarousel()
-        if (current.selectedSeason == season.seasonNumber) refreshNextUp(_uiState.value.episodes)
+        if (current.selectedSeason == seasonNumber) refreshNextUp(_uiState.value.episodes)
 
-        val previousWrite = seasonWatchWrites[season.seasonNumber]
-        seasonWatchWrites[season.seasonNumber] = viewModelScope.launch {
+        val previousWrite = seasonWatchWrites[seasonNumber]
+        seasonWatchWrites[seasonNumber] = viewModelScope.launch {
             // Serialize with the previous write for this season so a quick
             // reversal cannot reach the server before the request it reverses.
             previousWrite?.join()
             val result = personalDataRepository.setWatched(season.contentId, watched)
-            val isCurrentMutation =
-                seasonWatchMutationGenerations[season.seasonNumber] == mutationGeneration
-            if (!isCurrentMutation) return@launch
-            seasonWatchMutationGenerations.remove(season.seasonNumber)
+            val isCurrentMutation = seasonWatchMutationGenerations[seasonNumber] == mutationGeneration
+            val knownEpisodes = (baseline.windowPage ?: baseline.episodes).map { it.contentId }
+
             if (result !is ApiResult.Success) {
-                // Roll back only this season; restore the rail when it still
-                // shows the season we mutated.
+                // A superseded failure changes nothing: the newer write will
+                // roll back to the same confirmed baseline if it also fails.
+                if (!isCurrentMutation) return@launch
+                seasonWatchMutationGenerations.remove(seasonNumber)
+                seasonWatchBaselines.remove(seasonNumber)
                 _uiState.update {
                     it.copy(
                         seasons = it.seasons.map { entry ->
-                            if (entry.seasonNumber == season.seasonNumber) previousSeason else entry
+                            if (entry.seasonNumber == seasonNumber) baseline.season else entry
                         },
-                        episodes = if (previousEpisodes != null && it.selectedSeason == season.seasonNumber) {
-                            previousEpisodes
-                        } else {
-                            it.episodes
+                        episodes = it.episodes.map { episode ->
+                            baseline.episodes.firstOrNull { it.contentId == episode.contentId } ?: episode
                         },
                     )
                 }
-                previousWindowPage?.let { episodeWindow.put(season.seasonNumber, it) }
+                baseline.windowPage?.let { episodeWindow.put(seasonNumber, it) }
                 publishCarousel()
-                if (_uiState.value.selectedSeason == season.seasonNumber) refreshNextUp(_uiState.value.episodes)
+                if (_uiState.value.selectedSeason == seasonNumber) refreshNextUp(_uiState.value.episodes)
                 return@launch
             }
-            // The server resolved the season to its episodes; drop any local
-            // resume positions for those episodes so the overlay cannot offer
-            // Resume on an episode the server now reports as played.
-            val knownEpisodes = (previousWindowPage ?: previousEpisodes).orEmpty().map { it.contentId }
-            if (knownEpisodes.isNotEmpty()) userItemState.clearPlaybackProgress(knownEpisodes)
 
-            // Re-read server-resolved state, but only while this is still the
-            // latest watched mutation. A fresh-only read is required: a cached
-            // pre-mutation list would undo the optimistic state.
+            // The server resolved the season to its episodes. Confirm the ones
+            // this screen knows about right away so their local resume rows
+            // cannot offer Resume on an episode the server now reports played.
+            if (knownEpisodes.isNotEmpty()) userItemState.recordConfirmedWatched(knownEpisodes, watched)
+            if (!isCurrentMutation) {
+                // Superseded but confirmed: the newer pending write must roll
+                // back to this state, not to the one before it.
+                seasonWatchBaselines[seasonNumber] = baseline.applied(watched)
+                return@launch
+            }
+            seasonWatchMutationGenerations.remove(seasonNumber)
+            seasonWatchBaselines.remove(seasonNumber)
+
+            // Fresh-only reads: a cached pre-mutation list would undo the
+            // optimistic state. The episode page is always fetched so children
+            // this screen never loaded are confirmed too.
             val seasonsResult = catalogRepository.refreshSeasons(seriesContentId)
+            val page = catalogRepository.refreshEpisodes(seriesContentId, seasonNumber)
+            if (page is ApiResult.Success) {
+                val unconfirmed = page.data.episodes.map { it.contentId }.filterNot { it in knownEpisodes }
+                if (unconfirmed.isNotEmpty()) userItemState.recordConfirmedWatched(unconfirmed, watched)
+            }
             if (revision != watchedStateRevision) return@launch
             if (seasonsResult is ApiResult.Success) applySeasonUserData(seriesContentId, seasonsResult.data.seasons)
-            val selected = _uiState.value.selectedSeason
-            if (selected == season.seasonNumber) {
-                loadEpisodes(seriesContentId, season.seasonNumber, quiet = true, freshOnly = true)
-            } else if (episodeWindow.get(season.seasonNumber) != null) {
-                val page = catalogRepository.refreshEpisodes(seriesContentId, season.seasonNumber)
+            if (_uiState.value.selectedSeason == seasonNumber) {
+                loadEpisodes(seriesContentId, seasonNumber, quiet = true, freshOnly = true)
+            } else if (page is ApiResult.Success && episodeWindow.get(seasonNumber) != null) {
+                if (_uiState.value.detail?.contentId != seriesContentId) return@launch
+                val refreshed = withLocalProgress(page.data.episodes)
                 if (revision != watchedStateRevision) return@launch
-                if (page is ApiResult.Success && _uiState.value.detail?.contentId == seriesContentId) {
-                    if (knownEpisodes.isEmpty()) {
-                        userItemState.clearPlaybackProgress(page.data.episodes.map { it.contentId })
-                    }
-                    episodeWindow.put(season.seasonNumber, withLocalProgress(page.data.episodes))
-                    if (revision != watchedStateRevision) return@launch
-                    publishCarousel()
-                }
+                episodeWindow.put(seasonNumber, refreshed)
+                publishCarousel()
             }
         }
     }
@@ -909,6 +926,20 @@ class TvItemDetailViewModel(
      */
     private var watchedStateRevision = 0L
     private val seasonWatchWrites = mutableMapOf<Int, kotlinx.coroutines.Job>()
+    private val seasonWatchBaselines = mutableMapOf<Int, TvSeasonWatchBaseline>()
+
+    /** Last server-confirmed state of one season while a write for it is pending. */
+    private data class TvSeasonWatchBaseline(
+        val season: Season,
+        val episodes: List<EpisodeListItem>,
+        val windowPage: List<EpisodeListItem>?,
+    ) {
+        fun applied(watched: Boolean) = TvSeasonWatchBaseline(
+            season = season.withWatchedState(watched),
+            episodes = episodes.map { it.withWatchedPlaybackState(watched) },
+            windowPage = windowPage?.map { it.withWatchedPlaybackState(watched) },
+        )
+    }
 
     /** Reload only the season list; publish it only if no newer mutation began. */
     private suspend fun refreshSeasonUserData(seriesContentId: String, revision: Long) {

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt
@@ -76,6 +76,8 @@ fun TvSeasonPicker(
     modifier: Modifier = Modifier,
     horizontalContentPadding: Dp = 0.dp,
     onDirectionUp: (() -> Boolean)? = null,
+    /** Long-press action on a chip: "Mark Season N as Watched / Unwatched". */
+    onSetSeasonWatched: ((season: Season, watched: Boolean) -> Unit)? = null,
 ) {
     if (seasons.isEmpty()) return
     val listState = rememberLazyListState()
@@ -136,6 +138,14 @@ fun TvSeasonPicker(
                     Modifier.focusRequester(selectedFocusRequester)
                 } else {
                     Modifier
+                },
+                contextActions = onSetSeasonWatched?.let { setWatched ->
+                    val target = tvSeasonWatchedTargetLabel(season)
+                    TvMediaCardActions(
+                        onSetWatched = { watched -> setWatched(season, watched) },
+                        watchedLabel = "Mark $target as Watched",
+                        unwatchedLabel = "Mark $target as Unwatched",
+                    )
                 },
             )
         }
@@ -373,17 +383,19 @@ private fun Modifier.seriesModeFocusRing(visible: Boolean): Modifier = drawWithC
  * visuals (no Surface halo). 22sp label; idle transparent + white@0.25 1.5dp
  * outline; focus white@0.18 fill + scale 1.04; selected white fill / black label.
  */
-@OptIn(ExperimentalTvMaterial3Api::class)
+@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 private fun TvSeasonChip(
     season: Season,
     isSelected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    contextActions: TvMediaCardActions? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     var isFocused by remember { mutableStateOf(false) }
+    var menuExpanded by remember { mutableStateOf(false) }
     val shape = RoundedCornerShape(TvControlCorner)
 
     val fill by animateColorAsState(
@@ -418,14 +430,25 @@ private fun TvSeasonChip(
             .background(fill, shape)
             .border(borderWidth, borderColor, shape)
             .onFocusChanged { isFocused = it.isFocused }
-            .clickable(
+            .combinedClickable(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onClick,
+                onLongClick = contextActions?.let { { menuExpanded = true } },
             )
             .padding(horizontal = 13.dp, vertical = 7.dp),
         contentAlignment = Alignment.Center,
     ) {
+        if (contextActions != null) {
+            TvMediaCardContextMenu(
+                expanded = menuExpanded,
+                onDismiss = { menuExpanded = false },
+                actions = contextActions,
+                isPlayed = season.userData?.played == true,
+                isFavorite = false,
+                isInWatchlist = false,
+            )
+        }
         Text(
             text = tvSeasonPickerLabel(season),
             style = MaterialTheme.typography.titleLarge.copy(

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -56,6 +58,8 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import org.siloserver.silo.model.catalog.Season
 import org.siloserver.silo.model.catalog.isSpecialsForDisplay
+import org.siloserver.silo.tv.ui.components.TvMediaCardActions
+import org.siloserver.silo.tv.ui.components.TvMediaCardContextMenu
 import org.siloserver.silo.tv.ui.theme.TvControlCorner
 
 /**
@@ -154,6 +158,11 @@ fun TvSeriesModePicker(
     modifier: Modifier = Modifier,
     horizontalContentPadding: Dp = 0.dp,
     onDirectionUp: (() -> Boolean)? = null,
+    /**
+     * Long-press action on a season tab. Mirrors the tvOS season tab context
+     * menu: "Mark Season N as Watched / Unwatched" for that tab's season.
+     */
+    onSetSeasonWatched: ((season: Season, watched: Boolean) -> Unit)? = null,
 ) {
     val listState = rememberLazyListState()
     val selectedFocusRequester = remember { FocusRequester() }
@@ -226,21 +235,33 @@ fun TvSeriesModePicker(
                 } else {
                     Modifier
                 },
+                contextActions = onSetSeasonWatched?.let { setWatched ->
+                    TvMediaCardActions(
+                        onSetWatched = { watched -> setWatched(season, watched) },
+                        watchedLabel = "Mark ${tvSeasonWatchedTargetLabel(season)} as Watched",
+                        unwatchedLabel = "Mark ${tvSeasonWatchedTargetLabel(season)} as Unwatched",
+                    )
+                },
+                isPlayed = season.userData?.played == true,
             )
         }
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun TvSeriesModeTab(
     title: String,
     isSelected: Boolean,
     onActivated: () -> Unit,
     modifier: Modifier = Modifier,
+    contextActions: TvMediaCardActions? = null,
+    isPlayed: Boolean = false,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
     val isPressed by interactionSource.collectIsPressedAsState()
+    var menuExpanded by remember { mutableStateOf(false) }
     val fill by animateColorAsState(
         targetValue = when {
             isFocused -> Color.White
@@ -294,14 +315,25 @@ private fun TvSeriesModeTab(
             .onFocusChanged { focusState ->
                 if (focusState.isFocused && !isSelected) onActivated()
             }
-            .clickable(
+            .combinedClickable(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onActivated,
+                onLongClick = contextActions?.let { { menuExpanded = true } },
             )
             .padding(horizontal = 12.dp),
         contentAlignment = Alignment.Center,
     ) {
+        if (contextActions != null) {
+            TvMediaCardContextMenu(
+                expanded = menuExpanded,
+                onDismiss = { menuExpanded = false },
+                actions = contextActions,
+                isPlayed = isPlayed,
+                isFavorite = false,
+                isInWatchlist = false,
+            )
+        }
         Text(
             text = title,
             style = MaterialTheme.typography.titleMedium.copy(
@@ -313,6 +345,13 @@ private fun TvSeriesModeTab(
         )
     }
 }
+
+/**
+ * The mark-watched action names the season by number even when the tab shows
+ * a custom title such as "Series 2"; the action names the watched target.
+ */
+internal fun tvSeasonWatchedTargetLabel(season: Season): String =
+    if (season.isSpecialsForDisplay() || season.seasonNumber == 0) "Specials" else "Season ${season.seasonNumber}"
 
 private fun Modifier.seriesModeFocusRing(visible: Boolean): Modifier = drawWithContent {
     drawContent()

--- a/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt
+++ b/androidTvApp/src/androidMain/kotlin/org/siloserver/silo/tv/ui/screens/detail/TvSeasonPicker.kt
@@ -236,10 +236,11 @@ fun TvSeriesModePicker(
                     Modifier
                 },
                 contextActions = onSetSeasonWatched?.let { setWatched ->
+                    val target = tvSeasonWatchedTargetLabel(season)
                     TvMediaCardActions(
                         onSetWatched = { watched -> setWatched(season, watched) },
-                        watchedLabel = "Mark ${tvSeasonWatchedTargetLabel(season)} as Watched",
-                        unwatchedLabel = "Mark ${tvSeasonWatchedTargetLabel(season)} as Unwatched",
+                        watchedLabel = "Mark $target as Watched",
+                        unwatchedLabel = "Mark $target as Unwatched",
                     )
                 },
                 isPlayed = season.userData?.played == true,
@@ -351,7 +352,7 @@ private fun TvSeriesModeTab(
  * a custom title such as "Series 2"; the action names the watched target.
  */
 internal fun tvSeasonWatchedTargetLabel(season: Season): String =
-    if (season.isSpecialsForDisplay() || season.seasonNumber == 0) "Specials" else "Season ${season.seasonNumber}"
+    if (season.isSpecialsForDisplay()) "Specials" else "Season ${season.seasonNumber}"
 
 private fun Modifier.seriesModeFocusRing(visible: Boolean): Modifier = drawWithContent {
     drawContent()

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/CatalogApi.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/network/api/CatalogApi.kt
@@ -5,6 +5,8 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import org.siloserver.silo.model.catalog.*
 import org.siloserver.silo.network.ApiResult
+import org.siloserver.silo.network.AuthScopeSnapshot
+import org.siloserver.silo.network.authScope
 
 class CatalogApi(private val client: HttpClient) {
 
@@ -101,11 +103,15 @@ class CatalogApi(private val client: HttpClient) {
         client.get("/api/v1/catalog/series/$seriesId/seasons")
     }
 
+    /** [scope] pins the request to a captured identity; the outbox drain passes it. */
     suspend fun getEpisodes(
         seriesId: String,
-        seasonNumber: Int
+        seasonNumber: Int,
+        scope: AuthScopeSnapshot? = null,
     ): ApiResult<EpisodesResponse> = safeApiCall {
-        client.get("/api/v1/catalog/series/$seriesId/seasons/$seasonNumber/episodes")
+        client.get("/api/v1/catalog/series/$seriesId/seasons/$seasonNumber/episodes") {
+            scope?.let { authScope(it) }
+        }
     }
 
     suspend fun getWatchDetail(id: String): ApiResult<WatchDetail> = safeApiCall {

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/CatalogRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/CatalogRepository.kt
@@ -211,6 +211,35 @@ class CatalogRepository(
         }
     }
 
+    /**
+     * Re-read the season list after a watched mutation. Unlike [getSeasons],
+     * a network failure or 5xx never falls back to the pre-mutation cache,
+     * because a stale success here would silently undo the optimistic state
+     * the caller is trying to confirm.
+     */
+    suspend fun refreshSeasons(seriesId: String): ApiResult<SeasonsResponse> {
+        val requestIdentityGeneration = identityTransitions.generation.value
+        val result = catalogApi.getSeasons(seriesId)
+        if (result is ApiResult.Success) {
+            writeIfIdentityUnchanged(requestIdentityGeneration) { cacheWriteLease ->
+                catalogCache.cacheSeasons(seriesId, result.data, cacheWriteLease)
+            }
+        }
+        return result
+    }
+
+    /** Episode-list counterpart of [refreshSeasons]: fresh data or a failure, never stale cache. */
+    suspend fun refreshEpisodes(seriesId: String, seasonNumber: Int): ApiResult<EpisodesResponse> {
+        val requestIdentityGeneration = identityTransitions.generation.value
+        val result = catalogApi.getEpisodes(seriesId, seasonNumber)
+        if (result is ApiResult.Success) {
+            writeIfIdentityUnchanged(requestIdentityGeneration) { cacheWriteLease ->
+                catalogCache.cacheEpisodes(seriesId, seasonNumber, result.data, cacheWriteLease)
+            }
+        }
+        return result
+    }
+
     /** Returns the last cached season list without touching the network. */
     suspend fun getCachedSeasons(seriesId: String): SeasonsResponse? =
         catalogCache.getCachedSeasons(seriesId)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/PersonalDataRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/PersonalDataRepository.kt
@@ -18,6 +18,10 @@ import org.siloserver.silo.repository.port.NoOpUserItemStatePort
 import org.siloserver.silo.repository.port.UserItemStatePort
 import org.siloserver.silo.repository.port.canServeCache
 import org.siloserver.silo.repository.port.toWriteOutcome
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 open class PersonalDataRepository(
     private val personalDataApi: PersonalDataApi,
@@ -31,6 +35,11 @@ open class PersonalDataRepository(
     /** Offline read cache for the library list (Track B). No-op by default. */
     private val catalogCache: CatalogCachePort = NoOpCatalogCachePort,
     private val identityTransitions: IdentityTransitionBarrier = DefaultIdentityTransitionBarrier(),
+    /**
+     * Process-owned scope for work that must outlive the screen that started
+     * it. Child confirmation after a container write is the only user so far.
+     */
+    private val reconciliationScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
     // -- Libraries --
 
@@ -153,6 +162,39 @@ open class PersonalDataRepository(
             personalDataApi.markUnwatched(itemId, handle.scope)
         }
         userItemStatePort.resolve(handle, result.toWriteOutcome())
+        return result
+    }
+
+    /**
+     * [setWatched] for a container (season or series) whose children the
+     * server resolves. On success the children are confirmed locally through
+     * [UserItemStatePort.recordConfirmedWatched] so their resume rows cannot
+     * resurrect Resume. [knownChildIds] are confirmed immediately;
+     * [resolveChildIds] is then invoked to discover the rest. Both run on a
+     * repository-owned scope so leaving the screen cannot cancel them, and
+     * both are skipped if the active identity changed in the meantime.
+     */
+    open suspend fun setContainerWatched(
+        itemId: String,
+        watched: Boolean,
+        knownChildIds: List<String>,
+        resolveChildIds: suspend () -> List<String>?,
+    ): ApiResult<Unit> {
+        val identityGeneration = identityTransitions.generation.value
+        val result = setWatched(itemId, watched)
+        if (result !is ApiResult.Success) return result
+        reconciliationScope.launch {
+            if (identityTransitions.generation.value != identityGeneration) return@launch
+            if (knownChildIds.isNotEmpty()) {
+                userItemStatePort.recordConfirmedWatched(knownChildIds, watched)
+            }
+            val all = resolveChildIds() ?: return@launch
+            if (identityTransitions.generation.value != identityGeneration) return@launch
+            val remaining = all.filterNot { it in knownChildIds }
+            if (remaining.isNotEmpty()) {
+                userItemStatePort.recordConfirmedWatched(remaining, watched)
+            }
+        }
         return result
     }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/PersonalDataRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/PersonalDataRepository.kt
@@ -169,11 +169,14 @@ open class PersonalDataRepository(
         seriesId: String,
         seasonNumber: Int,
         knownEpisodeIds: List<String>,
+        /** From [reserveWatchedIntentStamp] at action time; 0 stamps at record time. */
+        intentStamp: Long = 0L,
     ): ApiResult<Unit> {
         val handle = userItemStatePort.recordContainerWatched(
             seasonId,
             watched,
             WatchedContainerChildren(seriesId, seasonNumber, knownEpisodeIds),
+            intentStamp,
         )
         val result = if (watched) {
             personalDataApi.markWatched(seasonId, handle.scope)
@@ -183,6 +186,9 @@ open class PersonalDataRepository(
         userItemStatePort.resolve(handle, result.toWriteOutcome())
         return result
     }
+
+    /** See [UserItemStatePort.reserveWatchedIntentStamp]. */
+    open suspend fun reserveWatchedIntentStamp(): Long = userItemStatePort.reserveWatchedIntentStamp()
 
     // -- Continue Watching dismissals --
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/PersonalDataRepository.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/PersonalDataRepository.kt
@@ -16,12 +16,9 @@ import org.siloserver.silo.repository.port.CatalogCacheWriteLease
 import org.siloserver.silo.repository.port.NoOpCatalogCachePort
 import org.siloserver.silo.repository.port.NoOpUserItemStatePort
 import org.siloserver.silo.repository.port.UserItemStatePort
+import org.siloserver.silo.repository.port.WatchedContainerChildren
 import org.siloserver.silo.repository.port.canServeCache
 import org.siloserver.silo.repository.port.toWriteOutcome
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 
 open class PersonalDataRepository(
     private val personalDataApi: PersonalDataApi,
@@ -35,11 +32,6 @@ open class PersonalDataRepository(
     /** Offline read cache for the library list (Track B). No-op by default. */
     private val catalogCache: CatalogCachePort = NoOpCatalogCachePort,
     private val identityTransitions: IdentityTransitionBarrier = DefaultIdentityTransitionBarrier(),
-    /**
-     * Process-owned scope for work that must outlive the screen that started
-     * it. Child confirmation after a container write is the only user so far.
-     */
-    private val reconciliationScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
     // -- Libraries --
 
@@ -166,35 +158,29 @@ open class PersonalDataRepository(
     }
 
     /**
-     * [setWatched] for a container (season or series) whose children the
-     * server resolves. On success the children are confirmed locally through
-     * [UserItemStatePort.recordConfirmedWatched] so their resume rows cannot
-     * resurrect Resume. [knownChildIds] are confirmed immediately;
-     * [resolveChildIds] is then invoked to discover the rest. Both run on a
-     * repository-owned scope so leaving the screen cannot cancel them, and
-     * both are skipped if the active identity changed in the meantime.
+     * [setWatched] for a season. The server fans the write out to the season's
+     * episodes; the port queues a durable child reconciliation so those
+     * episodes' local resume rows cannot resurrect Resume afterward, whether
+     * or not the screen that started the write is still alive.
      */
-    open suspend fun setContainerWatched(
-        itemId: String,
+    open suspend fun setSeasonWatched(
+        seasonId: String,
         watched: Boolean,
-        knownChildIds: List<String>,
-        resolveChildIds: suspend () -> List<String>?,
+        seriesId: String,
+        seasonNumber: Int,
+        knownEpisodeIds: List<String>,
     ): ApiResult<Unit> {
-        val identityGeneration = identityTransitions.generation.value
-        val result = setWatched(itemId, watched)
-        if (result !is ApiResult.Success) return result
-        reconciliationScope.launch {
-            if (identityTransitions.generation.value != identityGeneration) return@launch
-            if (knownChildIds.isNotEmpty()) {
-                userItemStatePort.recordConfirmedWatched(knownChildIds, watched)
-            }
-            val all = resolveChildIds() ?: return@launch
-            if (identityTransitions.generation.value != identityGeneration) return@launch
-            val remaining = all.filterNot { it in knownChildIds }
-            if (remaining.isNotEmpty()) {
-                userItemStatePort.recordConfirmedWatched(remaining, watched)
-            }
+        val handle = userItemStatePort.recordContainerWatched(
+            seasonId,
+            watched,
+            WatchedContainerChildren(seriesId, seasonNumber, knownEpisodeIds),
+        )
+        val result = if (watched) {
+            personalDataApi.markWatched(seasonId, handle.scope)
+        } else {
+            personalDataApi.markUnwatched(seasonId, handle.scope)
         }
+        userItemStatePort.resolve(handle, result.toWriteOutcome())
         return result
     }
 

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/port/UserItemStatePort.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/port/UserItemStatePort.kt
@@ -62,7 +62,17 @@ interface UserItemStatePort {
         contentId: String,
         watched: Boolean,
         children: WatchedContainerChildren,
+        /** A stamp from [reserveWatchedIntentStamp] taken when the user acted; 0 issues one now. */
+        intentStamp: Long = 0L,
     ): OutboxHandle = recordWatched(contentId, watched)
+
+    /**
+     * Issue the ordering stamp for a watched action at the moment the user
+     * performs it, so a container write that must wait behind an earlier
+     * write still orders before any child action made after it. 0 on the
+     * default port.
+     */
+    suspend fun reserveWatchedIntentStamp(): Long = 0L
 
     /**
      * Durably record a playback position for offline-safe resume + sync. Unlike

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/port/UserItemStatePort.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/port/UserItemStatePort.kt
@@ -47,18 +47,22 @@ interface UserItemStatePort {
     suspend fun resolve(handle: OutboxHandle, outcome: WriteOutcome)
 
     /**
-     * Apply a server-confirmed container-level watched mutation (season or
-     * series) to the children it fanned out to. [recordWatched] only touches
-     * the mutated content id; without this the children keep their local
-     * resume rows and the overlay resurrects Resume on episodes the server now
-     * reports as played. Implementations record each child exactly as a
-     * confirmed single-item watched write: the projection flips, resume rows
-     * and queued position writes are cleared, and a child whose position write
-     * is already in flight keeps a queued replay so that position cannot land
-     * last. No-op on the default port.
+     * [recordWatched] for a container (a season) whose children the server
+     * resolves. The container write alone leaves the children's local resume
+     * rows in place, and the overlay would resurrect Resume on episodes the
+     * server now reports as played. Implementations queue a durable child
+     * reconciliation next to the container op: once the container write is
+     * acknowledged, [children.knownChildIds] are confirmed immediately and the
+     * rest are discovered from the catalog and confirmed by the sync engine,
+     * retried until the lookup succeeds. Each child is confirmed only when no
+     * child-level intent newer than the container action exists. The default
+     * port records a plain watched write.
      */
-    suspend fun recordConfirmedWatched(contentIds: List<String>, watched: Boolean) {
-    }
+    suspend fun recordContainerWatched(
+        contentId: String,
+        watched: Boolean,
+        children: WatchedContainerChildren,
+    ): OutboxHandle = recordWatched(contentId, watched)
 
     /**
      * Durably record a playback position for offline-safe resume + sync. Unlike
@@ -225,6 +229,13 @@ data class LocalPlaybackProgress(
  * then false-ack/delete the op). Null for the no-op port (single-scope) →
  * unpinned, preserving the original behaviour.
  */
+/** Where a container's children live, for the durable child reconciliation. */
+data class WatchedContainerChildren(
+    val seriesId: String,
+    val seasonNumber: Int,
+    val knownChildIds: List<String>,
+)
+
 data class OutboxHandle(val opId: Long, val scope: AuthScopeSnapshot? = null) {
     companion object {
         val NONE = OutboxHandle(-1L)

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/port/UserItemStatePort.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/port/UserItemStatePort.kt
@@ -47,6 +47,17 @@ interface UserItemStatePort {
     suspend fun resolve(handle: OutboxHandle, outcome: WriteOutcome)
 
     /**
+     * Drop locally stored resume positions for the given items after the
+     * server confirmed a container-level watched mutation (season or series).
+     * [recordWatched] only clears progress for the mutated content id; the
+     * children it fans out to must be cleared here, or the local overlay would
+     * resurrect Resume on episodes the server now reports as played. No-op on
+     * the default port.
+     */
+    suspend fun clearPlaybackProgress(contentIds: List<String>) {
+    }
+
+    /**
      * Durably record a playback position for offline-safe resume + sync. Unlike
      * the mutations above there is no inline network call to [resolve]: the write
      * persists a file-level local projection (for resume) and enqueues a single

--- a/shared/src/commonMain/kotlin/org/siloserver/silo/repository/port/UserItemStatePort.kt
+++ b/shared/src/commonMain/kotlin/org/siloserver/silo/repository/port/UserItemStatePort.kt
@@ -47,14 +47,17 @@ interface UserItemStatePort {
     suspend fun resolve(handle: OutboxHandle, outcome: WriteOutcome)
 
     /**
-     * Drop locally stored resume positions for the given items after the
-     * server confirmed a container-level watched mutation (season or series).
-     * [recordWatched] only clears progress for the mutated content id; the
-     * children it fans out to must be cleared here, or the local overlay would
-     * resurrect Resume on episodes the server now reports as played. No-op on
-     * the default port.
+     * Apply a server-confirmed container-level watched mutation (season or
+     * series) to the children it fanned out to. [recordWatched] only touches
+     * the mutated content id; without this the children keep their local
+     * resume rows and the overlay resurrects Resume on episodes the server now
+     * reports as played. Implementations record each child exactly as a
+     * confirmed single-item watched write: the projection flips, resume rows
+     * and queued position writes are cleared, and a child whose position write
+     * is already in flight keeps a queued replay so that position cannot land
+     * last. No-op on the default port.
      */
-    suspend fun clearPlaybackProgress(contentIds: List<String>) {
+    suspend fun recordConfirmedWatched(contentIds: List<String>, watched: Boolean) {
     }
 
     /**

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/CatalogRepositoryDetailCacheTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/CatalogRepositoryDetailCacheTest.kt
@@ -221,6 +221,25 @@ class CatalogRepositoryDetailCacheTest {
         assertTrue(result is ApiResult.Success)
     }
 
+    /**
+     * A post-mutation refresh must surface the failure rather than hand back
+     * the pre-mutation cache as a success, or the caller would treat stale
+     * data as confirmation and undo its optimistic state.
+     */
+    @Test
+    fun refreshSeasonsDoesNotServeCacheOnServer5xx() = runTest {
+        val cache = FakeCache(seasonsPreset = SeasonsResponse(seasons = emptyList()))
+        val result = repo(HttpStatusCode.ServiceUnavailable, "{}", cache).refreshSeasons("series-1")
+        assertTrue(result !is ApiResult.Success)
+    }
+
+    @Test
+    fun refreshEpisodesDoesNotServeCacheOnServer5xx() = runTest {
+        val cache = FakeCache(episodesPreset = EpisodesResponse(episodes = emptyList()))
+        val result = repo(HttpStatusCode.BadGateway, "{}", cache).refreshEpisodes("series-1", 2)
+        assertTrue(result !is ApiResult.Success)
+    }
+
     @Test
     fun continueWatchingSeasonPrefetchUsesCachedNavigationWithoutNetwork() = runTest {
         val cache = FakeCache(

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/PersonalDataRepositoryPortTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/PersonalDataRepositoryPortTest.kt
@@ -4,6 +4,7 @@ import org.siloserver.silo.network.SiloJson
 import org.siloserver.silo.network.api.PersonalDataApi
 import org.siloserver.silo.repository.port.OutboxHandle
 import org.siloserver.silo.repository.port.UserItemStatePort
+import org.siloserver.silo.repository.port.WatchedContainerChildren
 import org.siloserver.silo.repository.port.WriteOutcome
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -13,12 +14,6 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -57,73 +52,56 @@ class PersonalDataRepositoryPortTest {
             resolvedWith = outcome
         }
 
-        val confirmed = mutableListOf<Pair<List<String>, Boolean>>()
-        override suspend fun recordConfirmedWatched(contentIds: List<String>, watched: Boolean) {
-            confirmed += contentIds to watched
+        val containers = mutableListOf<Triple<String, Boolean, WatchedContainerChildren>>()
+        override suspend fun recordContainerWatched(
+            contentId: String,
+            watched: Boolean,
+            children: WatchedContainerChildren,
+        ): OutboxHandle {
+            containers += Triple(contentId, watched, children)
+            recorded += "container=$watched"
+            return OutboxHandle(seq++)
         }
     }
 
-    private fun repo(
-        status: HttpStatusCode,
-        port: UserItemStatePort,
-        reconciliationScope: CoroutineScope? = null,
-    ): PersonalDataRepository {
+    private fun repo(status: HttpStatusCode, port: UserItemStatePort): PersonalDataRepository {
         val client = HttpClient(
             MockEngine { respond("{}", status, headersOf(HttpHeaders.ContentType, "application/json")) },
         ) {
             install(ContentNegotiation) { json(SiloJson) }
         }
-        return if (reconciliationScope == null) {
-            PersonalDataRepository(PersonalDataApi(client), port)
-        } else {
-            PersonalDataRepository(PersonalDataApi(client), port, reconciliationScope = reconciliationScope)
-        }
+        return PersonalDataRepository(PersonalDataApi(client), port)
     }
 
     /**
-     * A season write fans out on the server. The children must be confirmed
-     * locally even after the screen that started the write is gone, so the
-     * confirmation runs on the repository's scope, not the caller's.
+     * A season write hands the port everything the durable child
+     * reconciliation needs, then resolves the container op with the network
+     * outcome like any other content mutation.
      */
     @Test
-    fun setContainerWatchedConfirmsKnownAndResolvedChildrenOnItsOwnScope() = runTest {
+    fun setSeasonWatchedRecordsContainerWithChildrenThenResolves() = runTest {
         val port = RecordingPort()
-        val dispatcher = StandardTestDispatcher(testScheduler)
-        val repoScope = CoroutineScope(Job() + dispatcher)
-        val callerScope = CoroutineScope(Job() + dispatcher)
-        val repository = repo(HttpStatusCode.OK, port, reconciliationScope = repoScope)
-
-        var result: Any? = null
-        val call = callerScope.launch {
-            result = repository.setContainerWatched(
-                itemId = "season-1",
-                watched = true,
-                knownChildIds = listOf("e1"),
-                resolveChildIds = { listOf("e1", "e2", "e3") },
-            )
-        }
-        call.join()
-        // The caller leaves before reconciliation runs.
-        callerScope.cancel()
-        advanceUntilIdle()
-
+        val result = repo(HttpStatusCode.OK, port).setSeasonWatched(
+            seasonId = "season-1",
+            watched = true,
+            seriesId = "series-1",
+            seasonNumber = 2,
+            knownEpisodeIds = listOf("e1", "e2"),
+        )
         assertTrue(result is org.siloserver.silo.network.ApiResult.Success<*>)
-        assertEquals(listOf("watched=true"), port.recorded)
-        assertEquals(listOf(listOf("e1") to true, listOf("e2", "e3") to true), port.confirmed)
+        assertEquals(listOf("container=true"), port.recorded)
+        assertEquals(
+            listOf(Triple("season-1", true, WatchedContainerChildren("series-1", 2, listOf("e1", "e2")))),
+            port.containers,
+        )
+        assertEquals(WriteOutcome.SYNCED, port.resolvedWith)
     }
 
     @Test
-    fun setContainerWatchedDoesNotConfirmChildrenOnFailure() = runTest {
+    fun setSeasonWatchedResolvesTerminalOnForbidden() = runTest {
         val port = RecordingPort()
-        val dispatcher = StandardTestDispatcher(testScheduler)
-        val repository = repo(
-            HttpStatusCode.Forbidden,
-            port,
-            reconciliationScope = CoroutineScope(Job() + dispatcher),
-        )
-        repository.setContainerWatched("season-1", true, listOf("e1")) { listOf("e1", "e2") }
-        advanceUntilIdle()
-        assertTrue(port.confirmed.isEmpty())
+        repo(HttpStatusCode.Forbidden, port).setSeasonWatched("season-1", true, "series-1", 2, emptyList())
+        assertEquals(WriteOutcome.TERMINAL, port.resolvedWith)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/PersonalDataRepositoryPortTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/PersonalDataRepositoryPortTest.kt
@@ -57,6 +57,7 @@ class PersonalDataRepositoryPortTest {
             contentId: String,
             watched: Boolean,
             children: WatchedContainerChildren,
+            intentStamp: Long,
         ): OutboxHandle {
             containers += Triple(contentId, watched, children)
             recorded += "container=$watched"

--- a/shared/src/commonTest/kotlin/org/siloserver/silo/repository/PersonalDataRepositoryPortTest.kt
+++ b/shared/src/commonTest/kotlin/org/siloserver/silo/repository/PersonalDataRepositoryPortTest.kt
@@ -13,9 +13,16 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Locks the Track B dual-path contract on [PersonalDataRepository]: each
@@ -49,15 +56,74 @@ class PersonalDataRepositoryPortTest {
         override suspend fun resolve(handle: OutboxHandle, outcome: WriteOutcome) {
             resolvedWith = outcome
         }
+
+        val confirmed = mutableListOf<Pair<List<String>, Boolean>>()
+        override suspend fun recordConfirmedWatched(contentIds: List<String>, watched: Boolean) {
+            confirmed += contentIds to watched
+        }
     }
 
-    private fun repo(status: HttpStatusCode, port: UserItemStatePort): PersonalDataRepository {
+    private fun repo(
+        status: HttpStatusCode,
+        port: UserItemStatePort,
+        reconciliationScope: CoroutineScope? = null,
+    ): PersonalDataRepository {
         val client = HttpClient(
             MockEngine { respond("{}", status, headersOf(HttpHeaders.ContentType, "application/json")) },
         ) {
             install(ContentNegotiation) { json(SiloJson) }
         }
-        return PersonalDataRepository(PersonalDataApi(client), port)
+        return if (reconciliationScope == null) {
+            PersonalDataRepository(PersonalDataApi(client), port)
+        } else {
+            PersonalDataRepository(PersonalDataApi(client), port, reconciliationScope = reconciliationScope)
+        }
+    }
+
+    /**
+     * A season write fans out on the server. The children must be confirmed
+     * locally even after the screen that started the write is gone, so the
+     * confirmation runs on the repository's scope, not the caller's.
+     */
+    @Test
+    fun setContainerWatchedConfirmsKnownAndResolvedChildrenOnItsOwnScope() = runTest {
+        val port = RecordingPort()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val repoScope = CoroutineScope(Job() + dispatcher)
+        val callerScope = CoroutineScope(Job() + dispatcher)
+        val repository = repo(HttpStatusCode.OK, port, reconciliationScope = repoScope)
+
+        var result: Any? = null
+        val call = callerScope.launch {
+            result = repository.setContainerWatched(
+                itemId = "season-1",
+                watched = true,
+                knownChildIds = listOf("e1"),
+                resolveChildIds = { listOf("e1", "e2", "e3") },
+            )
+        }
+        call.join()
+        // The caller leaves before reconciliation runs.
+        callerScope.cancel()
+        advanceUntilIdle()
+
+        assertTrue(result is org.siloserver.silo.network.ApiResult.Success<*>)
+        assertEquals(listOf("watched=true"), port.recorded)
+        assertEquals(listOf(listOf("e1") to true, listOf("e2", "e3") to true), port.confirmed)
+    }
+
+    @Test
+    fun setContainerWatchedDoesNotConfirmChildrenOnFailure() = runTest {
+        val port = RecordingPort()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val repository = repo(
+            HttpStatusCode.Forbidden,
+            port,
+            reconciliationScope = CoroutineScope(Job() + dispatcher),
+        )
+        repository.setContainerWatched("season-1", true, listOf("e1")) { listOf("e1", "e2") }
+        advanceUntilIdle()
+        assertTrue(port.confirmed.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Problem

Series pages had no way to mark a whole season watched from the season selector. Android TV only offered "Mark Season Watched" for the currently selected season through the More menu, and the phone had no season-level action at all. Apple gained a long-press season menu in the matching silo-apple change, so the Android clients needed the same behaviour to stay aligned.

## Solution

Long-press a season chip on the phone, or hold Select on a season tab on TV, to get "Mark Season N as Watched" or "Mark Season N as Unwatched" for that chip's season. It works for any season, not only the selected page. The label names the season by number even when the server supplies a custom title such as "Series 2".

- **Phone**: `SeasonChips` gains an optional long-press handler and a `DropdownMenu`. `ItemDetailViewModel.setSeasonWatched` flips the chip and any loaded episode page optimistically, rolls back on failure, and re-reads the season list plus the affected episode page on success.
- **TV**: `TvSeriesModePicker` season tabs gain the existing `TvMediaCardContextMenu` popup with custom watched labels. `TvItemDetailViewModel.onSetSeasonWatched` mirrors the phone logic and also updates the cached carousel page so neighbouring cards agree.
- Marking a single episode now refreshes the season flags on both clients, so a chip cannot stay stale after its last episode is marked.

The existing episode-card long-press menu is unchanged. The TV More menu entry for the selected season is unchanged.

## Validation

- `./gradlew :androidApp:assembleDebug :androidTvApp:assembleDebug` passed.
- `./gradlew :androidApp:testDebugUnitTest :androidTvApp:testDebugUnitTest` passed, 0 failures.
- New tests: fresh-only reads (`refreshSeasonsDoesNotServeCacheOnServer5xx`, `refreshEpisodesDoesNotServeCacheOnServer5xx`); the season write contract (`setSeasonWatchedRecordsContainerWithChildrenThenResolves`, `setSeasonWatchedResolvesTerminalOnForbidden`); durable child reconciliation in Room and the sync engine (`recordContainerWatchedQueuesReconciliationBehindTheContainerWrite`, `confirmContainerChild*` x3, `reconcileWatchedChildren*` x4); and the schema v9 migration. All pass.
- After the review fixes both emulator flows were re-run: TV mark and unmark on Season 2 applied on the dev server and the rail followed; phone mark and unmark on Season 2 flipped the checkmarks. Test data restored.
- Android TV emulator (SiloTV, 1080p) against the dev server: long-press on the "Series 2" tab showed "Mark Season 2 as Watched"; selecting it added a checkmark to every Season 2 card and the dev database gained 4 completed rows for that season. Long-press again showed "Mark Season 2 as Unwatched"; selecting it cleared the checkmarks and the rows.
- Android phone emulator (Pixel-class, 1080x2400) against a second server: long-press on "Season 2" showed the menu, marking added checkmarks to the Season 2 page, and unmarking cleared them.
- Test data was restored to its original state afterward.

Screenshots and screen recordings of both flows were captured locally and are attached in a follow-up comment.

## Risks

- The optimistic season counts (`watchedCount`, `unplayedCount`) are approximated locally until the season list refresh lands. The refresh replaces them with server values.
- Four review passes added shared behaviours: fresh-only repository reads for post-write refresh; per-season write serialization with a confirmed-state baseline and completion-order refresh ownership; and a durable `RECONCILE_WATCHED_CHILDREN` outbox op that the sync engine drains after the season write is acknowledged, confirming every episode through the single-item watched path unless the episode carries a newer intent of its own. This adds a Room schema version (v9, one nullable-default column on `content_item_state`).
- The TV tab uses `combinedClickable` for long-press. The episode rail already relies on the same modifier for D-pad long-press and works on the Shield and the emulator, so this is a known-good path.

## Follow-up

- The matching Apple change is Silo-Server/silo-apple#270.

## AI disclosure

AI-assisted. Model: `claude-fable-5-1[1m]` (Claude Fable 5.1). Harness: Claude Code running inside T3 Code. No other AI tooling. The author directed the change, reviewed the diff, and ran the emulator validation described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added long-press actions on season chips and tabs to mark entire seasons or specials as watched or unwatched.
  * Added season-level watched-state controls across Android phone and TV detail screens.
  * Added configurable watched/unwatched action labels for TV media controls.
* **Bug Fixes**
  * Improved synchronization and rollback for overlapping or failed watched-state updates.
  * Season and episode indicators now refresh more reliably after changes.
  * Prevented stale cached data from replacing fresh post-update results.
  * Improved offline watched-state reconciliation and recovery after temporary sync failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




